### PR TITLE
Faster `dotnet restore` for backend container

### DIFF
--- a/backend/LexBoxApi/dev.Dockerfile
+++ b/backend/LexBoxApi/dev.Dockerfile
@@ -9,7 +9,7 @@ WORKDIR /src/backend
 # Copy the main source project files
 COPY */*.csproj *.sln ./
 # move them into the proper sub folders, based on the name of the project
-RUN for file in $(ls *.csproj); do dir=${file%.*} mkdir -p ${file%.*}/ && mv $file ${file%.*}/ && echo dotnet restore ${file%.*}/${file} >> restore-csprojs.sh; done; bash restore-csprojs.sh; rm restore-csprojs.sh
+RUN for file in $(ls *.csproj); do dir=${file%.*} mkdir -p ${file%.*}/ && mv $file ${file%.*}/; done; dotnet restore FixFwData/FixFwData.csproj; dotnet restore LexBoxApi/LexBoxApi.csproj
 
 COPY . .
 WORKDIR /src/backend/LexBoxApi

--- a/backend/LexBoxApi/dev.Dockerfile
+++ b/backend/LexBoxApi/dev.Dockerfile
@@ -9,7 +9,7 @@ WORKDIR /src/backend
 # Copy the main source project files
 COPY */*.csproj *.sln ./
 # move them into the proper sub folders, based on the name of the project
-RUN for file in $(ls *.csproj); do dir=${file%.*} mkdir -p ${file%.*}/ && mv $file ${file%.*}/ && dotnet restore ${file%.*}/${file}; done
+RUN for file in $(ls *.csproj); do dir=${file%.*} mkdir -p ${file%.*}/ && mv $file ${file%.*}/ && echo dotnet restore ${file%.*}/${file} >> restore-csprojs.sh; done; bash restore-csprojs.sh; rm restore-csprojs.sh
 
 COPY . .
 WORKDIR /src/backend/LexBoxApi


### PR DESCRIPTION
Now the `backend/dev.Dockerfile` build will copy all the .csproj files into place before running `dotnet restore` on any of them, which means the LexBoxApi.csproj file will be able to find its dependent projects at restore time, and restore all of them together.

Fixes #250.