### PR TITLE
add apis to allow restricting endpoints to specific audiences

### DIFF
--- a/backend/LexBoxApi/Auth/AuthKernel.cs
+++ b/backend/LexBoxApi/Auth/AuthKernel.cs
@@ -39,10 +39,18 @@ public static class AuthKernel
                 .Build();
             foreach (var audience in Enum.GetValues<LexboxAudience>())
             {
-                options.AddPolicy(audience.PolicyName(), builder =>
+                if (audience == LexboxAudience.Unknown) continue;
+                //for exclusive the endpoint is only accessible for the specified audience
+                options.AddPolicy(audience.PolicyName(true), builder =>
                 {
                     builder.RequireAuthenticatedUser();
                     builder.AddRequirements(new AudienceRequirement(audience));
+                });
+                //for non exclusive the endpoint is also accessible for the default audience
+                options.AddPolicy(audience.PolicyName(false), builder =>
+                {
+                    builder.RequireAuthenticatedUser();
+                    builder.AddRequirements(new AudienceRequirement(audience, LexboxAudience.LexboxApi));
                 });
             }
             //don't use RequireDefaultLexboxAuth here because that only allows the default audience

--- a/backend/LexBoxApi/Auth/JwtOptions.cs
+++ b/backend/LexBoxApi/Auth/JwtOptions.cs
@@ -6,26 +6,14 @@ public class JwtOptions
 {
     public static JwtOptions TestingOptions => new()
         {
-            Audience = "testing",
-            Issuer = "unitTest",
             Lifetime = TimeSpan.FromMinutes(1),
             RefreshLifetime = TimeSpan.FromMinutes(1),
             Secret = "this is only a test but must be long",
-            RefreshAudience = "testingRefresh",
             ClockSkew = TimeSpan.Zero
         };
 
     [Required]
     public required string Secret { get; init; }
-
-    [Required]
-    public required string Audience { get; init; }
-
-    [Required]
-    public required string RefreshAudience { get; init; }
-
-    [Required]
-    public required string Issuer { get; init; }
 
     [Required]
     public required TimeSpan Lifetime { get; init; }

--- a/backend/LexBoxApi/Auth/LexAuthService.cs
+++ b/backend/LexBoxApi/Auth/LexAuthService.cs
@@ -45,7 +45,7 @@ public class LexAuthService
             IssuerSigningKey = GetSigningKey(jwtOptions),
             //default audience, used for cookie tokens in JwtTicketDataFormat
             ValidAudience = LexboxAudience.LexboxApi.ToString(),
-            ValidAudiences = Enum.GetNames(typeof(LexboxAudience)),
+            ValidAudiences = Enum.GetNames<LexboxAudience>().Where(a => a != LexboxAudience.Unknown.ToString()),
             ValidIssuer = LexboxAudience.LexboxApi.ToString(),
             RequireSignedTokens = true,
             RequireExpirationTime = true,

--- a/backend/LexBoxApi/Auth/LexboxAudience.cs
+++ b/backend/LexBoxApi/Auth/LexboxAudience.cs
@@ -1,0 +1,16 @@
+﻿using System.Text.Json.Serialization;
+
+namespace LexBoxApi.Auth;
+
+[JsonConverter(typeof(JsonStringEnumConverter))]
+public enum LexboxAudience
+{
+    //these names are converted to strings and are used in jwt tokens, if the name is changed that will invalidate all existing tokens
+    LexboxApi,
+    ForgotPassword,
+}
+
+public static class LexboxAudienceHelper
+{
+    public static string PolicyName(this LexboxAudience audience) => $"RequireAudience{audience}Policy";
+}

--- a/backend/LexBoxApi/Auth/RequireAudienceAttribute.cs
+++ b/backend/LexBoxApi/Auth/RequireAudienceAttribute.cs
@@ -1,8 +1,15 @@
-﻿namespace LexBoxApi.Auth;
+﻿using LexCore.Auth;
 
+namespace LexBoxApi.Auth;
+
+//todo for now this attribute only supports a single audience, this may be fine for now.
+//once we are at dotnet 8 we can support multiple audiences using the new IAuthorizationRequirementData api
+//https://learn.microsoft.com/en-us/aspnet/core/release-notes/aspnetcore-8.0?view=aspnetcore-7.0#iauthorizationrequirementdata
 public class RequireAudienceAttribute : LexboxAuthAttribute
 {
-    public RequireAudienceAttribute(LexboxAudience audience) : base(audience.PolicyName())
+    /// <param name="audience">audience allowed to access this endpoint</param>
+    /// <param name="exclusive">when false the default audience is also allowed, when true the default audience is not allowed</param>
+    public RequireAudienceAttribute(LexboxAudience audience, bool exclusive = false) : base(audience.PolicyName(exclusive))
     {
     }
 }

--- a/backend/LexBoxApi/Auth/RequireAudienceAttribute.cs
+++ b/backend/LexBoxApi/Auth/RequireAudienceAttribute.cs
@@ -1,0 +1,16 @@
+﻿namespace LexBoxApi.Auth;
+
+public class RequireAudienceAttribute : LexboxAuthAttribute
+{
+    public RequireAudienceAttribute(LexboxAudience audience) : base(audience.PolicyName())
+    {
+    }
+}
+
+public  class AllowAnyAudienceAttribute : LexboxAuthAttribute
+{
+    public const string PolicyName = "AllowAnyAudiencePolicy";
+    public AllowAnyAudienceAttribute() : base(PolicyName)
+    {
+    }
+}

--- a/backend/LexBoxApi/Auth/Requirements/AudienceRequirementHandler.cs
+++ b/backend/LexBoxApi/Auth/Requirements/AudienceRequirementHandler.cs
@@ -1,0 +1,32 @@
+﻿using Microsoft.AspNetCore.Authorization;
+using Microsoft.IdentityModel.JsonWebTokens;
+
+namespace LexBoxApi.Auth.Requirements;
+
+public class AudienceRequirement : IAuthorizationRequirement
+{
+    public LexboxAudience Audience { get; }
+
+    public AudienceRequirement(LexboxAudience audience)
+    {
+        Audience = audience;
+    }
+}
+
+public class AudienceRequirementHandler : AuthorizationHandler<AudienceRequirement>
+{
+    protected override Task HandleRequirementAsync(AuthorizationHandlerContext context, AudienceRequirement requirement)
+    {
+        var claim = context.User.FindFirst(JwtRegisteredClaimNames.Aud);
+        if (claim?.Value == requirement.Audience.ToString())
+        {
+            context.Succeed(requirement);
+        }
+        else
+        {
+            context.Fail(new AuthorizationFailureReason(this,
+                $"Token does not have the required audience: {requirement.Audience}"));
+        }
+        return Task.CompletedTask;
+    }
+}

--- a/backend/LexBoxApi/Controllers/AuthTestingController.cs
+++ b/backend/LexBoxApi/Controllers/AuthTestingController.cs
@@ -1,0 +1,29 @@
+﻿using LexBoxApi.Auth;
+using Microsoft.AspNetCore.Mvc;
+
+namespace LexBoxApi.Controllers;
+
+[ApiController]
+[Route("/api/[controller]")]
+public class AuthTestingController : ControllerBase
+{
+    [HttpGet("requires-auth")]
+    public OkObjectResult RequiresAuth()
+    {
+        return Ok("success: " + User.Identity?.Name ?? "Unknown");
+    }
+
+    [HttpGet("requires-admin")]
+    [AdminRequired]
+    public OkResult RequiresAdmin()
+    {
+        return Ok();
+    }
+
+    [HttpGet("requires-forgot-password")]
+    [RequireAudience(LexboxAudience.ForgotPassword)]
+    public OkResult RequiresForgotPasswordAudience()
+    {
+        return Ok();
+    }
+}

--- a/backend/LexBoxApi/Controllers/AuthTestingController.cs
+++ b/backend/LexBoxApi/Controllers/AuthTestingController.cs
@@ -1,4 +1,5 @@
 ﻿using LexBoxApi.Auth;
+using LexCore.Auth;
 using Microsoft.AspNetCore.Mvc;
 
 namespace LexBoxApi.Controllers;
@@ -21,7 +22,7 @@ public class AuthTestingController : ControllerBase
     }
 
     [HttpGet("requires-forgot-password")]
-    [RequireAudience(LexboxAudience.ForgotPassword)]
+    [RequireAudience(LexboxAudience.ForgotPassword, true)]
     public OkResult RequiresForgotPasswordAudience()
     {
         return Ok();

--- a/backend/LexBoxApi/Controllers/LoginController.cs
+++ b/backend/LexBoxApi/Controllers/LoginController.cs
@@ -35,6 +35,7 @@ public class LoginController : ControllerBase
     }
 
     [HttpGet("loginRedirect")]
+    [AllowAnyAudience]
     public async Task<ActionResult> LoginRedirect(
         string jwt, // This is required because auth looks for a jwt in the query string
         string returnTo)
@@ -110,6 +111,7 @@ public class LoginController : ControllerBase
     public record ResetPasswordRequest([Required(AllowEmptyStrings = false)] string PasswordHash);
 
     [HttpPost("resetPassword")]
+    [RequireAudience(LexboxAudience.ForgotPassword)]
     public async Task<ActionResult> ResetPassword(ResetPasswordRequest request)
     {
         var passwordHash = request.PasswordHash;
@@ -118,6 +120,8 @@ public class LoginController : ControllerBase
         user.PasswordHash = PasswordHashing.HashPassword(passwordHash, user.Salt, true);
         await _lexBoxDbContext.SaveChangesAsync();
         await _emailService.SendPasswordChangedEmail(user);
+        //the old jwt is only valid for calling forgot password endpoints, we need to generate a new one
+        await RefreshJwt();
         return Ok();
     }
 }

