### PR TITLE
rewrite how awaiting migrations works to be simpler and less prone to race conditions

### DIFF
--- a/backend/LexCore/ServiceInterfaces/IRepoMigrationService.cs
+++ b/backend/LexCore/ServiceInterfaces/IRepoMigrationService.cs
@@ -19,4 +19,6 @@ public interface IRepoMigrationService
     /// <param name="status"></param>
     /// <returns></returns>
     ValueTask<IDisposable?> BeginSendReceive(string projectCode, ProjectMigrationStatus status = ProjectMigrationStatus.PublicRedmine);
+
+    Task WaitMigrationFinishedAsync(string projectCode, CancellationToken cancellationToken);
 }

--- a/backend/Testing/LexCore/Services/ProjectServiceTest.cs
+++ b/backend/Testing/LexCore/Services/ProjectServiceTest.cs
@@ -21,7 +21,7 @@ public class ProjectServiceTest
         var serviceProvider = testing.ConfigureServices(s =>
         {
             s.AddScoped<IHgService>(_ => Mock.Of<IHgService>());
-            s.AddScoped(_ => new RepoMigrationService(Mock.Of<IServiceProvider>()));
+            s.AddScoped<IRepoMigrationService>(_ => Mock.Of<IRepoMigrationService>());
             s.AddScoped<ProjectService>();
         });
         _projectService = serviceProvider.GetRequiredService<ProjectService>();


### PR DESCRIPTION
based on feedback in #292 