### PR TITLE
Add email services

### DIFF
--- a/backend/LexBoxApi/Config/EmailConfig.cs
+++ b/backend/LexBoxApi/Config/EmailConfig.cs
@@ -1,0 +1,20 @@
+﻿using System.ComponentModel.DataAnnotations;
+
+namespace LexBoxApi.Config;
+
+public class EmailConfig
+{
+    [Required]
+    public required int SmtpPort { get; init; }
+    [Required]
+    public required string SmtpUser { get; init; }
+    [Required]
+    public required string SmtpPassword { get; init; }
+    [Required]
+    public required string SmtpHost { get; init; }
+    [Required]
+    public required string From { get; init; }
+    
+    [Required]
+    public required string EmailRenderHost { get; init; }
+}

--- a/backend/LexBoxApi/Controllers/LoginController.cs
+++ b/backend/LexBoxApi/Controllers/LoginController.cs
@@ -1,4 +1,5 @@
 ﻿using LexBoxApi.Auth;
+using LexBoxApi.Services;
 using LexCore;
 using LexCore.Auth;
 using Microsoft.AspNetCore.Authentication;
@@ -12,10 +13,12 @@ namespace LexBoxApi.Controllers;
 public class LoginController : ControllerBase
 {
     private readonly LexAuthService _lexAuthService;
+    private readonly EmailService _emailService;
 
-    public LoginController(LexAuthService lexAuthService)
+    public LoginController(LexAuthService lexAuthService, EmailService emailService)
     {
         _lexAuthService = lexAuthService;
+        _emailService = emailService;
     }
 
     [HttpPost]
@@ -36,5 +39,12 @@ public class LoginController : ControllerBase
     public ActionResult<string> HashPassword(string pw, string salt)
     {
         return PasswordHashing.RedminePasswordHash(pw, salt, false);
+    }
+
+    [HttpPost("forgotPassword")]
+    public async Task<ActionResult> ForgotPassword(string email)
+    {
+        await _emailService.SendForgotPasswordEmail(email);
+        return Ok();
     }
 }

--- a/backend/LexBoxApi/LexBoxApi.csproj
+++ b/backend/LexBoxApi/LexBoxApi.csproj
@@ -15,6 +15,7 @@
         <PackageReference Include="HotChocolate.Diagnostics" Version="13.0.5" />
         <PackageReference Include="HotChocolate.Stitching" Version="13.0.5" />
         <PackageReference Include="Humanizer.Core" Version="2.14.1" />
+        <PackageReference Include="MailKit" Version="4.0.0" />
         <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="7.0.3" />
         <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="7.0.2" />
         <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="7.0.2">

--- a/backend/LexBoxApi/LexBoxKernel.cs
+++ b/backend/LexBoxApi/LexBoxKernel.cs
@@ -25,9 +25,14 @@ public static class LexBoxKernel
             .BindConfiguration("CloudFlare")
             .ValidateDataAnnotations()
             .ValidateOnStart();
+        services.AddOptions<EmailConfig>()
+            .BindConfiguration("Email")
+            .ValidateDataAnnotations()
+            .ValidateOnStart();
 
         services.AddScoped<LoggedInContext>();
         services.AddScoped<ProjectService>();
+        services.AddScoped<EmailService>();
         services.AddScoped<TurnstileService>();
         services.AddScoped<HgService>();
         services.AddScoped<ILexProxyService, LexProxyService>();

