### PR TITLE
Introduce floating-ui overlay to prevent cutting off dropdowns

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -19,6 +19,7 @@
 	"devDependencies": {
 		"@egoist/tailwindcss-icons": "^1.0.7",
 		"@eslint/js": "^8.48.0",
+		"@floating-ui/dom": "^1.5.3",
 		"@graphql-codegen/cli": "^3.3.1",
 		"@graphql-codegen/client-preset": "^2.1.1",
 		"@graphql-codegen/schema-ast": "^3.0.1",

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -64,6 +64,9 @@ devDependencies:
   '@eslint/js':
     specifier: ^8.48.0
     version: 8.48.0
+  '@floating-ui/dom':
+    specifier: ^1.5.3
+    version: 1.5.3
   '@graphql-codegen/cli':
     specifier: ^3.3.1
     version: 3.3.1(@babel/core@7.22.9)(graphql@16.6.0)
@@ -1234,6 +1237,23 @@ packages:
   /@eslint/js@8.48.0:
     resolution: {integrity: sha512-ZSjtmelB7IJfWD2Fvb7+Z+ChTIKWq6kjda95fLcQKNS5aheVHn4IkfgRQE3sIIzTcSLwLcLZUD9UBt+V7+h+Pw==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    dev: true
+
+  /@floating-ui/core@1.5.0:
+    resolution: {integrity: sha512-kK1h4m36DQ0UHGj5Ah4db7R0rHemTqqO0QLvUqi1/mUUp3LuAWbWxdxSIf/XsnH9VS6rRVPLJCncjRzUvyCLXg==}
+    dependencies:
+      '@floating-ui/utils': 0.1.6
+    dev: true
+
+  /@floating-ui/dom@1.5.3:
+    resolution: {integrity: sha512-ClAbQnEqJAKCJOEbbLo5IUlZHkNszqhuxS4fHAVxRPXPya6Ysf2G8KypnYcOTpx6I8xcgF9bbHb6g/2KpbV8qA==}
+    dependencies:
+      '@floating-ui/core': 1.5.0
+      '@floating-ui/utils': 0.1.6
+    dev: true
+
+  /@floating-ui/utils@0.1.6:
+    resolution: {integrity: sha512-OfX7E2oUDYxtBvsuS4e/jSn4Q9Qb6DzgeYtsAdkPZ47znpoNsMgZw0+tVijiv3uGNR6dgNlty6r9rzIzHjtd/A==}
     dev: true
 
   /@formatjs/ecma402-abstract@1.15.0:

--- a/frontend/src/lib/app.postcss
+++ b/frontend/src/lib/app.postcss
@@ -85,11 +85,6 @@ input[readonly]:focus {
   @apply flex-nowrap;
 }
 
-/* open dropdowns upwards for the last 2 table rows */
-table tr:nth-last-child(-n + 2) .dropdown {
-  @apply dropdown-top;
-}
-
 .prose :where(a) {
   /* bold is just a bit too loud, especially when there are lots of link (e.g. our login welcome message) */
   @apply font-normal;

--- a/frontend/src/lib/components/overlay/index.ts
+++ b/frontend/src/lib/components/overlay/index.ts
@@ -1,0 +1,102 @@
+import type { Action, ActionReturn } from 'svelte/action';
+import { autoUpdate, computePosition } from '@floating-ui/dom';
+import { flip, offset } from '@floating-ui/dom';
+
+import type { ActionParameters } from '$lib/svelte';
+import { onDestroy } from 'svelte';
+
+export const [overlayTarget, overlayContentWrapper] = createOnClickOverlay();
+
+function createOnClickOverlay(): [Action, Action] {
+  let targetElem: HTMLElement | undefined;
+  let contentWrapperElem: HTMLElement | undefined;
+  let contentElem: HTMLElement | undefined;
+
+  let cleanup: (() => void) | undefined;
+
+  function useTarget(...[node]: ActionParameters): ActionReturn {
+    const targetContent = node.querySelector<HTMLElement>('.overlay-content') as HTMLElement;
+    if (!targetContent) throw new Error('Overlay target must have a child with class "overlay-content"');
+
+    targetContent.remove();
+
+    function removeSelfFromOverlay(): void {
+      if (targetElem === node) {
+        targetElem = undefined;
+        contentElem = undefined;
+        targetContent.remove();
+        updateOverlay();
+      }
+    }
+
+    node.addEventListener('click', function (): void {
+      if (targetElem === node) {
+        removeSelfFromOverlay();
+      }
+      else {
+        targetElem = node;
+        contentElem = targetContent;
+        updateOverlay();
+      }
+    });
+
+    targetContent.addEventListener('focusout', function (event): void {
+      if (targetElem !== node) return;
+      else if (!event.relatedTarget || !node.contains(event.relatedTarget as Node)) removeSelfFromOverlay();
+    });
+
+    node.addEventListener('focusout', function (event): void {
+      if (targetElem !== node) return;
+      else if (!event.relatedTarget || !contentElem || !contentElem.contains(event.relatedTarget as Node)) removeSelfFromOverlay();
+    });
+
+    return {
+      destroy(): void {
+        removeSelfFromOverlay();
+        targetContent.remove();
+      }
+    };
+  }
+
+  function useContentWrapper(...[node]: ActionParameters): ActionReturn {
+    contentWrapperElem = node;
+    return {
+      destroy(): void {
+        contentWrapperElem = undefined;
+        updateOverlay();
+      }
+    };
+  }
+
+  function updateOverlay(): void {
+    cleanup?.();
+    if (!contentWrapperElem) return;
+
+    if (targetElem && contentElem) {
+      contentWrapperElem.replaceChildren(contentElem);
+      cleanup = autoUpdate(
+        targetElem,
+        contentWrapperElem,
+        () => {
+          if (!targetElem || !contentWrapperElem) return;
+          void computePosition(targetElem, contentWrapperElem, {
+            placement: 'bottom-end',
+            middleware: [offset(2), flip()]
+          }).then(({ x, y }) => {
+            if (!contentWrapperElem) return;
+            Object.assign(contentWrapperElem.style, {
+              left: `${x}px`,
+              top: `${y}px`,
+              display: '',
+            });
+          });
+        });
+    } else {
+      contentWrapperElem.style.display = 'none';
+    }
+  }
+
+  onDestroy(() => cleanup?.());
+
+  return [useTarget, useContentWrapper];
+}

--- a/frontend/src/routes/(authenticated)/admin/+page.svelte
+++ b/frontend/src/routes/(authenticated)/admin/+page.svelte
@@ -10,12 +10,12 @@
   import { DialogResponse } from '$lib/components/modals';
   import { Duration } from '$lib/util/time';
   import { Icon } from '$lib/icons';
-  import Dropdown from '$lib/components/Dropdown.svelte';
   import { RefineFilterMessage } from '$lib/components/Table';
   import type { AdminSearchParams, User } from './+page';
   import ProjectTable from './ProjectTable.svelte';
   import { getSearchParams, queryParam } from '$lib/util/query-params';
   import type { ProjectType } from '$lib/gql/types';
+  import { overlayTarget } from '$lib/components/overlay';
 
   export let data: PageData;
   $: allProjects = data.projects;
@@ -129,26 +129,24 @@
                   <FormatDate date={user.createdDate} />
                 </td>
                 <td class="p-0">
-                  <Dropdown let:close>
-                    <!-- svelte-ignore a11y-label-has-associated-control -->
-                    <label tabindex="-1" class="btn btn-ghost btn-square">
+                    <button use:overlayTarget class="btn btn-ghost btn-square">
                       <span class="i-mdi-dots-vertical text-lg" />
-                    </label>
-                    <ul slot="content" class="menu">
-                      <li>
-                        <button class="whitespace-nowrap" on:click={() => openModal(user)}>
-                          <Icon icon="i-mdi-pencil-outline"  />
-                          {$t('admin_dashboard.form_modal.title')}
-                        </button>
-                      </li>
-                      <li>
-                        <button class="whitespace-nowrap" on:click={() => {close();filterProjectsByUser(user);}}>
-                          <Icon icon="i-mdi-filter-outline"  />
-                          {$t('admin_dashboard.filter_projects')}
-                        </button>
-                      </li>
-                    </ul>
-                  </Dropdown>
+
+                      <ul class="menu overlay-content">
+                        <li>
+                          <button class="whitespace-nowrap" on:click={() => openModal(user)}>
+                            <Icon icon="i-mdi-pencil-outline"  />
+                            {$t('admin_dashboard.form_modal.title')}
+                          </button>
+                        </li>
+                        <li>
+                          <button class="whitespace-nowrap" on:click={() => {close(); filterProjectsByUser(user);}}>
+                            <Icon icon="i-mdi-filter-outline"  />
+                            {$t('admin_dashboard.filter_projects')}
+                          </button>
+                        </li>
+                      </ul>
+                    </button>
                 </td>
               </tr>
             {/each}

--- a/frontend/src/routes/(authenticated)/admin/ProjectTable.svelte
+++ b/frontend/src/routes/(authenticated)/admin/ProjectTable.svelte
@@ -6,7 +6,6 @@ import {_deleteProject} from '$lib/gql/mutations';
 import {DialogResponse} from '$lib/components/modals';
 import {notifyWarning} from '$lib/notify';
 import ConfirmDeleteModal from '$lib/components/modals/ConfirmDeleteModal.svelte';
-import Dropdown from '$lib/components/Dropdown.svelte';
 import TrashIcon from '$lib/icons/TrashIcon.svelte';
 import FormatDate from '$lib/components/FormatDate.svelte';
 import ProjectTypeSelect from '$lib/forms/ProjectTypeSelect.svelte';
@@ -18,6 +17,7 @@ import IconButton from '$lib/components/IconButton.svelte';
 import {bubbleFocusOnDestroy} from '$lib/util/focus';
 import Button from '$lib/forms/Button.svelte';
 import type { QueryParams } from '$lib/util/query-params';
+import { overlayTarget } from '$lib/components/overlay';
 
 export let projects: Project[];
 
@@ -196,21 +196,19 @@ async function softDeleteProject(project: Project): Promise<void> {
                     </td>
                     <td class="p-0">
                         {#if !project.deletedDate}
-                            <Dropdown>
-                                <!-- svelte-ignore a11y-label-has-associated-control -->
-                                <label tabindex="-1" class="btn btn-ghost btn-square">
-                                    <span class="i-mdi-dots-vertical text-lg"/>
-                                </label>
-                                <ul slot="content" class="menu">
-                                    <li>
-                                        <button class="text-error whitespace-nowrap"
-                                                on:click={() => softDeleteProject(project)}>
-                                            <TrashIcon/>
-                                            {$t('delete_project_modal.submit')}
-                                        </button>
-                                    </li>
+                            <button use:overlayTarget class="btn btn-ghost btn-square">
+                                <span class="i-mdi-dots-vertical text-lg"/>
+
+                                <ul class="menu overlay-content">
+                                  <li>
+                                    <button class="text-error whitespace-nowrap"
+                                            on:click={() => softDeleteProject(project)}>
+                                        <TrashIcon/>
+                                        {$t('delete_project_modal.submit')}
+                                    </button>
+                                  </li>
                                 </ul>
-                            </Dropdown>
+                            </button>
                         {/if}
                     </td>
                 </tr>

--- a/frontend/src/routes/+layout.svelte
+++ b/frontend/src/routes/+layout.svelte
@@ -11,6 +11,7 @@
   import { Duration } from '$lib/util/time';
   import { browser } from '$app/environment';
   import t from '$lib/i18n';
+  import { overlayContentWrapper } from '$lib/components/overlay';
 
   export let data: LayoutData;
   const { page, updated } = getStores();
@@ -47,3 +48,5 @@
 {/if}
 
 <Notify />
+
+<div use:overlayContentWrapper class="dropdown-content bg-base-200 shadow rounded-box z-[2] absolute" />


### PR DESCRIPTION
Fixes #284 

This is the more sophisticated fix rather than the one in #401. It's also what tailwind [recommends](https://github.com/tailwindlabs/tailwindui-issues/issues/147) (the comments actually recommend popper, but floating ui is popper's successor.

Floating-UI seems to be the cream of the crop for positioning overlays and such.

I implemented some teleporting so that we can share a single overlay and teleport elements with their context into it.