--- a/backend/LexBoxApi/Controllers/TestingController.cs
+++ b/backend/LexBoxApi/Controllers/TestingController.cs
@@ -31,30 +31,21 @@ public class TestingController : ControllerBase
         _redmineDbContext = redmineDbContext;
     }
 
-    [HttpGet("requires-auth")]
-    public OkObjectResult RequiresAuth()
-    {
-        return Ok("success: " + User.Identity?.Name ?? "Unknown");
-    }
 
-    [HttpGet("requires-admin")]
-    [AdminRequired]
-    public OkResult RequiresAdmin()
-    {
-        return Ok();
-    }
 
     [AllowAnonymous]
     [HttpGet("makeJwt")]
     [ProducesResponseType(StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status404NotFound)]
     [ProducesDefaultResponseType]
-    public async Task<ActionResult<string>> MakeJwt(string usernameOrEmail, UserRole userRole)
+    public async Task<ActionResult<string>> MakeJwt(string usernameOrEmail,
+        UserRole userRole,
+        LexboxAudience audience = LexboxAudience.LexboxApi)
     {
         var user = await _lexBoxDbContext.Users.Include(u => u.Projects).ThenInclude(p => p.Project)
             .FindByEmail(usernameOrEmail);
         if (user is null) return NotFound();
-        var (token, _) = _lexAuthService.GenerateJwt(new LexAuthUser(user) { Role = userRole });
+        var (token, _) = _lexAuthService.GenerateJwt(new LexAuthUser(user) { Role = userRole }, audience: audience);
         return token;
     }
 