--- a/backend/LexBoxApi/Services/EmailService.cs
+++ b/backend/LexBoxApi/Services/EmailService.cs
@@ -1,0 +1,86 @@
+﻿using System.Diagnostics;
+using LexBoxApi.Config;
+using LexBoxApi.Otel;
+using LexBoxApi.Services.Email;
+using LexData;
+using MailKit.Net.Smtp;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Options;
+using MimeKit;
+using MimeKit.Text;
+using OpenTelemetry.Trace;
+
+namespace LexBoxApi.Services;
+
+public class EmailService
+{
+    private readonly EmailConfig _emailConfig;
+    private readonly LexBoxDbContext _dbContext;
+    private readonly IHttpClientFactory _clientFactory;
+
+    public EmailService(IOptions<EmailConfig> emailConfig, LexBoxDbContext dbContext, IHttpClientFactory clientFactory)
+    {
+        _dbContext = dbContext;
+        _clientFactory = clientFactory;
+        _emailConfig = emailConfig.Value;
+    }
+
+    public async Task<bool> SendForgotPasswordEmail(string email)
+    {
+        var user = await _dbContext.Users.SingleOrDefaultAsync(u => u.Email == email);
+        // we want to silently return if the user doesn't exist, so we don't leak information.
+        if (user is null) return false;
+        var message = new MimeMessage();
+        message.To.Add(new MailboxAddress(user.Name, user.Email));
+        // todo generate jwt for password reset.
+        await RenderEmail(message, new ForgotPasswordEmail(user.Name, "https://lexbox.org"));
+        await SendEmailAsync(message);
+        return true;
+    }
+
+    private async Task SendEmailAsync(MimeMessage message)
+    {
+        message.From.Add(MailboxAddress.Parse(_emailConfig.From));
+        using var activity = LexBoxActivitySource.Get().StartActivity();
+        activity?.AddTag("app.email.subject", message.Subject);
+        try
+        {
+            using var client = new SmtpClient();
+            await client.ConnectAsync(_emailConfig.SmtpHost, _emailConfig.SmtpPort);
+            activity?.AddEvent(new("connected"));
+            await client.AuthenticateAsync(_emailConfig.SmtpUser, _emailConfig.SmtpPassword);
+            activity?.AddEvent(new("authenticated"));
+            await client.SendAsync(message);
+            activity?.AddEvent(new("sent"));
+            await client.DisconnectAsync(true);
+        }
+        catch (Exception e)
+        {
+            activity?.RecordException(e);
+            activity?.SetStatus(ActivityStatusCode.Error);
+            throw;
+        }
+    }
+
+    private record RenderResult(string Subject, string Html);
+
+    private async Task RenderEmail<T>(MimeMessage message, T parameters) where T : EmailTemplateBase
+    {
+        using var activity = LexBoxActivitySource.Get().StartActivity();
+        activity?.AddTag("app.email.template", typeof(T).Name);
+
+        var httpClient = _clientFactory.CreateClient();
+        httpClient.BaseAddress = new Uri("http://" + _emailConfig.EmailRenderHost);
+        var response = await httpClient.PostAsJsonAsync("email", parameters);
+        response.EnsureSuccessStatusCode();
+        var renderResult = await response.Content.ReadFromJsonAsync<RenderResult>();
+        if (renderResult is null)
+        {
+            activity?.SetStatus(ActivityStatusCode.Error, "RenderResult is null");
+            ArgumentNullException.ThrowIfNull(renderResult);
+        }
+
+        message.Subject = renderResult.Subject;
+        message.Body = new TextPart(TextFormat.Html) { Text = renderResult.Html };
+    }
+}

--- a/backend/LexBoxApi/Services/EmailTemplates/EmailTemplateBase.cs
+++ b/backend/LexBoxApi/Services/EmailTemplates/EmailTemplateBase.cs
@@ -1,0 +1,11 @@
+﻿using System.Text.Json.Serialization;
+
+namespace LexBoxApi.Services.Email;
+
+public record EmailTemplateBase(EmailTemplate Template);
+
+[JsonConverter(typeof(JsonStringEnumConverter))]
+public enum EmailTemplate
+{
+    ForgotPassword
+}

--- a/backend/LexBoxApi/Services/EmailTemplates/ForgotPasswordEmail.cs
+++ b/backend/LexBoxApi/Services/EmailTemplates/ForgotPasswordEmail.cs
@@ -1,0 +1,3 @@
+﻿namespace LexBoxApi.Services.Email;
+
+public record ForgotPasswordEmail(string Name, string ResetUrl): EmailTemplateBase(EmailTemplate.ForgotPassword);

--- a/backend/LexBoxApi/appsettings.Development.json
+++ b/backend/LexBoxApi/appsettings.Development.json
@@ -26,5 +26,13 @@
     "Jwt": {
       "Secret": "d5cf1adc-16e6-4064-8041-4cfa00174210"
     }
+  },
+  "Email": {
+    "SmtpHost": "localhost",
+    "SmtpPort": 1025,
+    "SmtpUser": "maildev",
+    "SmtpPassword": "maildev_pass",
+    "From": "Language Depot <no-reply@test.org>",
+    "EmailRenderHost": "localhost:5173"
   }
 }

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -38,6 +38,9 @@ services:
       Authentication__Jwt__Secret: dev-secret_but-it-must-be-32-characters-long
 # always passes key, more info here: https://developers.cloudflare.com/turnstile/frequently-asked-questions/#are-there-sitekeys-and-secret-keys-that-can-be-used-for-testing
       CloudFlare__TurnstileKey: 1x0000000000000000000000000000000AA
