### PR TITLE
Don't let admins change their own system role

### DIFF
--- a/backend/LexBoxApi/GraphQL/UserMutations.cs
+++ b/backend/LexBoxApi/GraphQL/UserMutations.cs
@@ -34,7 +34,7 @@ public class UserMutations
     )
     {
         if (loggedInContext.User.Id != input.UserId) throw new UnauthorizedAccessException();
-        return UpdateUser(input, dbContext, emailService, lexAuthService);
+        return UpdateUser(loggedInContext, input, dbContext, emailService, lexAuthService);
     }
 
     [Error<NotFoundException>]
@@ -42,16 +42,18 @@ public class UserMutations
     [Error<InvalidFormatException>]
     [AdminRequired]
     public Task<User> ChangeUserAccountByAdmin(
+        LoggedInContext loggedInContext,
         ChangeUserAccountByAdminInput input,
         LexBoxDbContext dbContext,
         EmailService emailService,
         LexAuthService lexAuthService
     )
     {
-        return UpdateUser(input, dbContext, emailService, lexAuthService);
+        return UpdateUser(loggedInContext, input, dbContext, emailService, lexAuthService);
     }
 
     private static async Task<User> UpdateUser(
+        LoggedInContext loggedInContext,
         ChangeUserAccountDataInput input,
         LexBoxDbContext dbContext,
         EmailService emailService,
@@ -68,7 +70,10 @@ public class UserMutations
 
         if (input is ChangeUserAccountByAdminInput adminInput)
         {
-            user.IsAdmin = adminInput.Role == UserRole.admin;
+            if (user.Id != loggedInContext.User.Id)
+            {
+                user.IsAdmin = adminInput.Role == UserRole.admin;
+            }
         }
 
         await dbContext.SaveChangesAsync();

--- a/frontend/src/lib/forms/Select.svelte
+++ b/frontend/src/lib/forms/Select.svelte
@@ -7,11 +7,12 @@
   export let id = randomFieldId();
   export let autofocus = false;
   export let error: string | string[] | undefined = undefined;
+  export let disabled = false;
 </script>
 
 <FormField {id} {label} {error} {autofocus}>
   <!-- svelte-ignore a11y-autofocus -->
-  <select bind:value {id} class="select select-bordered" {autofocus}>
+  <select {disabled} bind:value {id} class="select select-bordered" {autofocus}>
     <slot />
   </select>
 </FormField>

--- a/frontend/src/lib/forms/SystemRoleSelect.svelte
+++ b/frontend/src/lib/forms/SystemRoleSelect.svelte
@@ -7,10 +7,11 @@
   export let id = 'role';
   export let value: UserRole;
   export let error: string[] | undefined;
+  export let disabled = false;
 </script>
 
 <div class="contents" class:text-accent={value === UserRole.Admin}>
-  <Select {id} bind:value label={$t('system_role.label')} {error}>
+  <Select {id} bind:value label={$t('system_role.label')} {error} {disabled}>
     <option value={UserRole.User} class="text-base-content">
       {$t('system_role.user_description')}
     </option>

--- a/frontend/src/routes/(authenticated)/(dashboards)/admin/+page.svelte
+++ b/frontend/src/routes/(authenticated)/(dashboards)/admin/+page.svelte
@@ -170,6 +170,6 @@
     </div>
   </div>
 
-  <EditUserAccount bind:this={formModal} {deleteUser} />
+  <EditUserAccount bind:this={formModal} {deleteUser} currUser={data.user} />
   <DeleteUserModal bind:this={deleteModal} />
 </main>

--- a/frontend/src/routes/(authenticated)/(dashboards)/admin/EditUserAccount.svelte
+++ b/frontend/src/routes/(authenticated)/(dashboards)/admin/EditUserAccount.svelte
@@ -5,11 +5,12 @@
   import Input from '$lib/forms/Input.svelte';
   import { UserRole, type LoadAdminDashboardQuery } from '$lib/gql/types';
   import { _changeUserAccountByAdmin } from './+page';
-  import { hash } from '$lib/user';
+  import { hash, type LexAuthUser } from '$lib/user';
   import t from '$lib/i18n';
   import type { FormModalResult } from '$lib/components/modals/FormModal.svelte';
   import SystemRoleSelect from '$lib/forms/SystemRoleSelect.svelte';
 
+  export let currUser: LexAuthUser;
   export let deleteUser: CallableFunction;
   type UserRow = LoadAdminDashboardQuery['users'][0];
 
@@ -73,6 +74,7 @@
     id="role"
     bind:value={$form.role}
     error={errors.role}
+    disabled={_user.id === currUser.id}
   />
   <div class="text-error">
     <Input


### PR DESCRIPTION
Fixes #196 (part 2)

I decided that admin's shouldn't be able to "un-admin" themselves (by mistake).