### PR TITLE
Test: 348 make Playwright detect 500s

### DIFF
--- a/backend/Testing/Browser/Base/PageTest.cs
+++ b/backend/Testing/Browser/Base/PageTest.cs
@@ -17,6 +17,11 @@ public class PageTest : IAsyncLifetime
     public IPage Page => _fixture.Page;
     public IBrowser Browser => _fixture.Browser;
     public IBrowserContext Context => _fixture.Context;
+    /// <summary>
+    /// Exceptions that are deferred until the end of the test, because they can't
+    /// be cleanly thrown in sub-threads.
+    /// </summary>
+    private List<UnexpectedResponseException> DeferredExceptions { get; } = new();
 
     public PageTest()
     {
@@ -26,6 +31,21 @@ public class PageTest : IAsyncLifetime
     public ILocatorAssertions Expect(ILocator locator) => Assertions.Expect(locator);
     public IPageAssertions Expect(IPage page) => Assertions.Expect(page);
     public IAPIResponseAssertions Expect(IAPIResponse response) => Assertions.Expect(response);
+    /// <summary>
+    /// Consumes a deferred exception that was "thrown" in a sub-thread, and returns it
+    /// or throws if no exception of the given type is found.
+    /// </summary>
+    public UnexpectedResponseException ExpectDeferredException()
+    {
+        var exception = DeferredExceptions.ShouldHaveSingleItem();
+        DeferredExceptions.Clear();
+        return exception;
+    }
+
+    public void ExpectNoDeferredExceptions()
+    {
+        DeferredExceptions.ShouldBeEmpty();
+    }
 
     public virtual async Task InitializeAsync()
     {
@@ -39,6 +59,14 @@ public class PageTest : IAsyncLifetime
                 Sources = true
             });
         }
+
+        Context.Response += (_, response) =>
+        {
+            if (response.Status >= (int)HttpStatusCode.InternalServerError)
+            {
+                DeferredExceptions.Add(new UnexpectedResponseException(response));
+            }
+        };
     }
 
     public virtual async Task DisposeAsync()
@@ -52,6 +80,11 @@ public class PageTest : IAsyncLifetime
         }
 
         await _fixture.DisposeAsync();
+
+        if (DeferredExceptions.Any())
+        {
+            throw new AggregateException(DeferredExceptions);
+        }
     }
 
     static readonly HttpClient HttpClient = new HttpClient();

--- a/backend/Testing/Browser/Base/UnexpectedResponseException.cs
+++ b/backend/Testing/Browser/Base/UnexpectedResponseException.cs
@@ -1,0 +1,23 @@
+using System.Text.RegularExpressions;
+using Microsoft.Playwright;
+
+namespace Testing.Browser.Base;
+
+public partial class UnexpectedResponseException : SystemException
+{
+    public static string MaskUrl(string url)
+    {
+        return JwtRegex().Replace(url, "*****");
+    }
+
+    public UnexpectedResponseException(IResponse response)
+    : this(response.StatusText, response.Status, response.Url)
+    {
+    }
+
+    public UnexpectedResponseException(string statusText, int statusCode, string url)
+    : base($"Unexpected response: {statusText} ({statusCode}). URL: {MaskUrl(url)}.") { }
+
+    [GeneratedRegex("[A-Za-z0-9-_]{10,}\\.[A-Za-z0-9-_]{20,}\\.[A-Za-z0-9-_]{10,}")]
+    private static partial Regex JwtRegex();
+}

--- a/backend/Testing/Browser/SandboxPageTests.cs
+++ b/backend/Testing/Browser/SandboxPageTests.cs
@@ -1,4 +1,4 @@
-﻿using Shouldly;
+﻿using Microsoft.Playwright;
 using Testing.Browser.Base;
 using Testing.Browser.Page;
 
