### PR TITLE
More Send/Receive testing

### DIFF
--- a/backend/LexBoxApi/Program.cs
+++ b/backend/LexBoxApi/Program.cs
@@ -69,6 +69,7 @@ app.Use(async (context, next) =>
     await next();
 });
 
+app.MapHealthChecks("/api/healthz").AllowAnonymous();
 // Configure the HTTP request pipeline.
 //for now allow this to run in prod, maybe later we want to disable it.
 // if (app.Environment.IsDevelopment())
@@ -88,7 +89,6 @@ app.Use(async (context, next) =>
 app.UseAuthentication();
 app.UseAuthorization();
 
-app.MapHealthChecks("/api/healthz").AllowAnonymous();
 app.MapBananaCakePop("/api/graphql/ui").AllowAnonymous();
 if (app.Environment.IsDevelopment())
     //required for vite to generate types

--- a/backend/SyncReverseProxy/Auth/BasicAuthHandler.cs
+++ b/backend/SyncReverseProxy/Auth/BasicAuthHandler.cs
@@ -24,14 +24,14 @@ public class BasicAuthHandler : AuthenticationHandler<AuthenticationSchemeOption
     protected override async Task HandleForbiddenAsync(AuthenticationProperties properties)
     {
         //the Basic realm part is required by the HG client, otherwise it won't request again with a basic auth header
-        Response.Headers.WWWAuthenticate = "Basic,Basic realm=\"SyncProxy\"";
+        Response.Headers.WWWAuthenticate = "Basic realm=\"SyncProxy\"";
         await base.HandleForbiddenAsync(properties);
     }
 
     protected override async Task HandleChallengeAsync(AuthenticationProperties properties)
     {
         //the Basic realm part is required by the HG client, otherwise it won't request again with a basic auth header
-        Response.Headers.WWWAuthenticate = "Basic,Basic realm=\"SyncProxy\"";
+        Response.Headers.WWWAuthenticate = "Basic realm=\"SyncProxy\"";
         await base.HandleChallengeAsync(properties);
     }
 

--- a/backend/Testing/Logging/XunitStringBuilderProgress.cs
+++ b/backend/Testing/Logging/XunitStringBuilderProgress.cs
@@ -1,0 +1,33 @@
+// Copyright (c) 2016 SIL International
+// This software is licensed under the MIT license (http://opensource.org/licenses/MIT)
+using SIL.Progress;
+using Xunit.Abstractions;
+
+namespace Testing.Logging
+{
+    public class XunitStringBuilderProgress : StringBuilderProgress
+    {
+        private ITestOutputHelper _output { get; init; }
+        // public string Text { get; } // Inherited from base class
+
+        public XunitStringBuilderProgress(ITestOutputHelper output)
+        {
+            _output = output;
+        }
+
+        public override void WriteMessage(string message, params object[] args)
+        {
+            // Chorus logs things like 'log -r0 --template "{node}"' which causes C# to throw string formatting
+            // exceptions, so we only use the formatting version (with args) if format args were actually passed.
+            if (args is not null && args.Length > 0) {
+                _output.WriteLine(message, args);
+            } else {
+                _output.WriteLine(message);
+            }
+            base.WriteMessage(message, args);
+        }
+
+        // No need to override WriteMessageWithColor here, as the StringBuilderProgress class has WriteMessageWithColor call WriteMessage
+    }
+}
+

--- a/backend/Testing/Services/SendReceiveService.cs
+++ b/backend/Testing/Services/SendReceiveService.cs
@@ -6,14 +6,14 @@ namespace Testing.Services;
 
 public class SendReceiveService
 {
-    private readonly string _defaultBaseUrl;
+    private readonly string _baseUrl;
     private const string fdoDataModelVersion = "7000072";
     private readonly IProgress _progress;
 
-    public SendReceiveService(IProgress progress, string defaultBaseUrl = "http://localhost:8088/hg")
+    public SendReceiveService(IProgress progress, string baseUrl = "http://localhost")
     {
         // _sendReceiveOptions = sendReceiveOptions;
-        _defaultBaseUrl = defaultBaseUrl;
+        _baseUrl = baseUrl;
         _progress = progress;
     }
 
@@ -33,16 +33,19 @@ public class SendReceiveService
         return output;
     }
 
-    public string CloneProject(string projectCode, string destDir, string? baseUrlOpt = null)
+    public string CloneProject(string projectCode, string destDir, string username, string password)
     {
-        var chorusSettings = new Chorus.Model.ServerSettingsModel();
-        chorusSettings.Username = "manager";
-        chorusSettings.RememberPassword = false; // Necessary for tests to work on Linux
-        chorusSettings.Password = "pass";
-        chorusSettings.SaveUserSettings();
-        string baseUrl = baseUrlOpt ?? _defaultBaseUrl;
-        string repoUrl = $"{baseUrl}/{projectCode}";
-        Console.WriteLine($"Cloning {repoUrl} ...");
+        if (String.IsNullOrEmpty(username) && String.IsNullOrEmpty(password)) {
+            // No username or password supplied, so we explicitly do *not* save user settings
+        } else {
+            var chorusSettings = new Chorus.Model.ServerSettingsModel();
+            chorusSettings.Username = username;
+            chorusSettings.RememberPassword = false; // Necessary for tests to work on Linux
+            chorusSettings.Password = password;
+            chorusSettings.SaveUserSettings();
+        }
+        string repoUrl = $"{_baseUrl}/{projectCode}";
+        Console.WriteLine($"Cloning {repoUrl} with user {username} and password \"{password}\" ...");
         var flexBridgeOptions = new Dictionary<string, string>
         {
             { "fullPathToProject", destDir },
@@ -62,17 +65,20 @@ public class SendReceiveService
         return cloneResult;
     }
 
-    public string SendReceiveProject(string projectCode, string projectDir, string? baseUrlOpt = null)
+    public string SendReceiveProject(string projectCode, string projectDir, string username, string password)
     {
-        var chorusSettings = new Chorus.Model.ServerSettingsModel();
-        chorusSettings.Username = "manager";
-        chorusSettings.RememberPassword = false; // Necessary for tests to work on Linux
-        chorusSettings.Password = "pass";
-        chorusSettings.SaveUserSettings();
+        if (String.IsNullOrEmpty(username) && String.IsNullOrEmpty(password)) {
+            // No username or password supplied, so we explicitly do *not* save user settings
+        } else {
+            var chorusSettings = new Chorus.Model.ServerSettingsModel();
+            chorusSettings.Username = username;
+            chorusSettings.RememberPassword = false; // Necessary for tests to work on Linux
+            chorusSettings.Password = password;
+            chorusSettings.SaveUserSettings();
+        }
+        string repoUrl = $"{_baseUrl}/{projectCode}";
         string fwdataFilename = System.IO.Path.Join(projectDir, $"{projectCode}.fwdata");
-        string baseUrl = baseUrlOpt ?? _defaultBaseUrl;
-        string repoUrl = $"{baseUrl}/{projectCode}";
-        Console.WriteLine($"S/R for {repoUrl} ...");
+        Console.WriteLine($"S/R for {repoUrl} with user {username} and password \"{password}\" ...");
         var flexBridgeOptions = new Dictionary<string, string>
         {
             { "fullPathToProject", projectDir },

--- a/backend/Testing/Services/SendReceiveService.cs
+++ b/backend/Testing/Services/SendReceiveService.cs
@@ -35,6 +35,7 @@ public class SendReceiveService
 
     public string CloneProject(string projectCode, string destDir, string username, string password)
     {
+        string repoUrl = $"{_baseUrl}/{projectCode}";
         if (String.IsNullOrEmpty(username) && String.IsNullOrEmpty(password)) {
             // No username or password supplied, so we explicitly do *not* save user settings
         } else {
@@ -43,8 +44,8 @@ public class SendReceiveService
             chorusSettings.RememberPassword = false; // Necessary for tests to work on Linux
             chorusSettings.Password = password;
             chorusSettings.SaveUserSettings();
+            repoUrl = repoUrl.Replace("http://",$"http://{username}:{password}@");
         }
-        string repoUrl = $"{_baseUrl}/{projectCode}";
         Console.WriteLine($"Cloning {repoUrl} with user {username} and password \"{password}\" ...");
         var flexBridgeOptions = new Dictionary<string, string>
         {
@@ -67,6 +68,7 @@ public class SendReceiveService
 
     public string SendReceiveProject(string projectCode, string projectDir, string username, string password)
     {
+        string repoUrl = $"{_baseUrl}/{projectCode}";
         if (String.IsNullOrEmpty(username) && String.IsNullOrEmpty(password)) {
             // No username or password supplied, so we explicitly do *not* save user settings
         } else {
@@ -75,8 +77,8 @@ public class SendReceiveService
             chorusSettings.RememberPassword = false; // Necessary for tests to work on Linux
             chorusSettings.Password = password;
             chorusSettings.SaveUserSettings();
+            repoUrl = repoUrl.Replace("http://",$"http://{username}:{password}@");
         }
-        string repoUrl = $"{_baseUrl}/{projectCode}";
         string fwdataFilename = System.IO.Path.Join(projectDir, $"{projectCode}.fwdata");
         Console.WriteLine($"S/R for {repoUrl} with user {username} and password \"{password}\" ...");
         var flexBridgeOptions = new Dictionary<string, string>

--- a/backend/Testing/Services/TestingEnvironmentVariables.cs
+++ b/backend/Testing/Services/TestingEnvironmentVariables.cs
@@ -1,0 +1,7 @@
+namespace Testing.Services;
+
+public static class TestingEnvironmentVariables
+{
+    public static string StandardHgHostname = Environment.GetEnvironmentVariable("TEST_STANDARD_HG_HOSTNAME") ?? "hg.localhost";
+    public static string ResumableHgHostname = Environment.GetEnvironmentVariable("TEST_RESUMABLE_HG_HOSTNAME") ?? "resumable.localhost";
+}

--- a/backend/Testing/SyncReverseProxy/SendReceiveServiceTests.cs
+++ b/backend/Testing/SyncReverseProxy/SendReceiveServiceTests.cs
@@ -81,7 +81,7 @@ public class SendReceiveServiceTests
                 );
                 oldLength = new FileInfo(fwdataFile).Length;
             } else {
-                result.ShouldContain("abort: authorization failed");
+                result.ShouldMatch("abort: authorization failed|Server Response 'Unauthorized'");
             }
         } catch (Chorus.VcsDrivers.Mercurial.RepositoryAuthorizationException) {
             if (data.ShouldPass) {
@@ -110,7 +110,7 @@ public class SendReceiveServiceTests
                     () => new FileInfo(fwdataFile).Length.ShouldBe(oldLength)
                 );
             } else {
-                result2.ShouldContain("abort: authorization failed");
+                result2.ShouldMatch("abort: authorization failed|Server Response 'Unauthorized'");
             }
         } catch (Chorus.VcsDrivers.Mercurial.RepositoryAuthorizationException) {
             if (data.ShouldPass) {

--- a/backend/Testing/SyncReverseProxy/SendReceiveServiceTests.cs
+++ b/backend/Testing/SyncReverseProxy/SendReceiveServiceTests.cs
@@ -36,7 +36,10 @@ public class SendReceiveServiceTests
         version.ShouldStartWith("Mercurial Distributed SCM");
     }
 
-    private static IEnumerable<string[]> hostsAndTypes = new[] { new[] { "http://hg.localhost", "normal" }, new[] { "http://resumable.localhost", "resumable" } };
+    private static IEnumerable<string[]> hostsAndTypes = new[] {
+        new[] { $"http://{TestingEnvironmentVariables.StandardHgHostname}", "normal" },
+        new[] { $"http://{TestingEnvironmentVariables.ResumableHgHostname}", "resumable" }
+    };
     private static IEnumerable<string[]> goodCredentials = new[] { new[] { "manager", "pass" }/*, new[] { "admin", "pass" }*/ };
     private static IEnumerable<string[]> badCredentials = new[] { new[] { "manager", "incorrect_pass" }, new[] { "invalid_user", "pass" }, new[] { "", "" } };
 

--- a/backend/Testing/SyncReverseProxy/SendReceiveServiceTests.cs
+++ b/backend/Testing/SyncReverseProxy/SendReceiveServiceTests.cs
@@ -40,8 +40,8 @@ public class SendReceiveServiceTests
         version.ShouldStartWith("Mercurial Distributed SCM");
     }
 
-    private static IEnumerable<string[]> hostsAndTypes => new[] { new[] { "http://hg.localhost", "normal" }, new[] { "http://resumable.localhost", "resumable" } };
-    private static string[] goodCredentials = new[] { "manager", "pass" };
+    private static IEnumerable<string[]> hostsAndTypes = new[] { new[] { "http://hg.localhost", "normal" }, new[] { "http://resumable.localhost", "resumable" } };
+    private static IEnumerable<string[]> goodCredentials = new[] { new[] { "manager", "pass" }/*, new[] { "admin", "pass" }*/ };
     private static IEnumerable<string[]> badCredentials = new[] { new[] { "manager", "incorrect_pass" }, new[] { "invalid_user", "pass" }, new[] { "", "" } };
 
     public record SendReceiveTestData(string ProjectCode, string Host, string HostType, string Username, string Password, bool ShouldPass);
@@ -52,7 +52,10 @@ public class SendReceiveServiceTests
         {
             var host = data[0];
             var type = data[1];
-            yield return new[] { new SendReceiveTestData(projectCode, host, type, goodCredentials[0], goodCredentials[1], true) };
+            foreach (var credentials in goodCredentials)
+            {
+                yield return new[] { new SendReceiveTestData(projectCode, host, type, credentials[0], credentials[1], true) };
+            }
             foreach (var credentials in badCredentials)
             {
                 yield return new[] { new SendReceiveTestData(projectCode, host, type, credentials[0], credentials[1], false) };
@@ -62,7 +65,6 @@ public class SendReceiveServiceTests
 
     [Theory]
     [MemberData(nameof(GetTestDataForSR), "sena-3")]
-    // NOTE: resumable failing because can't read sena-3 repo, because owned by UID 82 (Alpine www-data) instead of 33 (Debian www-data)
     public void CloneProjectAndSendReceive(SendReceiveTestData data)
     {
         _srService = new SendReceiveService(_progress, data.Host);

--- a/backend/Testing/SyncReverseProxy/SendReceiveServiceTests.cs
+++ b/backend/Testing/SyncReverseProxy/SendReceiveServiceTests.cs
@@ -42,7 +42,7 @@ public class SendReceiveServiceTests
 
     private static IEnumerable<string[]> hostsAndTypes => new[] { new[] { "http://hg.localhost", "normal" }, new[] { "http://resumable.localhost", "resumable" } };
     private static string[] goodCredentials = new[] { "manager", "pass" };
-    private static IEnumerable<string[]> badCredentials = new[] { new[] { "manager", "incorrect_pass" }, new[] { "invalid_user", "pass" } };
+    private static IEnumerable<string[]> badCredentials = new[] { new[] { "manager", "incorrect_pass" }, new[] { "invalid_user", "pass" }, new[] { "", "" } };
 
     public record SendReceiveTestData(string ProjectCode, string Host, string HostType, string Username, string Password, bool ShouldPass);
 

--- a/backend/Testing/SyncReverseProxy/SendReceiveServiceTests.cs
+++ b/backend/Testing/SyncReverseProxy/SendReceiveServiceTests.cs
@@ -1,9 +1,5 @@
-using LexBoxApi.Config;
-using Microsoft.Extensions.Options;
-using Moq;
 using Shouldly;
 using SIL.Progress;
-using Testing.Fixtures;
 using Testing.Logging;
 using Xunit.Abstractions;
 

--- a/backend/Testing/SyncReverseProxy/SendReceiveServiceTests.cs
+++ b/backend/Testing/SyncReverseProxy/SendReceiveServiceTests.cs
@@ -40,7 +40,7 @@ public class SendReceiveServiceTests
         version.ShouldStartWith("Mercurial Distributed SCM");
     }
 
-    private static IEnumerable<string[]> hostsAndTypes => new[] { new[] { "http://localhost", "normal" }, new[] { "http://hgresumable", "resumable" } };
+    private static IEnumerable<string[]> hostsAndTypes => new[] { new[] { "http://hg.localhost", "normal" }, new[] { "http://resumable.localhost", "resumable" } };
     private static string[] goodCredentials = new[] { "manager", "pass" };
     private static IEnumerable<string[]> badCredentials = new[] { new[] { "manager", "incorrect_pass" }, new[] { "invalid_user", "pass" } };
 
@@ -89,6 +89,12 @@ public class SendReceiveServiceTests
             } else {
                 // This is a successful test, because the repo rejected the invalid password as it should
             };
+        } catch (System.UnauthorizedAccessException) {
+            if (data.ShouldPass) {
+                throw;
+            } else {
+                // This is a successful test, because the repo rejected the invalid password as it should
+            };
         }
 
         // Now do a Send/Receive which should get no changes
@@ -107,6 +113,12 @@ public class SendReceiveServiceTests
                 result2.ShouldContain("abort: authorization failed");
             }
         } catch (Chorus.VcsDrivers.Mercurial.RepositoryAuthorizationException) {
+            if (data.ShouldPass) {
+                throw;
+            } else {
+                // This is a successful test, because the repo rejected the invalid password as it should
+            };
+        } catch (System.UnauthorizedAccessException) {
             if (data.ShouldPass) {
                 throw;
             } else {

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -29,7 +29,7 @@ services:
 
       # for dev convenience
       - ./backend:/src/backend
-      - nuget-cache:/home/builder/.nuget/packages
+      - nuget-cache:/root/.nuget/packages
     env_file: .env
     environment:
       DbConfig__LexBoxConnectionString: Host=db;Port=5432;Username=postgres;Password=${POSTGRES_PASSWORD};Database=${POSTGRES_DB}

--- a/proxy/default.conf
+++ b/proxy/default.conf
@@ -15,3 +15,23 @@ server {
 		proxy_pass http://otel-collector:4318;
 	}
 }
+
+server {
+	listen 80;
+	listen [::]:80;
+	server_name hg.localhost;
+
+	location / {
+		proxy_pass http://lexbox-api:5158;
+	}
+}
+
+server {
+	listen 80;
+	listen [::]:80;
+	server_name resumable.localhost;
+
+	location / {
+		proxy_pass http://lexbox-api:5158;
+	}
+}


### PR DESCRIPTION
In addition to tests, this PR also changes the nginx proxy config to expect the names "hg.localhost" and "resumable.localhost" for the hgweb and hgresume servers. This allows it to easily forward the right Mercurial clone/push/pull operations to the right servers, which fixes the one remaining issue with the Send/Receive tests so far.

Fixes #96.