--- a/backend/LexBoxApi/appsettings.json
+++ b/backend/LexBoxApi/appsettings.json
@@ -23,9 +23,6 @@
   "Authentication": {
     "Jwt": {
       "Secret": null,
-      "Audience": "lexbox-api",
-      "RefreshAudience": "lexbox-api-refresh",
-      "Issuer": "lexbox-api",
 //      does not effect jwt used for the cookie
       "Lifetime": "01:00",
       "RefreshLifetime": "07:00:00",

--- a/backend/LexCore/Auth/LexAuthConstants.cs
+++ b/backend/LexCore/Auth/LexAuthConstants.cs
@@ -6,6 +6,7 @@ public static class LexAuthConstants
     public const string EmailClaimType = "email";
     public const string NameClaimType = "name";
     public const string IdClaimType = "sub";
+    public const string AudienceClaimType = "aud";
     public const string ProjectsClaimType = "proj";
     public const string EmailUnverifiedClaimType = "unver";
     public const string CanCreateProjectClaimType = "mkproj";

--- a/backend/LexCore/Auth/LexAuthUser.cs
+++ b/backend/LexCore/Auth/LexAuthUser.cs
@@ -82,8 +82,9 @@ public record LexAuthUser
 
     [JsonPropertyName(LexAuthConstants.IdClaimType)]
     public required Guid Id { get; set; }
+
     [JsonPropertyName(LexAuthConstants.AudienceClaimType)]
-    public LexboxAudience Audience { get; set; }
+    public LexboxAudience Audience { get; set; } = LexboxAudience.LexboxApi;
 
     [JsonPropertyName(LexAuthConstants.EmailClaimType)]
     public required string Email { get; set; }

--- a/backend/LexCore/Auth/LexAuthUser.cs
+++ b/backend/LexCore/Auth/LexAuthUser.cs
@@ -83,7 +83,7 @@ public record LexAuthUser
     [JsonPropertyName(LexAuthConstants.IdClaimType)]
     public required Guid Id { get; set; }
     [JsonPropertyName(LexAuthConstants.AudienceClaimType)]
-    public string Audience { get; set; }
+    public LexboxAudience Audience { get; set; }
 
     [JsonPropertyName(LexAuthConstants.EmailClaimType)]
     public required string Email { get; set; }

--- a/backend/LexCore/Auth/LexAuthUser.cs
+++ b/backend/LexCore/Auth/LexAuthUser.cs
@@ -4,18 +4,19 @@ using System.Security.Claims;
 using System.Text.Json;
 using System.Text.Json.Nodes;
 using System.Text.Json.Serialization;
+using System.Text.Json.Serialization.Metadata;
 using LexCore.Entities;
 
 namespace LexCore.Auth;
 
 public record LexAuthUser
 {
+    private static readonly JsonTypeInfo LexAuthUserTypeInfo = JsonSerializerOptions.Default.GetTypeInfo(typeof(LexAuthUser));
     public static LexAuthUser? FromClaimsPrincipal(ClaimsPrincipal principal)
     {
         if (principal.Identity?.IsAuthenticated is not true) return null;
         var jsonObject = new JsonObject();
-        var typeInfo = JsonSerializerOptions.Default.GetTypeInfo(typeof(LexAuthUser));
-        foreach (var property in typeInfo.Properties)
+        foreach (var property in LexAuthUserTypeInfo.Properties)
         {
             var isArray = property.PropertyType != typeof(string) &&
                           property.PropertyType.IsAssignableTo(typeof(IEnumerable));
@@ -81,6 +82,8 @@ public record LexAuthUser
 
     [JsonPropertyName(LexAuthConstants.IdClaimType)]
     public required Guid Id { get; set; }
+    [JsonPropertyName(LexAuthConstants.AudienceClaimType)]
+    public string Audience { get; set; }
 
     [JsonPropertyName(LexAuthConstants.EmailClaimType)]
     public required string Email { get; set; }

--- a/backend/LexCore/Auth/LexboxAudience.cs
+++ b/backend/LexCore/Auth/LexboxAudience.cs
@@ -1,16 +1,22 @@
 ﻿using System.Text.Json.Serialization;
 
-namespace LexBoxApi.Auth;
+namespace LexCore.Auth;
 
 [JsonConverter(typeof(JsonStringEnumConverter))]
 public enum LexboxAudience
 {
+    //default value of the enum, not a valid audience
+    Unknown,
     //these names are converted to strings and are used in jwt tokens, if the name is changed that will invalidate all existing tokens
     LexboxApi,
     ForgotPassword,
+    SendAndReceive,
 }
 
 public static class LexboxAudienceHelper
 {
-    public static string PolicyName(this LexboxAudience audience) => $"RequireAudience{audience}Policy";
+    public static string PolicyName(this LexboxAudience audience, bool exclusive)
+    {
+        return $"RequireAudience{audience}{(exclusive ? "Exclusive" : "")}Policy";
+    }
 }

--- a/backend/Testing/ApiTests/AuthTests.cs
+++ b/backend/Testing/ApiTests/AuthTests.cs
@@ -1,8 +1,8 @@
-﻿using System.Net;
+﻿using System.IdentityModel.Tokens.Jwt;
+using System.Net;
+using System.Net.Http.Headers;
 using System.Net.Http.Json;
-using System.Text;
-using System.Text.Json;
-using System.Text.Json.Nodes;
+using System.Security.Claims;
 using LexCore.Auth;
 using Shouldly;
 using Testing.Services;
@@ -35,6 +35,7 @@ public class AuthTests : ApiTestBase
     [Fact]
     public async Task TestGqlVerifyDifferentUsers()
     {
+        //language=GraphQL
         var query = """query testGetMe {  me {    id    email  }}""";
         await LoginAs("manager", TestingEnvironmentVariables.DefaultPassword);
         var manager = await ExecuteGql(query);
@@ -45,5 +46,94 @@ public class AuthTests : ApiTestBase
         var admin = await ExecuteGql(query);
         admin.ShouldNotBeNull();
         admin["data"]!["me"]!["email"]!.ToString().ShouldBe("admin@test.com");
+    }
+
+    [Fact]
+    public async Task NotLoggedInIsNotPermittedToCallRequiresAuthApi()
+    {
+        var response = await HttpClient.GetAsync($"{BaseUrl}/api/AuthTesting/requires-auth");
+        response.StatusCode.ShouldBe(HttpStatusCode.Unauthorized);
+    }
+
+    [Fact]
+    public async Task ManagerIsPermittedToCallRequiresAuthApi()
+    {
+        await LoginAs("manager", TestingEnvironmentVariables.DefaultPassword);
+        var response = await HttpClient.GetAsync($"{BaseUrl}/api/AuthTesting/requires-auth");
+        response.EnsureSuccessStatusCode();
+    }
+
+    [Fact]
+    public async Task ManagerIsForbiddenFromAdminApi()
+    {
+        await LoginAs("manager", TestingEnvironmentVariables.DefaultPassword);
+        var response = await HttpClient.GetAsync($"{BaseUrl}/api/AuthTesting/requires-admin");
+        response.StatusCode.ShouldBe(HttpStatusCode.Forbidden);
+    }
+
+    [Fact]
+    public async Task AdminIsPermittedToCallAdminApi()
+    {
+        await LoginAs("admin", TestingEnvironmentVariables.DefaultPassword);
+        var response = await HttpClient.GetAsync($"{BaseUrl}/api/AuthTesting/requires-admin");
+        response.EnsureSuccessStatusCode();
+    }
+
+    [Fact]
+    public async Task NoOneCanCallForgotPasswordApi()
+    {
+        await LoginAs("manager", TestingEnvironmentVariables.DefaultPassword);
+        var response = await HttpClient.GetAsync($"{BaseUrl}/api/AuthTesting/requires-forgot-password");
+        response.StatusCode.ShouldBe(HttpStatusCode.Forbidden);
+
+        await LoginAs("admin", TestingEnvironmentVariables.DefaultPassword);
+        response = await HttpClient.GetAsync($"{BaseUrl}/api/AuthTesting/requires-forgot-password");
+        response.StatusCode.ShouldBe(HttpStatusCode.Forbidden);
+    }
+
+    [Fact]
+    public async Task ClearingCookiesWorks()
+    {
+        await LoginAs("manager", TestingEnvironmentVariables.DefaultPassword);
+        ClearCookies();
+        var response = await HttpClient.GetAsync($"{BaseUrl}/api/AuthTesting/requires-auth");
+        response.StatusCode.ShouldBe(HttpStatusCode.Unauthorized);
+    }
+
+    [Fact]
+    public async Task CanUseBearerAuth()
+    {
+        var jwt = await LoginAs("manager", TestingEnvironmentVariables.DefaultPassword);
+        ClearCookies();
+        var response = await HttpClient.SendAsync(new HttpRequestMessage(HttpMethod.Get,
+            $"{BaseUrl}/api/AuthTesting/requires-auth")
+        {
+            Headers = { Authorization = new AuthenticationHeaderValue("Bearer", jwt) }
+        });
+        response.EnsureSuccessStatusCode();
+    }
+
+    [Fact]
+    public async Task JwtWithInvalidSignatureFailsAuth()
+    {
+        var jwt = await LoginAs("manager", TestingEnvironmentVariables.DefaultPassword);
+        ClearCookies();
+
+        //fiddle with jwt to try and elevate permissions
+        var tokenHandler = new JwtSecurityTokenHandler();
+        var originalJwtToken = tokenHandler.ReadJwtToken(jwt);
+        var claims = originalJwtToken.Payload.Claims.ToArray();
+        var roleClaimIndex = Array.FindIndex(claims, c => c.Type == LexAuthConstants.RoleClaimType);
+        //change role to admin
+        claims[roleClaimIndex] = new Claim(LexAuthConstants.RoleClaimType, UserRole.admin.ToString());
+        var payloadEncoded = new JwtPayload(claims).Base64UrlEncode();
+        var newJwt = $"{originalJwtToken.RawHeader}.{payloadEncoded}.{originalJwtToken.RawSignature}";
+
+        var response = await HttpClient.SendAsync(new HttpRequestMessage(HttpMethod.Get,
+            $"{BaseUrl}/api/AuthTesting/requires-auth")
+        {
+            Headers = { Authorization = new AuthenticationHeaderValue("Bearer", newJwt) }
+        });
+        response.StatusCode.ShouldBe(HttpStatusCode.Unauthorized);
     }
 }

--- a/frontend/schema.graphql
+++ b/frontend/schema.graphql
@@ -95,6 +95,7 @@ type LexAuthUser {
   canAccessProject(projectCode: String!): Boolean!
   hasProjectCreatePermission: Boolean!
   id: UUID!
+  audience: String!
   email: String!
   name: String!
   role: UserRole!

--- a/frontend/schema.graphql
+++ b/frontend/schema.graphql
@@ -95,7 +95,7 @@ type LexAuthUser {
   canAccessProject(projectCode: String!): Boolean!
   hasProjectCreatePermission: Boolean!
   id: UUID!
-  audience: String!
+  audience: LexboxAudience!
   email: String!
   name: String!
   role: UserRole!
@@ -481,6 +481,11 @@ enum CreateProjectResult {
 enum DbErrorCode {
   UNKNOWN
   DUPLICATE
+}
+
+enum LexboxAudience {
+  LEXBOX_API
+  FORGOT_PASSWORD
 }
 
 enum ProjectMigrationStatus {

--- a/frontend/schema.graphql
+++ b/frontend/schema.graphql
@@ -484,8 +484,10 @@ enum DbErrorCode {
 }
 
 enum LexboxAudience {
+  UNKNOWN
   LEXBOX_API
   FORGOT_PASSWORD
+  SEND_AND_RECEIVE
 }
 
 enum ProjectMigrationStatus {


### PR DESCRIPTION
related to #98 but does not close it as jwt still doesn't expire after a password change. This PR makes forgot password jwt unique and not valid for any other endpoint. It can be used to retrieve a valid jwt, but only after a user validation check.

This introduces some new jwt audiences which can be used to restrict the scope of a token. This means that for example the forgot password token can only be used to set the password. It also means that we can generate a jwt just for S&R and nothing else! That part isn't done here yet though.