### PR TITLE
Attempt to fix "subscribe to page store" error

### DIFF
--- a/frontend/src/routes/+layout.svelte
+++ b/frontend/src/routes/+layout.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { page, updated } from '$app/stores';
+  import { getStores } from '$app/stores';
   import '$lib/app.postcss';
   import { initErrorStore } from '$lib/error';
   import UnexpectedErrorAlert from '$lib/error/UnexpectedErrorAlert.svelte';
@@ -13,6 +13,7 @@
   import t from '$lib/i18n';
 
   export let data: LayoutData;
+  const { page, updated } = getStores();
 
   const error = initErrorStore(writable($page.error));
   $: $error = $page.error;


### PR DESCRIPTION
For some reason, the layout code is sometimes throwing an error about subscribing to the Svelte `$page` store outside of component initialization. It's unclear how that's happening as the only place we're using `$page` is in the component init, but let's try using Svelte's `getStores()` function to avoid that delayed subscription.

Will hopefully fix #229.