### PR TITLE
Remove do-nothing load() in root layout

### DIFF
--- a/frontend/src/routes/+layout.ts
+++ b/frontend/src/routes/+layout.ts
@@ -1,7 +1,2 @@
-import type { LayoutLoadEvent } from './$types';
-
 //setting this to false can help diagnose requests to the api as you can see them in the browser instead of sveltekit
 export const ssr = true;
-export function load(event: LayoutLoadEvent) {
-  return { ...event.data, traceParent: event.data.traceParent };
-}


### PR DESCRIPTION
The load() function in the root layout.ts file now does absolutely nothing; it takes the data from the parent layout and passes it along completely unchanged. Let's get rid of it and simplify our code.