### PR TITLE
enable logging trace id to console in .NET

### DIFF
--- a/backend/LexBoxApi/Program.cs
+++ b/backend/LexBoxApi/Program.cs
@@ -27,6 +27,7 @@ if (DevGqlSchemaWriterService.IsSchemaGenerationRequest(args))
 }
 
 var builder = WebApplication.CreateBuilder(args);
+builder.Logging.Configure(options => options.ActivityTrackingOptions = ActivityTrackingOptions.TraceId);
 builder.Host.UseConsoleLifetime();
 builder.WebHost.UseKestrel(o =>
 {

--- a/backend/LexBoxApi/appsettings.json
+++ b/backend/LexBoxApi/appsettings.json
@@ -1,5 +1,11 @@
 {
   "Logging": {
+    "Console": {
+      "FormatterName": "simple",
+      "FormatterOptions": {
+        "IncludeScopes": true
+      }
+    },
     "LogLevel": {
       "Default": "Information",
       "LexBoxApi": "Information",


### PR DESCRIPTION
ensures that we always log the trace id to console when relevant

example output:
```
info: Microsoft.AspNetCore.Hosting.Diagnostics[1]
      => TraceId:4b2f3f89c012b65368eaa39e378c78bf => ConnectionId:0HMV0RGDNJRM9 => RequestPath:/api/login RequestId:0HMV0RGDNJRM9:00000001
      Request starting HTTP/1.1 POST http://localhost:3000/api/login application/json 115
```