### PR TITLE
Chore/98 invalidate jwt on reset password

### DIFF
--- a/backend/LexBoxApi/Auth/Attributes/AdminRequiredAttribute.cs
+++ b/backend/LexBoxApi/Auth/Attributes/AdminRequiredAttribute.cs
@@ -1,4 +1,4 @@
-namespace LexBoxApi.Auth;
+namespace LexBoxApi.Auth.Attributes;
 
 [AttributeUsage(AttributeTargets.Class | AttributeTargets.Method)]
 public class AdminRequiredAttribute : LexboxAuthAttribute

--- a/backend/LexBoxApi/Auth/Attributes/CreateProjectRequiredAttribute.cs
+++ b/backend/LexBoxApi/Auth/Attributes/CreateProjectRequiredAttribute.cs
@@ -1,4 +1,4 @@
-﻿namespace LexBoxApi.Auth;
+﻿namespace LexBoxApi.Auth.Attributes;
 
 [AttributeUsage(AttributeTargets.Class | AttributeTargets.Method)]
 public class CreateProjectRequiredAttribute: LexboxAuthAttribute

--- a/backend/LexBoxApi/Auth/Attributes/LexboxAuthAttribute.cs
+++ b/backend/LexBoxApi/Auth/Attributes/LexboxAuthAttribute.cs
@@ -3,7 +3,7 @@ using HotChocolate.Types.Descriptors;
 using Microsoft.AspNetCore.Authorization;
 using AuthorizeAttribute = HotChocolate.Authorization.AuthorizeAttribute;
 
