### PR TITLE
Test: 282 fix playwright tests and upload traces in GitHub

### DIFF
--- a/.github/workflows/integration-test.yaml
+++ b/.github/workflows/integration-test.yaml
@@ -47,10 +47,16 @@ jobs:
           TEST_RESUMABLE_HG_HOSTNAME: resumable-staging.languagedepot.org
           TEST_PROJECT_CODE: 'sena-3'
           TEST_DEFAULT_PASSWORD: ${{ secrets.TEST_USER_PASSWORD }}
-        run: dotnet test --logger trx --results-directory ./testresults --filter Category=Integration
+        run: dotnet test --output ./bin --logger trx --results-directory ./testresults --filter Category=Integration
       - name: Upload test results
         uses: EnricoMi/publish-unit-test-result-action/composite@v2
         if: always() && !env.act
         with:
           check_name: Integration Tests ${{ matrix.os }}
           files: ./testresults/*.trx
+      - name: Upload playwright results
+        if: always()
+        uses: actions/upload-artifact@v3
+        with:
+          name: playwright-traces-${{ matrix.os }}
+          path: ./bin/playwright-traces

--- a/.github/workflows/integration-test.yaml
+++ b/.github/workflows/integration-test.yaml
@@ -47,13 +47,13 @@ jobs:
           TEST_RESUMABLE_HG_HOSTNAME: resumable-staging.languagedepot.org
           TEST_PROJECT_CODE: 'sena-3'
           TEST_DEFAULT_PASSWORD: ${{ secrets.TEST_USER_PASSWORD }}
-        run: dotnet test --output ./bin --logger trx --results-directory ./testresults --filter Category=Integration
+        run: dotnet test --output ./bin --logger trx --results-directory ./test-results --filter Category=Integration
       - name: Upload test results
         uses: EnricoMi/publish-unit-test-result-action/composite@v2
         if: always() && !env.act
         with:
           check_name: Integration Tests ${{ matrix.os }}
-          files: ./testresults/*.trx
+          files: ./test-results/*.trx
       - name: Upload playwright results
         if: always()
         uses: actions/upload-artifact@v3

--- a/.github/workflows/lexbox-api.yaml
+++ b/.github/workflows/lexbox-api.yaml
@@ -60,13 +60,13 @@ jobs:
       - name: Dotnet build
         run: dotnet build
       - name: Unit tests
-        run: dotnet test --logger xunit --results-directory ./testresults --filter "Category!=Integration"
+        run: dotnet test --logger xunit --results-directory ./test-results --filter "Category!=Integration"
       - name: Upload test results
         uses: EnricoMi/publish-unit-test-result-action@v2
         if: always()
         with:
           check_name: C# Unit Tests
-          files: ./testresults/*.xml
+          files: ./test-results/*.xml
 
       - name: Set Version
         id: setVersion

--- a/.github/workflows/lexbox-ui.yaml
+++ b/.github/workflows/lexbox-ui.yaml
@@ -42,13 +42,13 @@ jobs:
       - name: vitest
         working-directory: ./frontend
         run: |
-          pnpm run test:unit --reporter=default --reporter=junit --outputFile.junit=testresults/vitest-results.xml
+          pnpm run test:unit --reporter=default --reporter=junit --outputFile.junit=test-results/vitest-results.xml
       - name: Upload test results
         uses: EnricoMi/publish-unit-test-result-action@v2
         if: always()
         with:
           check_name: UI unit Tests
-          files: ./frontend/testresults/*.xml
+          files: ./frontend/test-results/*.xml
           action_fail_on_inconclusive: true
       - name: Set Version
         id: setVersion

--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ backend/Testing/SyncReverseProxy/TestData.cs
 deployment/dev/collector-config.yaml
 deployment/dev/local.env
 dump.sql
+test-results/

--- a/backend/Testing/ApiTests/ApiTestBase.cs
+++ b/backend/Testing/ApiTests/ApiTestBase.cs
@@ -25,12 +25,12 @@ public class ApiTestBase
     public async Task<JsonObject> ExecuteGql([StringSyntax("graphql")] string gql, bool expectGqlError = false)
     {
         var response = await HttpClient.PostAsJsonAsync($"{BaseUrl}/api/graphql", new { query = gql });
-        response.IsSuccessStatusCode.ShouldBeTrue($"code was {(int)response.StatusCode} ({response.ReasonPhrase})");
         var jsonResponse = await response.Content.ReadFromJsonAsync<JsonObject>();
-        jsonResponse.ShouldNotBeNull("for query " + gql);
+        jsonResponse.ShouldNotBeNull($"for query {gql} ({(int)response.StatusCode} ({response.ReasonPhrase}))");
         if (!expectGqlError)
         {
             jsonResponse["errors"].ShouldBeNull();
+            response.IsSuccessStatusCode.ShouldBeTrue($"code was {(int)response.StatusCode} ({response.ReasonPhrase})");
         }
         return jsonResponse;
     }

--- a/backend/Testing/ApiTests/NewProjectRaceCondition.cs
+++ b/backend/Testing/ApiTests/NewProjectRaceCondition.cs
@@ -43,18 +43,15 @@ public class NewProjectRaceCondition : ApiTestBase
                     description: "this is just a testing project for testing a race condition",
                     retentionPolicy: DEV
                 }) {
-                    project {
-                        name
-                        changesets {
-                            desc
-                        }
+                    createProjectResponse {
+                        id
                     }
                 }
             }
             """);
 
-        var project = response["data"]!["createProject"]!["project"].ShouldBeOfType<JsonObject>();
-        project["name"]!.GetValue<string>().ShouldBe(name);
+        var project = response["data"]!["createProject"]!["createProjectResponse"].ShouldBeOfType<JsonObject>();
+        project["id"]!.GetValue<string>().ShouldBe(id.ToString());
 
         // Query a 2nd time to ensure the instability of new repos isn't causing trouble
         response = await ExecuteGql($$"""

--- a/backend/Testing/Browser/Component/EmailVerificationAlert.cs
+++ b/backend/Testing/Browser/Component/EmailVerificationAlert.cs
@@ -4,7 +4,7 @@ namespace Testing.Browser.Component;
 
 public class EmailVerificationAlert : BaseComponent<EmailVerificationAlert>
 {
-    private const string PLEASE_VERIFY_SELECTOR = ":text('Please verify')";
+    private const string PLEASE_VERIFY_SELECTOR = ":text('We sent you an email, so that you can verify your email address')";
     private const string VERIFICATION_SENT_SELECTOR = ":text('check your inbox for the verification email')";
     private const string SUCCESSFULLY_VERIFIED_SELECTOR = ":text('successfully verified')";
     private const string REQUESTED_TO_CHANGE_SELECTOR = ":text('requested to change')";

--- a/backend/Testing/Browser/Page/ResetPasswordPage.cs
+++ b/backend/Testing/Browser/Page/ResetPasswordPage.cs
@@ -5,7 +5,7 @@ namespace Testing.Browser.Page;
 public class ResetPasswordPage : AuthenticatedBasePage<ResetPasswordPage>
 {
     public ResetPasswordPage(IPage page)
-    : base(page, "/resetPassword", page.GetByRole(AriaRole.Button, new() { Name = "Reset Password" }))
+    : base(page, "/resetPassword", page.GetByRole(AriaRole.Button, new() { Name = "Reset Password", Exact = true }))
     {
     }
 
@@ -16,7 +16,7 @@ public class ResetPasswordPage : AuthenticatedBasePage<ResetPasswordPage>
 
     public async Task<UserDashboardPage> Submit()
     {
-        await Page.GetByRole(AriaRole.Button, new() { Name = "Reset Password" }).ClickAsync();
+        await Page.GetByRole(AriaRole.Button, new() { Name = "Reset Password", Exact = true }).ClickAsync();
         return await new UserDashboardPage(Page).WaitFor();
     }
 }


### PR DESCRIPTION
Resolves #282 

- Some tests were actually simply broken, those are fixed.
- Now traces are available for download so we can see what happened on failed runs.
- I still observed some flakiness 😞 (as recorded in #299), but this is a big step forward.