### PR TITLE
Trace and intercept client-side fetches

### DIFF
--- a/frontend/src/app.d.ts
+++ b/frontend/src/app.d.ts
@@ -8,7 +8,7 @@ declare global {
   interface Window {
     /* eslint-disable @typescript-eslint/naming-convention */
     fetch_original: typeof window.fetch;
-    fetch_otel_instrumented: typeof window.fetch;
+    fetch_instrumented: typeof window.fetch;
     /* eslint-enable @typescript-eslint/naming-convention */
   }
 

--- a/frontend/src/app.html
+++ b/frontend/src/app.html
@@ -11,9 +11,9 @@
             // https://github.com/sveltejs/kit/issues/9530
             window.fetch_original = window.fetch;
             window.fetch = function () {
-                // use the instrumented version once otel\client.ts has put it in place
-                return window.fetch_otel_instrumented
-                    ? window.fetch_otel_instrumented(...arguments)
+                // use the instrumented version once otel.client.ts has put it in place
+                return window.fetch_instrumented
+                    ? window.fetch_instrumented(...arguments)
                     : window.fetch_original(...arguments);
             }
         </script>

--- a/frontend/src/lib/gql/gql-client.ts
+++ b/frontend/src/lib/gql/gql-client.ts
@@ -79,6 +79,7 @@ class GqlClient {
     const error = result.error;
     if (!error) return;
     if (this.is401(error)) throw redirect(307, '/logout');
+    if (error.networkError) throw error.networkError; // e.g. SvelteKit redirects
     throw error;
   }
 


### PR DESCRIPTION
Resolves #85

Wrap and trace all client-side fetch requests, so that we can (1) stamp errors with our own trace-ID and (2) watch for 401's and then redirect to `/logout`.

- Fine tune the tracing of errors by not tracing redirects, but otherwise preferring urql's `networkError`s.
- Rethrow urql's `networkError`s, beacuse they're the juicy part of the error if they're set and they might be SK redirects
- I don't like the `handleFetch` "setter". I was previously defining a function in `hooks.client.ts` and calling that from `otel.client.ts`, which I liked a bit more, but that lead to a circular dependency, which I didn't like. I also just didn't like that an otel file was referencing a hooks file at all.
- Slim down request tracing a tad