### PR TITLE
Trace urql/GQL errors and refactor tracing and urql client

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -60,13 +60,23 @@ tasks:
     cmds:
       - docker compose up maildev db hasura hgweb otel-collector hgresumable -d --wait={{.WAIT}}
 
+  backend-up:
+    vars:
+      WAIT: '{{default true .WAIT}}'
+    cmds:
+      # GraphQL breaks if changes are made while running in docker, so a restart is handy
+      - task: api-stop
+      # Needs to start before Hasura (can't use depends-on in docker-compose.yaml, because that wouldn't support running the api locally)
+      - task: api-up
+      - docker compose up hasura -d --wait={{.WAIT}}
+
   dev:
     deps: [ ui, api ]
 
   # ui
   ui:
     dir: ./frontend
-    deps: [ infra-up, ui-down, ui-install ]
+    deps: [ backend-up, ui-down, ui-install ]
     interactive: true
     cmds:
       - pnpm run dev
@@ -82,14 +92,18 @@ tasks:
   ui-down:
     cmds:
       - docker compose stop ui
-
   # api
   api:
     dir: ./backend/LexBoxApi
-    deps: [ infra-up, api-down ]
+    deps: [ infra-up, api-stop ]
     interactive: true
     cmds:
       - dotnet watch
-  api-down:
+  api-up:
+    vars:
+      WAIT: '{{default true .WAIT}}'
+    cmds:
+      - docker compose up lexbox-api --wait={{.WAIT}}
+  api-stop:
     cmds:
       - docker compose stop lexbox-api

--- a/frontend/src/app.d.ts
+++ b/frontend/src/app.d.ts
@@ -20,9 +20,11 @@ declare global {
 
     interface Error {
       traceId: string;
-      source: ErrorSource;
+      handler: ErrorHandler;
     }
   }
 
-  type ErrorSource = 'client-error' | 'client-unhandledrejection' | 'server-error-hook' | 'client-error-hook';
+  type ErrorHandler =
+    'client-error' | 'client-unhandledrejection' |
+    'server-error-hook' | 'client-error-hook';
 }

--- a/frontend/src/hooks.client.ts
+++ b/frontend/src/hooks.client.ts
@@ -1,17 +1,17 @@
 import type { HandleClientError } from '@sveltejs/kit';
+import { ensureErrorIsTraced } from '$lib/otel/client';
 import { getErrorMessage } from './hooks.shared';
 import { loadI18n } from '$lib/i18n';
-import { traceErrorEvent } from '$lib/otel/client';
 
 await loadI18n();
 
 export const handleError: HandleClientError = ({ error, event }) => {
-  const source = 'client-error-hook';
-  const traceId = traceErrorEvent(error, event, { ['app.error.source']: source });
+  const handler = 'client-error-hook';
+  const traceId = ensureErrorIsTraced(error, { event }, { ['app.error.source']: handler });
   const message = getErrorMessage(error);
   return {
     traceId,
     message,
-    source,
+    handler,
   };
 };

--- a/frontend/src/lib/error/UnexpectedError.svelte
+++ b/frontend/src/lib/error/UnexpectedError.svelte
@@ -13,7 +13,7 @@
     if (error) {
       return {
         ...error,
-        message: `${error?.message}\r\n(${error?.source})`,
+        message: `${error?.message}\r\n(${error?.handler})`,
       };
     }
   });

--- a/frontend/src/lib/error/index.ts
+++ b/frontend/src/lib/error/index.ts
@@ -1,31 +1,41 @@
 import { browser } from '$app/environment';
+import { ensureErrorIsTraced } from '$lib/otel';
 import { isObject } from '$lib/util/types';
 import { writable, type Writable } from 'svelte/store';
 
-export const error: Writable<App.Error | undefined | null> = writable();
+export const error: Writable<App.Error | null> = writable();
 
 export const dismiss = (): void => error.set(null);
 
