### PR TITLE
add redmine migration scripts

### DIFF
--- a/redmineMigration/README.md
+++ b/redmineMigration/README.md
@@ -1,0 +1,11 @@
+# Migration scripts 
+
+This folder contains scripts related to the transition from the old language depot VM to the new language depot running on the new lexbox service
+
+## Scripts in this folder are intended to be run sequentially as follows
+
+`loadSql/getSqlFromServer.sh` - download a SQL dump from language depot
+`loadSql/loadSql.sh` - run up a docker container with the SQL dump loaded into it
+`compareFolders/compareFolders.sh` - download a directory listing of folders on language depot, display a report, and create files for further analysis
+`compareSql/getSqlProjectCodes.sh` - extract language depot project codes from the local mariadb docker instance
+`compareSql/compareProjectDbAndFolders.sh` - create a report that shows projects that are missing either a folder or a SQL entry - i.e. the project is broken and cannot be used.  Conclusion: these projects should be removed before migration

--- a/redmineMigration/backupFolders/backupFolders.sh
+++ b/redmineMigration/backupFolders/backupFolders.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+#cd /var/vcs/public
+#BACKUP_DIR=/mnt/backups/orphanedFolders/2023-03-21/public
+BACKUP_DIR=../backups
+cd test
+#for d in `cat ~/public.projects.notInDbInFolder.10`; do
+for d in `cat ../../compareSql/public.projects.notInDbInFolder`; do
+    if [ -d "$d" ]; then
+        echo "Processing $d"
+        BACKUP_FILE="$d.tgz"
+        tar -czvf $BACKUP_FILE "$d"
+        mv $BACKUP_FILE $BACKUP_DIR
+        rm -r "$d"
+
+    else
+        echo "Error: Directory $d was not found"
+    fi
+done

--- a/redmineMigration/compareFolders/compareFolders.sh
+++ b/redmineMigration/compareFolders/compareFolders.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+ssh languagedepot ls -1 /var/vcs/public | sort > public.folders
+ssh languagedepot ls -1 /var/vcs/private | sort > private.folders
+cat public.folders private.folders | sort > all.folders.sorted
+cat all.folders.sorted | uniq > all.folders.sorted.uniq
+diff all.folders.sorted all.folders.sorted.uniq | grep "^<" | sed "s/^< //" | tee folders.inboth
+echo There are $(wc folders.inboth|awk '{print $1}') folders that occur in both public and private

--- a/redmineMigration/compareSql/compareProjectDbAndFolders.sh
+++ b/redmineMigration/compareSql/compareProjectDbAndFolders.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+echo -e "Public projects that exist in DB but have no corresponding folder\n"
+diff public.project.codes ../compareFolders/public.folders | grep "<" | sed "s/^< //" | tee public.projects.inDbNotInFolder
+echo -e "\n$(wc public.projects.inDbNotInFolder | awk '{print $1;}') items\n"
+
+echo -e "Public projects that DO NOT exist in DB but have a folder\n"
+diff public.project.codes ../compareFolders/public.folders | grep ">" | sed "s/^> //" | tee public.projects.notInDbInFolder
+echo -e "\n$(wc public.projects.notInDbInFolder | awk '{print $1;}') items\n"
+
+echo -e "Private projects that exist in DB but have no corresponding folder\n"
+diff private.project.codes ../compareFolders/private.folders | grep "<" | sed "s/^< //" | tee private.projects.inDbNotInFolder
+echo -e "\n$(wc private.projects.inDbNotInFolder | awk '{print $1;}') items\n"
+
+echo -e "Private projects that DO NOT exist in DB but have a folder\n"
+diff private.project.codes ../compareFolders/private.folders | grep ">" | sed "s/^> //" | tee private.projects.notInDbInFolder
+echo -e "\n$(wc private.projects.notInDbInFolder | awk '{print $1;}') items\n"

--- a/redmineMigration/compareSql/getSqlProjectCodes.sh
+++ b/redmineMigration/compareSql/getSqlProjectCodes.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+# assume running docker container mariadb-server
+docker exec mariadb-server mariadb languagedepot -e "select identifier from projects" | sort > public.project.codes
+docker exec mariadb-server mariadb languagedepotpvt -e "select identifier from projects" | sort > private.project.codes

--- a/redmineMigration/loadSql/getSqlFromServer.sh
+++ b/redmineMigration/loadSql/getSqlFromServer.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+ssh -t languagedepot "sudo mysqldump --databases --add-drop-database languagedepot languagedepotpvt | gzip > dump.sql.gz"
+scp languagedepot:dump.sql.gz .
+ssh languagedepot "rm dump.sql.gz"
+gunzip dump.sql.gz

--- a/redmineMigration/loadSql/loadSql.sh
+++ b/redmineMigration/loadSql/loadSql.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+docker stop mariadb-server
+docker run --name mariadb-server --network maria-network --rm --detach -e MARIADB_ALLOW_EMPTY_ROOT_PASSWORD=yes -dp 3306:3306 --mount type=bind,src=`pwd`/dump.sql,target=/docker-entrypoint-initdb.d/dump.sql mariadb:latest


### PR DESCRIPTION
Bash scripts intended for developer use to generate reports and datasets on project folders and language depot SQL

These scripts should be delete once we have finished the Redmine migration and shutdown the old language depot service.