### PR TITLE
Make integration test failures visible

### DIFF
--- a/.github/workflows/integration-test.yaml
+++ b/.github/workflows/integration-test.yaml
@@ -15,7 +15,6 @@ on:
 
 jobs:
   test:
-    continue-on-error: true
     timeout-minutes: 60
     concurrency: test-${{ inputs.test-domain }}
     name: Test ${{ matrix.os }} on ${{ inputs.test-domain }}

--- a/.github/workflows/release-pipeline.yaml
+++ b/.github/workflows/release-pipeline.yaml
@@ -68,7 +68,8 @@ jobs:
     name: Deploy Production
     uses: ./.github/workflows/deploy.yaml
     needs: [ integration-tests, set-version ]
-    if: always()
+    # we want to allow deployment even if some tests fail because they are currently flaky
+    if: ${{ needs.integration-tests.result == 'success' || needs.integration-tests.result == 'failure' }}
     secrets: inherit
     with:
       version: ${{ needs.set-version.outputs.version }}

--- a/.github/workflows/release-pipeline.yaml
+++ b/.github/workflows/release-pipeline.yaml
@@ -68,6 +68,7 @@ jobs:
     name: Deploy Production
     uses: ./.github/workflows/deploy.yaml
     needs: [ integration-tests, set-version ]
+    if: always()
     secrets: inherit
     with:
       version: ${{ needs.set-version.outputs.version }}


### PR DESCRIPTION
`continue-on-error: true` seems to mean that integration tests are always green.
- E.g. https://github.com/sillsdev/languageforge-lexbox/actions/runs/6903751246/job/18783194648
- https://stackoverflow.com/questions/62045967/is-there-a-way-to-continue-on-error-while-still-getting-correct-feedback

I expect that this change will make it possible to always (admittedly a bit more often than we really want) deploy to prod without hiding test failures.