### PR TITLE
Test: 347 make playwright wait for hydrated not networkidle

### DIFF
--- a/backend/Testing/Browser/Page/BasePage.cs
+++ b/backend/Testing/Browser/Page/BasePage.cs
@@ -36,11 +36,11 @@ public abstract class BasePage<T> where T : BasePage<T>
     {
         if (Url is not null)
         {
-            await Page.WaitForURLAsync(Url, new() { WaitUntil = WaitUntilState.NetworkIdle });
+            await Page.WaitForURLAsync(Url, new() { WaitUntil = WaitUntilState.Load });
         }
         else
         {
-            await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+            await Page.WaitForLoadStateAsync(LoadState.Load);
         }
         await Task.WhenAll(TestLocators.Select(l => l.WaitForAsync()));
         return (T)this;

--- a/frontend/src/lib/app.postcss
+++ b/frontend/src/lib/app.postcss
@@ -124,3 +124,46 @@ table tr:nth-last-child(-n + 2) .dropdown {
     transition: background-color 0.5s;
   }
 }
+
+.unhydrated {
+    .input, input, button {
+        visibility: hidden;
+    }
+
+    form {
+        & > * {
+            visibility: hidden;
+        }
+
+        position: relative;
+
+        &::before {
+            content: '';
+            position: absolute;
+            top: 0;
+            left: 0;
+            @apply w-full h-full;
+            @apply rounded-xl;
+
+            background-image: linear-gradient(110deg, var(--tw-gradient-stops));
+            @apply from-base-300;
+            @apply via-neutral-600;
+            @apply to-base-300;
+            background-size: 400% 400%;
+            animation: gradient 5s ease-in-out infinite;
+
+            @keyframes gradient {
+                0% {
+                    background-position: 0% 50%;
+                }
+                50% {
+                    background-position: 100% 50%;
+                }
+                100% {
+                    background-position: 0% 50%;
+                }
+            }
+
+        }
+    }
+}

