### PR TITLE
Add OpenTelemetry instrumentation: resource usage

### DIFF
--- a/backend/LexBoxApi/LexBoxApi.csproj
+++ b/backend/LexBoxApi/LexBoxApi.csproj
@@ -35,6 +35,8 @@
         <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.5.0-beta.1" />
         <PackageReference Include="OpenTelemetry.Instrumentation.EntityFrameworkCore" Version="1.0.0-beta.7" />
         <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.5.0-beta.1" />
+        <PackageReference Include="OpenTelemetry.Instrumentation.Process" Version="0.5.0-beta.3" />
+        <PackageReference Include="OpenTelemetry.Instrumentation.Runtime" Version="1.5.0" />
         <PackageReference Include="Swashbuckle.AspNetCore" Version="6.4.0" />
     </ItemGroup>
 

--- a/backend/LexBoxApi/Otel/OtelKernel.cs
+++ b/backend/LexBoxApi/Otel/OtelKernel.cs
@@ -62,6 +62,8 @@ public static class OtelKernel
                 .AddMeter(meter.Name)
                 .SetResourceBuilder(appResourceBuilder)
                 .AddAspNetCoreInstrumentation()
+                .AddRuntimeInstrumentation()
+                .AddProcessInstrumentation()
                 .AddHttpClientInstrumentation()
         );
     }


### PR DESCRIPTION
The RuntimeInstrumentation and ProcessInstrumentation telemetry will allow us to monitor CPU and memory usage so we can assign the correct amounts to the container.