### PR TITLE
Fix invalidate() not working

### DIFF
--- a/frontend/src/lib/user.ts
+++ b/frontend/src/lib/user.ts
@@ -45,7 +45,7 @@ type UserProjects = {
   code: string
   role: 'Manager' | 'Editor'
 }
-export const USER_LOAD_KEY = 'current-user';
+export const USER_LOAD_KEY = 'user:current';
 export const isAdmin = (user: LexAuthUser | null): boolean => user?.role === 'admin';
 
 export const getHomePath = (user: LexAuthUser | null): string => isAdmin(user) ? '/admin' : '/';


### PR DESCRIPTION
Fixes #200 (the rest of it)

Turns out `invalidate()` wasn't really working, because depends/invalidate keys need to start with `[a-z]+:`.

Without this change, I can access new projects that/as I create them, but I often don't initially have permission to manage them.

![image](https://github.com/sillsdev/languageforge-lexbox/assets/12587509/518222cd-b112-44d1-aced-e68143f92016)
