### PR TITLE
Reproduce 404 on project page after creation

### DIFF
--- a/backend/LexBoxApi/GraphQL/CustomTypes/ProjectGqlConfiguration.cs
+++ b/backend/LexBoxApi/GraphQL/CustomTypes/ProjectGqlConfiguration.cs
@@ -10,6 +10,7 @@ public class ProjectGqlConfiguration : ObjectType<Project>
     protected override void Configure(IObjectTypeDescriptor<Project> descriptor)
     {
         descriptor.Field(p => p.Code).IsProjected();
+        descriptor.Field(p => p.CreatedDate).IsProjected();
         // descriptor.Field("userCount").Resolve(ctx => ctx.Parent<Project>().UserCount);
     }
 }

--- a/backend/LexBoxApi/Services/HgService.cs
+++ b/backend/LexBoxApi/Services/HgService.cs
@@ -1,7 +1,6 @@
 using System.Text.Json;
 using System.Text.Json.Nodes;
 using LexBoxApi.Config;
-using LexBoxApi.GraphQL;
 using LexCore.Entities;
 using LexCore.ServiceInterfaces;
 using Microsoft.Extensions.Options;
@@ -20,6 +19,10 @@ public class HgService : IHgService
         _clientFactory = clientFactory;
     }
 
+    /// <summary>
+    /// Note: The repo is unstable and potentially unavailable for a short while after creation, so don't read from it right away.
+    /// See: https://github.com/sillsdev/languageforge-lexbox/issues/173#issuecomment-1665478630
+    /// </summary>
     public async Task InitRepo(string code)
     {
         await Task.Run(() => CopyFilesRecursively(
@@ -69,8 +72,6 @@ public class HgService : IHgService
         return logResponse?.Changesets ?? Array.Empty<Changeset>();
     }
 }
-
-
 
 public class LogResponse
 {

--- a/backend/LexCore/Entities/Project.cs
+++ b/backend/LexCore/Entities/Project.cs
@@ -14,7 +14,17 @@ public class Project : EntityBase
 
     public async Task<Changeset[]> GetChangesets(IHgService hgService)
     {
-        return await hgService.GetChangesets(Code);
+        var age = DateTimeOffset.UtcNow.Subtract(CreatedDate);
+        if (age.TotalSeconds < 40)
+        {
+            // The repo is unstable and potentially unavailable for a short while after creation, so don't read from it right away.
+            // See: https://github.com/sillsdev/languageforge-lexbox/issues/173#issuecomment-1665478630
+            return Array.Empty<Changeset>();
+        }
+        else
+        {
+            return await hgService.GetChangesets(Code);
+        }
     }
 }
 

--- a/backend/Testing/ApiTests/ApiTestBase.cs
+++ b/backend/Testing/ApiTests/ApiTestBase.cs
@@ -1,6 +1,5 @@
 ﻿using System.Diagnostics.CodeAnalysis;
 using System.Net.Http.Json;
-using System.Text;
 using System.Text.Json.Nodes;
 using Shouldly;
 using Testing.Services;
@@ -14,20 +13,25 @@ public class ApiTestBase
 
     protected async Task LoginAs(string user, string password)
     {
-        await HttpClient.PostAsJsonAsync(
+        var response = await HttpClient.PostAsJsonAsync(
             $"http://{Host}/api/login",
             new Dictionary<string, object>
             {
                 { "password", password }, { "emailOrUsername", user }, { "preHashedPassword", false }
             });
+        response.EnsureSuccessStatusCode();
     }
 
-    protected async Task<JsonObject> ExecuteGql([StringSyntax("graphql")] string gql)
+    protected async Task<JsonObject> ExecuteGql([StringSyntax("graphql")] string gql, bool expectGqlError = false)
     {
         var response = await HttpClient.PostAsJsonAsync($"http://{Host}/api/graphql", new { query = gql });
+        response.IsSuccessStatusCode.ShouldBeTrue($"code was {(int)response.StatusCode} ({response.ReasonPhrase})");
         var jsonResponse = await response.Content.ReadFromJsonAsync<JsonObject>();
-        response.IsSuccessStatusCode.ShouldBeTrue($"code was {(int)response.StatusCode} ({response.ReasonPhrase}), response was: {jsonResponse}");
         jsonResponse.ShouldNotBeNull("for query " + gql);
+        if (!expectGqlError)
+        {
+            jsonResponse["errors"].ShouldBeNull();
+        }
         return jsonResponse;
     }
 }

--- a/backend/Testing/ApiTests/NewProjectRaceCondition.cs
+++ b/backend/Testing/ApiTests/NewProjectRaceCondition.cs
@@ -3,38 +3,71 @@ using Shouldly;
 
 namespace Testing.ApiTests;
 
-// issue: https://github.com/sillsdev/languageforge-lexbox/issues/173
+// Issue: https://github.com/sillsdev/languageforge-lexbox/issues/173#issuecomment-1665478630
 [Trait("Category", "Integration")]
 public class NewProjectRaceCondition : ApiTestBase
 {
-    readonly Guid _projectId = Guid.Parse("3e81814d-ce7e-438f-b8e8-beac1cd7596b");
     [Fact]
-    public async Task CanCreateProjectAndQueryItRightAway()
+    public async Task CanCreateMultipleProjectsAndQueryThemRightAway()
     {
+        var project1Id = Guid.Parse("3e81814d-ce7e-438f-1111-beac1cd7596b");
+        var project2Id = Guid.Parse("3e81814d-ce7e-438f-2222-beac1cd7596b");
 
         await LoginAs("admin", "pass");
-        await HttpClient.DeleteAsync($"http://{Host}/api/project/project/{_projectId}");
-        await Task.Delay(TimeSpan.FromSeconds(1));
-        var response = await ExecuteGql($$"""
-mutation {
-    createProject(input: {
-        name: "Test race condition",
-        type: FL_EX,
-        id: "{{_projectId}}",
-        code: "test-race-flex",
-        description: "this is just a testing project for testing a race condition",
-        retentionPolicy: DEV
-    }) {
-        project {
-            name
-            changesets {
-                desc
-            }
+
+        try
+        {
+            await CreateQueryAndVerifyProject(project1Id);
+            // Create and query a 2nd project to ensure the HgWeb refresh-interval doesn't cause trouble
+            await CreateQueryAndVerifyProject(project2Id);
+        }
+        finally
+        {
+            await HttpClient.DeleteAsync($"http://{Host}/api/project/project/{project1Id}");
+            await HttpClient.DeleteAsync($"http://{Host}/api/project/project/{project2Id}");
         }
     }
-}
-""");
+
+    private async Task CreateQueryAndVerifyProject(Guid id)
+    {
+        var name = $"Name:{id}";
+
+        var response = await ExecuteGql($$"""
+            mutation {
+                createProject(input: {
+                    name: "{{name}}",
+                    type: FL_EX,
+                    id: "{{id}}",
+                    code: "{{id}}",
+                    description: "this is just a testing project for testing a race condition",
+                    retentionPolicy: DEV
+                }) {
+                    project {
+                        name
+                        changesets {
+                            desc
+                        }
+                    }
+                }
+            }
+            """);
+
         var project = response["data"]!["createProject"]!["project"].ShouldBeOfType<JsonObject>();
-        project["name"]!.GetValue<string>().ShouldBe("Test race condition");
+        project["name"]!.GetValue<string>().ShouldBe(name);
+
+        // Query a 2nd time to ensure the instability of new repos isn't causing trouble
+        response = await ExecuteGql($$"""
+            query {
+                projectByCode(code: "{{id}}") {
+                    name
+                    changesets {
+                        desc
+                    }
+                }
+            }
+            """);
+
+        project = response["data"]!["projectByCode"].ShouldBeOfType<JsonObject>();
+        project["name"]!.GetValue<string>().ShouldBe(name);
     }
 }

--- a/hgweb/hgweb.hgrc
+++ b/hgweb/hgweb.hgrc
@@ -4,6 +4,8 @@
 [web]
 allow_push=*
 push_ssl=False
+# default
+refreshinterval=20
 
 # enable old clients to push using the old wire protocol
 [server]


### PR DESCRIPTION
Fixes #173 

@hahn-kev The updated test in this branch seems to successfully reproduce the 404 after project creation.
I wrote some code to wait for the hg server to find the repo. It generally works, but can take a very long time.
In one case 150 seconds wasn't long enough 😕. I've never seen it take that long in the app, but I also don't create that many projects.

I think the problem with your test was that it always used the same code. Maybe it made it into hg's index and then everything was green after that 🤷.

UPDATE:
So, I'm not sure how to reproduce 150 seconds not being long enough, I'm not having that problem anymore. Now the hgweb `refreshinterval` config value (default: 20) is behaving as I would expect it to.
![image](https://github.com/sillsdev/languageforge-lexbox/assets/12587509/b130b317-7202-40eb-928d-01258ba31b18)

What the refresh interval actually means is: when a request comes in, if the index hasn't been refreshed for `[refreshinterval]s` then refresh it. So, when I run a test that generates multiple repos and immediately tries to read from them as they're created, then the first one usually works immediately (it's been > 20s since hgweb received a request) and the following requests all take exactly 20s.

Some options:
- Leave it the way it is (because it will likely usually be fine), but teach the server to wait when necessary
- Reduce `refreshinterval` to 0. Then the index is refreshed on every request 😬
- Find a way to manually trigger a refresh when a new repo is added