--- a/frontend/src/lib/app.postcss
+++ b/frontend/src/lib/app.postcss
@@ -126,44 +126,28 @@ table tr:nth-last-child(-n + 2) .dropdown {
 }
 
 .unhydrated {
-    .input, input, button {
-        visibility: hidden;
+  .input,
+  input,
+  button {
+    visibility: hidden;
+  }
+
+  form {
+    & > * {
+      visibility: hidden;
     }
 
-    form {
-        & > * {
-            visibility: hidden;
-        }
+    position: relative;
 
-        position: relative;
+    &::before {
+      content: '';
+      @apply loading loading-ring bg-primary;
+      @apply h-32 max-h-full w-auto;
 
-        &::before {
-            content: '';
-            position: absolute;
-            top: 0;
-            left: 0;
-            @apply w-full h-full;
-            @apply rounded-xl;
-
-            background-image: linear-gradient(110deg, var(--tw-gradient-stops));
-            @apply from-base-300;
-            @apply via-neutral-600;
-            @apply to-base-300;
-            background-size: 400% 400%;
-            animation: gradient 5s ease-in-out infinite;
-
-            @keyframes gradient {
-                0% {
-                    background-position: 0% 50%;
-                }
-                50% {
-                    background-position: 100% 50%;
-                }
-                100% {
-                    background-position: 0% 50%;
-                }
-            }
-
-        }
+      position: absolute;
+      top: 50%;
+      left: 50%;
+      transform: translate(-50%, -50%);
     }
+  }
 }

--- a/frontend/src/lib/app.postcss
+++ b/frontend/src/lib/app.postcss
@@ -125,7 +125,7 @@ table tr:nth-last-child(-n + 2) .dropdown {
   }
 }
 
-.unhydrated {
+.hydrating {
   .input,
   input,
   button {

--- a/frontend/src/routes/+layout.svelte
+++ b/frontend/src/routes/+layout.svelte
@@ -11,6 +11,8 @@
   import { Duration } from '$lib/util/time';
   import { browser } from '$app/environment';
   import t from '$lib/i18n';
+  import { onMount } from 'svelte';
+  import { blur } from 'svelte/transition';
 
   export let data: LayoutData;
   const { page, updated } = getStores();
@@ -22,6 +24,9 @@
       notifyWarning($t('notifications.update_detected'), Duration.Long);
     }
   }
+
+  let unhydrated = true;
+  onMount(() => unhydrated = false);
 </script>
 
 <svelte:head>
@@ -33,6 +38,13 @@
     <meta name="traceparent" content={data.traceParent} />
   {/if}
 </svelte:head>
+
+{#if unhydrated}
+  <div class="fixed top-0 bottom-0 left-0 right-0 z-10 flex flex-col items-center justify-center" out:blur={{duration: 1000}}>
+    <span class="loading loading-spinner bg-primary w-24 z-10"></span>
+    <div class="absolute top-0 bottom-0 left-0 right-0 bg-base-100 opacity-60"></div>
+  </div>
+{/if}
 
 <div class="flex flex-col justify-between min-h-full">
   <div class="flex flex-col flex-grow">

--- a/frontend/src/routes/+layout.svelte
+++ b/frontend/src/routes/+layout.svelte
@@ -24,8 +24,8 @@
     }
   }
 
-  let unhydrated = true;
-  onMount(() => unhydrated = false);
+  let hydrating = true;
+  onMount(() => hydrating = false);
 </script>
 
 <svelte:head>
@@ -38,7 +38,7 @@
   {/if}
 </svelte:head>
 
-<div class="flex flex-col justify-between min-h-full" class:unhydrated>
+<div class="flex flex-col justify-between min-h-full" class:hydrating>
   <div class="flex flex-col flex-grow">
     <slot />
   </div>

--- a/frontend/src/routes/+layout.svelte
+++ b/frontend/src/routes/+layout.svelte
@@ -12,7 +12,6 @@
   import { browser } from '$app/environment';
   import t from '$lib/i18n';
   import { onMount } from 'svelte';
-  import { blur } from 'svelte/transition';
 
   export let data: LayoutData;
   const { page, updated } = getStores();
@@ -39,14 +38,7 @@
   {/if}
 </svelte:head>
 
-{#if unhydrated}
-  <div class="fixed top-0 bottom-0 left-0 right-0 z-10 flex flex-col items-center justify-center" out:blur={{duration: 1000}}>
-    <span class="loading loading-spinner bg-primary w-24 z-10"></span>
-    <div class="absolute top-0 bottom-0 left-0 right-0 bg-base-100 opacity-60"></div>
-  </div>
-{/if}
-
-<div class="flex flex-col justify-between min-h-full">
+<div class="flex flex-col justify-between min-h-full" class:unhydrated>
   <div class="flex flex-col flex-grow">
     <slot />
   </div>


### PR DESCRIPTION
Resolves #347

Instead of explicitly making Playwright wait for hydration, it seemed more appropriate for the app to block user interaction before hydration.

I initially went for a minimal loading overlay (https://github.com/sillsdev/languageforge-lexbox/commit/5b79da9cd234df449502a04cbf48663ef0206813), which I included in the history, because it wasn't terrible.

But, it seemed so weird to cover up loaded HTML...

So, I transitioned to making things that tend to need hydration `visibility: hidden` and in cases where I know that it's a container (only a form so far), it's possible to add a "loading skeleton".

<details><summary>Out of date</summary>
<p>


https://github.com/sillsdev/languageforge-lexbox/assets/12587509/fb804cf6-f388-4792-82d7-10f26e78ab75

https://github.com/sillsdev/languageforge-lexbox/assets/12587509/24ec9992-1773-405a-a5c2-c987f01c1a83

</p>
</details> 

#### EDIT: new version (I just couldn't become friends with that weird huge gradient, so I transitioned to a simpler loading animation):

https://github.com/sillsdev/languageforge-lexbox/assets/12587509/ff683be4-63ff-4b75-bd3c-187a3d9a6230



![image](https://github.com/sillsdev/languageforge-lexbox/assets/12587509/5048edf5-762a-4c8b-975d-88204a29a00a)
