### PR TITLE
Improve app-update and 404 handling

### DIFF
--- a/frontend/src/app.d.ts
+++ b/frontend/src/app.d.ts
@@ -19,6 +19,7 @@ declare global {
     interface Error {
       traceId: string;
       handler: ErrorHandler;
+      updateDetected?: boolean;
     }
   }
 

--- a/frontend/src/hooks.client.ts
+++ b/frontend/src/hooks.client.ts
@@ -16,6 +16,7 @@ export const handleError: HandleClientError = async ({ error, event }) => {
 
   // someone has to have subscribed to updated before `check` is allowed to be called
   // this seems to work and provide the correct value :shrug:
+  // eslint-disable-next-line @typescript-eslint/no-empty-function
   updated.subscribe(() => { })();
   const updateDetected = await updated.check();
 
@@ -23,7 +24,7 @@ export const handleError: HandleClientError = async ({ error, event }) => {
     ['app.error.source']: handler,
     ...(updateDetected ? { ['app.update-detected']: true } : {}),
   });
-  let message = getErrorMessage(error);
+  const message = getErrorMessage(error);
   return {
     traceId,
     message,

--- a/frontend/src/lib/components/Markdown/LinkRenderer.svelte
+++ b/frontend/src/lib/components/Markdown/LinkRenderer.svelte
@@ -1,0 +1,9 @@
+<script lang="ts">
+  export let href: string;
+  export let title: string | undefined = undefined;
+  export let text: string;
+</script>
+
+<a {href} {title} class="link">
+  {text}
+</a>

--- a/frontend/src/lib/components/Markdown/index.ts
+++ b/frontend/src/lib/components/Markdown/index.ts
@@ -1,1 +1,2 @@
 export { default as NewTabLinkRenderer } from './NewTabLinkRenderer.svelte';
+export { default as LinkRenderer } from './LinkRenderer.svelte';

--- a/frontend/src/lib/error/UnexpectedError.svelte
+++ b/frontend/src/lib/error/UnexpectedError.svelte
@@ -10,9 +10,10 @@
 
   const error = derived(useError(), (error) => {
     if (error) {
+      const updatedDetected = error.updateDetected ? '\r\nUpdate detected' : '';
       return {
         ...error,
-        message: `${error?.message}\r\n(${error?.handler})`,
+        message: `${error?.message}\r\n(${error?.handler})${updatedDetected}`,
       };
     }
   });

--- a/frontend/src/lib/error/index.ts
+++ b/frontend/src/lib/error/index.ts
@@ -45,6 +45,7 @@ function setupGlobalErrorHandlers(error: Writable<App.Error | null>): void {
    */
 
   // https://developer.mozilla.org/en-US/docs/Web/API/GlobalEventHandlers/onerror#window.addEventListenererror
+  // eslint-disable-next-line @typescript-eslint/no-misused-promises
   window.addEventListener('error', async (event: ErrorEvent) => {
     const handler = 'client-error';
     const traceId = ensureErrorIsTraced(

--- a/frontend/src/lib/i18n/locales/en.json
+++ b/frontend/src/lib/i18n/locales/en.json
@@ -272,7 +272,9 @@ the [Linguistics Institute at Payap University](https://li.payap.ac.th/) in Chia
     "apology": "Woops, something went wrong on our end. Sorry!",
     "mail_us_at": "If you're stuck, let us know about this at",
     "please_include": "Please include the error code, a screenshot of your browser and a summary of the steps that lead to the error.",
-    "error_code": "Error code"
+    "error_code": "Error code",
+    "not_found": "404 - Woops, we can't find that page. Sorry!",
+    "go_home": "Perhaps you'd like to [go home](/)?",
   },
   "modal": {
     "dismiss": "Dismiss"
@@ -321,5 +323,8 @@ the [Linguistics Institute at Payap University](https://li.payap.ac.th/) in Chia
       "forbidden_characters": "The symbols &, +, and % are not allowed in passwords",
       "too_short": "Must be at least 4 characters"
     }
+  },
+  "notifications": {
+    "update_detected": "A new version of the application was detected. You may need to reload the page.",
   }
 }

--- a/frontend/src/lib/otel/otel.server.ts
+++ b/frontend/src/lib/otel/otel.server.ts
@@ -21,6 +21,7 @@ import {
   SERVICE_NAME,
   tracer,
 } from '.';
+import type { MaybePromise } from '$app/forms';
 
 export * from '.';
 
@@ -61,7 +62,7 @@ export function getRootTraceparent(): string | undefined {
 
 export async function traceRequest(
     event: RequestEvent,
-    responseBuilder: () => Promise<Response>,
+    responseBuilder: (requestSpan: Span) => MaybePromise<Response>,
 ): Promise<Response> {
   const tracparentContext = buildContextWithTraceparentBaggage(event);
   return context.with(tracparentContext, () => {
@@ -71,7 +72,7 @@ export async function traceRequest(
         .startActiveSpan(spanName, async (span) => {
           try {
             traceEventAttributes(span, event);
-            return await traceResponse(span, responseBuilder);
+            return await traceResponse(span, () => responseBuilder(span));
           } finally {
             span.end();
           }

--- a/frontend/src/lib/otel/otel.shared.ts
+++ b/frontend/src/lib/otel/otel.shared.ts
@@ -136,7 +136,10 @@ export function traceEventAttributes(span: Span, event: RequestEvent | Navigatio
     span.setAttribute(SemanticAttributes.HTTP_URL, url.href);
     span.setAttribute(
         SemanticAttributes.HTTP_TARGET,
-        `${url.pathname}${url.hash ?? ''}${url.search ?? ''}`,
+        `${url.pathname}${url.search ?? ''}`,
+        // In some cases the server throws an error when trying to access url.hash: (and we don't use it anyway)
+        // `${url.pathname}${url.hash ?? ''}${url.search ?? ''}`,
+        // "Cannot access event.url.hash. Consider using `$page.url.hash` inside a component instead"
     );
     span.setAttribute(SemanticAttributes.HTTP_SCHEME, url.protocol);
     span.setAttribute(SemanticAttributes.NET_HOST_NAME, url.hostname);

--- a/frontend/src/routes/+error.svelte
+++ b/frontend/src/routes/+error.svelte
@@ -4,7 +4,6 @@
   import UnexpectedError from '$lib/error/UnexpectedError.svelte';
   import t from '$lib/i18n';
   import { AppBar, Content, Page } from '$lib/layout';
-  import { error } from '@sveltejs/kit';
   import SvelteMarkdown from 'svelte-markdown';
 </script>
 

--- a/frontend/src/routes/+error.svelte
+++ b/frontend/src/routes/+error.svelte
@@ -1,12 +1,27 @@
 <script lang="ts">
+  import { page } from '$app/stores';
+  import { LinkRenderer } from '$lib/components/Markdown';
   import UnexpectedError from '$lib/error/UnexpectedError.svelte';
+  import t from '$lib/i18n';
   import { AppBar, Content, Page } from '$lib/layout';
+  import { error } from '@sveltejs/kit';
+  import SvelteMarkdown from 'svelte-markdown';
 </script>
 
 <AppBar user={undefined} />
 
 <Content>
   <Page>
-    <UnexpectedError />
+    {#if $page.status === 404}
+      <div class="flex flex-col gap-4 items-center">
+        <div class="flex gap-2">
+          <span class="i-mdi-emoticon-confused-outline text-3xl" />
+          <span class="text-2xl">{$t('errors.not_found')}</span>
+        </div>
+        <SvelteMarkdown source={$t('errors.go_home')} renderers={{ link: LinkRenderer }} />
+      </div>
+    {:else}
+      <UnexpectedError />
+    {/if}
   </Page>
 </Content>

--- a/frontend/src/routes/+layout.svelte
+++ b/frontend/src/routes/+layout.svelte
@@ -9,7 +9,6 @@
   import { writable } from 'svelte/store';
   import { notifyWarning } from '$lib/notify';
   import { Duration } from '$lib/util/time';
-  import { onDestroy } from 'svelte';
   import { browser } from '$app/environment';
   import t from '$lib/i18n';
 

--- a/frontend/src/routes/+layout.svelte
+++ b/frontend/src/routes/+layout.svelte
@@ -1,18 +1,27 @@
 <script lang="ts">
-  import { page } from '$app/stores';
+  import { page, updated } from '$app/stores';
   import '$lib/app.postcss';
-  import { goesToErrorPage, initErrorStore } from '$lib/error';
+  import { initErrorStore } from '$lib/error';
   import UnexpectedErrorAlert from '$lib/error/UnexpectedErrorAlert.svelte';
   import type { LayoutData } from './$types';
   import Notify from '$lib/notify/Notify.svelte';
   import { Footer } from '$lib/layout';
   import { writable } from 'svelte/store';
+  import { notifyWarning } from '$lib/notify';
+  import { Duration } from '$lib/util/time';
+  import { onDestroy } from 'svelte';
+  import { browser } from '$app/environment';
+  import t from '$lib/i18n';
 
   export let data: LayoutData;
 
   const error = initErrorStore(writable($page.error));
   $: $error = $page.error;
-
+  $: {
+    if (browser && $updated) {
+      notifyWarning($t('notifications.update_detected'), Duration.Long);
+    }
+  }
 </script>
 
 <svelte:head>
@@ -33,7 +42,7 @@
 </div>
 
 <!-- We don't want the alert as well if we're heading to +error.svelte -->
-{#if !goesToErrorPage($page.error)}
+{#if !$page.error}
   <UnexpectedErrorAlert />
 {/if}
 

--- a/frontend/src/routes/[...catch_all]/+page.server.ts
+++ b/frontend/src/routes/[...catch_all]/+page.server.ts
@@ -1,0 +1,16 @@
+import { error } from '@sveltejs/kit';
+import type { PageServerLoad } from './$types';
+import { traceRequest } from '$lib/otel/otel.server';
+
+/**
+ * A global fallback GET handler for routes that aren't known/mapped by the server
+ * E.g.
+ * - /kevin
+ * - /admin/kevin
+ */
+export const load = ((event) => {
+  return traceRequest(event, (span) => {
+    span.setAttribute('app.request.hit-catch-all-page', true);
+    throw error(404);
+  });
+}) satisfies PageServerLoad

--- a/frontend/src/routes/[...catch_all]/+server.ts
+++ b/frontend/src/routes/[...catch_all]/+server.ts
@@ -1,41 +1,26 @@
-import type { RequestEvent } from "../$types";
-import { redirect } from "@sveltejs/kit";
-import { traceRequest } from "$lib/otel/otel.server";
+import type { RequestEvent } from '../$types';
+import { traceRequest } from '$lib/otel/otel.server';
 
 /**
  * A global fallback GET handler for paths that aren't known/mapped by the server
- * GETs from the browser address bar do NOT land here. I'm not quite sure how SvelteKit decides
- * what lands here and what lands in [...catch_all]/+page.server.ts
- * E.g.
- * - /_app/immutable/nodes/1.835f1fca.js
+ * E.g. /_app/immutable/nodes/1.835f1fca.js
+ * GETs from the browser address bar WOULD land here if we didn't have the global fallback `load()` in [...catch_all]/+page.server.ts.
  */
 export function GET(event: RequestEvent): Promise<Response> {
+  /**
+   * If a JS file is being requested this will potentially lead to an occurence of "error loading dynamically imported module" https://github.com/sillsdev/languageforge-lexbox/issues/210
+   * although SvelteKit is pretty good at recovering from that state.
+   *
+   * We're not sure why or how often this happens in staging. We currently only have 1 recorded occurence in honeycomb and it's not the same as the occurence on the linked issue.
+   * It potentially happens when a user is active during and after an update/deployment (though SK seems to recover in that case)
+   * It seems likely that this is triggered on dev due to harmless race conditions caused by compilation/HMR etc.
+   *
+   * This server-side trace attribute should be valuable, because it should be more reliable than the client-side beacon traces.
+   * */
   return traceRequest(event, (span) => {
     span.setAttribute('app.request.hit-catch-all', true);
-    /**
-     * This `if` case would likely lead to an occurence of "error loading dynamically imported module" https://github.com/sillsdev/languageforge-lexbox/issues/210
-     * We're not sure how often this happens in staging. We currently only have 1 recorded occurence in honeycomb and it's not the same as the occurence on the linked issue.
-     * This server-side trace should be more reliable than the client-side beacon traces
-     *
-     * We believe the error above is triggered on:
-     * - dev: at all sorts of times (due to harmess race conditions caused by HMR etc.)
-     * - staging: when a user is active during and after an update/deployment
-     * */
-    if (event.url.pathname.endsWith('.js')) {
-      /**
-       * This is kind of cool, but I think we should observe it. I'm slightly wary of this idea, because it could:
-       * (1) hide errors and
-       * (2) trigger automatic page reloads at undesireable times by a user (e.g.) hovering over a link
-       * (Note: we have prompts in place that should prevent users from losing work in forms)
-       *  */
-      return new Response('location.reload();', {
-        headers: {
-          ['Content-Type']: 'application/javascript',
-        }
-      });
-    }
-
-    // Default behaviour if this catch-all GET doesn't exist
-    throw redirect(307, '/');
+    return new Response(null, { status: 404 });
+    // Default behaviour if this catch-all GET didn't exist. A 404 seems to make a lot more sense:
+    // throw redirect(307, '/');
   });
 }

--- a/frontend/src/routes/[...catch_all]/+server.ts
+++ b/frontend/src/routes/[...catch_all]/+server.ts
@@ -1,0 +1,41 @@
+import type { RequestEvent } from "../$types";
+import { redirect } from "@sveltejs/kit";
+import { traceRequest } from "$lib/otel/otel.server";
+
+/**
+ * A global fallback GET handler for paths that aren't known/mapped by the server
+ * GETs from the browser address bar do NOT land here. I'm not quite sure how SvelteKit decides
+ * what lands here and what lands in [...catch_all]/+page.server.ts
+ * E.g.
+ * - /_app/immutable/nodes/1.835f1fca.js
+ */
+export function GET(event: RequestEvent): Promise<Response> {
+  return traceRequest(event, (span) => {
+    span.setAttribute('app.request.hit-catch-all', true);
+    /**
+     * This `if` case would likely lead to an occurence of "error loading dynamically imported module" https://github.com/sillsdev/languageforge-lexbox/issues/210
+     * We're not sure how often this happens in staging. We currently only have 1 recorded occurence in honeycomb and it's not the same as the occurence on the linked issue.
+     * This server-side trace should be more reliable than the client-side beacon traces
+     *
+     * We believe the error above is triggered on:
+     * - dev: at all sorts of times (due to harmess race conditions caused by HMR etc.)
+     * - staging: when a user is active during and after an update/deployment
+     * */
+    if (event.url.pathname.endsWith('.js')) {
+      /**
+       * This is kind of cool, but I think we should observe it. I'm slightly wary of this idea, because it could:
+       * (1) hide errors and
+       * (2) trigger automatic page reloads at undesireable times by a user (e.g.) hovering over a link
+       * (Note: we have prompts in place that should prevent users from losing work in forms)
+       *  */
+      return new Response('location.reload();', {
+        headers: {
+          ['Content-Type']: 'application/javascript',
+        }
+      });
+    }
+
+    // Default behaviour if this catch-all GET doesn't exist
+    throw redirect(307, '/');
+  });
+}

--- a/frontend/svelte.config.js
+++ b/frontend/svelte.config.js
@@ -7,6 +7,9 @@ const config = {
     enableSourcemap: true
   },
   kit: {
+    version: {
+      pollInterval: 5000,
+    },
     adapter: adapter({
       precompress: true
     }),


### PR DESCRIPTION
Resolves #210 (maybe sort of?)

## ⚠️ This is a colorful PR 😁 

### Introduces app-update detection via polling (SvelteKit feature), so that we can
- Inform the user that they might want to reload the page
- Do our best to add that information to traces and error pages for better debugging

### Introduces global request handlers so we can
- Display a tidy 404 page for unknown routes
- Try out an experimental feature: Automatically reloading the page when a requested js file doesn't exist
- Hopefully trace the "error loading dynamically imported..." error more reliably:
More reliably, because client-side traces can get lost due to [Beacon API limits](https://github.com/sillsdev/languageforge-lexbox/issues/307), so doing it server-side should be more reliable.
Actually, it may be the case that the error message doesn't occur anymore, because of the introduced fallback to the default JS: `location.reload()`. However, I introduced a span attribute (`app.request.hit-catch-all`) that we should be able to use to track the same state that was triggering the original error message (when `url.path` ends with `.js`).