### PR TITLE
Chore/trace user

### DIFF
--- a/frontend/src/lib/otel/otel.client.ts
+++ b/frontend/src/lib/otel/otel.client.ts
@@ -3,7 +3,7 @@ import { BatchSpanProcessor, WebTracerProvider } from '@opentelemetry/sdk-trace-
 import { APP_VERSION } from '$lib/util/version';
 import { OTLPTraceExporterBrowserWithXhrRetry } from './trace-exporter-browser-with-xhr-retry';
 import { Resource } from '@opentelemetry/resources'
-import { SERVICE_NAME } from '.'
+import {SERVICE_NAME, traceUserAttributes} from '.';
 import { SemanticResourceAttributes } from '@opentelemetry/semantic-conventions'
 import { ZoneContextManager } from '@opentelemetry/context-zone'
 import { getWebAutoInstrumentations } from '@opentelemetry/auto-instrumentations-web'
@@ -26,6 +26,14 @@ const resource = Resource.default().merge(
 )
 const provider = new WebTracerProvider({
   resource: resource,
+});
+provider.addSpanProcessor({
+forceFlush: () => Promise.resolve(),
+  onStart: (span) => {
+    traceUserAttributes(span);
+  },
+  onEnd: () => {},
+  shutdown: () => Promise.resolve(),
 });
 const exporter = new OTLPTraceExporterBrowserWithXhrRetry({
   url: '/v1/traces'

--- a/frontend/src/lib/otel/otel.shared.ts
+++ b/frontend/src/lib/otel/otel.shared.ts
@@ -150,7 +150,7 @@ function getUser(event?: RequestEvent | NavigationEvent | Event): LexAuthUser | 
     }
   }
 }
-function traceUserAttributes(span: Span, event?: RequestEvent | NavigationEvent | Event): void {
+export function traceUserAttributes(span: Span, event?: RequestEvent | NavigationEvent | Event): void {
     const user = getUser(event);
     if (user) {
         span.setAttribute('app.user.id', user.id);


### PR DESCRIPTION
there are times when it would be useful to group telemetry queries by user id, but we can't do that for traces where the user id doesn't exist. This is an attempt to add it to all our traces.