+export const goesToErrorPage = (error: App.Error | null): boolean => error?.handler.endsWith('-hook') ?? false;
+
 if (browser) {
-  const { traceErrorEvent } = await import('$lib/otel/client');
+  /**
+   * Errors that land in these handlers should generally already be traced. The tracing here is only a weak fallback.
+   * These handlers are presumably never called in the context of a trace, so they have to create their own.
+   * The metadata defined here, could be used to identify/improve those cases.
+   */
 
   // https://developer.mozilla.org/en-US/docs/Web/API/GlobalEventHandlers/onerror#window.addEventListenererror
   window.addEventListener('error', (event: ErrorEvent) => {
-    const source = 'client-error';
-    const traceId = traceErrorEvent(event.error, event, { ['app.error.source']: source });
-    error.set({ message: event.message, traceId, source });
+    const handler = 'client-error';
+    const traceId = ensureErrorIsTraced(event.error, { event }, {
+      ['app.error.source']: handler,
+      ['app.error.traced_by_handler']: true,
+    });
+    error.set({ message: event.message, traceId, handler });
   });
 
   // https://developer.mozilla.org/en-US/docs/Web/API/PromiseRejectionEvent
   window.onunhandledrejection = (event: PromiseRejectionEvent) => {
-    const source = 'client-unhandledrejection';
-
+    const handler = 'client-unhandledrejection';
     const message = isObject(event.reason) ? event.reason.message as string : undefined;
     const keysForMissingMessageError = message ? undefined
       : isObject(event.reason) ? Object.keys(event.reason).join() : undefined;
-    const traceId = traceErrorEvent(event.reason, event, {
-      ['app.error.source']: source,
+    const traceId = ensureErrorIsTraced(event.reason, { event }, {
+      ['app.error.source']: handler,
       ['app.error.keys']: keysForMissingMessageError,
+      ['app.error.traced_by_handler']: true,
     });
 
     if (message?.startsWith('sendBeacon - cannot send')) {
@@ -34,6 +44,6 @@ if (browser) {
       return;
     }
 
-    error.set({ message: message ?? `We're not sure what happened.`, traceId, source });
+    error.set({ message: message ?? `We're not sure what happened.`, traceId, handler });
   };
 }

--- a/frontend/src/lib/gql/types.ts
+++ b/frontend/src/lib/gql/types.ts
@@ -1,5 +1,20 @@
-import type { OperationResult } from '@urql/svelte';
+import { TraceableMixin as AsTraceable } from '$lib/otel/types';
+import { CombinedError, type OperationResult } from '@urql/svelte';
 
 export * from './generated/graphql';
 
 export type $OpResult<T> = Promise<OperationResult<T>>;
+
+export type ServerError = { message: string, code?: string };
+
+export function hasError(value: unknown): value is { errors: ServerError[] } {
+  if (typeof value !== 'object' || value === null) return false;
+  return 'errors' in value && Array.isArray(value.errors);
+}
+
+export class LexGqlError extends AsTraceable(CombinedError) {
+  constructor(public readonly errors: ServerError[]) {
+    super({});
+    this.message = errors.map(e => e.message).join(', ');
+  }
+}

--- a/frontend/src/lib/layout/PageHeader.svelte
+++ b/frontend/src/lib/layout/PageHeader.svelte
@@ -5,7 +5,6 @@
 
     onMount(() => {
       const title = headerElem?.textContent;
-      console.log('set', title);
       window.document.title = title?.trim() ?? '';
     });
   </script>

--- a/frontend/src/lib/otel/client.ts
+++ b/frontend/src/lib/otel/client.ts
@@ -1,21 +1,14 @@
 import { BatchSpanProcessor, WebTracerProvider } from '@opentelemetry/sdk-trace-web'
 
-import { getWebAutoInstrumentations } from '@opentelemetry/auto-instrumentations-web'
-import { ZoneContextManager } from '@opentelemetry/context-zone'
 import { OTLPTraceExporter } from '@opentelemetry/exporter-trace-otlp-http'
-import { registerInstrumentations } from '@opentelemetry/instrumentation'
 import { Resource } from '@opentelemetry/resources'
+import { SERVICE_NAME } from '.'
 import { SemanticResourceAttributes } from '@opentelemetry/semantic-conventions'
-import type { NavigationEvent } from '@sveltejs/kit'
-import { traceErrorEvent as _traceErrorEvent, type ErrorAttributes, type TraceId } from './shared'
+import { ZoneContextManager } from '@opentelemetry/context-zone'
+import { getWebAutoInstrumentations } from '@opentelemetry/auto-instrumentations-web'
+import { registerInstrumentations } from '@opentelemetry/instrumentation'
 
-const serviceName = 'LexBox-SvelteKit-Client'
-
-export const traceErrorEvent = (
-  error: unknown,
-  event: NavigationEvent | Event,
-  metadata: ErrorAttributes,
-): TraceId => _traceErrorEvent(serviceName, error, event, metadata)
+export * from '.';
 
 // fetch_original & fetch_otel_instrumented are referenced by our fetch_proxy in app.html
 const fetchProxy = window.fetch;
@@ -34,7 +27,7 @@ try {
 
 const resource = Resource.default().merge(
   new Resource({
-    [SemanticResourceAttributes.SERVICE_NAME]: serviceName,
+    [SemanticResourceAttributes.SERVICE_NAME]: SERVICE_NAME,
     [SemanticResourceAttributes.SERVICE_VERSION]: '0.0.1',
   }),
 )

--- a/frontend/src/lib/otel/index.ts
+++ b/frontend/src/lib/otel/index.ts
@@ -1,0 +1,4 @@
+export * from './shared';
+export * from './types';
+// It's very intentional that we don't export ./server or ./client
+// Because those modules can only be loaded in the respective environments

--- a/frontend/src/lib/otel/shared.ts
+++ b/frontend/src/lib/otel/shared.ts
@@ -5,14 +5,29 @@ import {
   type Attributes,
   type Exception,
   type Span,
+  type Tracer,
+  context,
 } from '@opentelemetry/api';
 import { SemanticAttributes } from '@opentelemetry/semantic-conventions';
 import type { NavigationEvent, RequestEvent } from '@sveltejs/kit';
 import { page } from '$app/stores';
 import { get } from 'svelte/store';
+import { isTraced, type TraceId, isTraceable } from './types';
+import { makeOperation, type Exchange, type OperationResult, type AnyVariables, mapExchange } from '@urql/svelte';
+import { browser } from '$app/environment';
 
-export type ErrorAttributes = Attributes & { ['app.error.source']: ErrorSource };
-export type TraceId = string;
+export const SERVICE_NAME = browser ? 'LexBox-SvelteKit-Client' : 'LexBox-SvelteKit-Server';
+const GQL_ERROR_SOURCE = browser ? 'client-gql-error' : 'server-gql-error';
+
+export const tracer = (): Tracer => trace.getTracer(SERVICE_NAME);
+
+type ErrorTracer = ErrorHandler | 'server-gql-error' | 'client-gql-error';
+type ErrorAttributes = Attributes & { ['app.error.source']: ErrorTracer };
+
+interface ErrorContext {
+  event: RequestEvent | NavigationEvent | Event | undefined;
+  span: Span;
+}
 
 // Span and attribute names and values are based primarily on the OpenTelemetry semantic conventions for HTTP
 // https://opentelemetry.io/docs/reference/specification/trace/semantic_conventions/http/
@@ -48,30 +63,39 @@ const RECORDED_HEADERS_NORMALIZED = [
   'x_sveltekit_page',
 ].map(normalizeHeaderName);
 
-export const traceErrorEvent = (
-  serviceName: string,
+export const ensureErrorIsTraced = (
   error: unknown,
-  event: RequestEvent | NavigationEvent | Event,
-  metadata: ErrorAttributes,
-): TraceId =>
-  forActiveOrNewSpan(serviceName, 'error', (span) =>
-    recordErrorEvent(span, error, event, metadata),
-  );
-
-const recordErrorEvent = (
-  span: Span,
-  error: unknown,
-  event: RequestEvent | NavigationEvent | Event,
+  context: Partial<ErrorContext> | undefined,
   metadata: ErrorAttributes,
 ): TraceId => {
+  if (isTraced(error)) {
+    return error.traceId;
+  }
+  return ensureTraced('error', context?.span, (span) =>
+    traceErrorEvent(error, { span, event: context?.event }, metadata),
+  );
+}
+
+const traceErrorEvent = (
+  error: unknown,
+  context: ErrorContext,
+  metadata: ErrorAttributes,
+): TraceId => {
+  const { span, event } = context;
   span.recordException(error as Exception);
   span.setStatus({ code: SpanStatusCode.ERROR });
   if (metadata) {
     span.setAttributes(metadata);
   }
 
-  traceEventAttributes(span, event);
-  return span.spanContext().traceId;
+  if (event) traceEventAttributes(span, event);
+
+  const traceId = span.spanContext().traceId;
+  if (isTraceable(error)) {
+    error.trace(traceId);
+  }
+
+  return traceId;
 };
 
 export const traceHeaders = (span: Span, type: 'request' | 'response', headers: Headers): void => {
@@ -148,17 +172,25 @@ const traceBrowserAttributes = (span: Span, window: Window): void => {
   });
 };
 
-const forActiveOrNewSpan = (serviceName: string, name: string, action: (span: Span) => string): TraceId => {
-  const activeSpan = trace.getActiveSpan();
-  if (activeSpan) {
-    return action(activeSpan);
+/**
+ * Can be used if it is uncertain wether the caller is in the scope of an active trace.
+ * @param name The name to use if a new span needs to be created.
+ * @param currSpan The span to trace the error on. Used when explicit propagation is required.
+ * If not provided, the tracer will
+ * (1) try to find the active span itself or else
+ * (2) create its own span.
+ * @param instrumentedAction The action to perform in the context of whatever span ends up being used.
+ * The action is assumed to do all the necessary tracing and error handling.
+ * @returns The trace ID of whatever span ends up being used.
+ */
+const ensureTraced = (name: string, currSpan: Span | undefined, instrumentedAction: (span: Span) => string): TraceId => {
+  const foundSpan = currSpan ?? trace.getActiveSpan();
+  if (foundSpan) {
+    return instrumentedAction(foundSpan);
   } else {
-    return trace.getTracer(serviceName).startActiveSpan(name, (span) => {
+    return tracer().startActiveSpan(name, (span) => {
       try {
-        action(span);
-        return span.spanContext().traceId;
-      } catch (error) {
-        console.error('Error while processing span', error);
+        instrumentedAction(span);
         return span.spanContext().traceId;
       } finally {
         span.end();
@@ -174,3 +206,74 @@ const isBrowserEvent = (event: RequestEvent | NavigationEvent | Event): event is
 const isRequestEvent = (event: RequestEvent | NavigationEvent | Event): event is RequestEvent => {
   return 'cookies' in event;
 };
+
+/**
+ * We trace urql operations by both (1) wrapping entire queries and mutations and (2) intercepting operations with the tracingExchange.
+ * 1) Wrapping allows us to catch and trace thrown errors.
+ * 2) Intercepting gives us more context (e.g. the operation object), allows us to trace subscription setup (I think) and gives us a tidier place to hide the dirty work.
+ */
+
+export const traceOperation = <T extends OperationResult<unknown, AnyVariables>>(operation: () => Promise<T>): Promise<T> => {
+  return tracer().startActiveSpan('operation', async (span) => {
+    try {
+      return await operation();
+    } catch (error) {
+      ensureErrorIsTraced(error, { span }, { ['app.error.source']: GQL_ERROR_SOURCE });
+      throw error;
+    } finally {
+      span.end();
+    }
+  });
+}
+
+const ACTIVE_SPAN_KEY = 'ACTIVE_OTEL_OPERATION_SPAN';
+const CACHED_SPAN_KEY = 'CACHED_OTEL_OPERATION_SPAN';
+
+export const tracingExchange: Exchange = mapExchange({
+  onOperation: (operation) => {
+    const operationSpan = tracer().startSpan(`operation ${operation.kind}`, {
+      attributes: { 'graphql.operation.kind': operation.kind }
+    });
+    const operationSpanContext = trace.setSpan(context.active(), operationSpan);
+    return makeOperation(operation.kind, operation, {
+      ...operation.context,
+      fetch: operation.context.fetch ? context.bind(operationSpanContext, operation.context.fetch) : undefined,
+      [ACTIVE_SPAN_KEY]: operationSpan,
+    });
+  },
+  onResult: (result) => {
+    const operation = result.operation;
+    const cacheOutcome = operation.context.meta?.cacheOutcome;
+    const operationSpan = (result.extensions?.[CACHED_SPAN_KEY] ?? operation.context[ACTIVE_SPAN_KEY]) as Span | undefined;
+    const operationSpanContext = operationSpan?.spanContext();
+
+    if (result.error && (operation.kind === 'query' || operation.kind === 'subscription')) {
+      // queries/subscriptions generally won't lead to "expected" errors, so we trace them all.
+      // If something really went wrong we should have already traced it higher up anyway.
+      ensureErrorIsTraced(result.error, { span: operationSpan }, { ['app.error.source']: GQL_ERROR_SOURCE });
+    }
+
+    if (cacheOutcome && cacheOutcome !== 'miss') {
+      // We have no access to the span started above and it will therefore never end.
+      // That's alright, because this operation is not particularly interesting.
+      // Instead we (should) have access to the span/context of the original/cached operation, so we'll link to that.
+      tracer().startActiveSpan(`operation ${operation.kind} cache hit`, {
+        links: (operationSpanContext ? [{ context: operationSpanContext }] : [])
+      }, (span) => {
+        if (!operationSpanContext) { // :'(
+          const keys = Object.keys(operation.variables ?? {}).join();
+          span.setAttribute('app.urql.cache.missing_original_trace', `${operation.kind}: ${keys} (${operation.key})`);
+        }
+        span.end();
+      });
+    } else if (operationSpan) {
+      result.extensions ??= {};
+      // This is a bit of a hack that's only truly necessary in dev.
+      // In prod we get the cached operation, but in dev we only get the cached result, so that's where we need
+      // to store stuff if we ever want to see it again.
+      // https://github.com/urql-graphql/urql/blob/6a441884790bf6b07acb553f7bdc3702c3a1c315/packages/core/src/exchanges/cache.ts#L78
+      result.extensions[CACHED_SPAN_KEY] = operationSpan;
+      operationSpan?.end();
+    }
+  },
+});

--- a/frontend/src/lib/otel/types.ts
+++ b/frontend/src/lib/otel/types.ts
@@ -1,0 +1,50 @@
+import { type MixinConstructor, isObjectWhere } from '$lib/util/types';
+
+export type TraceId = string;
+export interface Traceable {
+  readonly traceId: TraceId | undefined;
+  trace: (traceId: TraceId) => void;
+}
+export interface Traced {
+  readonly traceId: TraceId;
+}
+
+export const isTraced = (value: unknown): value is Traced => {
+  return isObjectWhere<Traced>(value, traced => traced.traceId !== undefined);
+}
+
+export const isTraceable = (value: unknown): value is Traceable => {
+  return isObjectWhere<Traceable>(value, traceable => typeof traceable.trace === 'function');
+}
+
+class TraceableError extends Error {
+  constructor(readonly tracedValue: Traceable, message: string) {
+    super(message);
+  }
+}
+
+/* eslint-disable @typescript-eslint/naming-convention */
+// eslint-disable-next-line @typescript-eslint/explicit-function-return-type
+export function TraceableMixin<TBase extends MixinConstructor>(Base: TBase) {
+
+  return class _Traceable extends Base implements Traceable {
+
+    #traceId: TraceId | undefined;
+
+    get traceId(): TraceId | undefined {
+      return this.#traceId;
+    }
+
+    trace(traceId: TraceId): void {
+      if (this.#traceId) {
+        throw new TraceableError(this, `Object has already been traced (${this.#traceId} vs ${traceId}).`);
+      }
+
+      if (!traceId) {
+        throw new TraceableError(this, `No traceId provided.`);
+      }
+
+      this.#traceId = traceId;
+    }
+  };
+}

--- a/frontend/src/lib/user.ts
+++ b/frontend/src/lib/user.ts
@@ -26,7 +26,7 @@ type UserProjects = {
   role: 'Manager' | 'Editor'
 }
 
-export const isAdmin = (user: LexAuthUser | null) => user?.role === 'admin';
+export const isAdmin = (user: LexAuthUser | null): boolean => user?.role === 'admin';
 
 export async function login(userId: string, password: string): Promise<boolean> {
   const response = await fetch('/api/login', {

--- a/frontend/src/lib/util/types.ts
+++ b/frontend/src/lib/util/types.ts
@@ -1,5 +1,14 @@
 type Indexable = Record<string, string | number | boolean | undefined>;
+type IndexableObject<T = unknown> = unknown extends T ? Indexable & object : T;
 
-export function isObject(v: unknown): v is object & Indexable {
+export function isObject(v: unknown): v is IndexableObject {
   return v !== undefined && v !== null && typeof v === 'object';
 }
+
+export const isObjectWhere = <T = unknown>(value: unknown, predicate: (value: IndexableObject<T>) => boolean): boolean => {
+  return isObject(value) && predicate(value as IndexableObject<T>);
+}
+
+// https://www.typescriptlang.org/docs/handbook/mixins.html
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export type MixinConstructor = new (...args: any[]) => object;

--- a/frontend/src/routes/(authenticated)/(dashboards)/admin/+page.ts
+++ b/frontend/src/routes/(authenticated)/(dashboards)/admin/+page.ts
@@ -31,8 +31,8 @@ export async function load(event: PageLoadEvent) {
                 createdDate
             }
         }
-    `), {}, { fetch: event.fetch }).toPromise();
-  if (results.error) throw new Error(results.error.message);
+    `), {}, { fetch: event.fetch });
+
   return {
     projects: results.data?.projects ?? [],
     users: results.data?.users ?? []

--- a/frontend/src/routes/(authenticated)/+page.ts
+++ b/frontend/src/routes/(authenticated)/+page.ts
@@ -25,8 +25,7 @@ export async function load(event: PageLoadEvent): Promise<{ projects: Project[] 
                 }
             }
         }
-    `), { userId }, { fetch: event.fetch }).toPromise();
-  if (results.error) throw new Error(results.error.message);
+    `), { userId }, { fetch: event.fetch });
   if (!results.data) throw new Error('No data returned');
   return {
     ...parentData,

--- a/frontend/src/routes/(authenticated)/myaccount/+page.ts
+++ b/frontend/src/routes/(authenticated)/myaccount/+page.ts
@@ -31,8 +31,7 @@ export async function _changeUserAccountData(input: ChangeUserAccountDataInput):
       { input: input },
       //invalidates the graphql user cache, but who knows
       { additionalTypenames: ['Users'] },
-    )
-    .toPromise();
+    );
   if (!result.error) void invalidate(`user:${input.userId}`);
   return result;
 }

--- a/frontend/src/routes/(authenticated)/project/[project_code]/+page.ts
+++ b/frontend/src/routes/(authenticated)/project/[project_code]/+page.ts
@@ -22,7 +22,7 @@ export async function load(event: PageLoadEvent) {
   const client = getClient();
   const projectCode = event.params.project_code;
   const result = await client
-    .query<ProjectPageQuery>(
+    .query(
       graphql(`
 				query projectPage($projectCode: String!) {
 					projects(where: { code: { _eq: $projectCode } }) {
@@ -53,9 +53,7 @@ export async function load(event: PageLoadEvent) {
 				}
 			`),
       { projectCode }, { fetch: event.fetch },
-    )
-    .toPromise();
-  if (result.error) throw new Error(result.error.message);
+    );
 
   const projectId = result.data?.projects[0]?.id as string;
   event.depends(`project:${projectId}`);
@@ -86,8 +84,7 @@ export async function _addProjectMember(input: AddProjectMemberInput): $OpResult
       { input: input },
       //invalidates the graphql project cache
       { additionalTypenames: ['Projects'] },
-    )
-    .toPromise();
+    );
   if (!result.error) void invalidate(`project:${input.projectId}`);
   return result;
 }
@@ -114,8 +111,7 @@ export async function _changeProjectMemberRole(input: ChangeProjectMemberRoleInp
       { input: input },
       //invalidates the graphql project cache
       { additionalTypenames: ['Projects'] },
-    )
-    .toPromise();
+    );
   if (!result.error) void invalidate(`project:${input.projectId}`);
   return result;
 }
@@ -142,8 +138,7 @@ export async function _changeProjectName(input: ChangeProjectNameInput): $OpResu
       { input: input },
       //invalidates the graphql project cache
       { additionalTypenames: ['Projects'] },
-    )
-    .toPromise();
+    );
   if (!result.error) void invalidate(`project:${input.projectId}`);
   return result;
 }
@@ -170,8 +165,7 @@ export async function _changeProjectDescription(input: ChangeProjectDescriptionI
       { input: input },
       //invalidates the graphql project cache
       { additionalTypenames: ['Projects'] },
-    )
-    .toPromise();
+    );
   if (!result.error) void invalidate(`project:${input.projectId}`);
   return result;
 }
