### PR TITLE
Init change-role modal with current role

### DIFF
--- a/frontend/src/lib/forms/index.ts
+++ b/frontend/src/lib/forms/index.ts
@@ -5,7 +5,7 @@ import Input from './Input.svelte';
 import ProtectedForm, { type Token } from './ProtectedForm.svelte';
 import Select from './Select.svelte';
 import { lexSuperForm, lexSuperValidate } from './superforms';
-import { randomFieldId } from './utils';
+import { randomFieldId, tryParse } from './utils';
 
 export {
 	Button,
@@ -17,5 +17,6 @@ export {
 	Select,
 	lexSuperForm,
 	lexSuperValidate,
-	randomFieldId,
+  randomFieldId,
+  tryParse,
 };

--- a/frontend/src/lib/forms/utils.ts
+++ b/frontend/src/lib/forms/utils.ts
@@ -1,3 +1,14 @@
+import type { ZodDefault, ZodType } from "zod";
+
 export function randomFieldId(): string {
 	return crypto.randomUUID().split('-').at(-1) as string;
+}
+
+export function tryParse<T, ValidT>(zodType: ZodDefault<ZodType<ValidT>>, value: T, callback: (parsedValue: ValidT) => void): void
+export function tryParse<T, ValidT>(zodType: ZodType<ValidT>, value: T, callback: (parsedValue: ValidT) => void): void
+export function tryParse<T, ValidT>(zodType: ZodType<ValidT>, value: T, callback: (parsedValue: ValidT) => void): void {
+  const result = zodType.safeParse(value);
+  if (result.success) {
+      callback(result.data);
+  }
 }

--- a/frontend/src/lib/util/enums.ts
+++ b/frontend/src/lib/util/enums.ts
@@ -1,0 +1,19 @@
+import { ProjectRole } from '$lib/gql/graphql';
+
+export function toProjectRoleEnum(index: number): ProjectRole {
+	return toEnum(PROJECT_ROLES, index);
+}
+
+const PROJECT_ROLES = {
+	0: ProjectRole.Editor,
+	2: ProjectRole.Manager,
+	3: ProjectRole.Editor,
+} as const;
+
+function toEnum<T, K extends string | number | symbol>(_enum: Record<K, T>, key: K): T {
+	const value = _enum[key];
+	if (value === undefined) {
+		throw new RangeError(`Enum key out of bounds: ${String(key)} (${Object.keys(_enum).join()}).`);
+	}
+	return value;
+}

--- a/frontend/src/routes/project/[project_code]/+page.svelte
+++ b/frontend/src/routes/project/[project_code]/+page.svelte
@@ -18,6 +18,7 @@
 	} from './+page';
 	import AddProjectMember from './AddProjectMember.svelte';
 	import ChangeMemberRoleModal from './ChangeMemberRoleModal.svelte';
+	import { toProjectRoleEnum } from '$lib/util/enums';
 
 	export let data: PageData;
 
@@ -26,7 +27,7 @@
 
 	let changeMemberRoleModal: ChangeMemberRoleModal;
 	async function changeMemberRole(projectUser: ProjectUser) {
-		await changeMemberRoleModal.open({ userId: projectUser.User.id, name: projectUser.User.name });
+		await changeMemberRoleModal.open({ userId: projectUser.User.id, name: projectUser.User.name, role: toProjectRoleEnum(projectUser.role) });
 	}
 
 	let deleteUserModal: DeleteModal;

--- a/frontend/src/routes/project/[project_code]/ChangeMemberRoleModal.svelte
+++ b/frontend/src/routes/project/[project_code]/ChangeMemberRoleModal.svelte
@@ -5,6 +5,7 @@
 	import t from '$lib/i18n';
 	import { z } from 'zod';
 	import { _changeProjectMemberRole } from './+page';
+	import { tryParse } from '$lib/forms';
 
 	export let projectId: string;
 
@@ -15,8 +16,9 @@
 	$: form = formModal?.form();
 
 	let name: string;
-	export async function open(member: { userId: string; name: string }): Promise<void> {
+	export async function open(member: { userId: string; name: string, role: ProjectRole }): Promise<void> {
 		name = member.name;
+        tryParse(schema.role, member.role, (role) => $form.role = role);
 		await formModal.open(async (form) => {
 			const result = await _changeProjectMemberRole({
 				projectId,


### PR DESCRIPTION
Adds reusable code for mapping to the ProjectRole enum and initializing form fields based on the defined schema.