### PR TITLE
Stabilise email-result handling

### DIFF
--- a/frontend/src/lib/email/EmailVerificationStatus.svelte
+++ b/frontend/src/lib/email/EmailVerificationStatus.svelte
@@ -11,8 +11,7 @@
   import type { LexAuthUser } from '$lib/user';
   import { EmailResult } from '.';
   import { Button } from '$lib/forms';
-  import { onDestroy } from 'svelte';
-  import { Duration } from '$lib/util/time';
+  import { onNavigate } from '$app/navigation';
 
   export let user: LexAuthUser;
 
@@ -30,20 +29,9 @@
     }
   }
 
-  const emailResultUnsubscriber = emailResult.subscribe((result) => {
-    if (result) {
-      setTimeout(() => emailResult.set(null), Duration.Medium);
-    }
-  });
-  const requestedEmailUnsubscriber = requestedEmail.subscribe((result) => {
-    if (result) {
-      setTimeout(() => requestedEmail.set(null), Duration.Long);
-    }
-  });
-
-  onDestroy(() => {
-    emailResultUnsubscriber();
-    requestedEmailUnsubscriber();
+  onNavigate(() => {
+    emailResult.set(null);
+    requestedEmail.set(null);
   });
 </script>
 

--- a/frontend/src/routes/(authenticated)/user/+page.ts
+++ b/frontend/src/routes/(authenticated)/user/+page.ts
@@ -5,9 +5,7 @@ import type {
 
 } from '$lib/gql/types';
 import { getClient, graphql } from '$lib/gql';
-import { goto } from '$app/navigation';
 import type { PageLoad } from './$types';
-import { browser } from '$app/environment';
 import { EmailResult } from '$lib/email';
 
 const EMAIL_RESULTS = Object.values(EmailResult);
@@ -16,7 +14,6 @@ export const load = (({ url }) => {
   const emailResult = url.searchParams.get('emailResult') as EmailResult | null;
   if (emailResult) {
     if (!EMAIL_RESULTS.includes(emailResult)) throw new Error(`Invalid emailResult: ${emailResult}.`);
-    if (browser) void goto(`${url.pathname}`, { replaceState: true });
   }
   return { emailResult };
 }) satisfies PageLoad


### PR DESCRIPTION
This load function is fragile. It was tricky setting it up and when I changed to CSR (for experimentation) it stopped working.

I think we're generally not supposed to use stores in load functions, but I also think it's fine if it's only client-side. So, I think this is a good change, but I'm putting it in a PR so it's more visible.