### PR TITLE
Bug: when creating a project the description is required but doesn't display an error

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -35,12 +35,15 @@ tasks:
       - rm sena-3.zip
 
   # docker
-  up:
+  up: # e.g. task up -- otel-collector --build
     cmds:
-      - docker compose up --wait
+      - docker compose up --wait {{.CLI_ARGS}}
   down:
     cmds:
       - docker compose down
+  restart: # e.g. task restart -- lexbox-api
+    cmds:
+      - docker compose restart {{.CLI_ARGS}}
 
   # tests
   test:

--- a/frontend/src/lib/app.postcss
+++ b/frontend/src/lib/app.postcss
@@ -26,3 +26,13 @@ form {
 button.button-badge:not([disabled]) {
   @apply hover:drop-shadow-xl hover:brightness-90;
 }
+
+form {
+    input, select, textarea {
+        margin: 0;
+    }
+
+    .form-control {
+        @apply mb-2;
+    }
+}

--- a/frontend/src/lib/forms/Checkbox.svelte
+++ b/frontend/src/lib/forms/Checkbox.svelte
@@ -1,12 +1,14 @@
 <script lang="ts">
+  import { randomFieldId } from './utils';
+
   export let label: string;
   export let value: boolean;
+  export let id = randomFieldId();
 </script>
 
 <div class="form-control w-full">
   <label class="label cursor-pointer">
     <span class="label-text">{label}</span>
-
-    <input type="checkbox" bind:checked={value} class="checkbox" />
+    <input {id} type="checkbox" bind:checked={value} class="checkbox" />
   </label>
 </div>

--- a/frontend/src/lib/forms/FormField.svelte
+++ b/frontend/src/lib/forms/FormField.svelte
@@ -1,0 +1,27 @@
+<script lang="ts">
+  import { onMount } from 'svelte';
+  import FormFieldError from './FormFieldError.svelte';
+
+  export let label: string;
+  export let error: string | string[] | undefined;
+  export let id: string;
+  export let autofocus = false;
+
+  let elem: HTMLDivElement;
+
+  onMount(autofocusIfRequested);
+
+  function autofocusIfRequested(): void {
+    autofocus && elem.querySelector<HTMLElement>('input, select, textarea')?.focus();
+  }
+</script>
+
+<div class="form-control w-full" bind:this={elem}>
+  <label for={id} class="label">
+    <span class="label-text">
+      {label}
+    </span>
+  </label>
+  <slot />
+  <FormFieldError {id} {error} />
+</div>

--- a/frontend/src/lib/forms/FormFieldError.svelte
+++ b/frontend/src/lib/forms/FormFieldError.svelte
@@ -1,0 +1,10 @@
+<script lang="ts">
+  export let error: string | string[] | undefined;
+  export let id: string;
+</script>
+
+{#if error}
+  <label for={id} class="label">
+    <span class="label-text-alt text-error">{typeof error === 'string' ? error : error.join(', ')}</span>
+  </label>
+{/if}

--- a/frontend/src/lib/forms/Select.svelte
+++ b/frontend/src/lib/forms/Select.svelte
@@ -1,23 +1,16 @@
 <script lang="ts">
+  import FormField from './FormField.svelte';
+  import { randomFieldId } from './utils';
+
   export let label: string;
-  export let id: string;
-  export let autofocus = false;
-  export let error: string | string[] = '';
   export let value: string;
+  export let id = randomFieldId();
+  export let autofocus = false;
+  export let error: string | string[] | undefined = undefined;
 </script>
 
-<label for={id} class="label">
-  <span class="label-text">
-    {label}
-  </span>
-</label>
-<!-- svelte-ignore a11y-autofocus -->
-<select {autofocus} bind:value {id} class="select select-bordered">
-  <slot />
-</select>
-
-{#if error}
-  <label for={id} class="label">
-    <span class="label-text-alt text-error mb-2">{typeof error === 'string' ? error : error.join(', ')}</span>
-  </label>
-{/if}
+<FormField {id} {label} {error} {autofocus}>
+  <select bind:value {id} class="select select-bordered">
+    <slot />
+  </select>
+</FormField>

--- a/frontend/src/lib/forms/TextArea.svelte
+++ b/frontend/src/lib/forms/TextArea.svelte
@@ -2,30 +2,23 @@
   import { randomFieldId } from './utils';
   import FormField from './FormField.svelte';
 
-  export let id = randomFieldId();
   export let label: string;
   export let value = '';
-  export let type = 'text';
+  export let id = randomFieldId();
   export let autofocus = false;
   export let readonly = false;
   export let error: string | string[] | undefined = undefined;
   export let placeholder = '';
-
-  // works around "svelte(invalid-type)" warning, i.e., can't have a dynamic type AND bind:value...keep an eye on https://github.com/sveltejs/svelte/issues/3921
-  function typeWorkaround(node: HTMLInputElement): void {
-    node.type = type;
-  }
 </script>
 
 <!-- https://daisyui.com/components/input -->
 <FormField {id} {error} {label} {autofocus}>
-  <input
+  <textarea
     {id}
-    use:typeWorkaround
     bind:value
-    class:input-error={error}
+    class="textarea textarea-bordered h-24"
+    class:textarea-error={error}
     {placeholder}
-    class="input input-bordered"
     {readonly}
   />
 </FormField>

--- a/frontend/src/lib/forms/index.ts
+++ b/frontend/src/lib/forms/index.ts
@@ -4,6 +4,7 @@ import FormError from './FormError.svelte';
 import Input from './Input.svelte';
 import ProtectedForm, { type Token } from './ProtectedForm.svelte';
 import Select from './Select.svelte';
+import TextArea from './TextArea.svelte';
 import { lexSuperForm, lexSuperValidate } from './superforms';
 import { randomFieldId, tryParse } from './utils';
 
@@ -14,9 +15,11 @@ export {
   Input,
   ProtectedForm,
   Select,
+  TextArea,
   lexSuperForm,
   lexSuperValidate,
   randomFieldId,
-  tryParse, type Token
+  tryParse,
+  type Token,
 };
 

--- a/frontend/src/lib/i18n/locales/en.json
+++ b/frontend/src/lib/i18n/locales/en.json
@@ -81,7 +81,7 @@
     "project": "Project",
     "add_user": {
       "add_button": "Add Member",
-      "email_required": "Email Required!",
+      "email_required": "Email required",
       "modal_title": "Add a Member to this project",
       "submit_button": "Add Member"
     },

--- a/frontend/src/lib/otel/otel.shared.ts
+++ b/frontend/src/lib/otel/otel.shared.ts
@@ -223,7 +223,7 @@ export const tracingExchange: Exchange = mapExchange({
     const operationSpanContext = trace.setSpan(context.active(), operationSpan);
     return makeOperation(operation.kind, operation, {
       ...operation.context,
-      fetch: operation.context.fetch ? context.bind(operationSpanContext, operation.context.fetch) : undefined,
+      fetch: context.bind(operationSpanContext, operation.context.fetch ?? fetch),
       [ACTIVE_SPAN_KEY]: operationSpan,
     });
   },

--- a/frontend/src/routes/(authenticated)/project/[project_code]/AddProjectMember.svelte
+++ b/frontend/src/routes/(authenticated)/project/[project_code]/AddProjectMember.svelte
@@ -40,7 +40,6 @@
     type="email"
     label={$t('admin_dashboard.column_email')}
     bind:value={$form.email}
-    required
     error={errors.email}
     autofocus
   />

--- a/frontend/src/routes/(authenticated)/project/create/+page.svelte
+++ b/frontend/src/routes/(authenticated)/project/create/+page.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import { goto } from '$app/navigation';
-  import { FormError, lexSuperForm } from '$lib/forms';
+  import { FormError, TextArea, lexSuperForm } from '$lib/forms';
   import Checkbox from '$lib/forms/Checkbox.svelte';
   import Form from '$lib/forms/Form.svelte';
   import Input from '$lib/forms/Input.svelte';
@@ -68,13 +68,13 @@
   </svelte:fragment>
 
   <Form {enhance}>
-    <Input label={$t('project.create.name')} bind:value={$form.name} error={$errors.name} autofocus required />
-    <div class="form-control">
-      <label class="label" for="description">
-        <span class="label-text">{$t('project.create.description')}</span>
-      </label>
-      <textarea id="description" class="textarea textarea-bordered h-24" bind:value={$form.description} />
-    </div>
+    <Input label={$t('project.create.name')} bind:value={$form.name} error={$errors.name} autofocus />
+    <TextArea
+      id="description"
+      label={$t('project.create.description')}
+      bind:value={$form.description}
+      error={$errors.description}
+    />
     <Select id="type" label={$t('project.create.type')} bind:value={$form.type} error={$errors.type}>
       <option value={ProjectType.FlEx}>{$t('project_type.flex')}</option>
       <option value={ProjectType.WeSay}>{$t('project_type.weSay')}</option>

--- a/frontend/src/routes/(unauthenticated)/forgotPassword/+page.svelte
+++ b/frontend/src/routes/(unauthenticated)/forgotPassword/+page.svelte
@@ -27,7 +27,6 @@
       label={$t('register.label_email')}
       autofocus
       type="email"
-      required
       bind:value={$form.email}
       error={$errors.email}
     />

--- a/frontend/src/routes/(unauthenticated)/login/+page.svelte
+++ b/frontend/src/routes/(unauthenticated)/login/+page.svelte
@@ -42,7 +42,6 @@
       bind:value={$form.email}
       error={$errors.email}
       autofocus
-      required
     />
 
     <Input
@@ -51,7 +50,6 @@
       type="password"
       bind:value={$form.password}
       error={$errors.password}
-      required
     />
     <a class="link mt-0" href="/forgotPassword">
       {$t('login.forgot_password')}

--- a/frontend/src/routes/(unauthenticated)/register/+page.svelte
+++ b/frontend/src/routes/(unauthenticated)/register/+page.svelte
@@ -35,12 +35,11 @@
   <svelte:fragment slot="header">{$t('register.title')}</svelte:fragment>
 
   <ProtectedForm {enhance} bind:turnstileToken>
-    <Input id="name" label={$t('register.label_name')} required bind:value={$form.name} error={$errors.name} />
+    <Input id="name" label={$t('register.label_name')} bind:value={$form.name} error={$errors.name} />
     <Input
       id="email"
       label={$t('register.label_email')}
       type="email"
-      required
       bind:value={$form.email}
       error={$errors.email}
     />
@@ -48,7 +47,6 @@
       id="password"
       label={$t('register.label_password')}
       type="password"
-      required
       bind:value={$form.password}
       error={$errors.password}
     />


### PR DESCRIPTION
There was in fact no error message in the HTML 🤷.
I added some generic components, primarily `FormField`, that standardize these things for Inputs, Selects and Textareas.

And I noticed that we weren't tracing the "The file '/hg-repos/asd-flex/.hg/store/requires' already exists" exception that got thrown when I tried to create a project with the same code twice. So, I added a tad more tracing 😬.

Aaaand I noticed that tracing wasn't propogating for urql operations that don't use a custom fetch, soooo, I fixed that too 😬.