-namespace LexBoxApi.Auth;
+namespace LexBoxApi.Auth.Attributes;
 
 public abstract class LexboxAuthAttribute : DescriptorAttribute, IAuthorizeData
 {

--- a/backend/LexBoxApi/Auth/Attributes/RequireAudienceAttribute.cs
+++ b/backend/LexBoxApi/Auth/Attributes/RequireAudienceAttribute.cs
@@ -1,7 +1,7 @@
 ﻿using LexCore.Auth;
 using Microsoft.AspNetCore.Authorization;
 
-namespace LexBoxApi.Auth;
+namespace LexBoxApi.Auth.Attributes;
 
 public class RequireAudienceAttribute(params LexboxAudience[] audiences)
     : LexboxAuthAttribute(PolicyName), IAuthorizationRequirement, IAuthorizationRequirementData

--- a/backend/LexBoxApi/Auth/Attributes/RequireAudienceAttribute.cs
+++ b/backend/LexBoxApi/Auth/Attributes/RequireAudienceAttribute.cs
@@ -9,7 +9,7 @@ public class RequireAudienceAttribute(params LexboxAudience[] audiences)
     public const string PolicyName = "RequireAudiencePolicy";
     /// <param name="audience">audience allowed to access this endpoint</param>
     /// <param name="exclusive">when false the default audience is also allowed, when true the default audience is not allowed</param>
-    public RequireAudienceAttribute(LexboxAudience audience, bool exclusive) : this(exclusive
+    public RequireAudienceAttribute(LexboxAudience audience, bool exclusive = false) : this(exclusive
         ? [audience]
         : [audience, LexboxAudience.LexboxApi])
     {

--- a/backend/LexBoxApi/Auth/Attributes/RequireCurrentUserInfoAttribute.cs
+++ b/backend/LexBoxApi/Auth/Attributes/RequireCurrentUserInfoAttribute.cs
@@ -1,0 +1,15 @@
+﻿using Microsoft.AspNetCore.Authorization;
+
+namespace LexBoxApi.Auth.Attributes;
+
+/// <summary>
+/// validates the updated date of the jwt against the database, should be used to make a jwt expire if the user is updated
+/// </summary>
+[AttributeUsage(AttributeTargets.Class | AttributeTargets.Method)]
+public class RequireCurrentUserInfoAttribute: Attribute, IAuthorizationRequirement, IAuthorizationRequirementData
+{
+    public IEnumerable<IAuthorizationRequirement> GetRequirements()
+    {
+        yield return this;
+    }
+}

--- a/backend/LexBoxApi/Auth/Attributes/VerifiedEmailRequiredAttribute.cs
+++ b/backend/LexBoxApi/Auth/Attributes/VerifiedEmailRequiredAttribute.cs
@@ -1,4 +1,4 @@
-﻿namespace LexBoxApi.Auth;
+﻿namespace LexBoxApi.Auth.Attributes;
 
 [AttributeUsage(AttributeTargets.Class | AttributeTargets.Method)]
 public class VerifiedEmailRequiredAttribute : LexboxAuthAttribute

--- a/backend/LexBoxApi/Auth/AuthKernel.cs
+++ b/backend/LexBoxApi/Auth/AuthKernel.cs
@@ -171,7 +171,7 @@ public static class AuthKernel
     public static AuthorizationPolicyBuilder RequireDefaultLexboxAuth(this AuthorizationPolicyBuilder builder)
     {
         return builder.RequireAuthenticatedUser()
-            .AddRequirements(new RequireAudienceAttribute(LexboxAudience.LexboxApi));
+            .AddRequirements(new RequireAudienceAttribute(LexboxAudience.LexboxApi, true));
     }
 
     public static bool IsJwtRequest(this HttpRequest request)

--- a/backend/LexBoxApi/Auth/AuthKernel.cs
+++ b/backend/LexBoxApi/Auth/AuthKernel.cs
@@ -25,6 +25,7 @@ public static class AuthKernel
         if (environment.IsDevelopment())
         {
             IdentityModelEventSource.ShowPII = true;
+            IdentityModelEventSource.LogCompleteSecurityArtifact = true;
         }
 
         services.AddScoped<LexAuthService>();
@@ -37,24 +38,11 @@ public static class AuthKernel
             options.FallbackPolicy = options.DefaultPolicy = new AuthorizationPolicyBuilder()
                 .RequireDefaultLexboxAuth()
                 .Build();
-            foreach (var audience in Enum.GetValues<LexboxAudience>())
-            {
-                if (audience == LexboxAudience.Unknown) continue;
-                //for exclusive the endpoint is only accessible for the specified audience
-                options.AddPolicy(audience.PolicyName(true), builder =>
-                {
-                    builder.RequireAuthenticatedUser();
-                    builder.AddRequirements(new AudienceRequirement(audience));
-                });
-                //for non exclusive the endpoint is also accessible for the default audience
-                options.AddPolicy(audience.PolicyName(false), builder =>
-                {
-                    builder.RequireAuthenticatedUser();
-                    builder.AddRequirements(new AudienceRequirement(audience, LexboxAudience.LexboxApi));
-                });
-            }
+
             //don't use RequireDefaultLexboxAuth here because that only allows the default audience
             options.AddPolicy(AllowAnyAudienceAttribute.PolicyName, builder => builder.RequireAuthenticatedUser());
+            //we still need this policy, without it the default policy is used which requires the default audience
+            options.AddPolicy(RequireAudienceAttribute.PolicyName, builder => builder.RequireAuthenticatedUser());
 
             options.AddPolicy(AdminRequiredAttribute.PolicyName,
                 builder => builder.RequireDefaultLexboxAuth()
@@ -181,7 +169,7 @@ public static class AuthKernel
     public static AuthorizationPolicyBuilder RequireDefaultLexboxAuth(this AuthorizationPolicyBuilder builder)
     {
         return builder.RequireAuthenticatedUser()
-            .AddRequirements(new AudienceRequirement(LexboxAudience.LexboxApi));
+            .AddRequirements(new RequireAudienceAttribute(LexboxAudience.LexboxApi));
     }
 
     public static bool IsJwtRequest(this HttpRequest request)

--- a/backend/LexBoxApi/Auth/AuthKernel.cs
+++ b/backend/LexBoxApi/Auth/AuthKernel.cs
@@ -1,6 +1,7 @@
 using System.Diagnostics.CodeAnalysis;
 using System.Net.Http.Headers;
 using System.Text;
+using LexBoxApi.Auth.Attributes;
 using LexBoxApi.Auth.Requirements;
 using LexCore.Auth;
 using Microsoft.AspNetCore.Authentication.Cookies;

--- a/backend/LexBoxApi/Auth/AuthKernel.cs
+++ b/backend/LexBoxApi/Auth/AuthKernel.cs
@@ -31,6 +31,7 @@ public static class AuthKernel
 
         services.AddScoped<LexAuthService>();
         services.AddSingleton<IAuthorizationHandler, AudienceRequirementHandler>();
+        services.AddSingleton<IAuthorizationHandler, ValidateUserUpdatedHandler>();
         services.AddAuthorization(options =>
         {
             //fallback policy is used when there's no auth attribute.

--- a/backend/LexBoxApi/Auth/RequireAudienceAttribute.cs
+++ b/backend/LexBoxApi/Auth/RequireAudienceAttribute.cs
@@ -1,22 +1,32 @@
 ﻿using LexCore.Auth;
+using Microsoft.AspNetCore.Authorization;
 
 namespace LexBoxApi.Auth;
 
-//todo for now this attribute only supports a single audience, this may be fine for now.
-//once we are at dotnet 8 we can support multiple audiences using the new IAuthorizationRequirementData api
-//https://learn.microsoft.com/en-us/aspnet/core/release-notes/aspnetcore-8.0?view=aspnetcore-7.0#iauthorizationrequirementdata
-public class RequireAudienceAttribute : LexboxAuthAttribute
+public class RequireAudienceAttribute(params LexboxAudience[] audiences)
+    : LexboxAuthAttribute(PolicyName), IAuthorizationRequirement, IAuthorizationRequirementData
 {
+    public const string PolicyName = "RequireAudiencePolicy";
     /// <param name="audience">audience allowed to access this endpoint</param>
     /// <param name="exclusive">when false the default audience is also allowed, when true the default audience is not allowed</param>
-    public RequireAudienceAttribute(LexboxAudience audience, bool exclusive = false) : base(audience.PolicyName(exclusive))
+    public RequireAudienceAttribute(LexboxAudience audience, bool exclusive) : this(exclusive
+        ? [audience]
+        : [audience, LexboxAudience.LexboxApi])
     {
+    }
+
+    public LexboxAudience[] ValidAudiences { get; } = audiences;
+
+    public IEnumerable<IAuthorizationRequirement> GetRequirements()
+    {
+        yield return this;
     }
 }
 
-public  class AllowAnyAudienceAttribute : LexboxAuthAttribute
+public class AllowAnyAudienceAttribute : LexboxAuthAttribute
 {
     public const string PolicyName = "AllowAnyAudiencePolicy";
+
     public AllowAnyAudienceAttribute() : base(PolicyName)
     {
     }

--- a/backend/LexBoxApi/Auth/Requirements/AudienceRequirementHandler.cs
+++ b/backend/LexBoxApi/Auth/Requirements/AudienceRequirementHandler.cs
@@ -1,4 +1,5 @@
-﻿using LexCore.Auth;
+﻿using LexBoxApi.Auth.Attributes;
+using LexCore.Auth;
 using Microsoft.AspNetCore.Authorization;
 
 namespace LexBoxApi.Auth.Requirements;

--- a/backend/LexBoxApi/Auth/Requirements/AudienceRequirementHandler.cs
+++ b/backend/LexBoxApi/Auth/Requirements/AudienceRequirementHandler.cs
@@ -1,22 +1,12 @@
 ﻿using LexCore.Auth;
 using Microsoft.AspNetCore.Authorization;
-using Microsoft.IdentityModel.JsonWebTokens;
 
 namespace LexBoxApi.Auth.Requirements;
 
-public class AudienceRequirement : IAuthorizationRequirement
+public class AudienceRequirementHandler : AuthorizationHandler<RequireAudienceAttribute>
 {
-    public LexboxAudience[] ValidAudiences { get; }
-
-    public AudienceRequirement(params LexboxAudience[] validAudiences)
-    {
-        ValidAudiences = validAudiences;
-    }
-}
-
-public class AudienceRequirementHandler : AuthorizationHandler<AudienceRequirement>
-{
-    protected override Task HandleRequirementAsync(AuthorizationHandlerContext context, AudienceRequirement requirement)
+    protected override Task HandleRequirementAsync(AuthorizationHandlerContext context,
+        RequireAudienceAttribute requirement)
     {
         var claim = context.User.FindFirst(LexAuthConstants.AudienceClaimType);
         if (Enum.TryParse<LexboxAudience>(claim?.Value, out var audience) &&

--- a/backend/LexBoxApi/Auth/Requirements/AudienceRequirementHandler.cs
+++ b/backend/LexBoxApi/Auth/Requirements/AudienceRequirementHandler.cs
@@ -4,8 +4,9 @@ using Microsoft.AspNetCore.Authorization;
 
 namespace LexBoxApi.Auth.Requirements;
 
-public class AudienceRequirementHandler : AuthorizationHandler<RequireAudienceAttribute>
+public class AudienceRequirementHandler(ILogger<AudienceRequirementHandler> logger) : AuthorizationHandler<RequireAudienceAttribute>
 {
+
     protected override Task HandleRequirementAsync(AuthorizationHandlerContext context,
         RequireAudienceAttribute requirement)
     {
@@ -17,6 +18,7 @@ public class AudienceRequirementHandler : AuthorizationHandler<RequireAudienceAt
         }
         else
         {
+            logger.LogInformation("Token does not have the required audience: [{Audience}] not in {ValidAudiences}", claim?.Value, string.Join(',', requirement.ValidAudiences));
             context.Fail(new AuthorizationFailureReason(this,
                 $"Token does not have the required audience: {requirement.ValidAudiences}"));
         }

--- a/backend/LexBoxApi/Auth/Requirements/ValidateUserUpdatedHandler.cs
+++ b/backend/LexBoxApi/Auth/Requirements/ValidateUserUpdatedHandler.cs
@@ -6,7 +6,7 @@ using Microsoft.EntityFrameworkCore;
 
 namespace LexBoxApi.Auth.Requirements;
 
-public class ValidateUserUpdatedHandler(IHttpContextAccessor httpContextAccessor) : AuthorizationHandler<RequireCurrentUserInfoAttribute>
+public class ValidateUserUpdatedHandler(IHttpContextAccessor httpContextAccessor, ILogger<ValidateUserUpdatedHandler> logger) : AuthorizationHandler<RequireCurrentUserInfoAttribute>
 {
     protected override async Task HandleRequirementAsync(AuthorizationHandlerContext context, RequireCurrentUserInfoAttribute requirement)
     {
@@ -17,6 +17,7 @@ public class ValidateUserUpdatedHandler(IHttpContextAccessor httpContextAccessor
         var actualUpdatedDate = await userService.GetUserUpdatedDate(user.Id);
         if (actualUpdatedDate != user.UpdatedDate)
         {
+            logger.LogInformation("User has been updated since login, {UpdatedDate} != {ActualUpdatedDate}", user.UpdatedDate, actualUpdatedDate);
             context.Fail(new AuthorizationFailureReason(this, "User has been updated since login"));
         }
         else

--- a/backend/LexBoxApi/Auth/Requirements/ValidateUserUpdatedHandler.cs
+++ b/backend/LexBoxApi/Auth/Requirements/ValidateUserUpdatedHandler.cs
@@ -1,0 +1,27 @@
+﻿using LexBoxApi.Auth.Attributes;
+using LexBoxApi.Services;
+using LexData;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.EntityFrameworkCore;
+
+namespace LexBoxApi.Auth.Requirements;
+
+public class ValidateUserUpdatedHandler(IHttpContextAccessor httpContextAccessor) : AuthorizationHandler<RequireCurrentUserInfoAttribute>
+{
+    protected override async Task HandleRequirementAsync(AuthorizationHandlerContext context, RequireCurrentUserInfoAttribute requirement)
+    {
+        var httpContext = httpContextAccessor.HttpContext;
+        var user = httpContext?.RequestServices.GetRequiredService<LoggedInContext>().MaybeUser;
+        if (user is null) return;
+        var userService = httpContext!.RequestServices.GetRequiredService<UserService>();
+        var actualUpdatedDate = await userService.GetUserUpdatedDate(user.Id);
+        if (actualUpdatedDate != user.UpdatedDate)
+        {
+            context.Fail(new AuthorizationFailureReason(this, "User has been updated since login"));
+        }
+        else
+        {
+            context.Succeed(requirement);
+        }
+    }
+}

--- a/backend/LexBoxApi/Controllers/AdminController.cs
+++ b/backend/LexBoxApi/Controllers/AdminController.cs
@@ -1,5 +1,6 @@
 using System.ComponentModel.DataAnnotations;
 using LexBoxApi.Auth;
+using LexBoxApi.Auth.Attributes;
 using LexBoxApi.Services;
 using LexCore;
 using LexData;

--- a/backend/LexBoxApi/Controllers/AdminController.cs
+++ b/backend/LexBoxApi/Controllers/AdminController.cs
@@ -34,9 +34,9 @@ public class AdminController : ControllerBase
     public async Task<ActionResult> ResetPasswordAdmin(ResetPasswordAdminRequest request)
     {
         var passwordHash = request.PasswordHash;
-        var lexAuthUser = _loggedInContext.User;
         var user = await _lexBoxDbContext.Users.FirstAsync(u => u.Id == request.userId);
         user.PasswordHash = PasswordHashing.HashPassword(passwordHash, user.Salt, true);
+        user.UpdateUpdatedDate();
         await _lexBoxDbContext.SaveChangesAsync();
         await _emailService.SendPasswordChangedEmail(user);
         return Ok();

--- a/backend/LexBoxApi/Controllers/AuthTestingController.cs
+++ b/backend/LexBoxApi/Controllers/AuthTestingController.cs
@@ -1,4 +1,5 @@
 ﻿using LexBoxApi.Auth;
+using LexBoxApi.Auth.Attributes;
 using LexCore.Auth;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;

--- a/backend/LexBoxApi/Controllers/LoginController.cs
+++ b/backend/LexBoxApi/Controllers/LoginController.cs
@@ -1,5 +1,6 @@
 using System.ComponentModel.DataAnnotations;
 using LexBoxApi.Auth;
+using LexBoxApi.Auth.Attributes;
 using LexBoxApi.Models;
 using LexBoxApi.Otel;
 using LexBoxApi.Services;

--- a/backend/LexBoxApi/Controllers/LoginController.cs
+++ b/backend/LexBoxApi/Controllers/LoginController.cs
@@ -143,6 +143,7 @@ public class LoginController : ControllerBase
         var lexAuthUser = _loggedInContext.User;
         var user = await _lexBoxDbContext.Users.FirstAsync(u => u.Id == lexAuthUser.Id);
         user.PasswordHash = PasswordHashing.HashPassword(passwordHash, user.Salt, true);
+        user.UpdateUpdatedDate();
         await _lexBoxDbContext.SaveChangesAsync();
         await _emailService.SendPasswordChangedEmail(user);
         //the old jwt is only valid for calling forgot password endpoints, we need to generate a new one

--- a/backend/LexBoxApi/Controllers/LoginController.cs
+++ b/backend/LexBoxApi/Controllers/LoginController.cs
@@ -86,7 +86,10 @@ public class LoginController : ControllerBase
         var userId = _loggedInContext.User.Id;
         var user = await _lexBoxDbContext.Users.FindAsync(userId);
         if (user == null) return NotFound();
-        if (user.UpdatedDate.ToUnixTimeSeconds() != _loggedInContext.User.UpdatedDate)
+        //users can verify their email even if the updated date is out of sync when not changing their email
+        //this is to prevent some edge cases where changing their name and then using an old verify email link would fail
+        if (user.Email != _loggedInContext.User.Email &&
+            user.UpdatedDate.ToUnixTimeSeconds() != _loggedInContext.User.UpdatedDate)
         {
             return await EmailLinkExpired();
         }

--- a/backend/LexBoxApi/Controllers/LoginController.cs
+++ b/backend/LexBoxApi/Controllers/LoginController.cs
@@ -86,7 +86,7 @@ public class LoginController : ControllerBase
         var userId = _loggedInContext.User.Id;
         var user = await _lexBoxDbContext.Users.FindAsync(userId);
         if (user == null) return NotFound();
-        if (user.UpdatedDate != _loggedInContext.User.UpdatedDate)
+        if (user.UpdatedDate.ToUnixTimeSeconds() != _loggedInContext.User.UpdatedDate)
         {
             return await EmailLinkExpired();
         }

--- a/backend/LexBoxApi/Controllers/MigrationController.cs
+++ b/backend/LexBoxApi/Controllers/MigrationController.cs
@@ -1,4 +1,5 @@
 using LexBoxApi.Auth;
+using LexBoxApi.Auth.Attributes;
 using LexBoxApi.Services;
 using LexCore.Entities;
 using LexData;

--- a/backend/LexBoxApi/Controllers/ProjectController.cs
+++ b/backend/LexBoxApi/Controllers/ProjectController.cs
@@ -1,4 +1,5 @@
 using LexBoxApi.Auth;
+using LexBoxApi.Auth.Attributes;
 using LexBoxApi.Services;
 using LexCore.Entities;
 using LexCore.ServiceInterfaces;

--- a/backend/LexBoxApi/GraphQL/LexQueries.cs
+++ b/backend/LexBoxApi/GraphQL/LexQueries.cs
@@ -1,4 +1,5 @@
 using LexBoxApi.Auth;
+using LexBoxApi.Auth.Attributes;
 using LexCore.Auth;
 using LexCore.Entities;
 using LexCore.ServiceInterfaces;

--- a/backend/LexBoxApi/GraphQL/ProjectMutations.cs
+++ b/backend/LexBoxApi/GraphQL/ProjectMutations.cs
@@ -1,4 +1,5 @@
 ﻿using LexBoxApi.Auth;
+using LexBoxApi.Auth.Attributes;
 using LexBoxApi.GraphQL.CustomTypes;
 using LexBoxApi.Models.Project;
 using LexBoxApi.Services;

--- a/backend/LexBoxApi/GraphQL/TestQueries.cs
+++ b/backend/LexBoxApi/GraphQL/TestQueries.cs
@@ -1,4 +1,5 @@
 ﻿using LexBoxApi.Auth;
+using LexBoxApi.Auth.Attributes;
 using LexCore.Auth;
 
 namespace LexBoxApi.GraphQL;

--- a/backend/LexBoxApi/GraphQL/UserMutations.cs
+++ b/backend/LexBoxApi/GraphQL/UserMutations.cs
@@ -1,5 +1,6 @@
 ﻿using System.ComponentModel.DataAnnotations;
 using LexBoxApi.Auth;
+using LexBoxApi.Auth.Attributes;
 using LexBoxApi.GraphQL.CustomTypes;
 using LexBoxApi.Models.Project;
 using LexBoxApi.Services;

--- a/backend/LexBoxApi/GraphQL/UserMutations.cs
+++ b/backend/LexBoxApi/GraphQL/UserMutations.cs
@@ -81,7 +81,7 @@ public class UserMutations
                 user.IsAdmin = adminInput.Role == UserRole.admin;
             }
         }
-
+        user.UpdateUpdatedDate();
         await dbContext.SaveChangesAsync();
 
         if (!input.Email.IsNullOrEmpty() && !input.Email.Equals(user.Email, StringComparison.InvariantCultureIgnoreCase))

--- a/backend/LexBoxApi/Program.cs
+++ b/backend/LexBoxApi/Program.cs
@@ -2,6 +2,7 @@ using System.Net;
 using System.Text.Json.Serialization;
 using LexBoxApi;
 using LexBoxApi.Auth;
+using LexBoxApi.Auth.Attributes;
 using LexBoxApi.ErrorHandling;
 using LexBoxApi.Otel;
 using LexBoxApi.Services;

--- a/backend/LexBoxApi/Services/UserService.cs
+++ b/backend/LexBoxApi/Services/UserService.cs
@@ -18,10 +18,10 @@ public class UserService
             .ExecuteUpdateAsync(c => c.SetProperty(u => u.LastActive, DateTimeOffset.UtcNow));
     }
 
-    public async Task<DateTimeOffset> GetUserUpdatedDate(Guid id)
+    public async Task<long> GetUserUpdatedDate(Guid id)
     {
-        return await _dbContext.Users.Where(u => u.Id == id)
+        return (await _dbContext.Users.Where(u => u.Id == id)
             .Select(u => u.UpdatedDate)
-            .SingleOrDefaultAsync();
+            .SingleOrDefaultAsync()).ToUnixTimeSeconds();
     }
 }

--- a/backend/LexBoxApi/Services/UserService.cs
+++ b/backend/LexBoxApi/Services/UserService.cs
@@ -17,4 +17,11 @@ public class UserService
         await _dbContext.Users.Where(u => u.Id == id)
             .ExecuteUpdateAsync(c => c.SetProperty(u => u.LastActive, DateTimeOffset.UtcNow));
     }
+
+    public async Task<DateTimeOffset> GetUserUpdatedDate(Guid id)
+    {
+        return await _dbContext.Users.Where(u => u.Id == id)
+            .Select(u => u.UpdatedDate)
+            .SingleOrDefaultAsync();
+    }
 }

--- a/backend/LexCore/Auth/LexAuthConstants.cs
+++ b/backend/LexCore/Auth/LexAuthConstants.cs
@@ -10,6 +10,7 @@ public static class LexAuthConstants
     public const string ProjectsClaimType = "proj";
     public const string EmailUnverifiedClaimType = "unver";
     public const string CanCreateProjectClaimType = "mkproj";
+    public const string UpdatedDateClaimType = "date";
 }
 
 /// <summary>

--- a/backend/LexCore/Auth/LexAuthUser.cs
+++ b/backend/LexCore/Auth/LexAuthUser.cs
@@ -39,6 +39,11 @@ public record LexAuthUser
                         case ClaimValueTypes.Boolean:
                             jsonObject.Add(claim.Type, JsonValue.Create(bool.Parse(claim.Value)));
                             continue;
+                        case ClaimValueTypes.Integer:
+                        case ClaimValueTypes.Integer32:
+                        case ClaimValueTypes.Integer64:
+                            jsonObject.Add(claim.Type, JsonValue.Create(int.Parse(claim.Value)));
+                            continue;
                         default:
                             jsonObject.Add(claim.Type, JsonValue.Create(claim.Value));
                             continue;
@@ -83,7 +88,7 @@ public record LexAuthUser
         Email = user.Email;
         Role = user.IsAdmin ? UserRole.admin : UserRole.user;
         Name = user.Name;
-        UpdatedDate = user.UpdatedDate;
+        UpdatedDate = user.UpdatedDate.ToUnixTimeSeconds();
         Projects = user.IsAdmin
             ? Array.Empty<AuthUserProject>() // admins have access to all projects, so we don't include them to prevent going over the jwt limit
             : user.Projects.Select(p => new AuthUserProject(p.Role, p.ProjectId)).ToArray();
@@ -94,7 +99,7 @@ public record LexAuthUser
     [JsonPropertyName(LexAuthConstants.IdClaimType)]
     public required Guid Id { get; set; }
     [JsonPropertyName(LexAuthConstants.UpdatedDateClaimType)]
-    public required DateTimeOffset UpdatedDate { get; set; }
+    public required long UpdatedDate { get; set; }
     [JsonPropertyName(LexAuthConstants.AudienceClaimType)]
     public LexboxAudience Audience { get; set; } = LexboxAudience.LexboxApi;
 
@@ -184,6 +189,9 @@ public record LexAuthUser
                     yield return new Claim(jsonProperty.Name, jsonProperty.Value.ToString(), ClaimValueTypes.Boolean);
                     break;
                 case JsonValueKind.Null:
+                    break;
+                case JsonValueKind.Number:
+                    yield return new Claim(jsonProperty.Name, jsonProperty.Value.ToString(), ClaimValueTypes.Integer);
                     break;
                 default:
                     yield return new Claim(jsonProperty.Name, jsonProperty.Value.ToString());

--- a/backend/LexCore/Auth/LexAuthUser.cs
+++ b/backend/LexCore/Auth/LexAuthUser.cs
@@ -83,6 +83,7 @@ public record LexAuthUser
         Email = user.Email;
         Role = user.IsAdmin ? UserRole.admin : UserRole.user;
         Name = user.Name;
+        UpdatedDate = user.UpdatedDate;
         Projects = user.IsAdmin
             ? Array.Empty<AuthUserProject>() // admins have access to all projects, so we don't include them to prevent going over the jwt limit
             : user.Projects.Select(p => new AuthUserProject(p.Role, p.ProjectId)).ToArray();
@@ -92,7 +93,8 @@ public record LexAuthUser
 
     [JsonPropertyName(LexAuthConstants.IdClaimType)]
     public required Guid Id { get; set; }
-
+    [JsonPropertyName(LexAuthConstants.UpdatedDateClaimType)]
+    public required DateTimeOffset UpdatedDate { get; set; }
     [JsonPropertyName(LexAuthConstants.AudienceClaimType)]
     public LexboxAudience Audience { get; set; } = LexboxAudience.LexboxApi;
 

--- a/backend/LexCore/Auth/LexboxAudience.cs
+++ b/backend/LexCore/Auth/LexboxAudience.cs
@@ -12,11 +12,3 @@ public enum LexboxAudience
     ForgotPassword,
     SendAndReceive,
 }
-
-public static class LexboxAudienceHelper
-{
-    public static string PolicyName(this LexboxAudience audience, bool exclusive)
-    {
-        return $"RequireAudience{audience}{(exclusive ? "Exclusive" : "")}Policy";
-    }
-}

--- a/backend/LexCore/Entities/EntityBase.cs
+++ b/backend/LexCore/Entities/EntityBase.cs
@@ -5,4 +5,5 @@ public class EntityBase
     public Guid Id { get; init; }
     public DateTimeOffset CreatedDate { get; set; } = DateTimeOffset.UtcNow;
     public DateTimeOffset UpdatedDate { get; set; } = DateTimeOffset.UtcNow;
+    public void UpdateUpdatedDate() => UpdatedDate = DateTimeOffset.UtcNow;
 }

--- a/backend/Testing/ApiTests/ApiTestBase.cs
+++ b/backend/Testing/ApiTests/ApiTestBase.cs
@@ -10,7 +10,7 @@ namespace Testing.ApiTests;
 
 public class ApiTestBase
 {
-    public readonly string BaseUrl = TestingEnvironmentVariables.ServerBaseUrl;
+    public string BaseUrl => TestingEnvironmentVariables.ServerBaseUrl;
     private readonly HttpClientHandler _httpClientHandler = new();
     public readonly HttpClient HttpClient;
 

--- a/backend/Testing/Browser/EmailWorkflowTests.cs
+++ b/backend/Testing/Browser/EmailWorkflowTests.cs
@@ -97,8 +97,7 @@ public class EmailWorkflowTests : PageTest
 
         // Step: Verify email link has expired
         inboxPage = await MailInboxPage.Get(Page, mailinatorId).Goto();
-        emailPage = await inboxPage.OpenEmail();
-        //this is never returning a page for some reason
+        emailPage = await inboxPage.OpenEmail(1); // 0 is the password changed notification
         newPage = await Page.Context.RunAndWaitForPageAsync(emailPage.ClickResetPassword);
         loginPage = await new LoginPage(newPage).WaitFor();
         await Expect(loginPage.Page.GetByText("The email you clicked has expired")).ToBeVisibleAsync();

--- a/backend/Testing/Browser/EmailWorkflowTests.cs
+++ b/backend/Testing/Browser/EmailWorkflowTests.cs
@@ -1,4 +1,5 @@
-﻿using Testing.Browser.Base;
+﻿using Shouldly;
+using Testing.Browser.Base;
 using Testing.Browser.Page;
 using Testing.Browser.Page.External;
 
@@ -81,6 +82,8 @@ public class EmailWorkflowTests : PageTest
         // Step: Use reset password link
         var inboxPage = await MailInboxPage.Get(Page, mailinatorId).Goto();
         var emailPage = await inboxPage.OpenEmail();
+        var resetPasswordUrl = await emailPage.GetFirstLanguageDepotUrl();
+        resetPasswordUrl.ShouldNotBeNull().ShouldContain("resetpassword");
 
         var newPage = await Page.Context.RunAndWaitForPageAsync(emailPage.ClickResetPassword);
         var resetPasswordPage = await new ResetPasswordPage(newPage).WaitFor();
@@ -96,10 +99,8 @@ public class EmailWorkflowTests : PageTest
         await userDashboardPage.WaitFor();
 
         // Step: Verify email link has expired
-        inboxPage = await MailInboxPage.Get(Page, mailinatorId).Goto();
-        emailPage = await inboxPage.OpenEmail(1); // 0 is the password changed notification
-        newPage = await Page.Context.RunAndWaitForPageAsync(emailPage.ClickResetPassword);
-        loginPage = await new LoginPage(newPage).WaitFor();
+        await Page.GotoAsync(resetPasswordUrl);
+        loginPage = await new LoginPage(Page).WaitFor();
         await Expect(loginPage.Page.GetByText("The email you clicked has expired")).ToBeVisibleAsync();
     }
 }

--- a/backend/Testing/Browser/EmailWorkflowTests.cs
+++ b/backend/Testing/Browser/EmailWorkflowTests.cs
@@ -94,5 +94,13 @@ public class EmailWorkflowTests : PageTest
         await loginPage.FillForm(email, newPassword);
         await loginPage.Submit();
         await userDashboardPage.WaitFor();
+
+        // Step: Verify email link has expired
+        inboxPage = await MailInboxPage.Get(Page, mailinatorId).Goto();
+        emailPage = await inboxPage.OpenEmail();
+        //this is never returning a page for some reason
+        newPage = await Page.Context.RunAndWaitForPageAsync(emailPage.ClickResetPassword);
+        loginPage = await new LoginPage(newPage).WaitFor();
+        await Expect(loginPage.Page.GetByText("The email you clicked has expired")).ToBeVisibleAsync();
     }
 }

--- a/backend/Testing/Browser/Page/BasePage.cs
+++ b/backend/Testing/Browser/Page/BasePage.cs
@@ -46,13 +46,16 @@ public abstract class BasePage<T> where T : BasePage<T>
     {
         if (UrlPattern is not null)
         {
+            //assert to get a good error message
+            await Assertions.Expect(Page).ToHaveURLAsync(UrlPattern);
+            //still wait to make sure we reach the same state we expect
             await Page.WaitForURLAsync(UrlPattern, new() { WaitUntil = WaitUntilState.Load });
         }
         else
         {
             await Page.WaitForLoadStateAsync(LoadState.Load);
         }
-        await Task.WhenAll(TestLocators.Select(l => l.WaitForAsync()));
+        await Task.WhenAll(TestLocators.Select(l => Assertions.Expect(l).ToBeVisibleAsync()));
         return (T)this;
     }
 }

--- a/backend/Testing/LexCore/LexAuthUserTests.cs
+++ b/backend/Testing/LexCore/LexAuthUserTests.cs
@@ -32,7 +32,7 @@ public class LexAuthUserTests
         Email = "test@test.com",
         Role = UserRole.user,
         Name = "test",
-        UpdatedDate = DateTimeOffset.Now,
+        UpdatedDate = DateTimeOffset.Now.ToUnixTimeSeconds(),
         Projects = new[] { new AuthUserProject(ProjectRole.Manager, Guid.NewGuid()) }
     };
 

--- a/backend/Testing/LexCore/LexAuthUserTests.cs
+++ b/backend/Testing/LexCore/LexAuthUserTests.cs
@@ -32,6 +32,7 @@ public class LexAuthUserTests
         Email = "test@test.com",
         Role = UserRole.user,
         Name = "test",
+        UpdatedDate = DateTimeOffset.Now,
         Projects = new[] { new AuthUserProject(ProjectRole.Manager, Guid.NewGuid()) }
     };
 

