### PR TITLE
Feat 303: make multiple error pages to use [un]authenticated layouts

### DIFF
--- a/frontend/src/lib/components/Markdown/LinkRenderer.svelte
+++ b/frontend/src/lib/components/Markdown/LinkRenderer.svelte
@@ -1,9 +1,0 @@
-<script lang="ts">
-  export let href: string;
-  export let title: string | undefined = undefined;
-  export let text: string;
-</script>
-
-<a {href} {title} class="link">
-  {text}
-</a>

--- a/frontend/src/lib/components/Markdown/index.ts
+++ b/frontend/src/lib/components/Markdown/index.ts
@@ -1,2 +1,1 @@
 export { default as NewTabLinkRenderer } from './NewTabLinkRenderer.svelte';
-export { default as LinkRenderer } from './LinkRenderer.svelte';

--- a/frontend/src/lib/i18n/locales/en.json
+++ b/frontend/src/lib/i18n/locales/en.json
@@ -274,7 +274,7 @@ the [Linguistics Institute at Payap University](https://li.payap.ac.th/) in Chia
     "please_include": "Please include the error code, a screenshot of your browser and a summary of the steps that lead to the error.",
     "error_code": "Error code",
     "not_found": "404 - Woops, we can't find that page. Sorry!",
-    "go_home": "Perhaps you'd like to [go home](/)?",
+    "go_home": "Go home",
   },
   "modal": {
     "dismiss": "Dismiss"

--- a/frontend/src/lib/layout/AppBar.svelte
+++ b/frontend/src/lib/layout/AppBar.svelte
@@ -21,13 +21,13 @@
       <span class="i-mdi-open-in-new text-xl" />
     </a>
   {/if}
-  <div class="navbar justify-between bg-primary text-primary-content md:pl-6">
+  <div class="navbar justify-between bg-primary text-primary-content md:px-6">
     <a href={loggedIn ? '/' : '/login'} class="text-lg md:text-3xl tracking-wider hover:underline">
       {$t('appbar.app_name')}
     </a>
     <div>
       {#if user}
-        <Button on:click={() => dispatch('menuopen')} class="btn-primary normal-case">
+        <Button on:click={() => dispatch('menuopen')} class="btn-primary normal-case px-2">
           {user.name}
           <AuthenticatedUserIcon size="text-4xl" />
         </Button>

--- a/frontend/src/lib/layout/Layout.svelte
+++ b/frontend/src/lib/layout/Layout.svelte
@@ -1,0 +1,78 @@
+<script lang="ts">
+  import EmailVerificationStatus from '$lib/email/EmailVerificationStatus.svelte';
+  import t from '$lib/i18n';
+  import { AdminIcon } from '$lib/icons';
+  import { AdminContent, AppBar, AppMenu, Breadcrumbs, Content } from '$lib/layout';
+  import { onMount } from 'svelte';
+  import { ensureClientMatchesUser } from '$lib/gql';
+  import { beforeNavigate } from '$app/navigation';
+  import { page } from '$app/stores';
+  import type { LayoutData } from '../../routes/$types';
+
+  let menuToggle = false;
+  $: data = $page.data as LayoutData;
+  $: user = data.user;
+
+  function open(): void {
+    menuToggle = true;
+  }
+
+  function close(): void {
+    menuToggle = false;
+  }
+
+  function closeOnEscape(event: KeyboardEvent): void {
+    event.key === 'Escape' && close();
+  }
+  onMount(() => {
+    if (user) ensureClientMatchesUser(user);
+  });
+  beforeNavigate(() => close());
+</script>
+
+<svelte:window on:keydown={closeOnEscape} />
+
+{#if user}
+  <div class="drawer drawer-end">
+    <input type="checkbox" checked={menuToggle} class="drawer-toggle" />
+
+    <div class="drawer-content max-w-[100vw]">
+      <AppBar on:menuopen={open} {user} />
+      <div class="bg-neutral text-neutral-content p-2 md:px-6 flex justify-between items-center">
+        <Breadcrumbs />
+        <AdminContent>
+          <a href="/admin" class="btn btn-sm btn-accent">
+            <span class="max-sm:hidden">
+              {$t('admin_dashboard.title')}
+            </span>
+            <AdminIcon />
+          </a>
+        </AdminContent>
+      </div>
+
+      <div class="max-w-prose mx-auto email-status-container">
+        <EmailVerificationStatus {user} />
+      </div>
+
+      <Content>
+        <slot />
+      </Content>
+    </div>
+    <div class="drawer-side z-10">
+      <button class="drawer-overlay" on:click={close} on:keydown={close} />
+      <AppMenu {user} serverVersion={data.serverVersion} apiVersion={data.apiVersion} />
+    </div>
+  </div>
+{:else}
+  <AppBar user={undefined} />
+
+  <Content>
+    <slot />
+  </Content>
+{/if}
+
+<style lang="postcss">
+  :global(.email-status-container > div:first-child) {
+    @apply mt-6;
+  }
+</style>

--- a/frontend/src/lib/layout/index.ts
+++ b/frontend/src/lib/layout/index.ts
@@ -1,3 +1,4 @@
+import Layout from './Layout.svelte'
 import AdminContent from './AdminContent.svelte'
 import AppBar from './AppBar.svelte'
 import AppMenu from './AppMenu.svelte'
@@ -8,6 +9,7 @@ import Page from './Page.svelte'
 import PageHeader from './PageHeader.svelte'
 
 export {
+  Layout,
   AppBar,
   AppMenu,
   Page,

--- a/frontend/src/routes/(authenticated)/+layout.svelte
+++ b/frontend/src/routes/(authenticated)/+layout.svelte
@@ -36,7 +36,7 @@
 
   <div class="drawer-content max-w-[100vw]">
     <AppBar on:menuopen={open} {user}/>
-    <div class="bg-neutral text-neutral-content p-2 pl-6 flex justify-between items-center">
+    <div class="bg-neutral text-neutral-content p-2 md:px-6 flex justify-between items-center">
       <Breadcrumbs />
       <AdminContent>
         <a href="/admin" class="btn btn-sm btn-accent">

--- a/frontend/src/routes/(authenticated)/+layout.svelte
+++ b/frontend/src/routes/(authenticated)/+layout.svelte
@@ -1,69 +1,7 @@
-<script lang="ts">
-  import EmailVerificationStatus from '$lib/email/EmailVerificationStatus.svelte';
-  import t from '$lib/i18n';
-  import { AdminIcon } from '$lib/icons';
-  import { AdminContent, AppBar, AppMenu, Breadcrumbs, Content } from '$lib/layout';
-  import type { LayoutData } from './$types';
-  import {onMount} from 'svelte';
-  import {ensureClientMatchesUser} from '$lib/gql';
-  import {beforeNavigate} from '$app/navigation';
-
-  let menuToggle = false;
-  export let data: LayoutData;
-  $: user = data.user ;
-
-  function open(): void {
-    menuToggle = true;
-  }
-
-  function close(): void {
-    menuToggle = false;
-  }
-
-  function closeOnEscape(event: KeyboardEvent): void {
-    event.key === 'Escape' && close();
-  }
-  onMount(() => {
-    ensureClientMatchesUser(user);
-  });
-  beforeNavigate(() => close());
+<script>
+  import { Layout } from '$lib/layout';
 </script>
 
-<svelte:window on:keydown={closeOnEscape} />
-
-<div class="drawer drawer-end">
-  <input type="checkbox" checked={menuToggle} class="drawer-toggle" />
-
-  <div class="drawer-content max-w-[100vw]">
-    <AppBar on:menuopen={open} {user}/>
-    <div class="bg-neutral text-neutral-content p-2 md:px-6 flex justify-between items-center">
-      <Breadcrumbs />
-      <AdminContent>
-        <a href="/admin" class="btn btn-sm btn-accent">
-          <span class="max-sm:hidden">
-            {$t('admin_dashboard.title')}
-          </span>
-          <AdminIcon />
-        </a>
-      </AdminContent>
-    </div>
-
-    <div class="max-w-prose mx-auto email-status-container">
-      <EmailVerificationStatus {user} />
-    </div>
-
-    <Content>
-      <slot />
-    </Content>
-  </div>
-  <div class="drawer-side z-10" >
-    <button class="drawer-overlay" on:click={close} on:keydown={close}/>
-    <AppMenu {user} serverVersion={data.serverVersion} apiVersion={data.apiVersion} />
-  </div>
-</div>
-
-<style lang="postcss">
-  :global(.email-status-container > div:first-child) {
-    @apply mt-6;
-  }
-</style>
+<Layout>
+  <slot />
+</Layout>

--- a/frontend/src/routes/(unauthenticated)/+layout.svelte
+++ b/frontend/src/routes/(unauthenticated)/+layout.svelte
@@ -1,9 +1,7 @@
 <script>
-  import { AppBar, Content } from '$lib/layout';
+  import { Layout } from '$lib/layout';
 </script>
 
-<AppBar user={undefined} />
-
-<Content>
+<Layout>
   <slot />
-</Content>
+</Layout>

--- a/frontend/src/routes/(unauthenticated)/forgotPassword/+page.svelte
+++ b/frontend/src/routes/(unauthenticated)/forgotPassword/+page.svelte
@@ -15,6 +15,8 @@
       method: 'POST',
     });
     await goto('/forgotPassword/emailSent');
+  }, {
+    taintedMessage: null,
   });
 </script>
 

