### PR TITLE
Add startup probe to hg container so otel initializes

### DIFF
--- a/deployment/base/hg-deployment.yaml
+++ b/deployment/base/hg-deployment.yaml
@@ -60,6 +60,13 @@ spec:
         ports:
           - containerPort: 8088
 
+        startupProbe:
+          httpGet:
+            path: /
+            port: 8088
+          failureThreshold: 30
+          periodSeconds: 10
+
         volumeMounts:
           - name: repos
             mountPath: /var/hg/repos


### PR DESCRIPTION
Fixes #297 

I think this will fix our `ModifyProjectData` test failures.