### PR TITLE
put jwt on a diet

### DIFF
--- a/backend/LexBoxApi/Auth/LexAuthService.cs
+++ b/backend/LexBoxApi/Auth/LexAuthService.cs
@@ -138,7 +138,7 @@ public class LexAuthService
                 SecurityAlgorithms.HmacSha256
             )
         );
-        JwtTicketDataFormat.FixUpProjectClaims(jwt);
+        JwtTicketDataFormat.FixUpArrayClaims(jwt);
         var token = handler.WriteToken(jwt);
         return (token, tokenLifetime);
     }

--- a/backend/LexBoxApi/Auth/LoggedInContext.cs
+++ b/backend/LexBoxApi/Auth/LoggedInContext.cs
@@ -4,16 +4,15 @@ namespace LexBoxApi.Auth;
 
 public class LoggedInContext : IDisposable
 {
-    private readonly Lazy<LexAuthUser> _user;
+    private readonly Lazy<LexAuthUser?> _user;
 
     public LoggedInContext(IHttpContextAccessor httpContextAccessor)
     {
-        _user = new Lazy<LexAuthUser>(() =>
+        _user = new Lazy<LexAuthUser?>(() =>
         {
             var claimsPrincipal = httpContextAccessor.HttpContext?.User;
-            if (claimsPrincipal is null) throw new Exception("User is not logged in");
+            if (claimsPrincipal is null) return null;
             var user = LexAuthUser.FromClaimsPrincipal(claimsPrincipal);
-            if (user is null) throw new Exception("User is not logged in");
             return user;
         });
     }
@@ -25,7 +24,8 @@ public class LoggedInContext : IDisposable
         _disposed
             ? throw new ObjectDisposedException(nameof(LoggedInContext),
                 "this context has been disposed because the request that created it has finished")
-            : _user.Value;
+            : _user.Value ?? throw new Exception("User is not logged in");
+    public LexAuthUser? MaybeUser => _user.Value;
 
     private bool _disposed;
 

--- a/backend/LexBoxApi/Controllers/ProjectController.cs
+++ b/backend/LexBoxApi/Controllers/ProjectController.cs
@@ -15,14 +15,14 @@ public class ProjectController : ControllerBase
     private readonly ProjectService _projectService;
     private readonly LexBoxDbContext _lexBoxDbContext;
     private readonly IHgService _hgService;
-    private readonly LoggedInContext _loggedInContext;
+    private readonly IPermissionService _permissionService;
 
-    public ProjectController(ProjectService projectService, IHgService hgService, LexBoxDbContext lexBoxDbContext, LoggedInContext loggedInContext)
+    public ProjectController(ProjectService projectService, IHgService hgService, LexBoxDbContext lexBoxDbContext, IPermissionService permissionService)
     {
         _projectService = projectService;
         _hgService = hgService;
         _lexBoxDbContext = lexBoxDbContext;
-        _loggedInContext = loggedInContext;
+        _permissionService = permissionService;
     }
 
     [HttpPost("refreshProjectLastChanged")]
@@ -108,15 +108,13 @@ public class ProjectController : ControllerBase
         return project;
     }
 
-
-
     [HttpGet("awaitMigrated")]
     [ProducesResponseType(StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status401Unauthorized)]
     [ProducesDefaultResponseType]
     public async Task<ActionResult<bool>> AwaitMigrated(string projectCode)
     {
-        if (!_loggedInContext.User.CanAccessProject(projectCode))
+        if (!await _permissionService.CanAccessProject(projectCode))
             return Unauthorized();
 
         var token = CancellationTokenSource.CreateLinkedTokenSource(

--- a/backend/LexBoxApi/GraphQL/GraphQlSetupKernel.cs
+++ b/backend/LexBoxApi/GraphQL/GraphQlSetupKernel.cs
@@ -28,6 +28,7 @@ public static class GraphQlSetupKernel
             .RegisterService<LoggedInContext>()
             .RegisterService<EmailService>()
             .RegisterService<LexAuthService>()
+            .RegisterService<IPermissionService>()
             .AddDataAnnotationsValidator()
             .AddSorting(descriptor =>
             {

--- a/backend/LexBoxApi/GraphQL/LexQueries.cs
+++ b/backend/LexBoxApi/GraphQL/LexQueries.cs
@@ -1,6 +1,7 @@
 using LexBoxApi.Auth;
 using LexCore.Auth;
 using LexCore.Entities;
+using LexCore.ServiceInterfaces;
 using LexData;
 using Microsoft.EntityFrameworkCore;
 
@@ -36,9 +37,9 @@ public class LexQueries
 
     [UseSingleOrDefault]
     [UseProjection]
-    public IQueryable<Project> ProjectByCode(LexBoxDbContext context, LoggedInContext loggedInContext, string code)
+    public async Task<IQueryable<Project>> ProjectByCode(LexBoxDbContext context, IPermissionService permissionService, string code)
     {
-        loggedInContext.User.AssertCanAccessProject(code);
+        await permissionService.AssertCanAccessProject(code);
         return context.Projects.Where(p => p.Code == code);
     }
 

--- a/backend/LexBoxApi/GraphQL/ProjectMutations.cs
+++ b/backend/LexBoxApi/GraphQL/ProjectMutations.cs
@@ -76,7 +76,7 @@ public class ProjectMutations
         IPermissionService permissionService,
         LexBoxDbContext dbContext)
     {
-        permissionService.AssertCanManagerProjectMemberRole(input.ProjectId, input.UserId);
+        permissionService.AssertCanManageProjectMemberRole(input.ProjectId, input.UserId);
         var projectUser =
             await dbContext.ProjectUsers.Include(r => r.User).FirstOrDefaultAsync(u =>
                 u.ProjectId == input.ProjectId && u.UserId == input.UserId);

--- a/backend/LexBoxApi/LexBoxKernel.cs
+++ b/backend/LexBoxApi/LexBoxKernel.cs
@@ -36,6 +36,7 @@ public static class LexBoxKernel
             .ValidateOnStart();
         services.AddHttpClient();
         services.AddScoped<LoggedInContext>();
+        services.AddScoped<IPermissionService, PermissionService>();
         services.AddScoped<ProjectService>();
         services.AddScoped<UserService>();
         services.AddScoped<EmailService>();

--- a/backend/LexBoxApi/Services/PermissionService.cs
+++ b/backend/LexBoxApi/Services/PermissionService.cs
@@ -82,7 +82,7 @@ public class PermissionService : IPermissionService
 
     public void AssertCanDeleteAccount(Guid userId)
     {
-        if (User is { Role: UserRole.admin } user || user.Id == userId)
+        if (User is { Role: UserRole.admin } || User?.Id == userId)
             return;
         throw new UnauthorizedAccessException();
     }

--- a/backend/LexBoxApi/Services/PermissionService.cs
+++ b/backend/LexBoxApi/Services/PermissionService.cs
@@ -1,0 +1,94 @@
+﻿using LexBoxApi.Auth;
+using LexCore.Auth;
+using LexCore.Entities;
+using LexCore.ServiceInterfaces;
+using LexData;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Caching.Memory;
+
+namespace LexBoxApi.Services;
+
+public class PermissionService : IPermissionService
+{
+    private readonly LoggedInContext _loggedInContext;
+    private readonly LexBoxDbContext _dbContext;
+    private readonly IMemoryCache _memoryCache;
+    private LexAuthUser? User => _loggedInContext.MaybeUser;
+
+    public PermissionService(LoggedInContext loggedInContext,
+        LexBoxDbContext dbContext,
+        IMemoryCache memoryCache)
+    {
+        _loggedInContext = loggedInContext;
+        _dbContext = dbContext;
+        _memoryCache = memoryCache;
+    }
+
+    public async ValueTask<bool> CanAccessProject(string projectCode)
+    {
+        if (User is null) return false;
+        if (User.Role == UserRole.admin) return true;
+        return CanAccessProject(await LookupProjectId(projectCode));
+    }
+
+    public bool CanAccessProject(Guid projectId)
+    {
+        if (User is null) return false;
+        if (User.Role == UserRole.admin) return true;
+        return User.Projects.Any(p => p.ProjectId == projectId);
+    }
+
+    public async ValueTask AssertCanAccessProject(string projectCode)
+    {
+        if (!await CanAccessProject(projectCode)) throw new UnauthorizedAccessException();
+    }
+
+    public bool CanManageProject(Guid projectId)
+    {
+        if (User is null) return false;
+        if (User.Role == UserRole.admin) return true;
+        return User.Projects.Any(p => p.ProjectId == projectId && p.Role == ProjectRole.Manager);
+    }
+
+    public void AssertCanManageProject(Guid projectId)
+    {
+        if (!CanManageProject(projectId)) throw new UnauthorizedAccessException();
+    }
+
+    public void AssertCanManagerProjectMemberRole(Guid projectId, Guid userId)
+    {
+        if (User is null) throw new UnauthorizedAccessException();
+        AssertCanManageProject(projectId);
+        if (User.Role != UserRole.admin && userId == User.Id)
+            throw new UnauthorizedAccessException("Not allowed to change own project role.");
+    }
+
+    private async ValueTask<Guid> LookupProjectId(string projectCode)
+    {
+        var cacheKey = $"ProjectIdForCode:{projectCode}";
+        if (_memoryCache.TryGetValue(cacheKey, out Guid projectId)) return projectId;
+        projectId = await _dbContext.Projects
+            .Where(p => p.Code == projectCode)
+            .Select(p => p.Id)
+            .FirstOrDefaultAsync();
+        _memoryCache.Set(cacheKey, projectId, TimeSpan.FromHours(1));
+        return projectId;
+    }
+
+    public void AssertIsAdmin()
+    {
+        if (User is not { Role: UserRole.admin }) throw new UnauthorizedAccessException();
+    }
+
+    public void AssertCanDeleteAccount(Guid userId)
+    {
+        if (User is { Role: UserRole.admin } user && user.Id != userId)
+            return;
+        throw new UnauthorizedAccessException();
+    }
+
+    public bool HasProjectCreatePermission()
+    {
+        return User is { CanCreateProjects: true } or { Role: UserRole.admin };
+    }
+}

--- a/backend/LexBoxApi/Services/PermissionService.cs
+++ b/backend/LexBoxApi/Services/PermissionService.cs
@@ -55,7 +55,7 @@ public class PermissionService : IPermissionService
         if (!CanManageProject(projectId)) throw new UnauthorizedAccessException();
     }
 
-    public void AssertCanManagerProjectMemberRole(Guid projectId, Guid userId)
+    public void AssertCanManageProjectMemberRole(Guid projectId, Guid userId)
     {
         if (User is null) throw new UnauthorizedAccessException();
         AssertCanManageProject(projectId);
@@ -82,7 +82,7 @@ public class PermissionService : IPermissionService
 
     public void AssertCanDeleteAccount(Guid userId)
     {
-        if (User is { Role: UserRole.admin } user && user.Id != userId)
+        if (User is { Role: UserRole.admin } user || user.Id == userId)
             return;
         throw new UnauthorizedAccessException();
     }

--- a/backend/LexCore/ServiceInterfaces/IPermissionService.cs
+++ b/backend/LexCore/ServiceInterfaces/IPermissionService.cs
@@ -1,0 +1,14 @@
+﻿namespace LexCore.ServiceInterfaces;
+
+public interface IPermissionService
+{
+    ValueTask<bool> CanAccessProject(string projectCode);
+    bool CanAccessProject(Guid projectId);
+    ValueTask AssertCanAccessProject(string projectCode);
+    bool CanManageProject(Guid projectId);
+    void AssertCanManageProject(Guid projectId);
+    void AssertCanManagerProjectMemberRole(Guid projectId, Guid userId);
+    void AssertIsAdmin();
+    void AssertCanDeleteAccount(Guid userId);
+    bool HasProjectCreatePermission();
+}

--- a/backend/LexCore/ServiceInterfaces/IPermissionService.cs
+++ b/backend/LexCore/ServiceInterfaces/IPermissionService.cs
@@ -7,7 +7,7 @@ public interface IPermissionService
     ValueTask AssertCanAccessProject(string projectCode);
     bool CanManageProject(Guid projectId);
     void AssertCanManageProject(Guid projectId);
-    void AssertCanManagerProjectMemberRole(Guid projectId, Guid userId);
+    void AssertCanManageProjectMemberRole(Guid projectId, Guid userId);
     void AssertIsAdmin();
     void AssertCanDeleteAccount(Guid userId);
     bool HasProjectCreatePermission();

--- a/backend/Testing/LexCore/LexAuthUserTests.cs
+++ b/backend/Testing/LexCore/LexAuthUserTests.cs
@@ -17,9 +17,9 @@ public class LexAuthUserTests
 {
     private readonly LexAuthService _lexAuthService = new LexAuthService(
         new OptionsWrapper<JwtOptions>(JwtOptions.TestingOptions),
-        null,
-        null,
-        null);
+        null!,
+        null!,
+        null!);
 
     private readonly LexAuthUser _user = new()
     {

--- a/frontend/schema.graphql
+++ b/frontend/schema.graphql
@@ -17,7 +17,6 @@ type AlreadyExistsError implements Error {
 }
 
 type AuthUserProject {
-  code: String!
   role: ProjectRole!
   projectId: UUID!
 }
@@ -91,15 +90,13 @@ type IsAdminResponse {
 }
 
 type LexAuthUser {
-  canManageProject(projectId: UUID!): Boolean!
-  canAccessProject(projectCode: String!): Boolean!
-  hasProjectCreatePermission: Boolean!
   id: UUID!
   audience: LexboxAudience!
   email: String!
   name: String!
   role: UserRole!
   projects: [AuthUserProject!]!
+  projectsJson: String!
   emailVerificationRequired: Boolean
   canCreateProjects: Boolean
 }

--- a/frontend/src/lib/user.ts
+++ b/frontend/src/lib/user.ts
@@ -19,18 +19,9 @@ type JwtTokenUser = {
   name: string
   email: string
   role: 'admin' | 'user'
-  proj?: JwtTokenProject[],
+  proj?: string,
   unver: boolean | undefined,
   mkproj: boolean | undefined,
-}
-
-type JwtTokenProject = {
-  // eslint-disable-next-line @typescript-eslint/naming-convention
-  Code: string,
-  // eslint-disable-next-line @typescript-eslint/naming-convention
-  ProjectId: string,
-  // eslint-disable-next-line @typescript-eslint/naming-convention
-  Role: 'Manager' | 'Editor',
 }
 
 export type LexAuthUser = {
@@ -42,11 +33,10 @@ export type LexAuthUser = {
   emailVerified: boolean
   canCreateProject: boolean
 }
-
+type UserProjectRole = 'Manager' | 'Editor' | 'Unknown';
 type UserProjects = {
   projectId: string
-  code: string
-  role: 'Manager' | 'Editor'
+  role: UserProjectRole
 }
 export const USER_LOAD_KEY = 'user:current';
 
@@ -119,17 +109,36 @@ export function getUser(cookies: Cookies): LexAuthUser | null {
 }
 
 function jwtToUser(user: JwtTokenUser): LexAuthUser {
-  const { sub: id, name, email, proj: projects, role } = user;
+  const { sub: id, name, email, proj: projectsString, role } = user;
 
   return {
     id,
     name,
     email,
     role,
-    projects: projects?.map(p => ({code: p.Code, role: p.Role, projectId: p.ProjectId})) ?? [],
+    projects: projectsStringToProjects(projectsString),
     emailVerified: !user.unver,
     canCreateProject: user.mkproj === true,
   }
+}
+
+function projectsStringToProjects(projectsString: string | undefined): UserProjects[] {
+  if (!projectsString) return [];
+  const projects: UserProjects[] = [];
+  for (const pString of projectsString.split(',')) {
+    const roleCode = pString[0];
+    let role: UserProjectRole = 'Unknown';
+    switch (roleCode) {
+      case 'm':
+        role = 'Manager';
+        break;
+      case 'e':
+        role = 'Editor';
+        break;
+    }
+    projects.push(...pString.split('|').map(id => ({projectId: id, role})));
+  }
+  return projects;
 }
 
 export function logout(cookies?: Cookies): void {

--- a/frontend/src/routes/(authenticated)/project/[project_code]/+page.svelte
+++ b/frontend/src/routes/(authenticated)/project/[project_code]/+page.svelte
@@ -104,7 +104,7 @@
   }
 
   $: userId = user.id;
-  $: canManage = isAdmin(user) || project?.users.some(u => u.user.id == userId && u.role == ProjectRole.Manager);
+  $: canManage = isAdmin(user) || project?.users.find(u => u.user.id == userId)?.role == ProjectRole.Manager;
 
   const projectNameValidation = z.string().min(1, $t('project_page.project_name_empty_error'));
 

--- a/frontend/src/routes/(authenticated)/project/[project_code]/+page.svelte
+++ b/frontend/src/routes/(authenticated)/project/[project_code]/+page.svelte
@@ -30,7 +30,7 @@
   import MoreSettings from '$lib/components/MoreSettings.svelte';
   import { AdminContent, Page } from '$lib/layout';
   import SvelteMarkdown from 'svelte-markdown';
-  import { ProjectMigrationStatus, ResetStatus } from '$lib/gql/generated/graphql';
+  import { ProjectMigrationStatus, ProjectRole, ResetStatus } from '$lib/gql/generated/graphql';
   import { onMount } from 'svelte';
   import Button from '$lib/forms/Button.svelte';
   import Icon from '$lib/icons/Icon.svelte';
@@ -104,7 +104,7 @@
   }
 
   $: userId = user.id;
-  $: canManage = isAdmin(user) || user.projects.find((p) => p.code == project?.code)?.role == 'Manager';
+  $: canManage = isAdmin(user) || project?.users.some(u => u.user.id == userId && u.role == ProjectRole.Manager);
 
   const projectNameValidation = z.string().min(1, $t('project_page.project_name_empty_error'));
 


### PR DESCRIPTION
drop project code from the jwt and reduce the value to a string encoding the values in a simple format.

Also introduced a service for permissions because we now need to fetch the project id from the code for any request that uses the code instead of the id.

closes #387 