--- a/backend/Testing/Services/TestingEnvironmentVariables.cs
+++ b/backend/Testing/Services/TestingEnvironmentVariables.cs
@@ -2,7 +2,7 @@ namespace Testing.Services;
 
 public static class TestingEnvironmentVariables
 {
-    public static readonly string ServerHostname = Environment.GetEnvironmentVariable("TEST_SERVER_HOSTNAME") ?? "localhost";
+    public static string ServerHostname = Environment.GetEnvironmentVariable("TEST_SERVER_HOSTNAME") ?? "localhost";
     public static readonly bool IsDev = ServerHostname.StartsWith("localhost");
     public static string HttpScheme = IsDev ? "http://" : "https://";
     public static string ServerBaseUrl => $"{HttpScheme}{ServerHostname}";

--- a/frontend/schema.graphql
+++ b/frontend/schema.graphql
@@ -91,6 +91,7 @@ type IsAdminResponse {
 
 type LexAuthUser {
   id: UUID!
+  updatedDate: DateTime!
   audience: LexboxAudience!
   email: String!
   name: String!

--- a/frontend/src/lib/i18n/locales/en.json
+++ b/frontend/src/lib/i18n/locales/en.json
@@ -119,6 +119,7 @@
     "title": "Log in",
     "password_missing": "Password missing",
     "password_reset": "Your password has been reset",
+    "link_expired": "The email you clicked has expired. Please request a new one.",
     "welcome": "### Welcome to Language Depot!\n\
 Language Depot is a hosting service for [FieldWorks (FLEx)](https://software.sil.org/fieldworks/), \
 [Language Forge](https://languageforge.org/), [OneStory Editor](https://onestory.org/) and [WeSay](https://software.sil.org/wesay/) projects. \

--- a/frontend/src/routes/(unauthenticated)/login/+page.svelte
+++ b/frontend/src/routes/(unauthenticated)/login/+page.svelte
@@ -31,7 +31,13 @@
     }
   );
 
-  onMount(logout);
+  onMount(() => {
+    const code = new URLSearchParams(window.location.search).get('message');
+    if (code === 'link_expired') {
+      $message = $t('login.link_expired');
+    }
+    logout();
+  });
   let badCredentials = false;
 </script>
 


### PR DESCRIPTION
closes #98 

sends the user to the login page with an error when they click an expired jwt link where the jwt was expired because the user has been updated since it was generated.

@myieye I can't get the test to work, it's kinda hard to follow and figure out what I need to do to click on the link again.