### PR TITLE
Put fetch errors in fetch trace and standardize

### DIFF
--- a/frontend/src/hooks.client.ts
+++ b/frontend/src/hooks.client.ts
@@ -62,11 +62,15 @@ function shouldTryAutoReload(updateDetected: boolean): boolean {
  * This is obviously NOT a SvelteKit handler/feature. It just mimics the `handleFetch` in hooks.server.ts.
  */
 handleFetch(async ({ fetch, args }) => {
-  const response = await traceFetch(() => fetch(...args));
+  const response = await traceFetch(async () => {
+    const response = await fetch(...args);
 
-  validateFetchResponse(response,
-    location.pathname === '/login',
-    location.pathname === '/' || location.pathname === '/home' || location.pathname === '/admin');
+    validateFetchResponse(response,
+      location.pathname === '/login',
+      location.pathname === '/' || location.pathname === '/home' || location.pathname === '/admin');
+
+    return response;
+  });
 
   if (response.headers.get('lexbox-refresh-jwt') == 'true') {
     await invalidate(USER_LOAD_KEY);

--- a/frontend/src/hooks.server.ts
+++ b/frontend/src/hooks.server.ts
@@ -63,7 +63,7 @@ export const handleFetch: HandleFetch = async ({ event, request, fetch }) => {
       routeId.endsWith(AUTHENTICATED_ROOT) || routeId.endsWith('/home') || routeId.endsWith('/admin'));
 
     return response;
-  });
+  }, event);
 
   if (response.headers.has('lexbox-version')) {
     apiVersion.value = response.headers.get('lexbox-version');

--- a/frontend/src/hooks.server.ts
+++ b/frontend/src/hooks.server.ts
@@ -54,15 +54,20 @@ export const handleFetch: HandleFetch = async ({ event, request, fetch }) => {
     console.log('Skipping cookie forwarding for non-backend request', request.url);
   }
 
-  const response = await traceFetch(request, () => fetch(request));
+  const response = await traceFetch(request, async () => {
+    const response = await fetch(request);
+
+    const routeId = event.route.id ?? '';
+    validateFetchResponse(response,
+      routeId.endsWith('/login'),
+      routeId.endsWith(AUTHENTICATED_ROOT) || routeId.endsWith('/home') || routeId.endsWith('/admin'));
+
+    return response;
+  });
+
   if (response.headers.has('lexbox-version')) {
     apiVersion.value = response.headers.get('lexbox-version');
   }
-
-  const routeId = event.route.id ?? '';
-  validateFetchResponse(response,
-    routeId.endsWith('/login'),
-    routeId.endsWith(AUTHENTICATED_ROOT) || routeId.endsWith('/home') || routeId.endsWith('/admin'));
 
   return response;
 };

--- a/frontend/src/lib/gql/types.ts
+++ b/frontend/src/lib/gql/types.ts
@@ -1,4 +1,5 @@
 import { isObjectWhere } from '$lib/util/types';
+import type {Operation} from '@urql/core';
 
 export * from './generated/graphql';
 
@@ -50,4 +51,10 @@ export class LexGqlError<Typename extends string> {
     const codeErrors = this.errors.filter(error => error.__typename == typename) as GqlInputError<T>[];
     return codeErrors.length > 0 ? codeErrors : undefined;
   }
+}
+
+export function getOperationName(operation: Operation): string| undefined {
+  const def = operation.query.definitions[0];
+  if ('name' in def) return  def.name?.value;
+  return undefined;
 }

--- a/frontend/src/lib/otel/otel.server.ts
+++ b/frontend/src/lib/otel/otel.server.ts
@@ -14,7 +14,7 @@ import { OTLPTraceExporter } from '@opentelemetry/exporter-trace-otlp-http';
 import { Resource } from '@opentelemetry/resources';
 import { NodeSDK } from '@opentelemetry/sdk-node';
 import { SemanticAttributes, SemanticResourceAttributes } from '@opentelemetry/semantic-conventions';