@@ -8,16 +8,51 @@ namespace Testing.Browser;
 public class SandboxPageTests : PageTest
 {
     [Fact]
-    public async Task Goto500Works()
+    public async Task CatchGoto500InSameTab()
+    {
+
+        await new SandboxPage(Page).Goto();
+        await Page.RunAndWaitForResponseAsync(async () =>
+        {
+            await Page.GetByText("Goto 500 page").ClickAsync();
+        }, "/api/testing/test500NoException");
+        ExpectDeferredException();
+    }
+
+    [Fact]
+    public async Task CatchGoto500InNewTab()
     {
         await new SandboxPage(Page).Goto();
-        var request = await Page.RunAndWaitForRequestFinishedAsync(async () =>
+        await Context.RunAndWaitForPageAsync(async () =>
         {
-            await Page.GetByText("goto 500 page").ClickAsync();
+            await Page.GetByText("goto 500 new tab").ClickAsync();
         });
-        var response = await request.ResponseAsync();
-        response.ShouldNotBeNull();
-        response.Ok.ShouldBeFalse();
-        response.Status.ShouldBe(500);
+        ExpectDeferredException();
+    }
+
+    [Fact(Skip = "Playwright doesn't catch the document load request of pages opened with Ctrl+Click")]
+    public async Task CatchGoto500InNewTabWithCtrl()
+    {
+        await new SandboxPage(Page).Goto();
+        await Context.RunAndWaitForPageAsync(async () =>
+        {
+            await Page.GetByText("Goto 500 page").ClickAsync(new()
+            {
+                Modifiers = new[] { KeyboardModifier.Control },
+            });
+        });
+        ExpectDeferredException();
+    }
+
+    [Fact]
+    public async Task CatchFetch500()
+    {
+        await new SandboxPage(Page).Goto();
+        await Page.RunAndWaitForResponseAsync(async () =>
+        {
+            await Page.GetByText("Fetch 500").ClickAsync();
+        }, "/api/testing/test500NoException");
+        ExpectDeferredException();
+        await Expect(Page.Locator(".modal-box.bg-error:has-text('Internal Server Error (500)')")).ToBeVisibleAsync();
     }
 }

--- a/frontend/src/hooks.client.ts
+++ b/frontend/src/hooks.client.ts
@@ -63,11 +63,18 @@ function shouldTryAutoReload(updateDetected: boolean): boolean {
  */
 handleFetch(async ({ fetch, args }) => {
   const response = await traceFetch(() => fetch(...args));
+
   if (response.status === 401 && location.pathname !== '/login') {
     throw redirect(307, '/logout');
   }
+
+  if (response.status >= 500) {
+    throw new Error(`Unexpected response: ${response.statusText} (${response.status}). URL: ${response.url}.`);
+  }
+
   if (response.headers.get('lexbox-refresh-jwt') == 'true') {
     await invalidate(USER_LOAD_KEY);
   }
+
   return response;
 });

--- a/frontend/src/routes/(unauthenticated)/sandbox/+page.svelte
+++ b/frontend/src/routes/(unauthenticated)/sandbox/+page.svelte
@@ -5,11 +5,17 @@
   function uploadFinished(): void {
       alert('upload done!');
   }
+
+  async function fetch500(): Promise<Response> {
+    return fetch('/api/testing/test500NoException');
+  }
 </script>
 <div class="grid gap-2">
   <h2>Sandbox</h2>
   <div class="card w-96 bg-base-200 shadow-lg">
     <a rel="external" class="btn" href="/api/testing/test500NoException">Goto 500 page</a>
+    <a rel="external" target="_blank" class="btn" href="/api/testing/test500NoException">Goto 500 new tab</a>
+    <button class="btn" on:click={fetch500}>Fetch 500</button>
   </div>
   <div class="card w-96 bg-base-200 shadow-lg">
     <div class="card-body">


### PR DESCRIPTION
Resolves #348
Resolves #349

Status code handling is further improved in a draft PR (#357) that is waiting for this one to be merged.

Here's what the output looks like for the tests that were getting 500s. It's still a lot to parse, but at least there's a 500 in there:

<details><summary>EmailWorkflowTests.RegisterVerifyUpdateVerifyEmailAdress</summary>
<p>
[xUnit.net 00:00:40.47]     Testing.Browser.EmailWorkflowTests.RegisterVerifyUpdateVerifyEmailAdre
ss [FAIL]
  Failed Testing.Browser.EmailWorkflowTests.RegisterVerifyUpdateVerifyEmailAdress [37 s]
  Error Message:
   System.AggregateException : One or more errors occurred. (Timeout 30000ms exceeded.
=========================== logs ===========================
waiting for navigation to "/user" until "NetworkIdle"
============================================================) (One or more errors occurred. (Unexp
ected response: Internal Server Error (500). URL: http://localhost/api/login/verifyEmail?jwt=*****
&returnTo=%2Fuser%3FemailResult%3DverifiedEmail&email=54fb1b67-e426-4367-928a-f863514b1159@mailina
tor.com.))
---- System.TimeoutException : Timeout 30000ms exceeded.
=========================== logs ===========================
waiting for navigation to "/user" until "NetworkIdle"
============================================================
-------- System.TimeoutException : Timeout 30000ms exceeded.
---- System.AggregateException : One or more errors occurred. (Unexpected response: Internal Serve
r Error (500). URL: http://localhost/api/login/verifyEmail?jwt=*****&returnTo=%2Fuser%3FemailResul
t%3DverifiedEmail&email=54fb1b67-e426-4367-928a-f863514b1159@mailinator.com.)
-------- Testing.Browser.Base.UnexpectedResponseException : Unexpected response: Internal Server E
rror (500). URL: http://localhost/api/login/verifyEmail?jwt=*****&returnTo=%2Fuser%3FemailResult%3
DverifiedEmail&email=54fb1b67-e426-4367-928a-f863514b1159@mailinator.com.
  Stack Trace:

----- Inner Stack Trace #1 (System.TimeoutException) -----
   at Microsoft.Playwright.Core.Waiter.WaitForPromiseAsync[T](Task`1 task, Action dispose) in /_/s
rc/Playwright/Core/Waiter.cs:line 219
   at Microsoft.Playwright.Core.Frame.WaitForNavigationInternalAsync(Waiter waiter, String url, Fu
nc`2 urlFunc, Regex urlRegex, String urlString, Nullable`1 waitUntil) in /_/src/Playwright/Core/Fr
ame.cs:line 257
   at Microsoft.Playwright.Core.Frame.RunAndWaitForNavigationAsync(Func`1 action, FrameRunAndWaitF
orNavigationOptions options) in /_/src/Playwright/Core/Frame.cs:line 225
   at Testing.Browser.Page.BasePage`1.WaitFor() in D:\code\languageforge-lexbox\backend\Testing\Br
owser\Page\BasePage.cs:line 39
   at Testing.Browser.EmailWorkflowTests.RegisterVerifyUpdateVerifyEmailAdress() in D:\code\langua
geforge-lexbox\backend\Testing\Browser\EmailWorkflowTests.cs:line 31
   at Testing.Browser.EmailWorkflowTests.RegisterVerifyUpdateVerifyEmailAdress() in D:\code\langua
geforge-lexbox\backend\Testing\Browser\EmailWorkflowTests.cs:line 63
--- End of stack trace from previous location ---
----- Inner Stack Trace -----
   at Microsoft.Playwright.Helpers.TaskHelper.<>c__DisplayClass2_0.<WithTimeout>b__0() in /_/src/P
laywright/Helpers/TaskHelper.cs:line 73
   at Microsoft.Playwright.Helpers.TaskHelper.WithTimeout(Task task, Func`1 timeoutAction, TimeSpa
n timeout, CancellationToken cancellationToken) in /_/src/Playwright/Helpers/TaskHelper.cs:line 10
9
   at Microsoft.Playwright.Core.Waiter.WaitForPromiseAsync[T](Task`1 task, Action dispose) in /_/s
rc/Playwright/Core/Waiter.cs:line 211
----- Inner Stack Trace #2 (System.AggregateException) -----
   at Testing.Browser.Base.PageTest.DisposeAsync() in D:\code\languageforge-lexbox\backend\Testing
\Browser\Base\PageTest.cs:line 91
----- Inner Stack Trace -----
</p>
</details>

<details><summary>EmailWorkflowTests.ForgotPassword</summary>
<p>
[xUnit.net 00:00:43.78]     Testing.Browser.EmailWorkflowTests.ForgotPassword [FAIL]
  Failed Testing.Browser.EmailWorkflowTests.ForgotPassword [40 s]
  Error Message:
   System.AggregateException : One or more errors occurred. (response.Status
    should be
200
    but was
403

Additional Info:
    code was 403 (Forbidden)) (One or more errors occurred. (Unexpected response: Internal Server
Error (500). URL: http://localhost/api/login/resetPassword.))
---- Shouldly.ShouldAssertException : response.Status
    should be
200
    but was
403

Additional Info:
    code was 403 (Forbidden)
---- System.AggregateException : One or more errors occurred. (Unexpected response: Internal Serve
r Error (500). URL: http://localhost/api/login/resetPassword.)
-------- Testing.Browser.Base.UnexpectedResponseException : Unexpected response: Internal Server E
rror (500). URL: http://localhost/api/login/resetPassword.
  Stack Trace:

----- Inner Stack Trace #1 (Shouldly.ShouldAssertException) -----
   at Testing.Browser.Util.HttpUtils.ExecuteGql(IPage page, String gql, Boolean expectGqlError) in
 D:\code\languageforge-lexbox\backend\Testing\Browser\Util\HttpUtils.cs:line 16
   at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()
   at System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess(Task task)
   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task tas
k)
   at System.Runtime.CompilerServices.TaskAwaiter`1.GetResult()
   at Testing.Browser.Page.TempUserDashboardPage.DisposeAsync() in D:\code\languageforge-lexbox\ba
ckend\Testing\Browser\Page\TempUserDashboardPage.cs:line 17
   at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()
   at System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess(Task task)
   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task tas
k)
   at Testing.Browser.EmailWorkflowTests.ForgotPassword() in D:\code\languageforge-lexbox\backend\
Testing\Browser\EmailWorkflowTests.cs:line 96
   at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()
   at System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess(Task task)
   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task tas
k)
--- End of stack trace from previous location ---
   at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()
   at System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess(Task task)
   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task tas
k)
   at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()
   at System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess(Task task)
   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task tas
k)
----- Inner Stack Trace #2 (System.AggregateException) -----
   at Testing.Browser.Base.PageTest.DisposeAsync() in D:\code\languageforge-lexbox\backend\Testing
\Browser\Base\PageTest.cs:line 91
----- Inner Stack Trace -----
</p>
</details>

Here's the error dialog that will now be shown if "Reset password" gets a 500 response:
![image](https://github.com/sillsdev/languageforge-lexbox/assets/12587509/87ef619a-17db-4fef-a24b-9fa7884466cc)
