### PR TITLE
Fix: clearing project filters clears user filter too

### DIFF
--- a/frontend/src/lib/util/object.ts
+++ b/frontend/src/lib/util/object.ts
@@ -1,0 +1,7 @@
+export function pick<T extends object, K extends keyof T>(obj: T, keys: Iterable<K>): Pick<T, K> {
+  const filteredObj: Partial<T> = {};
+  for (const key of keys) {
+    filteredObj[key] = obj[key];
+  }
+  return filteredObj as Pick<T, K>;
+}


### PR DESCRIPTION
Fixes #415 

I'm not sure how good it is to be filtering the keys inside the component (as we were doing before already, but not entirely), but I think we can just wait until the component gets a bit more usage before we change anything.