### PR TITLE
Tidy up env warning and simplify test users

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,9 +62,9 @@ dotnet watch
 Once the database is created by the dotnet backend, it will also seed some data in the database.
 The following users are available, password for them all is just `pass`:
 
-* KindLion@test.com: super admin
-* InnocentMoth@test.com: project manager
-* PlayfulFish@test.com: project editor
+* admin@test.com: super admin
+* manager@test.com: project manager
+* editor@test.com: project editor
 
 There will also be a single project, Sena 3.
 There will not be an hg repository however, see optional setup below if this is desired.

--- a/backend/LexBoxApi/Program.cs
+++ b/backend/LexBoxApi/Program.cs
@@ -34,9 +34,9 @@ builder.Services.AddSwaggerGen(options =>
         Description = """
             This is the open api for LexBox, most of api is in the [graphql endpoint](/api/graphql/ui).
             However there are some test users for login here, with the default password of `pass`:
-            * KindLion@test.com (site admin)
-            * InnocentMoth@test.com (Sena 3 manager)
-            * PlayfulFish@test.com (Sena 3 editor)
+            * admin@test.com (site admin)
+            * manager@test.com (Sena 3 manager)
+            * editor@test.com (Sena 3 editor)
             """,
     });
 });

--- a/backend/LexData/SeedingData.cs
+++ b/backend/LexData/SeedingData.cs
@@ -6,7 +6,7 @@ namespace LexData;
 
 public class SeedingData
 {
-    public static readonly Guid KindLionId = new("cf430ec9-e721-450a-b6a1-9a853212590b");
+    public static readonly Guid TestAdminId = new("cf430ec9-e721-450a-b6a1-9a853212590b");
     private readonly LexBoxDbContext _lexBoxDbContext;
 
     public SeedingData(LexBoxDbContext lexBoxDbContext)
@@ -34,10 +34,10 @@ public class SeedingData
 
         _lexBoxDbContext.Attach(new User
         {
-            Id = KindLionId,
-            Email = "KindLion@test.com",
-            Name = "Kind Lion",
-            Username = "KindLion",
+            Id = TestAdminId,
+            Email = "admin@test.com",
+            Name = "Test Admin",
+            Username = "admin",
             Salt = PwSalt,
             PasswordHash = _passwordHash,
             IsAdmin = true
@@ -60,9 +60,9 @@ public class SeedingData
                     User = new()
                     {
                         Id = new Guid("703701a8-005c-4747-91f2-ac7650455118"),
-                        Email = "InnocentMoth@test.com",
-                        Name = "Innocent Moth",
-                        Username = "InnocentMoth",
+                        Email = "manager@test.com",
+                        Name = "Test Manager",
+                        Username = "manager",
                         IsAdmin = false,
                         Salt = PwSalt,
                         PasswordHash = _passwordHash
@@ -75,9 +75,9 @@ public class SeedingData
                     User = new()
                     {
                         Id = new Guid("6dc9965b-4021-4606-92df-133fcce75fcb"),
-                        Email = "PlayfulFish@test.com",
-                        Name = "Playful Fish",
-                        Username = "PlayfulFish",
+                        Email = "editor@test.com",
+                        Name = "Test Editor",
+                        Username = "editor",
                         IsAdmin = false,
                         Salt = PwSalt,
                         PasswordHash = _passwordHash

--- a/backend/Testing/LexCore/Services/ProjectServiceTest.cs
+++ b/backend/Testing/LexCore/Services/ProjectServiceTest.cs
@@ -26,7 +26,7 @@ public class ProjectServiceTest : IClassFixture<TestingServicesFixture>
     {
         var projectId = await _projectService.CreateProject(
             new(null, "TestProject", "Test", "test", ProjectType.FLEx, RetentionPolicy.Test),
-            SeedingData.KindLionId
+            SeedingData.TestAdminId
         );
         projectId.ShouldNotBe(default);
     }
@@ -37,12 +37,12 @@ public class ProjectServiceTest : IClassFixture<TestingServicesFixture>
         //first project should be created
         await _projectService.CreateProject(
             new(null, "TestProject", "Test", "test-dup-code", ProjectType.FLEx, RetentionPolicy.Test),
-            SeedingData.KindLionId
+            SeedingData.TestAdminId
         );
 
         var exception = await _projectService.CreateProject(
             new(null, "Test2", "Test desc", "test-dup-code", ProjectType.Unknown, RetentionPolicy.Dev),
-            SeedingData.KindLionId
+            SeedingData.TestAdminId
         ).ShouldThrowAsync<DbUpdateException>();
 
         exception.InnerException.ShouldBeOfType<PostgresException>()

--- a/frontend/src/lib/i18n/locales/en.json
+++ b/frontend/src/lib/i18n/locales/en.json
@@ -26,7 +26,7 @@
 		"dont-remove": "Don't remove",
 		"remove": "Remove {entityName}"
 	},
-	"environment-warning": "This is the {environmentName} environment. Please confirm you are in the right place.",
+	"environment-warning": "This is a {environmentName} environment. Are you looking for public.languagedepot.org?",
 	"forgot_password": {
 		"send_email": "Send reset email"
 	},

--- a/frontend/src/lib/layout/AppBar.svelte
+++ b/frontend/src/lib/layout/AppBar.svelte
@@ -15,12 +15,10 @@
 		{$t('appbar.app_name')}
 	</span>
 	{#if environmentName !== 'production'}
-		<div class="alert alert-warning">
-			<div class="items-center">
-				<span>
-					{ $t('environment-warning', {environmentName}) }
-				</span>
-			</div>
+		<div class="alert alert-warning justify-center">
+			<span>
+				{ $t('environment-warning', {environmentName}) }
+			</span>
 		</div>
 	{/if}
 	<div class="navbar-end">


### PR DESCRIPTION
Looks like the warning was intended to be centered and I seem to like it that way a bit more, soo....
![image](https://github.com/sillsdev/languageforge-lexbox/assets/12587509/8260c2cf-4721-467f-927e-7065257cf995)


As much as I like the cool test user names. I think our lives will be easier if we just name them what they are.