### PR TITLE
Mask secrets in Playwright traces in CI

### DIFF
--- a/.github/workflows/integration-test.yaml
+++ b/.github/workflows/integration-test.yaml
@@ -49,6 +49,8 @@ jobs:
           TEST_PROJECT_CODE: 'sena-3'
           TEST_DEFAULT_PASSWORD: ${{ secrets.TEST_USER_PASSWORD }}
         run: dotnet test --output ./bin --logger trx --results-directory ./test-results --filter Category=Integration
+      - name: Mask Playwright playwright-traces
+        run: pwsh backend/Testing/Browser/mask-playwright-traces.ps1 --dir ./bin/playwright-traces --values ${{ secrets.TEST_USER_PASSWORD }},another-example-secret
       - name: Upload test results
         uses: EnricoMi/publish-unit-test-result-action/composite@v2
         if: always() && !env.act

--- a/backend/Testing/Browser/mask-playwright-traces.ps1
+++ b/backend/Testing/Browser/mask-playwright-traces.ps1
@@ -1,0 +1,49 @@
+param(
+    [Parameter(Mandatory)][string] $dir,
+    [Parameter(Mandatory)][string[]] $values
+)
+
+Add-Type -Assembly  System.IO.Compression.FileSystem
+
+# trace = Core trace info
+# network = Network log
+# json = Network log payloads
+$filesToEdit = "\.(json|trace|network)$"
+$files = Get-ChildItem -path $dir -Filter *.zip
+
+Write-Output "Masking $($values.Count) values in $($files.Count) traces.";
+
+foreach ($file in $files) {
+    try {
+        Write-Output "Masking $file"
+        $zip = [System.IO.Compression.ZipFile]::Open($file.FullName, "Update")
+        $entries = $zip.Entries.Where({ $_.Name -match $filesToEdit })
+        $traceMaskCount = 0;
+        foreach ($entry in $entries) {
+            $reader = [System.IO.StreamReader]::new($entry.Open())
+            $content = $reader.ReadToEnd()
+            $entryMaskCount = 0;
+            foreach ($value in $values) {
+                $pieces = $content -split "\b$value\b"
+                $entryMaskCount += $pieces.Count - 1;
+                $content = $pieces -join $pieces, "*******"
+            }
+            $reader.Dispose()
+            $writer = [System.IO.StreamWriter]::new($entry.Open())
+            $writer.BaseStream.SetLength(0)
+            $writer.Write($content)
+            $writer.Dispose()
+            Write-Output "- $entry ($entryMaskCount)"
+        }
+        Write-Output "Finished masking $file ($traceMaskCount)"
+    }
+    catch {
+        Write-Warning $_.Exception.Message
+        continue
+    }
+    finally {
+        if ($zip) {
+            $zip.Dispose()
+        }
+    }
+}


### PR DESCRIPTION
Resolves #304 

Adds a PS script to CI that masks Playwright traces before they're uploaded.

Now we just need to make sure that we keep the list of secrets that it's aware of up to date.