### PR TITLE
Fix undefined reading _def

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -47,7 +47,7 @@
 		"svelte-eslint-parser": "^0.30.0",
 		"svelte-preprocess": "^5.0.3",
 		"svelte-turnstile": "^0.3.1",
-		"sveltekit-superforms": "^0.8.7",
+		"sveltekit-superforms": "^1.1.3",
 		"tailwindcss": "^3.3.2",
 		"tslib": "^2.5.2",
 		"typescript": "^4.9.5",

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -133,8 +133,8 @@ devDependencies:
     specifier: ^0.3.1
     version: 0.3.1
   sveltekit-superforms:
-    specifier: ^0.8.7
-    version: 0.8.7(@sveltejs/kit@1.18.0)(svelte@3.59.1)(zod@3.21.4)
+    specifier: ^1.1.3
+    version: 1.1.3(@sveltejs/kit@1.18.0)(svelte@3.59.1)(zod@3.21.4)
   tailwindcss:
     specifier: ^3.3.2
     version: 3.3.2
@@ -7394,11 +7394,11 @@ packages:
     resolution: {integrity: sha512-pKj8fEBmqf6mq3/NfrB9SLtcJcUvjYSWyePlfCqN9gujLB25RitWK8PvFzlwim6hD/We35KbPlRteuA6rnPGcQ==}
     engines: {node: '>= 8'}
 
-  /sveltekit-superforms@0.8.7(@sveltejs/kit@1.18.0)(svelte@3.59.1)(zod@3.21.4):
-    resolution: {integrity: sha512-0aFK31TNz4AM3N7dzL99QUXlVF2O+W/TNVU+M41VVaAKtJKFNasbv8GNLd5wrhN7UWN6kNJnt4MlZBPISkIQ6w==}
+  /sveltekit-superforms@1.1.3(@sveltejs/kit@1.18.0)(svelte@3.59.1)(zod@3.21.4):
+    resolution: {integrity: sha512-BMyzxYXppdSyzeMPd5VFfJRr0Gr/EpUISz4d97vSFuP+/HTACg7qTI+M0sddJ7IvVw/9PAzIvKFh+FRfmeOmaQ==}
     peerDependencies:
       '@sveltejs/kit': 1.x
-      svelte: 3.x
+      svelte: 3.x || 4.x
       zod: 3.x
     dependencies:
       '@sveltejs/kit': 1.18.0(svelte@3.59.1)(vite@4.3.8)

--- a/frontend/src/lib/forms/index.ts
+++ b/frontend/src/lib/forms/index.ts
@@ -5,7 +5,7 @@ import Input from './Input.svelte';
 import ProtectedForm, { type Token } from './ProtectedForm.svelte';
 import Select from './Select.svelte';
 import TextArea from './TextArea.svelte';
-import { lexSuperForm, lexSuperValidate } from './superforms';
+import { lexSuperForm } from './superforms';
 import { randomFieldId, tryParse } from './utils';
 
 export {
@@ -17,7 +17,6 @@ export {
   Select,
   TextArea,
   lexSuperForm,
-  lexSuperValidate,
   randomFieldId,
   tryParse,
   type Token,


### PR DESCRIPTION
Fixes #158

So, all we needed was an update of the super-forms lib. Only took me 2 hours to notice 😉.
Also, it started creating warnings, because of the `undefined` in `superForm<S>(undefined`, so I fixed that as well by using the new `superValidateSync` and swapped out our usage of the deprecated `Validation` type.