### PR TITLE
Bug: subscribing to page store outside svelte component

### DIFF
--- a/frontend/src/lib/error/UnexpectedError.svelte
+++ b/frontend/src/lib/error/UnexpectedError.svelte
@@ -9,7 +9,7 @@
   let alertMessageElem: HTMLElement | undefined;
   let traceIdElem: HTMLElement;
 
-  const error = derived(_error, (error) => {
+  const error = derived(_error(), (error) => {
     if (error) {
       return {
         ...error,

--- a/frontend/src/lib/error/UnexpectedErrorAlert.svelte
+++ b/frontend/src/lib/error/UnexpectedErrorAlert.svelte
@@ -10,7 +10,7 @@
   beforeNavigate(dismiss);
 
   onDestroy(
-    error.subscribe((e) => {
+    error().subscribe((e) => {
       if (!dialog) return;
       e ? open() : close();
     })

--- a/frontend/src/lib/error/index.ts
+++ b/frontend/src/lib/error/index.ts
@@ -1,13 +1,18 @@
+import { getContext, setContext } from 'svelte';
+import { isObject, isRedirect } from '$lib/util/types';
+
+import type { Writable } from 'svelte/store';
 import { browser } from '$app/environment';
 import { ensureErrorIsTraced } from '$lib/otel';
-import { isObject, isRedirect } from '$lib/util/types';
-import { writable, type Writable } from 'svelte/store';
 
-export const error: Writable<App.Error | null> = writable();
+const ERROR_STORE_KEY = 'ERROR_STORE_KEY';
 
-export const dismiss = (): void => error.set(null);
+export const initErrorStore = (error: Writable<App.Error | null>): Writable<App.Error | null> => setContext(ERROR_STORE_KEY, error);
+export const error = (): Writable<App.Error | null> => getContext(ERROR_STORE_KEY);
+export const dismiss = (): void => error().set(null);
 
 export const goesToErrorPage = (error: App.Error | null): boolean => error?.handler?.endsWith('-hook') ?? false;
+
 
 if (browser) {
   /**
@@ -19,11 +24,15 @@ if (browser) {
   // https://developer.mozilla.org/en-US/docs/Web/API/GlobalEventHandlers/onerror#window.addEventListenererror
   window.addEventListener('error', (event: ErrorEvent) => {
     const handler = 'client-error';
-    const traceId = ensureErrorIsTraced(event.error, { event }, {
-      ['app.error.source']: handler,
-      ['app.error.traced_by_handler']: true,
-    });
-    error.set({ message: event.message, traceId, handler });
+    const traceId = ensureErrorIsTraced(
+      event.error,
+      { event },
+      {
+        ['app.error.source']: handler,
+        ['app.error.traced_by_handler']: true,
+      }
+    );
+    error().set({ message: event.message, traceId, handler });
   });
 
   // https://developer.mozilla.org/en-US/docs/Web/API/PromiseRejectionEvent
@@ -34,14 +43,21 @@ if (browser) {
     }
 
     const handler = 'client-unhandledrejection';
-    const message = isObject(event.reason) ? event.reason.message as string : undefined;
-    const keysForMissingMessageError = message ? undefined
-      : isObject(event.reason) ? Object.keys(event.reason).join() : undefined;
-    const traceId = ensureErrorIsTraced(event.reason, { event }, {
-      ['app.error.source']: handler,
-      ['app.error.keys']: keysForMissingMessageError,
-      ['app.error.traced_by_handler']: true,
-    });
+    const message = isObject(event.reason) ? (event.reason.message as string) : undefined;
+    const keysForMissingMessageError = message
+      ? undefined
+      : isObject(event.reason)
+      ? Object.keys(event.reason).join()
+      : undefined;
+    const traceId = ensureErrorIsTraced(
+      event.reason,
+      { event },
+      {
+        ['app.error.source']: handler,
+        ['app.error.keys']: keysForMissingMessageError,
+        ['app.error.traced_by_handler']: true,
+      }
+    );
 
     if (message?.startsWith('sendBeacon - cannot send')) {
       // The user doesn't care if a few OTEL beacons are failing
@@ -49,6 +65,6 @@ if (browser) {
       return;
     }
 
-    error.set({ message: message ?? `We're not sure what happened.`, traceId, handler });
+    error().set({ message: message ?? `We're not sure what happened.`, traceId, handler });
   };
 }

--- a/frontend/src/routes/+error.svelte
+++ b/frontend/src/routes/+error.svelte
@@ -1,6 +1,19 @@
 <script lang="ts">
+  import { browser } from '$app/environment';
+  import { page } from '$app/stores';
+  import { error } from '$lib/error';
   import UnexpectedError from '$lib/error/UnexpectedError.svelte';
   import { Content, Page } from '$lib/layout';
+  import { onDestroy } from 'svelte';
+
+  
+  if (browser) {
+    onDestroy(
+      page.subscribe((p) => {
+        error.set(p.error);
+      })
+    );
+  }
 </script>
 
 <Content>

--- a/frontend/src/routes/+error.svelte
+++ b/frontend/src/routes/+error.svelte
@@ -1,19 +1,6 @@
 <script lang="ts">
-  import { browser } from '$app/environment';
-  import { page } from '$app/stores';
-  import { error } from '$lib/error';
   import UnexpectedError from '$lib/error/UnexpectedError.svelte';
   import { Content, Page } from '$lib/layout';
-  import { onDestroy } from 'svelte';
-
-  
-  if (browser) {
-    onDestroy(
-      page.subscribe((p) => {
-        error.set(p.error);
-      })
-    );
-  }
 </script>
 
 <Content>

--- a/frontend/src/routes/+layout.svelte
+++ b/frontend/src/routes/+layout.svelte
@@ -1,15 +1,24 @@
 <script lang="ts">
   import { page } from '$app/stores';
   import '$lib/app.postcss';
-  import { goesToErrorPage } from '$lib/error';
+  import { goesToErrorPage, initErrorStore } from '$lib/error';
   import UnexpectedErrorAlert from '$lib/error/UnexpectedErrorAlert.svelte';
   import type { LayoutData } from './$types';
   import Notify from '$lib/notify/Notify.svelte';
   import { Footer } from '$lib/layout';
+  import { writable } from 'svelte/store';
+  import { onDestroy } from 'svelte';
 
   // https://www.w3.org/TR/trace-context/#traceparent-header
   // so the page-load instrumentation can be correlated with the server load
   export let data: LayoutData;
+
+  const error = initErrorStore(writable());
+  onDestroy(
+    page.subscribe((p) => {
+      error.set(p.error);
+    })
+  );
 </script>
 
 <svelte:head>

--- a/frontend/src/routes/+layout.svelte
+++ b/frontend/src/routes/+layout.svelte
@@ -1,18 +1,11 @@
 <script lang="ts">
   import { page } from '$app/stores';
   import '$lib/app.postcss';
-  import { error, goesToErrorPage } from '$lib/error';
+  import { goesToErrorPage } from '$lib/error';
   import UnexpectedErrorAlert from '$lib/error/UnexpectedErrorAlert.svelte';
-  import { onDestroy } from 'svelte';
   import type { LayoutData } from './$types';
   import Notify from '$lib/notify/Notify.svelte';
   import { Footer } from '$lib/layout';
-
-  onDestroy(
-    page.subscribe((p) => {
-      error.set(p.error);
-    })
-  );
 
   // https://www.w3.org/TR/trace-context/#traceparent-header
   // so the page-load instrumentation can be correlated with the server load


### PR DESCRIPTION
Fixes #229 (Maybe)

I know, my first commit changed when/how we subscribe to the `page` store and my second commit reverts that, so reopen the issue if the error log shows up again, however...

My original suspiscion was that this error only showed up when Svelte was broken.
My new suspiscion is that Svelte was a bit confused and the error store was the real problem.

The docs say:
> On the server, this store can only be subscribed to during component initialization.

I believe that layout initialization counts as component initialization. So, either (1) I'm looking in the wrong place, (2) the error message isn't quite accurate or (3) the log only occurs when Svelte is broken and then it's confused.

What I do know, is that we did have a bug, namely that a global error store was being shared between clients on the server 😬. So, I fixed that by using the context API as [the docs suggest](https://kit.svelte.dev/docs/state-management#using-stores-with-context). And I'm hoping that was the "real" issue 😕.