### PR TITLE
Fix: Bug/375 admin edit user requires a password and defaults to the password being the string undefined

### DIFF
--- a/frontend/src/lib/components/modals/FormModal.svelte
+++ b/frontend/src/lib/components/modals/FormModal.svelte
@@ -30,7 +30,7 @@
 
 
   export async function open(
-    value: Partial<FormType> | undefined,  //eslint-disable-line @typescript-eslint/no-redundant-type-constituents
+    value: FormType | undefined,  //eslint-disable-line @typescript-eslint/no-redundant-type-constituents
     onSubmit: SubmitCallback
   ): Promise<FormModalResult<Schema>>;
   export async function open(onSubmit: SubmitCallback): Promise<FormModalResult<Schema>>;

--- a/frontend/src/lib/components/modals/FormModal.svelte
+++ b/frontend/src/lib/components/modals/FormModal.svelte
@@ -41,6 +41,8 @@
     const onSubmit = _onSubmit ?? (valueOrOnSubmit as SubmitCallback);
     const value = _onSubmit ? (valueOrOnSubmit as Partial<FormType>) : undefined;
 
+    reset();
+
     if (value) _form.set(value, { taint: false });
 
     const response = await openModal(onSubmit);

--- a/frontend/src/lib/forms/utils.ts
+++ b/frontend/src/lib/forms/utils.ts
@@ -16,3 +16,7 @@ export function passwordFormRules($t: Translater): z.ZodString {
     .min(4, $t('form.password.too_short'))
     .regex(/^[^&%+]+$/, $t('form.password.forbidden_characters'));
 }
+
+export function emptyString(): z.ZodString {
+  return z.string().length(0);
+}

--- a/frontend/src/lib/i18n/locales/en.json
+++ b/frontend/src/lib/i18n/locales/en.json
@@ -34,7 +34,7 @@
       "title": "Edit User",
       "email_label": "Email",
       "name_label": "Display name",
-      "password_label": "Password",
+      "password_label": "Change User Password",
       "update_user": "Update User",
       "lock": "Lock User",
       "unlock": "Unlock User",

--- a/frontend/src/routes/(authenticated)/admin/EditUserAccount.svelte
+++ b/frontend/src/routes/(authenticated)/admin/EditUserAccount.svelte
@@ -9,7 +9,7 @@
   import t from '$lib/i18n';
   import type { FormModalResult } from '$lib/components/modals/FormModal.svelte';
   import { Button, SystemRoleSelect } from '$lib/forms';
-  import { passwordFormRules } from '$lib/forms/utils';
+  import { emptyString, passwordFormRules } from '$lib/forms/utils';
   import {hash} from '$lib/util/hash';
 
   export let currUser: LexAuthUser;
@@ -18,7 +18,7 @@
   const schema = z.object({
     email: z.string().email(),
     name: z.string(),
-    password: passwordFormRules($t).optional(),
+    password: passwordFormRules($t).or(emptyString()),
     role: z.enum([UserRole.User, UserRole.Admin]),
   });
   type Schema = typeof schema;
@@ -33,7 +33,7 @@
   export async function openModal(user: User): Promise<FormModalResult<Schema>> {
     _user = user;
     const role = user.isAdmin ? UserRole.Admin : UserRole.User;
-    return await formModal.open({ name: user.name, email: user.email, role }, async () => {
+    return await formModal.open({ name: user.name, email: user.email, role, password: '' }, async () => {
       const { error, data } = await _changeUserAccountByAdmin({
         userId: user.id,
         email: $form.email,

--- a/frontend/src/routes/(authenticated)/project/[project_code]/ChangeMemberRoleModal.svelte
+++ b/frontend/src/routes/(authenticated)/project/[project_code]/ChangeMemberRoleModal.svelte
@@ -10,7 +10,7 @@
   export let projectId: string;
 
   const schema = z.object({
-    role: z.enum([ProjectRole.Editor, ProjectRole.Manager]).default(ProjectRole.Editor),
+    role: z.enum([ProjectRole.Editor, ProjectRole.Manager]),
   });
   type Schema = typeof schema;
   let formModal: FormModal<Schema>;


### PR DESCRIPTION
Resolves #375 

For some reason the super-form defaults sort of blow up when we call form.set().
They also blow up without that if the schema type for the field is "slightly" complicated. 🤷 

It's just all a tad fragile. So, in general it's safest to (1) force all form fields to have an initial value and (2) use `.or(emptyString())` instead of `optional()`. Which has advantages and perhaps also minor disadvantages.

I tried out the ChangeMemberRoleModal change and if `tryParse` fails for some reason, the behaviour is the same as before: Editor is selected by default and submitting successfully sets the role to editor.