### PR TITLE
Fix dropdowns getting cut off with some padding

### DIFF
--- a/frontend/src/lib/app.postcss
+++ b/frontend/src/lib/app.postcss
@@ -85,9 +85,14 @@ input[readonly]:focus {
   @apply flex-nowrap;
 }
 
-/* open dropdowns upwards for the last 2 table rows */
-table tr:nth-last-child(-n + 2) .dropdown {
+/* open dropdowns upwards for the last 2 table rows as long as they're not the first 2 */
+table tr:nth-last-child(-n + 2):not(:nth-child(-n + 2)) .dropdown {
   @apply dropdown-top;
+}
+
+/* add some padding for dropdowns if the table has less than 3 elements */
+.overflow-x-auto:has(> table .dropdown):not(:has(> table tr:nth-child(3))) {
+    padding-bottom: 80px;
 }
 
 .prose :where(a) {


### PR DESCRIPTION
Fixes #284

The minor downsides to this fix are:
- It's slightly complicated
- On mobile (i.e. when the tables are stacked) there will be a peculiar amount of space between the 2 tables if the project table has less than 3 rows. Wow....that's quite the edge case 😆.

I've got a more sophisticated fix lined up for v1: #400
But....now that this is almost perfect, perhaps that's really just overkill.