### PR TITLE
Prefill create project form from project request email

### DIFF
--- a/backend/LexBoxApi/Models/Project/CreateProjectInput.cs
+++ b/backend/LexBoxApi/Models/Project/CreateProjectInput.cs
@@ -6,7 +6,7 @@ namespace LexBoxApi.Models.Project;
 public record CreateProjectInput(
     Guid? Id,
     string Name,
-    string? Description,
+    string Description,
     [property: MinLength(4), RegularExpression(@"[a-z-\d]+")]
     string Code,
     ProjectType Type,

--- a/frontend/schema.graphql
+++ b/frontend/schema.graphql
@@ -268,7 +268,7 @@ input ChangeUserAccountDataInput {
 input CreateProjectInput {
   id: UUID
   name: String!
-  description: String
+  description: String!
   code: String!
   type: ProjectType!
   retentionPolicy: RetentionPolicy!

--- a/frontend/src/lib/email/CreateProjectRequest.svelte
+++ b/frontend/src/lib/email/CreateProjectRequest.svelte
@@ -4,12 +4,13 @@
     import type {CreateProjectInput} from '$lib/gql/generated/graphql';
     import {FormatProjectType} from '$lib/components/ProjectType';
     import FormatRetentionPolicy from '$lib/components/FormatRetentionPolicy.svelte';
+    import { toSearchParams } from '$lib/util/query-params';
 
     export let name: string;
     export let baseUrl: string;
     export let project: CreateProjectInput;
     export let user: { name: string; email: string };
-    let createUrl = new URL('/project/create', baseUrl);
+    let createUrl = new URL(`/project/create?${toSearchParams(project)}`, baseUrl);
 </script>
 
 <Email subject={$t('emails.create_project_request_email.subject', {projectName: project.name})} {name}>
@@ -20,12 +21,12 @@
             <td>{project.name}</td>
         </tr>
         <tr>
-            <td>{$t('project.create.description')}</td>
-            <td>{project.description}</td>
-        </tr>
-        <tr>
             <td>{$t('project.create.code')}</td>
             <td>{project.code}</td>
+        </tr>
+        <tr>
+            <td>{$t('project.create.description')}</td>
+            <td>{project.description}</td>
         </tr>
         <tr>
             <td>{$t('project.create.type')}</td>

--- a/frontend/src/lib/util/query-params.ts
+++ b/frontend/src/lib/util/query-params.ts
@@ -47,6 +47,10 @@ export function getSearchParams<T extends Record<string, unknown>>(options: Quer
   }
 }
 
+export function getSearchParamValues<T extends Record<string, unknown>>(): T {
+  return Object.fromEntries(new URLSearchParams(location.search).entries()) as T;
+}
+
 function getDefaults<T extends Record<string, unknown>>(
   options: QueryParamConfig<T>): T {
   const defaultValues: Partial<T> = {};

--- a/frontend/src/routes/email/tester/+page.ts
+++ b/frontend/src/routes/email/tester/+page.ts
@@ -1,0 +1,1 @@
+﻿export const ssr = false;

--- a/frontend/src/routes/email/tester/+page@.svelte
+++ b/frontend/src/routes/email/tester/+page@.svelte
@@ -32,10 +32,26 @@
             baseUrl: 'http://localhost:3000',
             template: EmailTemplate.CreateProjectRequest,
             project: {
-                id: null,
                 name: 'My Project',
-                code: 'MYPROJ',
-                type: ProjectType.FlEx,
+                code: 'myproj-test-onestory',
+                type: ProjectType.OneStoryEditor,
+                description: 'My project description',
+                retentionPolicy: RetentionPolicy.Test
+            },
+            user: {
+                name: 'Bob',
+                email: 'test@test.com'
+            }
+        },
+        {
+            label: 'Create Project Request - custom code',
+            name: 'Admin',
+            baseUrl: 'http://localhost:3000',
+            template: EmailTemplate.CreateProjectRequest,
+            project: {
+                name: 'My Project',
+                code: 'my-proj-custom-onestory',
+                type: ProjectType.WeSay,
                 description: 'My project description',
                 retentionPolicy: RetentionPolicy.Dev
             },

--- a/frontend/src/routes/email/tester/+page@.svelte
+++ b/frontend/src/routes/email/tester/+page@.svelte
@@ -5,7 +5,7 @@
     import type {RenderEmailResult} from '$lib/email/emailRenderer.server';
 
     function absoluteUrl(path: string): string {
-      return browser ? `${location.origin}/${path}` : path;
+      return `${location.origin}/${path}`;
     }
 
     let emails: Array<EmailTemplateProps & { label?: string }> = [
@@ -29,7 +29,7 @@
         {
             label: 'Create Project Request',
             name: 'Admin',
-            baseUrl: 'http://localhost:3000',
+            baseUrl: location.origin,
             template: EmailTemplate.CreateProjectRequest,
             project: {
                 name: 'My Project',
@@ -46,7 +46,7 @@
         {
             label: 'Create Project Request - custom code',
             name: 'Admin',
-            baseUrl: 'http://localhost:3000',
+            baseUrl: location.origin,
             template: EmailTemplate.CreateProjectRequest,
             project: {
                 name: 'My Project',


### PR DESCRIPTION
Fixes #404 

When admins get an email requesting a project be created for them, they can now click the "Create project" button and the form will be filled out for them using what the user submitted.

This can be easily tested at /email/tester with the 2 test Request project emails.
The custom code email request (which shouldn't actually ever happen) behaves differently based on whether the user is an admin or not (which also shouldn't ever happen, but who knows 🤷).

I've made Description required everywhere. I'm not sure if that's what we want, but we were enforcing it in some places, so I just made it consistent.

Here's a non-admin trying to create a dev project with a custom code:
![image](https://github.com/sillsdev/languageforge-lexbox/assets/12587509/36f2c8cf-c149-44f5-a077-0e3667254b52)
And here's what an admin gets:
![image](https://github.com/sillsdev/languageforge-lexbox/assets/12587509/4af042b8-2d29-4dc3-a641-935877394e50)
