### PR TITLE
Only cache GraphQL clinet on client, not server

### DIFF
--- a/frontend/.env
+++ b/frontend/.env
@@ -3,5 +3,5 @@ PUBLIC_TURNSTILE_SITE_KEY=1x00000000000000000000AA
 PUBLIC_ENV_NAME=dev
 
 # these are here so the app can be run outside of a docker if desired
-BACKEND_HOST=http://localhost:5158
+BACKEND_HOST=http://localhost:5173  # Avoids CORS issues in dev, see https://kit.svelte.dev/faq#how-do-i-use-a-different-backend-api-server
 OTEL_ENDPOINT=http://localhost:4318

--- a/frontend/src/hooks.server.ts
+++ b/frontend/src/hooks.server.ts
@@ -1,6 +1,6 @@
 import { is_authn } from '$lib/user'
 import { redirect, type Handle, type HandleFetch, type HandleServerError, type ResolveOptions } from '@sveltejs/kit'
-import { initClient } from '$lib/graphQLClient'
+import { storeGqlEndpoint } from '$lib/graphQLClient'
 import {loadI18n} from "$lib/i18n";
 import { traceErrorEvent, traceResponse, traceRequest, traceFetch } from '$lib/otel/server'
 import {env} from "$env/dynamic/private";
@@ -14,6 +14,8 @@ const public_routes = [
 	'/forgotPassword/emailSent',
 ]
 
+storeGqlEndpoint(env.BACKEND_HOST);
+
 export const handle = (async ({ event, resolve }) => {
 	return traceRequest(event, async () => {
 		await loadI18n();
@@ -21,8 +23,6 @@ export const handle = (async ({ event, resolve }) => {
 		const options: ResolveOptions = {
 			filterSerializedResponseHeaders: () => true,
 		}
-
-		initClient(event, env.BACKEND_HOST)
 
 		return traceResponse({ method: event.request.method, route: event.route.id }, () => {
 			if (public_routes.includes(pathname)) {

--- a/frontend/src/routes/(dashboards)/admin/+page.ts
+++ b/frontend/src/routes/(dashboards)/admin/+page.ts
@@ -3,7 +3,7 @@ import {getClient} from "$lib/graphQLClient";
 import { graphql } from "$lib/gql";
 
 export async function load(event: PageLoadEvent) {
-    const client = getClient(event);
+    const client = getClient();
 
     //language=GraphQL
     const results = await client.query(graphql(`
@@ -31,7 +31,7 @@ export async function load(event: PageLoadEvent) {
                 createdDate
             }
         }
-    `), {}).toPromise();
+    `), {}, {fetch: event.fetch}).toPromise();
     if (results.error) throw new Error(results.error.message);
     return {
         projects: results.data?.projects ?? [],

--- a/frontend/src/routes/+layout.ts
+++ b/frontend/src/routes/+layout.ts
@@ -10,6 +10,6 @@ export function load(event: LayoutLoadEvent) {
     logout();
   }
 	user.set(_user);
-	if (browser) initClient(event);
+	if (browser) initClient();
 	return { traceParent: event.data.traceParent, userId: _user?.id };
 }

--- a/frontend/src/routes/+page.ts
+++ b/frontend/src/routes/+page.ts
@@ -2,12 +2,14 @@ import type { PageLoadEvent } from "./$types";
 import type { Project } from "$lib/project";
 import { getClient } from "$lib/graphQLClient";
 import { graphql } from "$lib/gql";
-
+import { browser } from '$app/environment';
 
 export async function load(event: PageLoadEvent): Promise<{ projects: Project[] }> {
-    const userId = (await event.parent()).userId;
+  // TODO: Invalidate this load() when user ID changes, so that logging out and logging in fetches a different project list
+  // Currently Svelte-Kit is skipping re-running this load if you log out and back in, which results in stale project lists
+  const userId = (await event.parent()).userId;
     if (!userId) return {projects: []};
-    const client = getClient(event);
+    const client = getClient();
     //language=GraphQL
     const results = await client.query(graphql(`
         query loadProjects($userId: uuid) {
@@ -23,7 +25,7 @@ export async function load(event: PageLoadEvent): Promise<{ projects: Project[] 
                 }
             }
         }
-    `), {userId}).toPromise();
+    `), {userId}, {fetch: event.fetch}).toPromise();
     if (results.error) throw new Error(results.error.message);
     if (!results.data) throw new Error("No data returned");
     return {

--- a/frontend/src/routes/project/[project_code]/+page.ts
+++ b/frontend/src/routes/project/[project_code]/+page.ts
@@ -15,7 +15,7 @@ import logsample from './logsample.json';
 export type ProjectUser = ProjectPageQuery['projects'][0]['ProjectUsers'][number];
 
 export async function load(event: PageLoadEvent) {
-	const client = getClient(event);
+	const client = getClient();
 	const projectCode = event.params.project_code;
 	const result = await client
 		.query(
@@ -48,7 +48,7 @@ export async function load(event: PageLoadEvent) {
 					}
 				}
 			`),
-			{ projectCode },
+			{ projectCode }, { fetch: event.fetch },
 		)
 		.toPromise();
 	if (result.error) throw new Error(result.error.message);


### PR DESCRIPTION
This eliminates the problem where one user could end up getting another user's data.

Fixes #108.