### PR TITLE
Enable api to respect x-forwarded headers

### DIFF
--- a/backend/LexBoxApi/Program.cs
+++ b/backend/LexBoxApi/Program.cs
@@ -84,12 +84,19 @@ builder.Services.AddHttpLogging(options =>
 {
     options.LoggingFields = HttpLoggingFields.RequestPropertiesAndHeaders |
                             HttpLoggingFields.ResponsePropertiesAndHeaders;
-    options.ResponseHeaders.Add("WWW-Authenticate");
-    options.ResponseHeaders.Add("lexbox-version");
-#if DEBUG
-    options.RequestHeaders.Add("Cookie");
-#endif
 });
+builder.Services.AddOptions<HttpLoggingOptions>()
+    .PostConfigure((HttpLoggingOptions options, IConfiguration configuration) =>
+    {
+        foreach (var requestHeader in configuration.GetSection("HttpLoggingOptions:AdditionalRequestHeaders").GetChildren())
+        {
+            options.RequestHeaders.Add(requestHeader.Value!);
+        }
+        foreach (var requestHeader in configuration.GetSection("HttpLoggingOptions:AdditionalResponseHeaders").GetChildren())
+        {
+            options.ResponseHeaders.Add(requestHeader.Value!);
+        }
+    });
 
 builder.Services.AddLexData(builder.Environment.IsDevelopment());
 builder.Services.AddLexBoxApi(builder.Configuration, builder.Environment);

--- a/backend/LexBoxApi/appsettings.Development.json
+++ b/backend/LexBoxApi/appsettings.Development.json
@@ -15,6 +15,18 @@
       "10.1.0.0/16"
     ]
   },
+  "HttpLoggingOptions": {
+    "AdditionalRequestHeaders": [
+      "X-Forwarded-Proto",
+      "X-Forwarded-Host",
+      "X-Forwarded-For",
+      "Cookie"
+    ],
+    "AdditionalResponseHeaders": [
+      "WWW-Authenticate",
+      "lexbox-version"
+    ]
+  },
   "CloudFlare": {
 //    always passes key, more info here: https://developers.cloudflare.com/turnstile/frequently-asked-questions/#are-there-sitekeys-and-secret-keys-that-can-be-used-for-testing
     "TurnstileKey": "1x0000000000000000000000000000000AA",

--- a/backend/LexBoxApi/appsettings.Development.json
+++ b/backend/LexBoxApi/appsettings.Development.json
@@ -10,6 +10,11 @@
     "LexBoxConnectionString": "Host=localhost;Port=5433;Username=postgres;Password=972b722e63f549938d07bd8c4ee5086c;Database=lexbox;Include Error Detail=true",
     "RedmineConnectionString": "server=localhost;database=languagedepot;user=root;"
   },
+  "ForwardedHeadersOptions": {
+    "KnownNetworks": [
+      "10.1.0.0/16"
+    ]
+  },
   "CloudFlare": {
 //    always passes key, more info here: https://developers.cloudflare.com/turnstile/frequently-asked-questions/#are-there-sitekeys-and-secret-keys-that-can-be-used-for-testing
     "TurnstileKey": "1x0000000000000000000000000000000AA",
@@ -33,7 +38,7 @@
   },
   "Tus" : {
     "TestUploadPath": "testUploadPath",
-    "ResetUploadPath": "resetUploadPath",
+    "ResetUploadPath": "resetUploadPath"
   },
   "Email": {
     "SmtpHost": "localhost",

--- a/backend/LexBoxApi/appsettings.json
+++ b/backend/LexBoxApi/appsettings.json
@@ -10,8 +10,19 @@
       "Default": "Information",
       "LexBoxApi": "Information",
       "Microsoft.AspNetCore": "Information",
+      "Microsoft.AspNetCore.HttpOverrides.ForwardedHeadersMiddleware": "Debug",
       "Microsoft.EntityFrameworkCore": "Information"
     }
+  },
+  "ForwardedHeadersOptions": {
+    "ForwardedHeaders": "All",
+    "AllowedHosts": [
+      "localhost",
+      "languagedepot.org",
+      "*.languagedepot.org",
+      "*.languageforge.org"
+    ],
+    "KnownNetworks": []
   },
   "AllowedHosts": "*",
   "DbConfig": {

--- a/backend/LexBoxApi/appsettings.json
+++ b/backend/LexBoxApi/appsettings.json
@@ -24,6 +24,17 @@
     ],
     "KnownNetworks": []
   },
+  "HttpLoggingOptions": {
+    "AdditionalRequestHeaders": [
+      "X-Forwarded-Proto",
+      "X-Forwarded-Host",
+      "X-Forwarded-For"
+    ],
+    "AdditionalResponseHeaders": [
+      "WWW-Authenticate",
+      "lexbox-version"
+    ]
+  },
   "AllowedHosts": "*",
   "DbConfig": {
     "LexBoxConnectionString": null

--- a/deployment/base/lexbox-deployment.yaml
+++ b/deployment/base/lexbox-deployment.yaml
@@ -111,6 +111,8 @@ spec:
               secretKeyRef:
                   key: Authentication__Jwt__Secret
                   name: lexbox-api
+          - name: ForwardedHeadersOptions__KnownNetworks__0
+            value: "10.42.0.0/16"
           - name: HgConfig__RepoPath
             value: /hg-repos
           - name: HgConfig__HgWebUrl

--- a/deployment/local-dev/ingress-deployment.yaml
+++ b/deployment/local-dev/ingress-deployment.yaml
@@ -323,6 +323,7 @@ data:
   allow-snippet-annotations: "true"
   proxy-buffer-size: "16k"
   large-client-header-buffers: "4 16k"
+  use-forwarded-headers: "true"
 
 kind: ConfigMap
 metadata:

--- a/deployment/local-dev/lexbox-deployment.patch.yaml
+++ b/deployment/local-dev/lexbox-deployment.patch.yaml
@@ -25,6 +25,9 @@ spec:
             value: "dev-secret_but-it-must-be-32-characters-long"
 #            intentionally set this to no value
             valueFrom:
+
+          - name: ForwardedHeadersOptions__KnownNetworks__0
+            value: "10.1.0.0/16"
           - name: CloudFlare__TurnstileKey
             value: "1x0000000000000000000000000000000AA"
             valueFrom:


### PR DESCRIPTION
Configures dotnet with a trusted network for where it can read forwarded headers from so that it updates request data correctly. Also made that and http logging configurable via environment variables.