### PR TITLE
Improve Mercurial log viewer

### DIFF
--- a/frontend/src/lib/components/HgLogView.svelte
+++ b/frontend/src/lib/components/HgLogView.svelte
@@ -23,6 +23,9 @@
     export let json: LogEntry[];  // JSON-format hg log
 
     function assignRowsAndColumns(entries: ExpandedLogEntry[]) {
+        // Walk the log top-down (most recent entry first) and assign circle locations for each log entry ("node")
+        // Basic idea is to keep them as far left as possible, only assigning extra columns when a node had multiple parents (a merge)
+        // Nodes with multiple children usually represent forks in the original repo, and those are placed under their leftmost child
         const cols = {} as { [node: string]: number };
         let curCol = 0;
         let curRow = 0;
@@ -47,6 +50,8 @@
                 if (parent in cols) {
                     // Parent has already been assigned a column, but maybe it can move to the left.
                     // Therefore, use either its column or the current column, *whichever is lower* (important)
+                    // This typically happens when a node had multiple children, i.e. it was a fork point, and by
+                    // moving as far left as possible we usually end up under the leftmost child, often in column 0
                     curCol = Math.min(cols[parent], curCol);
                     cols[parent] = curCol;
                 } else {

--- a/frontend/src/lib/components/HgLogView.svelte
+++ b/frontend/src/lib/components/HgLogView.svelte
@@ -6,6 +6,7 @@
 <script lang="ts">
     import FormatDate from './FormatDate.svelte';
     import TrainTracks from './TrainTracks.svelte';
+    import type { Path, Circle } from './TrainTracks.svelte';
 
     type LogEntry = {
         node: string,
@@ -80,7 +81,7 @@
 
     function assignPaths(entries: ExpandedLogEntry[]) {
         let indices = {} as { [node: string]: number };
-        let paths: [number, number][] = [];
+        let paths: Path[] = [];
         for (const entry of entries) {
             const { node, row } = entry;
             indices[node] = row;
@@ -90,7 +91,7 @@
             const { parents } = entry;
             for (const parent of parents) {
                 const parentIdx = indices[parent];
-                paths.push([curIdx, parentIdx]);
+                paths.push({fromIdx: curIdx, toIdx: parentIdx});
             }
             curIdx++;
         }
@@ -109,7 +110,7 @@
         return orig.replace(logEntryRe, "");
     }
 
-    $: circles = expandedLog.map((entry, idx) => ({ row: idx, col: entry.col }));
+    $: circles = expandedLog.map((entry, idx) => ({ row: idx, col: entry.col } as Circle));
     $: paths = assignPaths(expandedLog);
 
     let heights: number[] = [];

--- a/frontend/src/lib/components/TrainTracks.svelte
+++ b/frontend/src/lib/components/TrainTracks.svelte
@@ -90,10 +90,12 @@
 </script>
 
 <svg width={maxWidth}>
+{#if rowHeights?.length > 0}
     {#each curves as curve}
         <path fill="none" stroke="{curve.color}" stroke-width="1.5" d="{curve.d}"></path>
     {/each}
     {#each svgDots as c}
         <circle cx={c.x} cy={c.y} r={circleSize} fill={c.color} stroke="none" style=""></circle>
     {/each}
+{/if}
 </svg>

--- a/frontend/src/lib/components/TrainTracks.svelte
+++ b/frontend/src/lib/components/TrainTracks.svelte
@@ -15,7 +15,7 @@
     export let firstColOffset = 10;
     export let colWidthDefault = 20; // May be auto-calculated in the future
     export let rowHeightDefault = 20;
-    export let circleSize = 4;
+    export let circleSize = 5;
 
     export let colors = [ // Default set of colors works nicely, but allow overriding if needed
         "#4e79a7",

--- a/frontend/src/lib/components/TrainTracks.svelte
+++ b/frontend/src/lib/components/TrainTracks.svelte
@@ -1,12 +1,13 @@
 <script lang="ts" context="module">
-    type Circle = {row:number, col:number};
+    export type Circle = {row:number, col:number};
+    export type Path = {fromIdx:number, toIdx:number};  // Indices into array of circles
     type SVGDot = {x:number, y:number, color?:string};
     type SVGStroke = {color?:string, d:string}
 </script>
 <script lang="ts">
     // We need a list of dots and lines, i.e. which dots go to which parents
     // Each dot has one or two parents, and needs a Bezier curve to the parent
-    export let paths: [number, number][] = [];  // Format is [0,1],[1,2],[2,3],[2,4]. Dot 0 connects to dot 1. Dot 1 connects to dot 2. Dot 2 connects to both both 3 and 4, but they are separate paths.
+    export let paths: Path[] = [];  // Format is [{fromIdx:0,toIdx:1},{fromIdx:1,toIdx:2},{fromIdx:1,toIdx:3}], and so on. Dot 0 connects to dot 1. Dot 1 connects to both dots 2 and 3, because it was a fork or a merge.
     export let circles: Circle[] = [];  // Format is [{row:0,col:0},{row:1,col:0},{row:2,col:0},{row:2,col:1}]. Each dot has a row and column, which are auto-translated to x and y
     export let rowHeights: number[] = [];
 
@@ -91,7 +92,7 @@
 
     $: {
         cumulativeHeights;  // Lets Svelte know about the hidden dependency on this array in bezier()
-        curves = paths.map(([f,t]) => bezier(circles[f], circles[t]));
+        curves = paths.map(({ fromIdx:f, toIdx:t }) => bezier(circles[f], circles[t]));
         svgCircles = circles.map(({ row, col }) => ({ y: rowHeight(row), x: colWidth(col), color: color(col) }))
     };
 

--- a/frontend/src/lib/components/TrainTracks.svelte
+++ b/frontend/src/lib/components/TrainTracks.svelte
@@ -34,7 +34,7 @@
         return colors[colIdx % colorLength];
     }
 
-    function calculateCumulativeHeights(simpleHeights: number[]) {
+    function calculateCumulativeHeights(simpleHeights: number[]): number[] {
         let firstRow = (simpleHeights && simpleHeights.length > 0) ? (simpleHeights[0] / 2) : firstRowOffset;
         let total = firstRow;
         let result = [firstRow];

--- a/frontend/src/lib/components/TrainTracks.svelte
+++ b/frontend/src/lib/components/TrainTracks.svelte
@@ -46,7 +46,7 @@
     }
     $: cumulativeHeights = calculateCumulativeHeights(rowHeights);
 
-    function bezier(from: SVGDot, to: SVGDot) {
+    function bezier(from: SVGDot, to: SVGDot): SVGStroke {
         /*
         - If parent was in same column, M (child X,Y) and then V (parent Y)
         - If no parent, vertical line to bottom of graph (same as above but V (bottom-of-graph Y) instead of parent Y) - TODO

--- a/frontend/src/lib/components/TrainTracks.svelte
+++ b/frontend/src/lib/components/TrainTracks.svelte
@@ -57,10 +57,9 @@
             - S Px,Hy Px,Py (starting point of Hx, Hy is implied in SVG S command)
             - Note that parents are *below* children in this graph, so Hy is below Cy and above Py
         */
-        let { x: fromX, y: fromY, color: fromColor } = from;
+        let { x: fromX, y: fromY, color: strokeColor } = from;
         if (to) {
-            let { x: toX, y: toY, color: toColor } = to;
-            let strokeColor = fromColor;  // Consider using toColor instead
+            let { x: toX, y: toY } = to;
             if (fromX == toX) {
                 return { color: strokeColor, d: `M${fromX} ${fromY}V${toY}` };
             } else {
@@ -68,7 +67,7 @@
                 let halfY = (fromY + toY) / 2;
                 return { color: strokeColor, d: `M${fromX} ${fromY}S${fromX} ${halfY},${halfX} ${halfY}S${toX} ${halfY},${toX} ${toY}` };
             }
-        } else return { color: fromColor, d: ''}  // TODO: Path should be V${bottomY} to draw a line to the bottom of the graph, but how can we know bottomY?
+        } else return { color: strokeColor, d: ''}  // TODO: Path should be V${bottomY} to draw a line to the bottom of the graph, but how can we know bottomY?
     }
 
     let curves: SVGStroke[] = [];

--- a/frontend/src/lib/components/TrainTracks.svelte
+++ b/frontend/src/lib/components/TrainTracks.svelte
@@ -44,7 +44,7 @@
         return result;
     }
     $: cumulativeHeights = calculateCumulativeHeights(rowHeights);
-    
+
     function rowHeight(rowIdx: number) {
         return cumulativeHeights[rowIdx] ? cumulativeHeights[rowIdx] : rowHeightDefault * rowIdx + firstRowOffset;
     }
@@ -54,7 +54,7 @@
     }
 
     function bezier(from: Circle, to: Circle) {
-        /* 
+        /*
         - If parent was in same column, M (child X,Y) and then V (parent Y)
         - If no parent, vertical line to bottom of graph (same as above but V (bottom-of-graph Y) instead of parent Y)
         - If parent was in different column, Bezier curve as follows:

--- a/frontend/src/lib/components/TrainTracks.svelte
+++ b/frontend/src/lib/components/TrainTracks.svelte
@@ -60,14 +60,10 @@
         - If no parent, vertical line to bottom of graph (same as above but V (bottom-of-graph Y) instead of parent Y)
         - If parent was in different column, Bezier curve as follows:
             - Calculate halfway-point between parent and child. Call it Hx, Hy. Cx, Cy is child, and Px, Py is parent.
-            - M child X,Y
-            - C Cx,Cy to Cx,Hy to Hx,Hy
-            - C Hx,Hy to Px,Hy to Px,Py
-            - Note that parents are *below* children in this graph, so Hy is below Cy and above Py
-            - If I understand that correctly, that could become:
             - M Cx, Cy
-            - S Cx,Hy Hx,Hy
-            - S Px,Hy Px,Py
+            - S Cx,Hy Hx,Hy (starting point of Cx, Cy is implied in SVG S command)
+            - S Px,Hy Px,Py (starting point of Hx, Hy is implied in SVG S command)
+            - Note that parents are *below* children in this graph, so Hy is below Cy and above Py
         */
         if (from && to) {  // TODO: Fix this hack once I figure out why the "to" is sometimes undefined
         let { row: fromRow, col: fromCol } = from;


### PR DESCRIPTION
As per suggestions in https://github.com/sillsdev/languageforge-lexbox/pull/64#pullrequestreview-1440906595, refactored the TrainTracks code to be simpler, including removing some hidden dependencies so that all dependencies are visible to Svelte and it can figure out when to rerun the code. We also hide the SVG train tracks until the row heights are available, so that instead of rendering once at the wrong height and then re-rendering, it is blank until the calculations are done and then pops into visibility.

Fixes #74.