### PR TITLE
Ensure passwords aren't rendered in plain text

### DIFF
--- a/frontend/src/lib/forms/Input.svelte
+++ b/frontend/src/lib/forms/Input.svelte
@@ -6,7 +6,7 @@
   export let label: string;
   export let description: string | undefined = undefined;
   export let value: string | undefined = undefined;
-  export let type = 'text';
+  export let type: 'text' | 'email' | 'password' = 'text';
   export let autofocus = false;
   export let readonly = false;
   export let error: string | string[] | undefined = undefined;
@@ -14,19 +14,18 @@
   // Despite the compatibility table, 'new-password' seems to work well in Chrome, Edge & Firefox
   // https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/autocomplete#browser_compatibility
   export let autocomplete: 'new-password' | undefined = undefined;
-
-  // works around "svelte(invalid-type)" warning, i.e., can't have a dynamic type AND bind:value...keep an eye on https://github.com/sveltejs/svelte/issues/3921
-  function typeWorkaround(node: HTMLInputElement): void {
-    node.type = type;
-  }
 </script>
 
 <!-- https://daisyui.com/components/input -->
 <FormField {id} {error} {label} {autofocus} {description}>
   <!-- svelte-ignore a11y-autofocus -->
+  <!--
+    {...{type}} prevents a Svelte compile error (https://github.com/sveltejs/svelte/issues/3921)
+    and is perfectly safe, because we limit the type to string values
+  -->
   <input
     {id}
-    use:typeWorkaround
+    {...{ type }}
     bind:value
     class:input-error={error}
     {placeholder}


### PR DESCRIPTION
Set the `type` of `<input>`s server-side, so that passwords are never rendered in plain text