### PR TITLE
remove projects from admin jwt

### DIFF
--- a/backend/LexBoxApi/GraphQL/LexQueries.cs
+++ b/backend/LexBoxApi/GraphQL/LexQueries.cs
@@ -14,8 +14,8 @@ public class LexQueries
     [UseSorting]
     public IQueryable<Project> MyProjects(LoggedInContext loggedInContext, LexBoxDbContext context)
     {
-        var projectCodes = loggedInContext.User.Projects.Select(p => p.Code);
-        return context.Projects.Where(p => projectCodes.Contains(p.Code));
+        var userId = loggedInContext.User.Id;
+        return context.Projects.Where(p => p.Users.Select(u => u.UserId).Contains(userId));
     }
 
     [UseProjection]

--- a/backend/LexBoxApi/Services/MySqlMigrationService.cs
+++ b/backend/LexBoxApi/Services/MySqlMigrationService.cs
@@ -89,6 +89,11 @@ public class MySqlMigrationService
                 user.IsAdmin = true;
             }
 
+            if (user.LastActive < rmUser.LastLoginOn)
+            {
+                user.LastActive = rmUser.LastLoginOn?.ToUniversalTime() ?? default(DateTimeOffset);
+            }
+
             if (!user.CanCreateProjects && userProjects.Any(p => p.Role == ProjectRole.Manager))
             {
                 user.CanCreateProjects = true;

--- a/backend/LexCore/Auth/LexAuthUser.cs
+++ b/backend/LexCore/Auth/LexAuthUser.cs
@@ -80,7 +80,9 @@ public record LexAuthUser
         Email = user.Email;
         Role = user.IsAdmin ? UserRole.admin : UserRole.user;
         Name = user.Name;
-        Projects = user.Projects.Select(p => new AuthUserProject(p.Project.Code, p.Role, p.ProjectId)).ToArray();
+        Projects = user.IsAdmin
+            ? Array.Empty<AuthUserProject>()
+            : user.Projects.Select(p => new AuthUserProject(p.Project.Code, p.Role, p.ProjectId)).ToArray();
         EmailVerificationRequired = user.EmailVerified ? null : true;
         CanCreateProjects = user.CanCreateProjects ? true : null;
     }

--- a/backend/Testing/ApiTests/HeaderTests.cs
+++ b/backend/Testing/ApiTests/HeaderTests.cs
@@ -1,0 +1,37 @@
+﻿using System.Net;
+using Shouldly;
+
+namespace Testing.ApiTests;
+
+public class HeaderTests : ApiTestBase
+{
+    public HeaderTests()
+    {
+    }
+
+    [Fact]
+    public async Task CheckCloudflareHeaderSizeLimit()
+    {
+        //from testing done in November 2023, we started getting errors at 10,225 chars
+        int headerSize = 10210;
+
+        var response = await HttpClient.SendAsync(
+            new HttpRequestMessage(HttpMethod.Get, "https://staging.languagedepot.org/api/healthz")
+            {
+                Headers = { { "test", RandomString(headerSize) } }
+            });
+        response.StatusCode.ShouldBe(HttpStatusCode.OK, $"header size: {headerSize}");
+    }
+
+    private string RandomString(int length)
+    {
+        const string chars = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
+        Span<char> randomArray = stackalloc char[length];
+        for (int i = 0; i < length; i++)
+        {
+            randomArray[i] = chars[Random.Shared.Next(chars.Length)];
+        }
+
+        return new string(randomArray);
+    }
+}

--- a/backend/Testing/LexCore/LexAuthUserTests.cs
+++ b/backend/Testing/LexCore/LexAuthUserTests.cs
@@ -37,7 +37,7 @@ public class LexAuthUserTests
         var idClaim = new Claim(LexAuthConstants.IdClaimType, _user.Id.ToString());
         var emailClaim = new Claim(LexAuthConstants.EmailClaimType, _user.Email);
         var roleClaim = new Claim(LexAuthConstants.RoleClaimType, _user.Role.ToString());
