### PR TITLE
Fix HTTP 413 (Request Too Large) on hg push of large repos

### DIFF
--- a/backend/LexBoxApi/Program.cs
+++ b/backend/LexBoxApi/Program.cs
@@ -24,6 +24,11 @@ if (DevGqlSchemaWriterService.IsSchemaGenerationRequest(args))
 
 var builder = WebApplication.CreateBuilder(args);
 builder.Host.UseConsoleLifetime();
+builder.WebHost.UseKestrel(o =>
+{
+    //allow large pushes from hg, can't scope this only to hg requests as this setting is still respected in some cases
+    o.Limits.MaxRequestBodySize = null;
+});
 // Add services to the container.
 
 builder.Services.AddOpenTelemetryInstrumentation(builder.Configuration);

--- a/backend/Testing/SyncReverseProxy/SendReceiveServiceTests.cs
+++ b/backend/Testing/SyncReverseProxy/SendReceiveServiceTests.cs
@@ -182,7 +182,7 @@ public class SendReceiveServiceTests
         //add a bunch of small files, must be in separate commits otherwise hg runs out of memory. But we want the push to be large
         const int totalSizeMb = 1100;
         const int fileCount = 25;
-        for (int i = 1; i < fileCount; i++)
+        for (int i = 1; i <= fileCount; i++)
         {
             var bigFileName = $"big-file{i}.bin";
             WriteBigFile(Path.Combine(sendReceiveParams.DestDir, bigFileName), totalSizeMb / fileCount);

--- a/deployment/base/proxy-deployment.yaml
+++ b/deployment/base/proxy-deployment.yaml
@@ -6,6 +6,7 @@ metadata:
   namespace: languagedepot
   annotations:
     nginx.ingress.kubernetes.io/proxy-buffer-size: "16k"
+#    https://kubernetes.github.io/ingress-nginx/user-guide/nginx-configuration/annotations/#custom-max-body-size
     nginx.ingress.kubernetes.io/proxy-body-size: "0"
 spec:
   ingressClassName: nginx

--- a/deployment/base/proxy-deployment.yaml
+++ b/deployment/base/proxy-deployment.yaml
@@ -6,6 +6,7 @@ metadata:
   namespace: languagedepot
   annotations:
     nginx.ingress.kubernetes.io/proxy-buffer-size: "16k"
+    nginx.ingress.kubernetes.io/proxy-body-size: "0"
 spec:
   ingressClassName: nginx
   defaultBackend:

--- a/hgweb/httpd.conf
+++ b/hgweb/httpd.conf
@@ -551,3 +551,6 @@ SSLRandomSeed connect builtin
 
 IncludeOptional conf/sites/*.conf
 IncludeOptional conf/opentelemetry_module.conf
+
+# Request body limit defaults to 1GiB, we need more than that to allow "hg push" of larger projects
+LimitRequestBody 0


### PR DESCRIPTION
Fixes #310.

There are three places that need to have their settings changed:

- [X] Ingress (NGINX) proxy
- [x] ASP.NET Kestrel server
- [X] Apache config in hgweb container

Currently this PR contains tweaks for NGINX and Apache but not Kestrel.