### PR TITLE
Add init system to Hasura and API containers

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -4,6 +4,7 @@ services:
   lexbox-api:
     tty: true # for dev tools
     stdin_open: true # for dev tools
+    init: true
     build:
       context: backend
       dockerfile: LexBoxApi/dev.Dockerfile
@@ -68,6 +69,7 @@ services:
 
   hasura:
     build: ./hasura
+    init: true
     ports:
       - "8081:8080" # 8081 exposed here for dev tools
     depends_on:


### PR DESCRIPTION
This allows faster (and cleaner) shutdown.

Fixes #67.

Note that this is a short-term solution because it works on Docker Compose but not on Kubernetes. A long-term solution will involve adding the `tini` package to these two containers, then modifying the entrypoint to be `tini -- /path/to/docker-entrypoint.sh`. Then the Kubernetes containers will also contain the `tini` init system. But until we do that, this PR at least fixes the issue for local development.