### PR TITLE
Improve password-checking regex

### DIFF
--- a/frontend/src/lib/forms/utils.ts
+++ b/frontend/src/lib/forms/utils.ts
@@ -15,5 +15,5 @@ export function tryParse<T, ValidT>(zodType: ZodType<ValidT>, value: T): ValidT 
 export function passwordFormRules($t: Translater): z.ZodString {
   return z.string()
     .min(4, $t('form.password.too_short'))
-    .regex(/^[a-zA-Z0-9-]+$/, $t('form.password.allowed_characters'));
+    .regex(/^[^&%+]+$/, $t('form.password.forbidden_characters'));
 }

--- a/frontend/src/lib/i18n/locales/en.json
+++ b/frontend/src/lib/i18n/locales/en.json
@@ -309,7 +309,7 @@ the [Linguistics Institute at Payap University](https://li.payap.ac.th/) in Chia
   },
   "form": {
     "password": {
-      "forbidden_characters": "The symbols &, +, and % can cause problems in passwords",
+      "forbidden_characters": "The symbols &, +, and % are not allowed in passwords",
       "too_short": "Must be at least 4 characters"
     }
   }

--- a/frontend/src/lib/i18n/locales/en.json
+++ b/frontend/src/lib/i18n/locales/en.json
@@ -309,7 +309,7 @@ the [Linguistics Institute at Payap University](https://li.payap.ac.th/) in Chia
   },
   "form": {
     "password": {
-      "allowed_characters": "Only letters, numbers and dashes (-) are allowed",
+      "forbidden_characters": "The symbols & (ampersand), + (plus), and % (percent) can cause problems in passwords",
       "too_short": "Must be at least 4 characters"
     }
   }

--- a/frontend/src/lib/i18n/locales/en.json
+++ b/frontend/src/lib/i18n/locales/en.json
@@ -309,7 +309,7 @@ the [Linguistics Institute at Payap University](https://li.payap.ac.th/) in Chia
   },
   "form": {
     "password": {
-      "forbidden_characters": "The symbols & (ampersand), + (plus), and % (percent) can cause problems in passwords",
+      "forbidden_characters": "The symbols &, +, and % can cause problems in passwords",
       "too_short": "Must be at least 4 characters"
     }
   }


### PR DESCRIPTION
Now that we've verified that only the three symbols &, +, and % cause problems in passwords submitted through Chorus, we can loosen the password rules to allow any character except those three.

Fixes #255.