### PR TITLE
Test user page

### DIFF
--- a/backend/Testing/Browser/Base/PageTest.cs
+++ b/backend/Testing/Browser/Base/PageTest.cs
@@ -1,10 +1,14 @@
-﻿using Microsoft.Playwright;
-using Microsoft.Playwright.TestAdapter;
+﻿using System.Net;
+using System.Net.Http.Json;
+using Microsoft.Playwright;
+using Shouldly;
+using Testing.Services;
 
 namespace Testing.Browser.Base;
 
 public class PageTest : IAsyncLifetime
 {
+    protected bool EnableTrace { get; init; }
     private readonly PlaywrightFixture _fixture;
     public IPage Page => _fixture.Page;
     public IBrowser Browser => _fixture.Browser;
@@ -19,14 +23,61 @@ public class PageTest : IAsyncLifetime
     public IPageAssertions Expect(IPage page) => Assertions.Expect(page);
     public IAPIResponseAssertions Expect(IAPIResponse response) => Assertions.Expect(response);
 
-    public async Task InitializeAsync()
+    public virtual async Task InitializeAsync()
     {
         await _fixture.InitializeAsync();
+        if (EnableTrace)
+        {
+            await Context.Tracing.StartAsync(new ()
+            {
+                Screenshots = true,
+                Snapshots = true,
+                Sources = true
+            });
+        }
     }
 
-    public async Task DisposeAsync()
+    public virtual async Task DisposeAsync()
     {
+        if (EnableTrace)
+        {
+            await Context.Tracing.StopAsync(new() { Path = "trace.zip" });
+        }
+
         await _fixture.DisposeAsync();
+    }
+
+    static readonly HttpClient HttpClient = new HttpClient();
+
+    public async Task LoginAs(string user, string password)
+    {
+        var responseMessage = await HttpClient.PostAsJsonAsync(
+            $"http://{TestingEnvironmentVariables.ServerHostname}/api/login",
+            new Dictionary<string, object>
+            {
+                { "password", password }, { "emailOrUsername", user }, { "preHashedPassword", false }
+            });
+        responseMessage.Headers.ToDictionary(kvp => kvp.Key, kvp => kvp.Value, StringComparer.OrdinalIgnoreCase)
+            .ShouldContainKey("Set-Cookie");
+        var cookies = responseMessage.Headers.GetValues("Set-Cookie").ToArray();
+        cookies.ShouldNotBeEmpty();
+        var cookieContainer = new CookieContainer();
+        foreach (var cookie in cookies)
+        {
+            cookieContainer.SetCookies(new($"http://{TestingEnvironmentVariables.ServerHostname}"), cookie);
+        }
+
+        await Context.AddCookiesAsync(cookieContainer.GetAllCookies()
+            .Select(cookie => new Microsoft.Playwright.Cookie
+            {
+                Value = cookie.Value,
+                Domain = cookie.Domain,
+                Expires = (float) cookie.Expires.Subtract(DateTime.UnixEpoch).TotalSeconds,
+                Name = cookie.Name,
+                Path = cookie.Path,
+                Secure = cookie.Secure,
+                HttpOnly = cookie.HttpOnly
+            }));
     }
 }
 

--- a/backend/Testing/Browser/LoginPageTests.cs
+++ b/backend/Testing/Browser/LoginPageTests.cs
@@ -11,7 +11,7 @@ public class LoginPageTests: PageTest
     [Fact]
     public async Task CanLogin()
     {
-        await Page.GotoAsync($"https://{_host}/login");
+        await Page.GotoAsync($"https://{_host}/login", new (){WaitUntil = WaitUntilState.NetworkIdle});
 
         await Page.GetByLabel("Email (or Send/Receive username)").ClickAsync();
         await Page.GetByLabel("Email (or Send/Receive username)").FillAsync("admin");

--- a/backend/Testing/Browser/UserPageTest.cs
+++ b/backend/Testing/Browser/UserPageTest.cs
@@ -1,0 +1,49 @@
+using Microsoft.Playwright;
+using Testing.Browser.Base;
+using Testing.Services;
+
+namespace Testing.Browser;
+
+[Trait("Category", "Integration")]
+public class UserPageTest : PageTest
+{
+    private string _host = TestingEnvironmentVariables.ServerHostname;
+
+    [Fact]
+    public async Task CanUpdateAccountInfo()
+    {
+        await Page.GotoAsync($"https://{_host}/user");
+        await Page.GetByLabel("Display name").ClickAsync();
+        await Page.GetByLabel("Display name").FillAsync("Test Admin Changed");
+        await Page.GetByLabel("Email").ClickAsync();
+        await Page.GetByLabel("Email").FillAsync("admin_new@test.com");
+        // Submit the form
+        await Page.ClickAsync("text=Update account info");
+        await Page.WaitForLoadStateAsync(LoadState.DOMContentLoaded);
+        var successMessage = await Page.QuerySelectorAsync("text=Your account has been updated.");
+        Assert.NotNull(successMessage);
+    }
+
+    [Fact]
+    public async Task DisplaysFormErrorsOnInvalidData()
+    {
+        await Page.GotoAsync($"https://{_host}/user");
+        await Page.FillAsync("#email", "");
+        await Page.FillAsync("#name", "");
+        await Page.ClickAsync("text=Update account info");
+        await Page.WaitForLoadStateAsync(LoadState.DOMContentLoaded);
+        var emailError = await Page.QuerySelectorAsync("text=Invalid email");
+        //var nameError = await Page.QuerySelectorAsync("text=Name is required"); this doesn't happen
+        Assert.NotNull(emailError);
+    }
+
+    [Fact]
+    public async Task CanResetPassword()
+    {
+        await Page.GotoAsync($"https://{_host}/user");
+        await Page.ClickAsync("text=Reset your password instead?");
+        await Page.WaitForLoadStateAsync(LoadState.DOMContentLoaded);
+        Assert.Contains("/resetPassword", Page.Url);
+    }
+}
+


### PR DESCRIPTION
Some basic tests for `/user`
`CanUpdateAccountInfo`
- changes the email address and display name and ensures a success notification is shown
- it might be good to change this to check if the email verification shows up but I'm out of time

`DisplaysFormErrorsOnInvalidData`
-  If the email is blank there should be an error

`CanResetPassword`
- Simply ensures that clicking on the reset password link works

** I'm having some trouble running any tests so this is a draft, this is mostly just me trying to figure out tests and hopefully, it can actually help