### PR TITLE
Feat/311 ensure jwt tokens from email links dont end up in logs

### DIFF
--- a/deployment/base/lexbox-deployment.yaml
+++ b/deployment/base/lexbox-deployment.yaml
@@ -144,7 +144,7 @@ spec:
             value: http://localhost
 
       - name: otel-collector
-        image: otel/opentelemetry-collector:0.73.0
+        image: otel/opentelemetry-collector-contrib:0.87.0
         # https://kubernetes.io/docs/concepts/configuration/manage-resources-containers
         resources:
           requests: # TODO: need to establish resource limits, possibly after seeing it in action for some regular and/or load testing
@@ -155,7 +155,7 @@ spec:
           - containerPort: 4318
           - containerPort: 4317
         volumeMounts:
-          - mountPath: /etc/otelcol
+          - mountPath: /etc/otelcol-contrib
             name: otel-config
             readOnly: true
 

--- a/otel/collector-config.yaml
+++ b/otel/collector-config.yaml
@@ -49,7 +49,7 @@ service:
   pipelines:
     traces:
       receivers: [otlp]
-      processors: [memory_limiter, redaction]
+      processors: [memory_limiter, redaction, batch]
       exporters: [otlp, logging]
     metrics:
       receivers: [otlp]

--- a/otel/collector-config.yaml
+++ b/otel/collector-config.yaml
@@ -21,6 +21,11 @@ processors:
   memory_limiter:
     check_interval: 1s
     limit_mib: 400
+  redaction: # https://pkg.go.dev/github.com/open-telemetry/opentelemetry-collector-contrib/processor/redactionprocessor#section-readme
+    allow_all_keys: true
+    blocked_values:
+      - "[A-Za-z0-9-_]{10,}\\.[A-Za-z0-9-_]{20,}\\.[A-Za-z0-9-_]{10,}" # jwt
+    summary: debug
 
 exporters:
   logging:
@@ -44,7 +49,7 @@ service:
   pipelines:
     traces:
       receivers: [otlp]
-      processors: [memory_limiter]
+      processors: [memory_limiter, redaction]
       exporters: [otlp, logging]
     metrics:
       receivers: [otlp]


### PR DESCRIPTION
Resolves #311 

Example of a masked URL: https://ui.honeycomb.io/sil-language-forge/environments/test/result/3e3S9B7T5Mr/trace/aKf38Lst7wM?fields[]=c_name&fields[]=c_service.name&span=685e686dc94b767f
![image](https://github.com/sillsdev/languageforge-lexbox/assets/12587509/231ee772-eb6a-45cb-8c7b-601b9f419536)

I could have gone with a more context-specific Regex that covers the cases we're currently aware of (e.g. /jwt=[jwt-pattern]/) and is presumably less computationally expensive, but...I like the idea of a future-proof and mistake-proof regex.

The redaction processor is part of the contrib collector distribution, so we had to start using that, which expects the config to be in a different spot. Contrib is a fair bit bigger, so I created [an issue](https://github.com/sillsdev/languageforge-lexbox/issues/339) to potentially slim it down.

And just for fun we updated to the latest version.