+      # additional email settings are required for prod, but the dev defaults will work for dev, see appsettings.Development.json
+      Email__SmtpHost: maildev
+      Email__EmailRenderHost: ui:3000
 
       # for dev convenience
       ASPNETCORE_ENVIRONMENT: Development
@@ -47,6 +50,17 @@ services:
       interval: 5s
       timeout: 5s
       retries: 5
+  maildev: 
+    image: maildev/maildev
+#    config: https://github.com/maildev/maildev/blob/master/README.md#usage
+    ports:
+#      ui port
+      - "1080:1080"
+#      smtp port
+      - "1025:1025"
+    environment:
+      MAILDEV_INCOMING_USER: maildev
+      MAILDEV_INCOMING_PASS: maildev_pass
 
   hasura:
     build: ./hasura
@@ -63,6 +77,7 @@ services:
       HASURA_GRAPHQL_METADATA_DATABASE_URL: postgres://postgres:${POSTGRES_PASSWORD}@db:5432/${POSTGRES_DB}
       PG_DATABASE_URL: postgres://postgres:${POSTGRES_PASSWORD}@db:5432/${POSTGRES_DB}
 
+# supported variables for hasura https://hasura.io/docs/latest/deployment/graphql-engine-flags/reference/
       # for dev convenience
       HASURA_GRAPHQL_WEBSOCKET_KEEPALIVE: 20
       HASURA_GRAPHQL_DEV_MODE: "true"

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -66,6 +66,8 @@
 		"@opentelemetry/sdk-node": "^0.36.0",
 		"@opentelemetry/sdk-trace-web": "^1.10.0",
 		"@opentelemetry/semantic-conventions": "^1.10.1",
+		"@types/mjml": "^4.7.1",
+		"mjml": "^4.14.1",
 		"svelte-intl-precompile": "^0.12.1"
 	}
 }

