### PR TITLE
Add login and remove created from admin user table

### DIFF
--- a/frontend/src/lib/i18n/locales/en.json
+++ b/frontend/src/lib/i18n/locales/en.json
@@ -2,8 +2,8 @@
   "admin_dashboard": {
     "title": "Admin Dashboard",
     "column_code": "Code",
-    "column_created": "Created",
     "column_email": "Email",
+    "column_login": "Login",
     "column_last_change": "Last Change",
     "column_migrated": "Migrated",
     "column_name": "Name",

--- a/frontend/src/routes/(authenticated)/admin/+page.svelte
+++ b/frontend/src/routes/(authenticated)/admin/+page.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
   import { Badge } from '$lib/components/Badges';
-  import FormatDate from '$lib/components/FormatDate.svelte';
   import Input from '$lib/forms/Input.svelte';
   import t from '$lib/i18n';
   import type { PageData } from './$types';
@@ -103,9 +102,9 @@
               <th>
                 {$t('admin_dashboard.column_name')}<span class="i-mdi-sort-ascending text-xl align-[-5px] ml-2" />
               </th>
+              <th>{$t('admin_dashboard.column_login')}</th>
               <th>{$t('admin_dashboard.column_email')}</th>
               <th>{$t('admin_dashboard.column_role')}</th>
-              <th>{$t('admin_dashboard.column_created')}</th>
               <th />
             </tr>
           </thead>
@@ -113,6 +112,11 @@
             {#each shownUsers as user}
               <tr>
                 <td>{user.name}</td>
+                <td>
+                  {#if user.username}
+                    {user.username}
+                  {/if}
+                </td>
                 <td>
                   <span class="inline-flex items-center gap-2 text-left">
                     {user.email}
@@ -127,9 +131,6 @@
                 </td>
                 <td class:text-accent={user.isAdmin}>
                   {user.isAdmin ? $t('user_types.admin') : $t('user_types.user')}
-                </td>
-                <td>
-                  <FormatDate date={user.createdDate} />
                 </td>
                 <td class="p-0">
                   <Dropdown let:close>

--- a/frontend/src/routes/(authenticated)/admin/+page.ts
+++ b/frontend/src/routes/(authenticated)/admin/+page.ts
@@ -80,8 +80,8 @@ export async function load(event: PageLoadEvent) {
                 id
                 name
                 email
+                username
                 isAdmin
-                createdDate
                 emailVerified
                 projects {
                     id


### PR DESCRIPTION
Fixes #423 
![image](https://github.com/sillsdev/languageforge-lexbox/assets/12587509/0544200f-ad9d-4db1-a142-2f730389f49b)


I like the idea of showing the login for each row, because it's something that admins actually search for. They'll never search for created date.