-import type { MaybePromise, RequestEvent } from '@sveltejs/kit';
+import type { MaybePromise, RequestEvent, NavigationEvent } from '@sveltejs/kit';
 import {
   traceFetch as _traceFetch,
   traceEventAttributes,
@@ -92,6 +92,7 @@ async function traceResponse(
 export async function traceFetch(
     request: Request,
     fetch: () => Promise<Response>,
+    event?: RequestEvent | NavigationEvent | Event
 ): Promise<Response> {
   return _traceFetch(() => tracer()
       .startActiveSpan(`${request.method} ${request.url}`, async (span) => {
@@ -107,7 +108,7 @@ export async function traceFetch(
         } finally {
           span.end();
         }
-      }));
+      }), event);
 }
 
 function traceResponseAttributes(span: Span, response: Response): void {

--- a/frontend/src/lib/otel/otel.server.ts
+++ b/frontend/src/lib/otel/otel.server.ts
@@ -16,6 +16,7 @@ import { NodeSDK } from '@opentelemetry/sdk-node';
 import { SemanticAttributes, SemanticResourceAttributes } from '@opentelemetry/semantic-conventions';
 import type { MaybePromise, RequestEvent } from '@sveltejs/kit';
 import {
+  traceFetch as _traceFetch,
   traceEventAttributes,
   traceHeaders,
   SERVICE_NAME,
@@ -92,13 +93,13 @@ export async function traceFetch(
     request: Request,
     fetch: () => Promise<Response>,
 ): Promise<Response> {
-  return tracer()
+  return _traceFetch(() => tracer()
       .startActiveSpan(`${request.method} ${request.url}`, async (span) => {
         try {
           span.setAttributes({
             [SemanticAttributes.HTTP_METHOD]: request.method,
             [SemanticAttributes.HTTP_TARGET]: request.url,
-          })
+          });
           traceHeaders(span, 'request', request.headers);
           const traceparent = buildTraceparent(span);
           request.headers.set('Traceparent', traceparent);
@@ -106,7 +107,7 @@ export async function traceFetch(
         } finally {
           span.end();
         }
-      });
+      }));
 }
 
 function traceResponseAttributes(span: Span, response: Response): void {

--- a/frontend/src/lib/otel/otel.shared.ts
+++ b/frontend/src/lib/otel/otel.shared.ts
@@ -16,6 +16,7 @@ import { isTraced, type TraceId, isTraceable, traceIt } from './types';
 import {makeOperation, type Exchange, mapExchange, type OperationContext} from '@urql/svelte';
 import { browser } from '$app/environment';
 import { isRedirect } from '$lib/util/types';
+import {getOperationName} from '$lib/gql/types';
 
 export const SERVICE_NAME = browser ? 'LexBox-SvelteKit-Client' : 'LexBox-SvelteKit-Server';
 
@@ -267,10 +268,11 @@ function getOpContextSpan(context: OperationContext): Span | undefined {
 
 export const tracingExchange: Exchange = mapExchange({
   onOperation: (operation) => {
-    const operationSpan = tracer().startSpan(`operation ${operation.kind}`, {
+    const operationName = getOperationName(operation);
+    const operationSpan = tracer().startSpan(`${operation.kind} ${operationName ?? ''}`, {
       attributes: { 'graphql.operation.kind': operation.kind }
     });
-
+    if (operationName) operationSpan.setAttribute('graphql.operation.name', operationName);
     const operationSpanContext = trace.setSpan(context.active(), operationSpan);
     const opContext = {
       ...operation.context,

--- a/frontend/src/lib/user.ts
+++ b/frontend/src/lib/user.ts
@@ -3,7 +3,7 @@ import { redirect, type Cookies } from '@sveltejs/kit'
 import jwtDecode from 'jwt-decode'
 import { deleteCookie, getCookie } from './util/cookies'
 import {hash} from '$lib/util/hash';
-import { ensureErrorIsTraced } from './otel'
+import { ensureErrorIsTraced, errorSourceTag } from './otel'
 
 type RegisterResponseErrors = {
   errors: {
@@ -110,8 +110,7 @@ export function getUser(cookies: Cookies): LexAuthUser | null {
     return jwtToUser(jwtDecode<JwtTokenUser>(token));
   } catch (error) {
     const traceId = ensureErrorIsTraced(error, undefined, {
-      'app.error.source': 'jwt-decode-error',
-      'app.environment': browser ? 'browser' : 'server',
+      'app.error.source': errorSourceTag('jwt-decode'),
     });
     console.error(error, `Trace ID: ${traceId}.`);
     return null;


### PR DESCRIPTION
Resolves #384 

## Tested using the the "FETCH 500" button on /sandbox

### [Before](https://ui.honeycomb.io/sil-language-forge/environments/test/trace/qRSMourhizj?fields[]=s_name&fields[]=s_serviceName&span=fb2271e252253d6f)
![image](https://github.com/sillsdev/languageforge-lexbox/assets/12587509/3d761e8e-5f66-433b-9816-555d732174c6)

### [After](https://ui.honeycomb.io/sil-language-forge/environments/test/trace/ziiBBH112Er?fields[]=s_serviceName&fields[]=s_name&span=faa51942fdba06fb)
![image](https://github.com/sillsdev/languageforge-lexbox/assets/12587509/92d2d490-b70b-4ba7-8e7f-910dff06afa9)

As can be seen in the change set, I also further standardized how we tag errors and trace fetches.