@@ -189,8 +183,7 @@ export async function _deleteProjectUser(projectId: string, userId: string): Pro
       { input: { projectId: projectId, userId: userId } },
       // invalidates the cached project so invalidate below will actually reload the project
       { additionalTypenames: ['Projects'] },
-    )
-    .toPromise();
+    );
   if (!result.error) {
     void invalidate(`project:${projectId}`);
   }

--- a/frontend/src/routes/(authenticated)/project/create/+page.ts
+++ b/frontend/src/routes/(authenticated)/project/create/+page.ts
@@ -18,7 +18,6 @@ export async function _createProject(input: CreateProjectInput): $OpResult<Creat
 
         }
         `),
-    { input }
-  ).toPromise();
+    { input });
   return result;
 }

--- a/frontend/src/routes/+layout.svelte
+++ b/frontend/src/routes/+layout.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import { page } from '$app/stores';
   import '$lib/app.postcss';
-  import { error } from '$lib/error';
+  import { error, goesToErrorPage } from '$lib/error';
   import UnexpectedErrorAlert from '$lib/error/UnexpectedErrorAlert.svelte';
   import { onDestroy } from 'svelte';
   import type { LayoutData } from './$types';
@@ -28,7 +28,7 @@
   <slot />
 </div>
 
-<!-- We don't want the alert for "hook" errors, because they land on +error.svelte -->
-{#if !$page.error?.source?.endsWith('-hook')}
+<!-- We don't want the alert as well if we're heading to +error.svelte -->
+{#if !goesToErrorPage($page.error)}
   <UnexpectedErrorAlert />
 {/if}

--- a/frontend/src/routes/+layout.ts
+++ b/frontend/src/routes/+layout.ts
@@ -1,14 +1,11 @@
-import { logout } from '$lib/user';
-
 import type { LayoutLoadEvent } from './$types';
-import { browser } from '$app/environment';
-import { initClient } from '$lib/gql';
+import { logout } from '$lib/user';
 
 export function load(event: LayoutLoadEvent) {
   const _user = event.data.user;
   if (!_user) {
     logout();
   }
-  if (browser) initClient();
+
   return { ...event.data, traceParent: event.data.traceParent, userId: _user?.id };
 }


### PR DESCRIPTION
Adds a new `GqlClient` class that wraps the urql client for the purposes of
1) Enforcing `fetch` to be passed for queries
2) Extending the API to allow (or for queries to default to) explicitly/automatically throwing errors
3) Wrapping and tracing operations (now urql errors that land in our error handlers are pre-traced and have a juicy trace-ID to display)

Traces urql operations at 2 levels (with different advantages) and links cached-result traces to original traces.

Merges the request and response spans into 1 for handled requests.