### PR TITLE
Feat (312): stabilize client side otel export

### DIFF
--- a/frontend/src/lib/otel/trace-exporter-browser-with-xhr-retry.ts
+++ b/frontend/src/lib/otel/trace-exporter-browser-with-xhr-retry.ts
@@ -1,0 +1,39 @@
+// We explicitly reference the browser version so that we have proper types
+
+import { OTLPTraceExporter } from '@opentelemetry/exporter-trace-otlp-http/build/src/platform/browser';
+import type { ReadableSpan } from '@opentelemetry/sdk-trace-web';
+
+// these save us a dependency
+type SendOnErrorCallback = Parameters<OTLPTraceExporter['send']>[2];
+type ExporterConfig = ConstructorParameters<typeof OTLPTraceExporter>[0];
+
+export class OTLPTraceExporterBrowserWithXhrRetry extends OTLPTraceExporter {
+
+  private readonly xhrTraceExporter: OTLPTraceExporter;
+
+  constructor(config?: ExporterConfig) {
+    super(config);
+    this.xhrTraceExporter = new OTLPTraceExporter({
+      ...(config ?? {}),
+      // passing a truthy value here causes XHR to be used: https://github.com/open-telemetry/opentelemetry-js/blob/main/experimental/packages/otlp-exporter-base/src/platform/browser/OTLPExporterBrowserBase.ts#L40
+      headers: {},
+    });
+  }
+
+  send(items: ReadableSpan[], onSuccess: () => void, onError: SendOnErrorCallback): void {
+    super.send(items, onSuccess, (error) => {
+      if (error.message.toLocaleLowerCase().includes('beacon')) {
+        this.xhrTraceExporter.send(items, onSuccess, (xhrError) => {
+          onError({
+            ...error,
+            message: `${error.message} --- [XHR retry message: ${xhrError.message}; code: ${xhrError.code}].`,
+            code: error.code,
+            data: `${error.data} --- [XHR retry data: ${xhrError.data}].`,
+          });
+        });
+      } else {
+        onError(error);
+      }
+    });
+  }
+}


### PR DESCRIPTION
An attempt at #312 

If an export fails it gets retried with XHR. We can try a more ambitious export size now, because it doesn't matter as much if it fails. Also, a higher number helps us pump things through faster, so it's less likely that we'll lose something on page unload. I initially thought we'd lose insight into export failures this way, but I think that's not really the case, because either:
1) We'll just retry with XHR and it will probably be ok, so the failure doesn't matter
2) It's too late to retry and so we likely wouldn't see the failure anyway

There's of course the 3rd scenario: when the error would have been reported before: (1) we start the retry instead, (2) the page gets unloaded and (3) the XHR/retry gets canceled and we can't report the failure. But that shouldn't happen too often. 

Of course, we're not really trying to instrument our instrumentation export failures, but it is nice to know if it's not working well.