### PR TITLE
Better login via load functions

### DIFF
--- a/frontend/src/app.d.ts
+++ b/frontend/src/app.d.ts
@@ -1,5 +1,7 @@
 /// <reference types='@sveltejs/kit' />
 
+import type { LexAuthUser } from '$lib/user';
+
 export { }; // for some reason this is required in order to make global changes
 
 declare global {
@@ -13,6 +15,7 @@ declare global {
   namespace App {
     interface Locals {
       client: import('@urql/svelte').Client;
+      getUser: (() => LexAuthUser | null);
     }
 
     interface Error {

--- a/frontend/src/hooks.server.ts
+++ b/frontend/src/hooks.server.ts
@@ -1,4 +1,4 @@
-import { isAuthn } from '$lib/user'
+import { getUser, isAuthn } from '$lib/user'
 import { redirect, type Handle, type HandleFetch, type HandleServerError, type ResolveOptions } from '@sveltejs/kit'
 import { storeGqlEndpoint } from '$lib/gql'
 import { loadI18n } from '$lib/i18n';
@@ -17,6 +17,7 @@ const PUBLIC_ROUTES = [
 storeGqlEndpoint(env.BACKEND_HOST);
 
 export const handle = (async ({ event, resolve }) => {
+  event.locals.getUser = () => getUser(event.cookies);
   return traceRequest(event, async () => {
     await loadI18n();
     const { cookies, url: { pathname } } = event

--- a/frontend/src/lib/layout/AdminContent.svelte
+++ b/frontend/src/lib/layout/AdminContent.svelte
@@ -2,7 +2,7 @@
   import { isAdmin } from '$lib/user';
   import { page } from '$app/stores'
 </script>
-
+<!-- eslint-disable-next-line @typescript-eslint/no-unsafe-argument -->
 {#if isAdmin($page.data.user)}
     <slot />
 {/if}

--- a/frontend/src/lib/layout/AdminContent.svelte
+++ b/frontend/src/lib/layout/AdminContent.svelte
@@ -1,7 +1,8 @@
 <script>
   import { isAdmin } from '$lib/user';
+  import { page } from '$app/stores'
 </script>
 
-{#if $isAdmin}
+{#if isAdmin($page.data.user)}
     <slot />
 {/if}

--- a/frontend/src/lib/layout/AppBar.svelte
+++ b/frontend/src/lib/layout/AppBar.svelte
@@ -2,7 +2,7 @@
   import { env } from '$env/dynamic/public';
   import t from '$lib/i18n';
   import { AuthenticatedUserIcon, UserAddOutline } from '$lib/icons';
-  import { user } from '$lib/user';
+  import { page } from '$app/stores';
   import { createEventDispatcher } from 'svelte';
 
   let environmentName = env.PUBLIC_ENV_NAME;
@@ -24,7 +24,7 @@
     </a>
   {/if}
   <div class="navbar-end">
-    {#if $user}
+    {#if $page.data.user}
       <button on:click={() => dispatch('menuopen')} class="btn btn-primary btn-circle">
         <AuthenticatedUserIcon size="text-4xl" />
       </button>

--- a/frontend/src/lib/layout/AppMenu.svelte
+++ b/frontend/src/lib/layout/AppMenu.svelte
@@ -1,7 +1,7 @@
 <script>
   import t from '$lib/i18n';
   import { AdminIcon, AuthenticatedUserIcon, HomeIcon, LogoutIcon } from '$lib/icons';
-  import { user } from '$lib/user';
+  import { page } from '$app/stores';
   import AdminContent from './AdminContent.svelte';
 </script>
 
@@ -11,8 +11,8 @@
   <!-- https://daisyui.com/components/menu  -->
   <ul class="menu bg-base-100 min-w-[33%]">
     <header class="prose flex flex-col items-end p-4 mb-4">
-      <h2 class="mb-0">{$user?.name}</h2>
-      <span class="font-light">{$user?.email}</span>
+      <h2 class="mb-0">{$page.data.user?.name}</h2>
+      <span class="font-light">{$page.data.user?.email}</span>
     </header>
 
     <li>

--- a/frontend/src/lib/otel/shared.ts
+++ b/frontend/src/lib/otel/shared.ts
@@ -7,7 +7,7 @@ import {
   type Span,
 } from '@opentelemetry/api';
 import { SemanticAttributes } from '@opentelemetry/semantic-conventions';
-import type { Cookies, NavigationEvent, RequestEvent } from '@sveltejs/kit';
+import type { NavigationEvent, RequestEvent } from '@sveltejs/kit';
 import { page } from '$app/stores';
 import { get } from 'svelte/store';
 

--- a/frontend/src/lib/otel/shared.ts
+++ b/frontend/src/lib/otel/shared.ts
@@ -1,4 +1,4 @@
-import { getUserId, type LexAuthUser } from '$lib/user';
+import type { LexAuthUser } from '$lib/user';
 import {
   SpanStatusCode,
   trace,
@@ -115,8 +115,7 @@ export const traceEventAttributes = (span: Span, event: RequestEvent | Navigatio
     span.setAttribute(SemanticAttributes.NET_HOST_NAME, url.hostname);
     span.setAttribute(SemanticAttributes.NET_HOST_PORT, url.port);
     if (isRequestEvent(event)) {
-      const { request, cookies } = event;
-      trySetUserIdAttribute(span, cookies);
+      const { request } = event;
       span.setAttribute(SemanticAttributes.HTTP_CLIENT_IP, event.getClientAddress());
       span.setAttribute(SemanticAttributes.HTTP_METHOD, request.method);
       span.setAttribute(
@@ -165,13 +164,6 @@ const forActiveOrNewSpan = (serviceName: string, name: string, action: (span: Sp
         span.end();
       }
     });
-  }
-};
-
-const trySetUserIdAttribute = (span: Span, cookies: Cookies): void => {
-  const userId = getUserId(cookies);
-  if (userId) {
-    span.setAttribute('app.user.id', userId);
   }
 };
 

--- a/frontend/src/lib/otel/shared.ts
+++ b/frontend/src/lib/otel/shared.ts
@@ -84,22 +84,15 @@ export const traceHeaders = (span: Span, type: 'request' | 'response', headers: 
 };
 
 function getUser(event: RequestEvent | NavigationEvent | Event): LexAuthUser | null {
-  if (isBrowserEvent(event)) {
+  if (isBrowserEvent(event) || isNavigationEvent(event)) {
     try {
       const data = get(page).data;
       return data.user as LexAuthUser;
     } catch {
       return null;
     }
-  } else if (isRequestEvent(event)) {
-    return event.locals.getUser();
   } else {
-    try {
-      const data = get(page).data;
-      return data.user as LexAuthUser;
-    } catch {
-      return null;
-    }
+    return event.locals.getUser();
   }
 }
 
@@ -189,3 +182,7 @@ const isBrowserEvent = (event: RequestEvent | NavigationEvent | Event): event is
 const isRequestEvent = (event: RequestEvent | NavigationEvent): event is RequestEvent => {
   return 'cookies' in event;
 };
+
+const isNavigationEvent = (event: RequestEvent | NavigationEvent): event is NavigationEvent => {
+  return !isRequestEvent(event);
+}

--- a/frontend/src/lib/otel/shared.ts
+++ b/frontend/src/lib/otel/shared.ts
@@ -84,15 +84,15 @@ export const traceHeaders = (span: Span, type: 'request' | 'response', headers: 
 };
 
 function getUser(event: RequestEvent | NavigationEvent | Event): LexAuthUser | null {
-  if (isBrowserEvent(event) || isNavigationEvent(event)) {
+  if (isRequestEvent(event)) {
+    return event.locals.getUser();
+  } else {
     try {
       const data = get(page).data;
       return data.user as LexAuthUser;
     } catch {
       return null;
     }
-  } else {
-    return event.locals.getUser();
   }
 }
 
@@ -179,10 +179,6 @@ const isBrowserEvent = (event: RequestEvent | NavigationEvent | Event): event is
   return 'bubbles' in event;
 };
 
-const isRequestEvent = (event: RequestEvent | NavigationEvent): event is RequestEvent => {
+const isRequestEvent = (event: RequestEvent | NavigationEvent | Event): event is RequestEvent => {
   return 'cookies' in event;
 };
-
-const isNavigationEvent = (event: RequestEvent | NavigationEvent): event is NavigationEvent => {
-  return !isRequestEvent(event);
-}

--- a/frontend/src/lib/otel/shared.ts
+++ b/frontend/src/lib/otel/shared.ts
@@ -97,11 +97,11 @@ function getUser(event: RequestEvent | NavigationEvent | Event): LexAuthUser | n
 }
 
 export const traceEventAttributes = (span: Span, event: RequestEvent | NavigationEvent | Event): void => {
+  const user = getUser(event);
+  if (user) {
+    span.setAttribute('app.user.id', user.id);
+  }
   if (isBrowserEvent(event)) {
-    const userId = getUser(event)?.id;
-    if (userId) {
-      span.setAttribute('app.user.id', userId);
-    }
     traceBrowserAttributes(span, window);
   } else {
     const { route, url } = event;

--- a/frontend/src/lib/user.ts
+++ b/frontend/src/lib/user.ts
@@ -1,7 +1,6 @@
 import { browser } from '$app/environment'
 import { redirect, type Cookies } from '@sveltejs/kit'
 import jwtDecode from 'jwt-decode'
-import { writable } from 'svelte/store'
 
 type JwtTokenUser = {
   sub: string

--- a/frontend/src/lib/user.ts
+++ b/frontend/src/lib/user.ts
@@ -1,7 +1,7 @@
 import { browser } from '$app/environment'
 import { redirect, type Cookies } from '@sveltejs/kit'
 import jwtDecode from 'jwt-decode'
-import { derived, writable } from 'svelte/store'
+import { writable } from 'svelte/store'
 
 type JwtTokenUser = {
   sub: string
@@ -128,10 +128,9 @@ export async function hash(password: string): Promise<string> {
       else {
         console.log('crypto is', crypto);
         throw new Error('crypto found but crypto.subtle not there');
-        throw "crypto found but crypto.subtle not there";
       }
     } catch (err) {
-      console.log('ERROR: crypto module not available -- are we running on an old version of Node?');
+      console.log('ERROR: crypto module not available -- are we running on an old version of Node? Error was', err);
       hashBuffer = new ArrayBuffer(0); // Should cause the hash comparison to fail
     }
   }

--- a/frontend/src/lib/user.ts
+++ b/frontend/src/lib/user.ts
@@ -17,7 +17,7 @@ type JwtTokenUser = {
   }
 }
 
-type LexAuthUser = Omit<JwtTokenUser, 'sub' | 'proj' | 'errors'> & {
+export type LexAuthUser = Omit<JwtTokenUser, 'sub' | 'proj' | 'errors'> & {
   id: string
   projects: UserProjects[]
 }
@@ -28,7 +28,7 @@ type UserProjects = {
 }
 
 export const user = writable<LexAuthUser | null>();
-export const isAdmin = derived(user, (user) => user?.role === 'admin');
+export const isAdmin = (user: LexAuthUser | null) => user?.role === 'admin';
 
 export async function login(userId: string, password: string): Promise<boolean> {
   clear()

--- a/frontend/src/lib/user.ts
+++ b/frontend/src/lib/user.ts
@@ -27,12 +27,9 @@ type UserProjects = {
   role: 'Manager' | 'Editor'
 }
 
-export const user = writable<LexAuthUser | null>();
 export const isAdmin = (user: LexAuthUser | null) => user?.role === 'admin';
 
 export async function login(userId: string, password: string): Promise<boolean> {
-  clear()
-
   const response = await fetch('/api/login', {
     method: 'post',
     headers: {
@@ -47,7 +44,6 @@ export async function login(userId: string, password: string): Promise<boolean> 
   if (!response.ok) {
     return false;
   }
-  user.set(jwtToUser(await response.json() as JwtTokenUser));
   return true;
 }
 type RegisterResponse = { error?: { turnstile: boolean, accountExists: boolean }, user?: LexAuthUser };
@@ -71,7 +67,6 @@ export async function register(password: string, name: string, email: string, tu
     return { error: { turnstile: 'TurnstileToken' in error, accountExists: 'Email' in error } };
   }
   const userJson: LexAuthUser = jwtToUser(responseJson);
-  user.set(userJson);
   return { user: userJson };
 }
 
@@ -102,15 +97,10 @@ export function getUserId(cookies: Cookies): string | undefined {
 }
 
 export function logout(cookies?: Cookies): void {
-  browser && clear()
   cookies && cookies.delete('.LexBoxAuth')
   if (browser && window.location.pathname !== '/login') {
     throw redirect(307, '/login');
   }
-}
-
-function clear(): void {
-  user.set(null)
 }
 
 export async function hash(password: string): Promise<string> {

--- a/frontend/src/lib/user.ts
+++ b/frontend/src/lib/user.ts
@@ -116,23 +116,12 @@ function clear(): void {
 export async function hash(password: string): Promise<string> {
   const msgUint8 = new TextEncoder().encode(password) // encode as (utf-8) Uint8Array
   let hashBuffer: ArrayBuffer;
-  // const c = crypto ? crypto : await import('node:crypto');
-  if (crypto && crypto.subtle) {
-    hashBuffer = await crypto.subtle.digest('SHA-1', msgUint8) // hash the message
+  const c = crypto ? crypto : await import('node:crypto');
+  if (c && c.subtle) {
+    hashBuffer = await c.subtle.digest('SHA-1', msgUint8) // hash the message
   } else {
-    // Running server-side
-    try {
-      const crypto = await import('node:crypto');
-      if (crypto.subtle)
-        hashBuffer = await crypto.subtle.digest('SHA-1', msgUint8) // hash the message
-      else {
-        console.log('crypto is', crypto);
-        throw new Error('crypto found but crypto.subtle not there');
-      }
-    } catch (err) {
-      console.log('ERROR: crypto module not available -- are we running on an old version of Node? Error was', err);
-      hashBuffer = new ArrayBuffer(0); // Should cause the hash comparison to fail
-    }
+      console.log('crypto.subtle not found; cryptop module was', c);
+      throw new Error('crypto.subtle not found -- are we running on an old version of Node?');
   }
   const hashArray = Array.from(new Uint8Array(hashBuffer)) // convert buffer to byte array
   const hashHex = hashArray.map(b => b.toString(16).padStart(2, '0')).join('') // convert bytes to hex string

--- a/frontend/src/lib/user.ts
+++ b/frontend/src/lib/user.ts
@@ -115,7 +115,26 @@ function clear(): void {
 
 export async function hash(password: string): Promise<string> {
   const msgUint8 = new TextEncoder().encode(password) // encode as (utf-8) Uint8Array
-  const hashBuffer = await crypto.subtle.digest('SHA-1', msgUint8) // hash the message
+  let hashBuffer: ArrayBuffer;
+  // const c = crypto ? crypto : await import('node:crypto');
+  if (crypto && crypto.subtle) {
+    hashBuffer = await crypto.subtle.digest('SHA-1', msgUint8) // hash the message
+  } else {
+    // Running server-side
+    try {
+      const crypto = await import('node:crypto');
+      if (crypto.subtle)
+        hashBuffer = await crypto.subtle.digest('SHA-1', msgUint8) // hash the message
+      else {
+        console.log('crypto is', crypto);
+        throw new Error('crypto found but crypto.subtle not there');
+        throw "crypto found but crypto.subtle not there";
+      }
+    } catch (err) {
+      console.log('ERROR: crypto module not available -- are we running on an old version of Node?');
+      hashBuffer = new ArrayBuffer(0); // Should cause the hash comparison to fail
+    }
+  }
   const hashArray = Array.from(new Uint8Array(hashBuffer)) // convert buffer to byte array
   const hashHex = hashArray.map(b => b.toString(16).padStart(2, '0')).join('') // convert bytes to hex string
 

--- a/frontend/src/lib/user.ts
+++ b/frontend/src/lib/user.ts
@@ -92,10 +92,6 @@ function jwtToUser(user: JwtTokenUser): LexAuthUser {
   }
 }
 
-export function getUserId(cookies: Cookies): string | undefined {
-  return getUser(cookies)?.id
-}
-
 export function logout(cookies?: Cookies): void {
   cookies && cookies.delete('.LexBoxAuth')
   if (browser && window.location.pathname !== '/login') {

--- a/frontend/src/routes/(authenticated)/+page.ts
+++ b/frontend/src/routes/(authenticated)/+page.ts
@@ -6,8 +6,9 @@ import type { Project } from '$lib/project';
 export async function load(event: PageLoadEvent): Promise<{ projects: Project[] }> {
   // TODO: Invalidate this load() when user ID changes, so that logging out and logging in fetches a different project list
   // Currently Svelte-Kit is skipping re-running this load if you log out and back in, which results in stale project lists
-  const userId = (await event.parent()).userId;
-  if (!userId) return { projects: [] };
+  const parentData = await event.parent();
+  const userId = (parentData).userId;
+  if (!userId) return { ...parentData, projects: [] };
   const client = getClient();
   //language=GraphQL
   const results = await client.query(graphql(`
@@ -28,6 +29,7 @@ export async function load(event: PageLoadEvent): Promise<{ projects: Project[] 
   if (results.error) throw new Error(results.error.message);
   if (!results.data) throw new Error('No data returned');
   return {
+    ...parentData,
     projects: results.data.projects.map(p => ({
       id: p.id,
       name: p.name,

--- a/frontend/src/routes/(authenticated)/myaccount/+page.svelte
+++ b/frontend/src/routes/(authenticated)/myaccount/+page.svelte
@@ -5,14 +5,17 @@
     import t from '$lib/i18n';
     import { Button, Form, Input } from '$lib/forms';
     import { Page } from '$lib/layout';
-    import { user } from '$lib/user';
     import {_changeUserAccountData} from './+page';
     import type {ChangeUserAccountDataInput} from '$lib/gql/types';
+    import type { PageData } from './$types';
+
+    export let data: PageData;
 
     // Get users data (reactive)
-    $: users_name = $user?.name; // not to be confused with username
-    $: email = $user?.email;
-    $: userid = $user?.id;
+    $: user = data.user;
+    $: users_name = user?.name; // not to be confused with username
+    $: email = user?.email;
+    $: userid = user?.id;
     let newName: string = users_name || '';
     let changed = false;
 

--- a/frontend/src/routes/(authenticated)/project/[project_code]/+page.svelte
+++ b/frontend/src/routes/(authenticated)/project/[project_code]/+page.svelte
@@ -8,7 +8,7 @@
   import DeleteModal from '$lib/components/modals/DeleteModal.svelte';
   import type { $OpResult, ChangeProjectDescriptionMutation, ChangeProjectNameMutation } from '$lib/gql/types';
   import t from '$lib/i18n';
-  import { isAdmin, user } from '$lib/user';
+  import { isAdmin } from '$lib/user';
   import { toProjectRoleEnum } from '$lib/util/enums';
   import { z } from 'zod';
   import type { PageData } from './$types';
@@ -18,6 +18,7 @@
 
   export let data: PageData;
 
+  $: user = data.user;
   $: project = data.project;
   $: _project = project as NonNullable<typeof project>;
 
@@ -50,8 +51,8 @@
     });
   }
 
-  $: userId = $user?.id;
-  $: canManage = $isAdmin || $user?.projects.find((project) => project.code == project.code)?.role == 'Manager';
+  $: userId = user?.id;
+  $: canManage = isAdmin(user) || user?.projects.find((project) => project.code == project.code)?.role == 'Manager';
 
   const projectNameValidation = z.string().min(1, $t('project_page.project_name_empty_error'));
 </script>
@@ -115,7 +116,7 @@
           <div class="dropdown dropdown-end">
             <MemberBadge
               member={{ name: member.User.name, role: member.role }}
-              canManage={canManage && (member.User.id != userId || $isAdmin)}
+              canManage={canManage && (member.User.id != userId || isAdmin(user))}
             />
             <ul class="dropdown-content menu bg-base-200 p-2 shadow rounded-box">
               <li>

--- a/frontend/src/routes/(unauthenticated)/login/+page.svelte
+++ b/frontend/src/routes/(unauthenticated)/login/+page.svelte
@@ -3,7 +3,7 @@
   import { Button, Form, Input, lexSuperForm } from '$lib/forms';
   import t from '$lib/i18n';
   import { Page } from '$lib/layout';
-  import { login, logout, isAdmin } from '$lib/user';
+  import { login, logout } from '$lib/user';
   import { onMount } from 'svelte';
   import { z } from 'zod';
 
@@ -15,7 +15,7 @@
     formSchema,
     async () => {
       if (await login($form.email, $form.password)) {
-        await goto($isAdmin ? '/admin' : '/');
+        await goto('/home');
         return;
       }
       $message = $t('login.bad_credentials');

--- a/frontend/src/routes/+layout.server.ts
+++ b/frontend/src/routes/+layout.server.ts
@@ -1,9 +1,11 @@
 import type { LayoutServerLoadEvent } from './$types'
 import { getRootTraceparent } from '$lib/otel/server'
 
-export function load({ locals }: LayoutServerLoadEvent) {
+export function load({ locals, depends }: LayoutServerLoadEvent) {
   const user = locals.getUser();
   const traceParent = getRootTraceparent()
+
+  if (user) depends(`user:${user.id}`);
 
   return {
     user,

--- a/frontend/src/routes/+layout.server.ts
+++ b/frontend/src/routes/+layout.server.ts
@@ -2,8 +2,8 @@ import type { LayoutServerLoadEvent } from './$types'
 import { getRootTraceparent } from '$lib/otel/server'
 import { getUser } from '$lib/user'
 
-export function load({ cookies }: LayoutServerLoadEvent) {
-  const user = getUser(cookies)
+export function load({ locals }: LayoutServerLoadEvent) {
+  const user = locals.getUser();
   const traceParent = getRootTraceparent()
 
   return {

--- a/frontend/src/routes/+layout.server.ts
+++ b/frontend/src/routes/+layout.server.ts
@@ -1,6 +1,5 @@
 import type { LayoutServerLoadEvent } from './$types'
 import { getRootTraceparent } from '$lib/otel/server'
-import { getUser } from '$lib/user'
 
 export function load({ locals }: LayoutServerLoadEvent) {
   const user = locals.getUser();

--- a/frontend/src/routes/+layout.ts
+++ b/frontend/src/routes/+layout.ts
@@ -1,16 +1,14 @@
-import { logout, user } from '$lib/user';
+import { logout } from '$lib/user';
 
 import type { LayoutLoadEvent } from './$types';
 import { browser } from '$app/environment';
-import { get } from 'svelte/store';
 import { initClient } from '$lib/gql';
 
-export function load(event: LayoutLoadEvent) {
-  const _user = event.data.user ?? get(user);
+export async function load(event: LayoutLoadEvent) {
+  const _user = event.data.user;
   if (!_user) {
     logout();
   }
-  user.set(_user);
   if (browser) initClient();
-  return { traceParent: event.data.traceParent, userId: _user?.id };
+  return { ...event.data, traceParent: event.data.traceParent, userId: _user?.id };
 }

--- a/frontend/src/routes/+layout.ts
+++ b/frontend/src/routes/+layout.ts
@@ -4,7 +4,7 @@ import type { LayoutLoadEvent } from './$types';
 import { browser } from '$app/environment';
 import { initClient } from '$lib/gql';
 
-export async function load(event: LayoutLoadEvent) {
+export function load(event: LayoutLoadEvent) {
   const _user = event.data.user;
   if (!_user) {
     logout();

--- a/frontend/src/routes/home/+server.ts
+++ b/frontend/src/routes/home/+server.ts
@@ -1,0 +1,13 @@
+import type { RequestHandler } from './$types'
+import { isAdmin, logout } from '$lib/user'
+import { redirect } from '@sveltejs/kit'
+
+export const GET: RequestHandler = ({ locals }) => {
+  const user = locals.getUser();
+  if (user) {
+    const dest = isAdmin(user) ? '/admin' : '/';
+    throw redirect(307, dest);
+  } else {
+    throw redirect(303, '/login');
+  }
+}

--- a/frontend/src/routes/home/+server.ts
+++ b/frontend/src/routes/home/+server.ts
@@ -1,5 +1,5 @@
 import type { RequestHandler } from './$types'
-import { isAdmin, logout } from '$lib/user'
+import { isAdmin } from '$lib/user'
 import { redirect } from '@sveltejs/kit'
 
 export const GET: RequestHandler = ({ locals }) => {


### PR DESCRIPTION
The preferred approach for keeping track of users in Svelte-Kit is as follows:

- The `handle` hook adds a `getUser` function to `event.locals`, which will be called later on when user info is needed
    - The function closes over `event.cookies`, so it can be called later on without parameters
- The root layout, in the **server** `load` function, calls `getUser` and puts user info into its return value
- Any load function that needs user data can do `const { user } = await event.parent()`
- Any *page* that needs user data can access `$page.data.user`
- Most important: if someone signs out, the load function re-runs itself so that `$page.data.user` is always up-to-date and doesn't end up getting stale

This PR modifies the login logic to follow that algorithm.