### PR TITLE
Cake demo

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -7,6 +7,12 @@
       "commands": [
         "dotnet-ef"
       ]
+    },
+    "cake.tool": {
+      "version": "3.0.0",
+      "commands": [
+        "dotnet-cake"
+      ]
     }
   }
 }

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ riderModule.iml
 **/Mercurial/
 **/MercurialExtensions/
 backend/Testing/SyncReverseProxy/TestData.cs
+tools/

--- a/build.cake
+++ b/build.cake
@@ -1,0 +1,33 @@
+#addin nuget:?package=Cake.Docker&version=1.2.0
+#addin nuget:?package=Cake.Pnpm&version=1.0.0
+#addin nuget:?package=Cake.DoInDirectory&version=6.0.0
+
+var target = Argument("target", "test");
+
+Task("back")
+	.Does(() => {
+		DockerComposeUp(new DockerComposeUpSettings { DetachedMode = true },
+            "db", "hasura", "otel-collector", "maildev", "hgweb");
+    });
+
+Task("front")
+    .IsDependentOn("back")
+	.Does(() => DoInDirectory("./frontend", () => PnpmRun("dev")));
+
+Task("api")
+	.Does(() => DoInDirectory("./backend/LexBoxApi", () =>
+        StartAndReturnProcess("dotnet", new ProcessSettings {
+            Arguments = ProcessArgumentBuilder.FromString("watch")
+        })));
+
+Task("test-sr")
+    .IsDependentOn("back")
+	.Does(() => DotNetTest("./backend/Testing/Testing.csproj",
+        new DotNetTestSettings {Filter = "SendReceive"}));
+
+Task("back-down")
+	.Does(() => {
+		DockerComposeDown();
+    });
+
+RunTarget(target);


### PR DESCRIPTION
Prototype for #97 

Here's a minimal example of what Cake usage looks like. `dotnet watch` is particularly gorgeous.

Can only be called from the root directory I believe. Usage e.g.: `dotnet cake --target=test-sr`.

At some point Intellisense suddenly started working. 🤷 
That's perhaps a bonus over task.
![image](https://github.com/sillsdev/languageforge-lexbox/assets/12587509/18483b4e-60db-477c-85e3-3e24fe887679)