--- a/frontend/src/hooks.server.ts
+++ b/frontend/src/hooks.server.ts
@@ -8,6 +8,7 @@ import {env} from "$env/dynamic/private";
 const public_routes = [
 	'/login',
 	'/register',
+	'/email'
 ]
 
 export const handle = (async ({ event, resolve }) => {

--- a/frontend/src/lib/email/Email.svelte
+++ b/frontend/src/lib/email/Email.svelte
@@ -1,0 +1,23 @@
+﻿<script lang="ts">
+    import Subject from "$lib/email/Subject.svelte";
+
+    const silLogo = "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAGQAAABkAgMAAAANjH3HAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAAAAMUExURSh2xABcuVaT0fj7/aZ5vGgAAAAJcEhZcwAALiAAAC4gAdUcHhsAAAEQSURBVEjH7dS7DcIwEAZglsgSNIzACEGEMygUGYEpaOjdU4I3oKLKCIxAQZkuSODDzgOi5P6CQJlrIvmTT+c7xyNCMcggg/wsC7MHMmG+EY2NptgcmzJnZkt05pRCfjQlhDJFsnDgF7qy9PKUJIKy9nKXJGHOZydJXNHaf7uyYSYk9o/iKghkcVVfZHEnzWpJ2t2xsijXnFTMRmXb0OQCKVsx7VTc4weUieLW5MkV6eS7U9QdiOLTaVlC3zpR1r5sUdyVu34rqseeCErYrc2UwZ/z2HJlxO+oe1BFQwiJhXKHcoWi6xvSlpyA2C21s1VR/Avlu1PF8F73kSMSZZDERgNZHZDEOyRq931t1OekRC8admBBuTG0EgAAAABJRU5ErkJggg==";
+    export let subject: string;
+</script>
+<Subject value={subject}/>
+<!--https://documentation.mjml.io/#getting-started-->
+<mjml>
+    <mj-body>
+        <slot/>
+        <mj-section>
+            <mj-column vertical-align="middle">
+                <mj-text align="right" font-size="15px">
+                    Language Depot
+                </mj-text>
+            </mj-column>
+            <mj-column vertical-align="middle" width="50px" padding="0px">
+                <mj-image src={silLogo}  padding="0px" alt="SIL Logo" height="50px" width="50px"/>
+            </mj-column>
+        </mj-section>
+    </mj-body>
+</mjml> 

--- a/frontend/src/lib/email/ForgotPassword.svelte
+++ b/frontend/src/lib/email/ForgotPassword.svelte
@@ -1,0 +1,19 @@
+<script lang="ts">
+    import Subject from './Subject.svelte';
+
+    export let name: string = 'hello';
+</script>
+
+<Subject value="Hello world!"/>
+<mjml>
+    <mj-body>
+        <mj-section>
+            <mj-column>
+                <mj-text font-size="32px" color="#F45E43" font-family="helvetica">
+                    Hello {name}!
+                </mj-text>
+                <mj-divider border-color="#F45E43"/>
+            </mj-column>
+        </mj-section>
+    </mj-body>
+</mjml> 

--- a/frontend/src/lib/email/ForgotPassword.svelte
+++ b/frontend/src/lib/email/ForgotPassword.svelte
@@ -1,19 +1,24 @@
 <script lang="ts">
     import Subject from './Subject.svelte';
+    import Email from "$lib/email/Email.svelte";
 
     export let name: string = 'hello';
+    export let resetUrl: string;
 </script>
 
-<Subject value="Hello world!"/>
-<mjml>
-    <mj-body>
-        <mj-section>
-            <mj-column>
-                <mj-text font-size="32px" color="#F45E43" font-family="helvetica">
-                    Hello {name}!
-                </mj-text>
-                <mj-divider border-color="#F45E43"/>
-            </mj-column>
-        </mj-section>
-    </mj-body>
-</mjml> 
+<Email subject="Forgot your password?">
+    <mj-section>
+        <mj-column>
+            <mj-text font-size="20px">
+                Hello {name}!
+            </mj-text>
+            <mj-divider border-color="black"/>
+            <mj-text>
+                To reset your password, click the button below.
+            </mj-text>
+            <mj-button href={resetUrl}>
+                Reset password
+            </mj-button>
+        </mj-column>
+    </mj-section>
+</Email>

--- a/frontend/src/lib/email/Subject.svelte
+++ b/frontend/src/lib/email/Subject.svelte
@@ -1,0 +1,7 @@
+<script lang="ts">
+    export let value: string = '';
+</script>
+
+<svelte:head>
+    <title>{value}</title>
+</svelte:head>

--- a/frontend/src/lib/email/emailRenderer.server.ts
+++ b/frontend/src/lib/email/emailRenderer.server.ts
@@ -1,0 +1,29 @@
+﻿import {parse, walk} from "svelte/compiler";
+import mjml2html from 'mjml';
+import type {TemplateNode} from "svelte/types/compiler/interfaces";
+
+type RenderResult = { head: string, html: string, css: string };
+
+function getSubject(head: string): string {
+    // using the Subject.svelte component a title should have been placed in the head.
+    // we need to parse the head and find the title and extract the text
+    const headAst = parse(head, {filename: 'file.html'});
+    let subject: string | undefined;
+    walk(headAst.html, {
+        enter(node: TemplateNode, parent, prop, index) {
+            if (node.type === 'Element' && node.name === 'title') {
+                subject = node.children?.[0].data;
+            }
+        }
+    } as Parameters<typeof walk>[1]);
+    if (!subject) throw new Error('subject not found');
+    return subject;
+}
+
+export function render(emailComponent: any, props: Record<string, any>): { subject: string; html: string } {
+    const result: RenderResult = emailComponent.render(props);
+    return {
+        html: mjml2html(result.html).html,
+        subject: getSubject(result.head)
+    };
+}

--- a/frontend/src/lib/email/emailRenderer.server.ts
+++ b/frontend/src/lib/email/emailRenderer.server.ts
@@ -23,7 +23,7 @@ function getSubject(head: string): string {
 export function render(emailComponent: any, props: Record<string, any>): { subject: string; html: string } {
     const result: RenderResult = emailComponent.render(props);
     return {
-        html: mjml2html(result.html).html,
+        html: mjml2html(result.html, {validationLevel: 'strict'}).html,
         subject: getSubject(result.head)
     };
 }

--- a/frontend/src/routes/email/+server.ts
+++ b/frontend/src/routes/email/+server.ts
@@ -1,9 +1,41 @@
 ﻿import type {RequestEvent} from './$types';
 import {json} from "@sveltejs/kit";
 import ForgotPassword from "$lib/email/ForgotPassword.svelte";
-import {render} from "$lib/email/emailRenderer";
+import {render} from "$lib/email/emailRenderer.server";
 
+const enum EmailTemplate {
+    ForgotPassword = 'ForgotPassword'
+}
 
-export function GET(request: RequestEvent) {
-    return json(render(ForgotPassword, {name: 'John Doe'}));
+const componentMap = {
+    [EmailTemplate.ForgotPassword]: ForgotPassword
+} satisfies Record<EmailTemplate, object>;
+
+interface EmailTemplatePropsBase<T extends EmailTemplate> {
+    template: T;
+}
+
+interface ForgotPasswordProps extends EmailTemplatePropsBase<EmailTemplate.ForgotPassword> {
+    name: string;
+    resetUrl: string;
+}
+
+type EmailTemplateProps = ForgotPasswordProps;
+
+export async function POST(event: RequestEvent) {
+    const request = await event.request.json() as EmailTemplateProps;
+    const {template, ...props} = request;
+    const component = componentMap[template];
+    if (!component) throw new Error(`invalid template${template}`);
+    return json(render(component, props));
+}
+
+// just for testing
+export async function GET(event: RequestEvent) {
+    const {type, ...props} = {
+        type: EmailTemplate.ForgotPassword,
+        name: 'John Doe',
+        resetUrl: 'https://example.com/reset'
+    };
+    return json(render(componentMap[type], props));
 }

--- a/frontend/src/routes/email/+server.ts
+++ b/frontend/src/routes/email/+server.ts
@@ -1,0 +1,9 @@
+﻿import type {RequestEvent} from './$types';
+import {json} from "@sveltejs/kit";
+import ForgotPassword from "$lib/email/ForgotPassword.svelte";
+import {render} from "$lib/email/emailRenderer";
+
+
+export function GET(request: RequestEvent) {
+    return json(render(ForgotPassword, {name: 'John Doe'}));
+}

--- a/frontend/src/routes/email/email.http
+++ b/frontend/src/routes/email/email.http
@@ -1,0 +1,11 @@
+﻿###
+# @name Email Renderer
+
+POST http://localhost:5173/email
+Content-Type: application/json
+
+{
+  "template": "ForgotPassword",
+  "name": "http test",
+  "resetUrl": "http://localhost:5173/reset-password?token=1234567890"
+}

--- a/frontend/src/routes/email/tester/+page.server.ts
+++ b/frontend/src/routes/email/tester/+page.server.ts
@@ -1,0 +1,6 @@
+﻿import {render} from "$lib/email/emailRenderer.server";
+import ForgotPassword from "$lib/email/ForgotPassword.svelte";
+
+export function load() {
+    return render(ForgotPassword, {name: 'John Doe'});
+}

--- a/frontend/src/routes/email/tester/+page.ts
+++ b/frontend/src/routes/email/tester/+page.ts
@@ -1,0 +1,6 @@
+﻿
+import type {PageLoadEvent} from "./$types";
+// stub, just return data loaded on the server since we can't do that client side.
+export function load(event: PageLoadEvent) {
+    return event.data;
+}

--- a/frontend/src/routes/email/tester/+page@.svelte
+++ b/frontend/src/routes/email/tester/+page@.svelte
@@ -3,7 +3,7 @@
 
     export let data: PageData;
 </script>
-<div class="m-3 mockup-window border bg-base-300">
-    <span>Subject: {data.subject}</span>
+<div class="m-3 mockup-window border bg-white">
+    <span class="text-black">Subject: {data.subject}</span>
     {@html data.html}
 </div>

--- a/frontend/src/routes/email/tester/+page@.svelte
+++ b/frontend/src/routes/email/tester/+page@.svelte
@@ -1,0 +1,9 @@
+<script lang="ts">
+    import type {PageData} from "./$types";
+
+    export let data: PageData;
+</script>
+<div class="m-3 mockup-window border bg-base-300">
+    <span>Subject: {data.subject}</span>
+    {@html data.html}
+</div>


### PR DESCRIPTION
This rendering and designing emails in svelte, (preview at /email/testing) and adds an endpoints in dotnet `/api/login/forgotPassword` that will render an email via svelte and then send it via smtp. This does not complete the forgot password feature, it's just a sample to prove out the required features of email.

For #36