### PR TITLE
Display correct trace-id when throwing GraphQL errors after the fact

### DIFF
--- a/frontend/src/hooks.client.ts
+++ b/frontend/src/hooks.client.ts
@@ -1,13 +1,16 @@
 import type { HandleClientError } from '@sveltejs/kit';
-import { getErrorMessage } from './hooks.shared';
+import { getErrorMessage, getTraceId } from './hooks.shared';
 import { loadI18n } from '$lib/i18n';
 import { trace_error_event } from '$lib/otel/client';
 
 await loadI18n();
 
 export const handleError: HandleClientError = ({ error, event }) => {
-	const source = 'client-error-hook';
-	const traceId = trace_error_event(error, event, { ['app.error.source']: source });
+  const source = 'client-error-hook';
+  // if it's already been traced, we don't want to create another trace just for this error
+  // and we want to display the original / real trace-id.
+  const traceId = getTraceId(error)
+    ?? trace_error_event(error, event, { ['app.error.source']: source });
 	const message = getErrorMessage(error);
 	return {
 		traceId,

--- a/frontend/src/hooks.shared.ts
+++ b/frontend/src/hooks.shared.ts
@@ -17,3 +17,10 @@ export const getErrorMessage = (error: unknown): string => {
 		sayWuuuuuuut
 	);
 };
+
+export const getTraceId = (error: unknown): string | undefined => {
+  if (typeof error === 'object') {
+    const _error = (error ?? {}) as Record<string, string>;
+    return _error.traceId;
+  }
+};

--- a/frontend/src/lib/otel/server.ts
+++ b/frontend/src/lib/otel/server.ts
@@ -5,7 +5,6 @@ import {
 	trace,
 	type Span,
 	type Context,
-  type Attributes,
 } from '@opentelemetry/api';
 
 import { SemanticAttributes } from '@opentelemetry/semantic-conventions';

--- a/frontend/src/routes/project/[project_code]/+page.ts
+++ b/frontend/src/routes/project/[project_code]/+page.ts
@@ -51,7 +51,7 @@ export async function load(event: PageLoadEvent) {
 			{ projectCode },
 		)
 		.toPromise();
-	if (result.error) throw new Error(result.error.message);
+  if (result.error) throw result.error;
 	event.depends(`project:${result.data?.projects[0]?.id}`);
 	return {
 		project: result.data?.projects[0],


### PR DESCRIPTION
The main goal here is to display the original trace-id of a GraphQL client-side fetch even though we throw the error **after** the fetch is complete.

This is ugly, but I couldn't figure out how else to preserve / put the trace-id on the error.

I believe we can't just cleanly access the trace context of the fetch instrumentation, because it never uses "startActiveSpan" instead it always explicitly sets the parent of each span.

A better way to do it would probably be to use GraphQL extensions ([`OperationResult.extensions`](https://spec.graphql.org/October2021/#sel-EAPHJCAACCoGu9J)) and send the trace-id back from the server, but I couldn't figure out how to do that with HotChocolate.

We could also put it in a response-header the same way we send `"lexbox-version"`, but error I was getting was breaking the app before that header was added. So, that also wasn't satisfying.