### PR TITLE
Automatically refresh jwt on some mutations

### DIFF
--- a/backend/LexBoxApi/Auth/LexAuthService.cs
+++ b/backend/LexBoxApi/Auth/LexAuthService.cs
@@ -17,7 +17,7 @@ namespace LexBoxApi.Auth;
 
 public class LexAuthService
 {
-    public const string RefreshHeaderName = "lexbox-refresh";
+    public const string RefreshHeaderName = "lexbox-refresh-jwt";
     private readonly IOptions<JwtOptions> _userOptions;
     private readonly LexBoxDbContext _lexBoxDbContext;
     private readonly EmailService _emailService;

--- a/backend/LexBoxApi/Controllers/LoginController.cs
+++ b/backend/LexBoxApi/Controllers/LoginController.cs
@@ -86,8 +86,6 @@ public class LoginController : ControllerBase
     {
         var user = await _lexAuthService.RefreshUser(_loggedInContext.User.Id);
         if (user == null) return Unauthorized();
-        await HttpContext.SignInAsync(user.GetPrincipal("Refresh"),
-            new AuthenticationProperties { IsPersistent = true });
         return user;
     }
 

--- a/backend/LexBoxApi/GraphQL/CustomTypes/RefreshJwtAttribute.cs
+++ b/backend/LexBoxApi/GraphQL/CustomTypes/RefreshJwtAttribute.cs
@@ -1,0 +1,35 @@
+﻿using System.Reflection;
+using HotChocolate.Resolvers;
+using HotChocolate.Types.Descriptors;
+using LexBoxApi.Auth;
+
+namespace LexBoxApi.GraphQL.CustomTypes;
+
+public class RefreshJwtAttribute: ObjectFieldDescriptorAttribute
+{
+    protected override void OnConfigure(IDescriptorContext context, IObjectFieldDescriptor descriptor, MemberInfo member)
+    {
+        descriptor.Use<RefreshJwtMiddleware>();
+    }
+
+    public class RefreshJwtMiddleware
+    {
+        private readonly FieldDelegate _next;
+
+        public RefreshJwtMiddleware(FieldDelegate next)
+        {
+            _next = next;
+        }
+
+        public async Task InvokeAsync(IMiddlewareContext context, LoggedInContext loggedInContext, LexAuthService authService)
+        {
+            await _next(context);
+            if (context.HasErrors)
+            {
+                return;
+            }
+
+            await authService.RefreshUser(loggedInContext.User.Id);
+        }
+    }
+}

--- a/backend/LexBoxApi/GraphQL/ProjectMutations.cs
+++ b/backend/LexBoxApi/GraphQL/ProjectMutations.cs
@@ -1,4 +1,5 @@
 ﻿using LexBoxApi.Auth;
+using LexBoxApi.GraphQL.CustomTypes;
 using LexBoxApi.Models.Project;
 using LexBoxApi.Services;
 using LexCore.Entities;
@@ -14,6 +15,7 @@ public class ProjectMutations
 {
     [Error<DbError>]
     [UseMutationConvention]
+    [RefreshJwt]
     public async Task<Project?> CreateProject(
         LoggedInContext loggedInContext,
         CreateProjectInput input,

--- a/backend/LexBoxApi/GraphQL/UserMutations.cs
+++ b/backend/LexBoxApi/GraphQL/UserMutations.cs
@@ -1,5 +1,6 @@
 ﻿using System.ComponentModel.DataAnnotations;
 using LexBoxApi.Auth;
+using LexBoxApi.GraphQL.CustomTypes;
 using LexBoxApi.Services;
 using LexBoxApi.Models.Project;
 using LexCore.Auth;
@@ -22,6 +23,7 @@ public class UserMutations
     [Error<InvalidFormatException>]
     [ProducesResponseType(StatusCodes.Status401Unauthorized)]
     [UseMutationConvention]
+    [RefreshJwt]
     public Task<User> ChangeUserAccountData(
         LoggedInContext loggedInContext,
         ChangeUserAccountDataInput input,

--- a/frontend/src/hooks.client.ts
+++ b/frontend/src/hooks.client.ts
@@ -4,6 +4,8 @@ import { redirect, type HandleClientError } from '@sveltejs/kit';
 import { getErrorMessage } from './hooks.shared';
 import { loadI18n } from '$lib/i18n';
 import { handleFetch } from '$lib/util/fetch-proxy';
+import {invalidate} from '$app/navigation';
+import {USER_LOAD_KEY} from '$lib/user';
 
 await loadI18n();
 
@@ -25,6 +27,9 @@ handleFetch(async ({ fetch, args }) => {
   const response = await traceFetch(() => fetch(...args));
   if (response.status === 401 && location.pathname !== '/login') {
     throw redirect(307, '/logout');
+  }
+  if (response.headers.get('lexbox-refresh') == 'true') {
+    await invalidate(USER_LOAD_KEY);
   }
   return response;
 });

--- a/frontend/src/hooks.client.ts
+++ b/frontend/src/hooks.client.ts
@@ -28,7 +28,7 @@ handleFetch(async ({ fetch, args }) => {
   if (response.status === 401 && location.pathname !== '/login') {
     throw redirect(307, '/logout');
   }
-  if (response.headers.get('lexbox-refresh') == 'true') {
+  if (response.headers.get('lexbox-refresh-jwt') == 'true') {
     await invalidate(USER_LOAD_KEY);
   }
   return response;

--- a/frontend/src/lib/user.ts
+++ b/frontend/src/lib/user.ts
@@ -44,7 +44,7 @@ type UserProjects = {
   code: string
   role: 'Manager' | 'Editor'
 }
-
+export const USER_LOAD_KEY = 'current-user';
 export const isAdmin = (user: LexAuthUser | null): boolean => user?.role === 'admin';
 
 export async function login(userId: string, password: string): Promise<boolean> {

--- a/frontend/src/routes/(authenticated)/user/+page.ts
+++ b/frontend/src/routes/(authenticated)/user/+page.ts
@@ -5,8 +5,7 @@ import type {
 
 } from '$lib/gql/types';
 import { getClient, graphql } from '$lib/gql';
-import { goto, invalidate } from '$app/navigation';
-import { refreshJwt } from '$lib/user';
+import { goto } from '$app/navigation';
 import type { PageLoad } from './$types';
 import { browser } from '$app/environment';
 import { EmailResult } from '$lib/email';
@@ -47,9 +46,5 @@ export async function _changeUserAccountData(input: ChangeUserAccountDataInput):
       //invalidates the graphql user cache, but who knows
       { additionalTypenames: ['Users'] },
     );
-  if (!result.error) {
-    await refreshJwt();
-    await invalidate(`user:${input.userId}`);
-  }
   return result;
 }

--- a/frontend/src/routes/+layout.server.ts
+++ b/frontend/src/routes/+layout.server.ts
@@ -2,12 +2,15 @@ import {APP_VERSION, apiVersion} from '$lib/util/verstion';
 
 import type { LayoutServerLoadEvent } from './$types'
 import { getRootTraceparent } from '$lib/otel/otel.server'
+import {USER_LOAD_KEY} from '$lib/user';
 
 export async function load({locals, depends, fetch}: LayoutServerLoadEvent) {
   const user = locals.getUser();
   const traceParent = getRootTraceparent()
 
-  if (user) depends(`user:${user.id}`);
+  //depend even if we're not currently logged in as later on we won't and we can invalidate if we don't depend on it
+  //todo consider moving this and the user related code into the (authenticated) +layout.server.ts file
+  depends(USER_LOAD_KEY);
   if (apiVersion.value === null) {
     const response = await fetch('/api/healthz');
     apiVersion.value = response.headers.get('lexbox-version');


### PR DESCRIPTION
closes #200 

this introduces a hotchocolate attribute that allows us to indicate that a mutation should refresh the users jwt token. It also adds a header to the response for the client side js to notice this and refresh what it knows about the user from the jwt in the cookie.