### PR TITLE
Log error trace-IDs in .NET

### DIFF
--- a/backend/LexBoxApi/Auth/JwtTicketDataFormat.cs
+++ b/backend/LexBoxApi/Auth/JwtTicketDataFormat.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics;
 using System.Globalization;
 using System.IdentityModel.Tokens.Jwt;
 using System.Security.Claims;
@@ -131,7 +132,8 @@ public class JwtTicketDataFormat : ISecureDataFormat<AuthenticationTicket>
             }
             catch (Exception e)
             {
-                _logger.LogError(e, "Error validating token");
+                var traceId = Activity.Current?.TraceId;
+                _logger.LogError(e, "Error validating token. Trace ID: {TraceID}.", traceId);
             }
         }
 

--- a/backend/LexBoxApi/GraphQL/ErrorLoggingDiagnosticsEventListener.cs
+++ b/backend/LexBoxApi/GraphQL/ErrorLoggingDiagnosticsEventListener.cs
@@ -72,17 +72,17 @@ public class ErrorLoggingDiagnosticsEventListener : ExecutionDiagnosticEventList
 
     private void LogError(IError error, [CallerMemberName] string source = "")
     {
-        log.LogError(error.Exception, "{Source}: {Message}", source, error.Message);
-        TraceError(error, source);
+        var traceId = TraceError(error, source);
+        log.LogError(error.Exception, "{Source}: {Message}. Trace ID: {TraceId}.", source, error.Message, traceId);
     }
 
     private void LogException(Exception exception, [CallerMemberName] string source = "")
     {
-        log.LogError(exception, "{Source}: {Message}", source, exception.Message);
-        TraceException(exception, source);
+        var traceId = TraceException(exception, source);
+        log.LogError(exception, "{Source}: {Message}. Trace ID: {TraceId}.", source, exception.Message, traceId);
     }
 
-    private void TraceError(IError error, string source)
+    private ActivityTraceId? TraceError(IError error, string source)
     {
         if (error.Exception != null)
         {
@@ -96,9 +96,10 @@ public class ErrorLoggingDiagnosticsEventListener : ExecutionDiagnosticEventList
                 ["error.code"] = error.Code,
             }));
         }
+        return Activity.Current?.TraceId;
     }
 
-    private void TraceException(Exception exception, string source)
+    private ActivityTraceId? TraceException(Exception exception, string source)
     {
         Activity.Current?
             .SetStatus(ActivityStatusCode.Error)
@@ -112,5 +113,7 @@ public class ErrorLoggingDiagnosticsEventListener : ExecutionDiagnosticEventList
         {
             TraceException(exception.InnerException, $"{source} - Inner");
         }
+
+        return Activity.Current?.TraceId;
     }
 }

--- a/backend/LexBoxApi/Services/HgService.cs
+++ b/backend/LexBoxApi/Services/HgService.cs
@@ -187,7 +187,8 @@ public class HgService : IHgService
         var output = await process.StandardOutput.ReadToEndAsync(cancellationToken);
         var description =
             $"rsync for project {project.Code} failed with exit code {process.ExitCode}. Error: {error}. Output: {output}";
-        _logger.LogError(description);
+        var traceId = Activity.Current?.TraceId;
+        _logger.LogError("{description}. Trace ID: {TraceId}.", description, traceId);
         activity?.SetStatus(ActivityStatusCode.Error, description);
         return false;
     }

--- a/backend/SyncReverseProxy/ForwarderTelemetryConsumer.cs
+++ b/backend/SyncReverseProxy/ForwarderTelemetryConsumer.cs
@@ -91,7 +91,8 @@ public class ForwarderTelemetryConsumer : IForwarderTelemetryConsumer
 
     public void OnForwarderFailed(DateTime timestamp, ForwarderError error)
     {
-        _logger.LogError("Forwarder Failed: {Error}", error.ToString());
+        var traceId = Activity.Current?.TraceId;
+        _logger.LogError("Forwarder Failed: {Error}. Trace ID: {TraceID}.", error.ToString(), traceId);
         Activity.Current?.SetStatus(ActivityStatusCode.Error, "Forwarder failed: " + error.ToString());
         Activity.Current?.AddEvent(new("Forwarder failed", timestamp));
     }


### PR DESCRIPTION
I realized that it's often not easy to map an error log to a trace, so it makes sense to try to include trace-IDs in our error logs.

This PR does that for .NET code.
I made the change for node code in #357 (which was admittedly somewhat inappropriate, but minimal).