-        var projectClaim = new Claim("proj", JsonSerializer.Serialize(_user.Projects[0]));
+        var projectClaim = new Claim("proj", _user.ProjectsJson);
         claims.ShouldSatisfyAllConditions(
             () => claims.ShouldContain(idClaim.ToString()),
             () => claims.ShouldContain(emailClaim.ToString()),
@@ -51,7 +51,7 @@ public class LexAuthUserTests
     {
         var claims = _user.GetPrincipal("Testing");
         var newUser = LexAuthUser.FromClaimsPrincipal(claims);
-        _user.ShouldBeEquivalentTo(newUser);
+        newUser.ShouldBeEquivalentTo(_user);
     }
 
     [Fact]
@@ -63,7 +63,7 @@ public class LexAuthUserTests
         var outputJwt = tokenHandler.ReadJwtToken(encodedJwt);
         var principal = new ClaimsPrincipal(new ClaimsIdentity(outputJwt.Claims, "Testing"));
         var newUser = LexAuthUser.FromClaimsPrincipal(principal);
-        _user.ShouldBeEquivalentTo(newUser);
+        newUser.ShouldBeEquivalentTo(_user);
     }
 
     [Fact]
@@ -96,5 +96,27 @@ public class LexAuthUserTests
         var principal = new ClaimsPrincipal(new ClaimsIdentity(outputJwt.Claims, "Testing"));
         var newUser = LexAuthUser.FromClaimsPrincipal(principal);
         _user.ShouldBeEquivalentTo(newUser);
+    }
+
+    //from testing done in November 2023, we started getting errors at 10,225 chars
+    private const int MaxJwtLength = 9000;
+
+    [Fact]
+    public void CheckingJwtLength()
+    {
+        var user = _user with { Projects = Array.Empty<AuthUserProject>() };
+        var projectCode = new string(Enumerable.Range(0, 15).Select(i => (char)('a' + i)).ToArray());
+        for (int projectCount = 0; projectCount < 170; projectCount++)
+        {
+            user = user with
+            {
+                Projects = Enumerable.Range(0, projectCount).Select(i =>
+                    new AuthUserProject(projectCode,
+                        i % 2 == 0 ? ProjectRole.Manager : ProjectRole.Editor,
+                        Guid.NewGuid())).ToArray()
+            };
+            var (jwt, _) = _lexAuthService.GenerateJwt(user);
+            jwt.Length.ShouldBeLessThan(MaxJwtLength, $"project count: {projectCount}, valid size {projectCount - 1}");
+        }
     }
 }

--- a/backend/Testing/LexCore/LexAuthUserTests.cs
+++ b/backend/Testing/LexCore/LexAuthUserTests.cs
@@ -37,7 +37,7 @@ public class LexAuthUserTests
         var idClaim = new Claim(LexAuthConstants.IdClaimType, _user.Id.ToString());
         var emailClaim = new Claim(LexAuthConstants.EmailClaimType, _user.Email);
         var roleClaim = new Claim(LexAuthConstants.RoleClaimType, _user.Role.ToString());
-        var projectClaim = new Claim("proj", _user.ProjectsJson);
+        var projectClaim = new Claim("proj", JsonSerializer.Serialize(_user.Projects[0]));
         claims.ShouldSatisfyAllConditions(
             () => claims.ShouldContain(idClaim.ToString()),
             () => claims.ShouldContain(emailClaim.ToString()),
@@ -106,7 +106,7 @@ public class LexAuthUserTests
     {
         var user = _user with { Projects = Array.Empty<AuthUserProject>() };
         var projectCode = new string(Enumerable.Range(0, 15).Select(i => (char)('a' + i)).ToArray());
-        for (int projectCount = 0; projectCount < 170; projectCount++)
+        for (int projectCount = 0; projectCount < 60; projectCount++)
         {
             user = user with
             {


### PR DESCRIPTION
starts working on avoiding header limits, for now just removes projects from admin jwt so they can login. related to #387 