### PR TITLE
cache user when using basic auth

### DIFF
--- a/backend/SyncReverseProxy/Auth/UserHasAccessToProjectRequirementHandler.cs
+++ b/backend/SyncReverseProxy/Auth/UserHasAccessToProjectRequirementHandler.cs
@@ -25,17 +25,7 @@ public class UserHasAccessToProjectRequirementHandler : AuthorizationHandler<Use
             return Task.CompletedTask;
         }
 
-        string? projectCode = null;
-        //this is used for hg requests. the key we're using is defined in app settings hg.path.match
-        if (_httpContextAccessor.HttpContext.Request.RouteValues.TryGetValue("project-code", out var projectCodeObj))
-        {
-            projectCode = projectCodeObj?.ToString() ?? null;
-        }
-        //this is for resumable requests.
-        else if (_httpContextAccessor.HttpContext.Request.Query.TryGetValue("repoId", out var projectCodeValues))
-        {
-            projectCode = projectCodeValues.ToString();
-        }
+        var projectCode = _httpContextAccessor.HttpContext.Request.GetProjectCode();
         if (string.IsNullOrEmpty(projectCode))
         {
             context.Fail(new AuthorizationFailureReason(this, "No repoId query parameter"));

--- a/backend/SyncReverseProxy/HgHelpers.cs
+++ b/backend/SyncReverseProxy/HgHelpers.cs
@@ -1,0 +1,21 @@
+﻿namespace LexSyncReverseProxy;
+
+public static class HgHelpers
+{
+    public static string? GetProjectCode(this HttpRequest request)
+    {
+        string? projectCode = null;
+        //this is used for hg requests. the key we're using is defined in app settings hg.path.match
+        if (request.RouteValues.TryGetValue("project-code", out var projectCodeObj))
+        {
+            projectCode = projectCodeObj?.ToString() ?? null;
+        }
+        //this is for resumable requests.
+        else if (request.Query.TryGetValue("repoId", out var projectCodeValues))
+        {
+            projectCode = projectCodeValues.ToString();
+        }
+
+        return projectCode;
+    }
+}

--- a/backend/SyncReverseProxy/ProxyKernel.cs
+++ b/backend/SyncReverseProxy/ProxyKernel.cs
@@ -35,6 +35,7 @@ public static class ProxyKernel
 
         services.AddHttpContextAccessor();
         services.AddScoped<ProxyEventsService>();
+        services.AddMemoryCache();
         services.AddScoped<IAuthorizationHandler, UserHasAccessToProjectRequirementHandler>();
         var reverseProxyConfig = configuration.GetSection("ReverseProxy");
         if (!reverseProxyConfig.Exists())

--- a/backend/Testing/SyncReverseProxy/ProxyHgRequestTests.cs
+++ b/backend/Testing/SyncReverseProxy/ProxyHgRequestTests.cs
@@ -18,7 +18,7 @@ public class ProxyHgRequests
     //cli "C:\Program Files (x86)\SIL\FLExBridge3\Mercurial\hg" clone -U  "https://{userName}:{password}@hg-public.languageforge.org/{projectCode}" "C:\ProgramData\SIL\FieldWorks\Projects\lkj"
     [Theory]
     // [InlineData("hg-public.languageforge.org")]
-    [InlineData("localhost:8034")]
+    [InlineData("localhost:5158")]
     public async Task TestGet(string host)
     {
         var responseMessage = await Client.SendAsync(new HttpRequestMessage(HttpMethod.Get,


### PR DESCRIPTION
right now any request using basic auth (all hg and resumable requests) will cause a database query in order to validate the password and permissions. This PR caches the user response using a hash of the username and password for the cache key.

closes #99