### PR TITLE
Now corepack won't install pnpm if it already is installed

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -77,7 +77,7 @@ tasks:
       - package.json
       - pnpm-lock.yaml
     cmds:
-      - corepack enable
+      - corepack enable || true
       - pnpm install
   ui-down:
     cmds:


### PR DESCRIPTION
```corepack enable``` was causing an error in the taskfile if ```pnpm``` was already installed.