### PR TITLE
Add turnstile to forgot-password page

### DIFF
--- a/backend/LexBoxApi/Controllers/LoginController.cs
+++ b/backend/LexBoxApi/Controllers/LoginController.cs
@@ -112,9 +112,9 @@ public class LoginController : ControllerBase
     [ProducesDefaultResponseType]
     public async Task<ActionResult> ForgotPassword(ForgotPasswordInput input)
     {
-        using var registerActivity = LexBoxActivitySource.Get().StartActivity("ForgotPassword");
+        using var activity = LexBoxActivitySource.Get().StartActivity();
         var validToken = await _turnstileService.IsTokenValid(input.TurnstileToken, input.Email);
-        registerActivity?.AddTag("app.turnstile_token_valid", validToken);
+        activity?.AddTag("app.turnstile_token_valid", validToken);
         if (!validToken)
         {
             ModelState.AddModelError<ForgotPasswordInput>(r => r.TurnstileToken, "token invalid");

--- a/backend/LexBoxApi/Models/ForgotPasswordInput.cs
+++ b/backend/LexBoxApi/Models/ForgotPasswordInput.cs
@@ -1,0 +1,7 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace LexBoxApi.Models;
+
+public record ForgotPasswordInput(
+    [EmailAddress] string Email,
+    string TurnstileToken);

--- a/frontend/src/lib/i18n/locales/en.json
+++ b/frontend/src/lib/i18n/locales/en.json
@@ -244,7 +244,6 @@ the [Linguistics Institute at Payap University](https://li.payap.ac.th/) in Chia
     "label_name": "Name",
     "label_password": "Password",
     "name_missing": "Name missing",
-    "turnstile_error": "Captcha Error, try again"
   },
   "reset_password": {
     "title": "Reset Password",
@@ -326,5 +325,8 @@ the [Linguistics Institute at Payap University](https://li.payap.ac.th/) in Chia
   },
   "notifications": {
     "update_detected": "A new version of the application was detected. You may need to reload the page.",
+  },
+  "turnstile": {
+    "invalid": "Captcha Error, try again",
   }
 }

--- a/frontend/src/routes/(unauthenticated)/register/+page.svelte
+++ b/frontend/src/routes/(unauthenticated)/register/+page.svelte
@@ -18,7 +18,7 @@
     const { user, error } = await register($form.password, $form.name, $form.email, turnstileToken);
     if (error) {
       if (error.turnstile) {
-        $message = $t('register.turnstile_error');
+        $message = $t('turnstile.invalid');
       }
       if (error.accountExists) {
         $errors.email = [$t('register.account_exists')];


### PR DESCRIPTION
Resolves #326 

Add turnstile to forgot-password page

(For the screenshot I just made the back-end block. That's why there's a discrepency.)
![image](https://github.com/sillsdev/languageforge-lexbox/assets/12587509/3c131108-cdc3-4f26-a408-8b75e3e8b286)