--- a/frontend/src/routes/+error.svelte
+++ b/frontend/src/routes/+error.svelte
@@ -3,13 +3,11 @@
   import { LinkRenderer } from '$lib/components/Markdown';
   import UnexpectedError from '$lib/error/UnexpectedError.svelte';
   import t from '$lib/i18n';
-  import { AppBar, Content, Page } from '$lib/layout';
+  import { Layout, Page } from '$lib/layout';
   import SvelteMarkdown from 'svelte-markdown';
 </script>
 
-<AppBar user={undefined} />
-
-<Content>
+<Layout>
   <Page>
     {#if $page.status === 404}
       <div class="flex flex-col gap-4 items-center">
@@ -23,4 +21,4 @@
       <UnexpectedError />
     {/if}
   </Page>
-</Content>
+</Layout>

--- a/frontend/src/routes/+error.svelte
+++ b/frontend/src/routes/+error.svelte
@@ -1,10 +1,8 @@
 <script lang="ts">
   import { page } from '$app/stores';
-  import { LinkRenderer } from '$lib/components/Markdown';
   import UnexpectedError from '$lib/error/UnexpectedError.svelte';
   import t from '$lib/i18n';
   import { Layout, Page } from '$lib/layout';
-  import SvelteMarkdown from 'svelte-markdown';
 </script>
 
 <Layout>
@@ -15,10 +13,12 @@
           <span class="i-mdi-emoticon-confused-outline text-3xl" />
           <span class="text-2xl">{$t('errors.not_found')}</span>
         </div>
-        <SvelteMarkdown source={$t('errors.go_home')} renderers={{ link: LinkRenderer }} />
       </div>
     {:else}
       <UnexpectedError />
     {/if}
+    <div class="mt-8 text-center">
+      <a class="btn btn-success" href="/">{$t('errors.go_home')} <span class="i-mdi-home-outline text-xl"></span></a>
+    </div>
   </Page>
 </Layout>


### PR DESCRIPTION
![image](https://github.com/sillsdev/languageforge-lexbox/assets/12587509/093457f7-8b57-470d-9d86-78ff564ca563)

I realized that in order to have a root error page (e.g. 404) that could properly show the correct header (based on authenticated) we needed to have a smart layout/component. So, I just added that instead of adding sub-route error pages, which would have been redundant.

The (authenticated) and (unauthenticated) layouts have now converged. They both still exist, because (somewhat awkwardly) it would be a bit more work to make the email tester happy if we added everything to our root +layout.svelte.

All that said...there's obvious room for improvement, but this seems good for now.

closes #303