### PR TITLE
Dont await goto in load function

### DIFF
--- a/frontend/src/routes/(authenticated)/user/+page.ts
+++ b/frontend/src/routes/(authenticated)/user/+page.ts
@@ -13,11 +13,11 @@ import { EmailResult } from '$lib/email';
 
 const EMAIL_RESULTS = Object.values(EmailResult);
 
-export const load = (async ({ url }) => {
+export const load = (({ url }) => {
   const emailResult = url.searchParams.get('emailResult') as EmailResult | null;
   if (emailResult) {
     if (!EMAIL_RESULTS.includes(emailResult)) throw new Error(`Invalid emailResult: ${emailResult}.`);
-    if (browser) await goto(`${url.pathname}`, { replaceState: true });
+    if (browser) void goto(`${url.pathname}`, { replaceState: true });
   }
   return { emailResult };
 }) satisfies PageLoad


### PR DESCRIPTION
Fixes #195 

With the `await` the load function gets triggered multiple times. Without the `await` it doesn't. Seems odd to me.

It feels like the first case ends up wiring up some handlers twice, which is potentially/presumably a Svelte bug.
The behaviour is the same in my [Svelte v4 repro](https://github.com/myieye/svelte-double-content-bug).

I created a [SvelteKit issue](https://github.com/sveltejs/kit/issues/10469).