### PR TITLE
Chore/145 shorter lived email jwt

### DIFF
--- a/backend/LexBoxApi/Auth/JwtOptions.cs
+++ b/backend/LexBoxApi/Auth/JwtOptions.cs
@@ -8,6 +8,7 @@ public class JwtOptions
         {
             Lifetime = TimeSpan.FromMinutes(1),
             RefreshLifetime = TimeSpan.FromMinutes(1),
+            EmailJwtLifetime = TimeSpan.FromMinutes(1),
             Secret = "this is only a test but must be long",
             ClockSkew = TimeSpan.Zero
         };
@@ -17,6 +18,8 @@ public class JwtOptions
 
     [Required]
     public required TimeSpan Lifetime { get; init; }
+    [Required]
+    public required TimeSpan EmailJwtLifetime { get; init; }
 
     [Required]
     public required TimeSpan RefreshLifetime { get; init; }

--- a/backend/LexBoxApi/Auth/LexAuthService.cs
+++ b/backend/LexBoxApi/Auth/LexAuthService.cs
@@ -2,7 +2,6 @@ using System.Globalization;
 using System.IdentityModel.Tokens.Jwt;
 using System.Security.Claims;
 using System.Text;
-using LexBoxApi.Services;
 using LexCore;
 using LexCore.Auth;
 using LexCore.Entities;
@@ -21,17 +20,14 @@ public class LexAuthService
     public const string RefreshHeaderName = "lexbox-refresh-jwt";
     private readonly IOptions<JwtOptions> _userOptions;
     private readonly LexBoxDbContext _lexBoxDbContext;
-    private readonly EmailService _emailService;
     private readonly IHttpContextAccessor _httpContextAccessor;
 
     public LexAuthService(IOptions<JwtOptions> userOptions,
         LexBoxDbContext lexBoxDbContext,
-        EmailService emailService,
         IHttpContextAccessor httpContextAccessor)
     {
         _userOptions = userOptions;
         _lexBoxDbContext = lexBoxDbContext;
-        _emailService = emailService;
         _httpContextAccessor = httpContextAccessor;
     }
 

--- a/backend/LexBoxApi/Auth/LexAuthService.cs
+++ b/backend/LexBoxApi/Auth/LexAuthService.cs
@@ -62,14 +62,7 @@ public class LexAuthService
         return new SymmetricSecurityKey(Encoding.UTF8.GetBytes(jwtOptions.Secret));
     }
 
-    public async Task ForgotPassword(string email)
-    {
-        var (lexAuthUser, user) = await GetUser(email);
-        // we want to silently return if the user doesn't exist, so we don't leak information.
-        if (lexAuthUser is null || user?.CanLogin() is not true) return;
-        var (jwt, _) = GenerateJwt(lexAuthUser, audience: LexboxAudience.ForgotPassword);
-        await _emailService.SendForgotPasswordEmail(jwt, user);
-    }
+
 
     public async Task<LexAuthUser?> Login(LoginRequest loginRequest)
     {
@@ -97,7 +90,7 @@ public class LexAuthService
         return jwtUser;
     }
 
-    private async Task<(LexAuthUser? lexAuthUser, User? user)> GetUser(string emailOrUsername)
+    public async Task<(LexAuthUser? lexAuthUser, User? user)> GetUser(string emailOrUsername)
     {
         var user = await _lexBoxDbContext.Users
             .FilterByEmail(emailOrUsername)

--- a/backend/LexBoxApi/Auth/LexAuthService.cs
+++ b/backend/LexBoxApi/Auth/LexAuthService.cs
@@ -96,13 +96,11 @@ public class LexAuthService
     }
 
     public (string token, TimeSpan tokenLifetime) GenerateJwt(LexAuthUser user,
-        TimeSpan? lifetime = null,
-        LexboxAudience audience = LexboxAudience.LexboxApi)
+        LexboxAudience audience = LexboxAudience.LexboxApi,
+        bool useEmailLifetime = false)
     {
-        lifetime ??= TimeSpan.MaxValue;
         var options = _userOptions.Value;
-        // use the min lifetime, prevents the caller setting a longer lifetime then is configured in the application.
-        return GenerateToken(user, audience, lifetime.Value > options.Lifetime ? options.Lifetime : lifetime.Value);
+        return GenerateToken(user, audience, useEmailLifetime ? options.EmailJwtLifetime : options.Lifetime);
     }
 
     private (string token, TimeSpan tokenLifetime) GenerateToken(LexAuthUser user,

--- a/backend/LexBoxApi/Controllers/LoginController.cs
+++ b/backend/LexBoxApi/Controllers/LoginController.cs
@@ -149,7 +149,7 @@ public class LoginController : ControllerBase
             return ValidationProblem(ModelState);
         }
 
-        await _lexAuthService.ForgotPassword(input.Email);
+        await _userService.ForgotPassword(input.Email);
         return Ok();
     }
 

--- a/backend/LexBoxApi/Controllers/UserController.cs
+++ b/backend/LexBoxApi/Controllers/UserController.cs
@@ -87,7 +87,7 @@ public class UserController : ControllerBase
         await HttpContext.SignInAsync(user.GetPrincipal("Registration"),
             new AuthenticationProperties { IsPersistent = true });
 
-        await SendVerificationEmail(user, userEntity);
+        await _emailService.SendVerifyAddressEmail(userEntity);
         return Ok(user);
     }
 
@@ -100,14 +100,8 @@ public class UserController : ControllerBase
         var lexUser = _loggedInContext.User;
         var user = await _lexBoxDbContext.Users.FindAsync(lexUser.Id);
         if (user?.CanLogin() is not true) return NotFound();
-        await SendVerificationEmail(lexUser, user);
+        await _emailService.SendVerifyAddressEmail(user);
         return Ok();
-    }
-
-    private async Task SendVerificationEmail(LexAuthUser lexUser, User user)
-    {
-        var (jwt, _) = _lexAuthService.GenerateJwt(lexUser with { EmailVerificationRequired = null });
-        await _emailService.SendVerifyAddressEmail(jwt, user);
     }
 
     [HttpGet("currentUser")]

--- a/backend/LexBoxApi/Services/EmailService.cs
+++ b/backend/LexBoxApi/Services/EmailService.cs
@@ -32,7 +32,7 @@ public class EmailService(
         var (lexAuthUser, user) = await lexAuthService.GetUser(emailAddress);
         // we want to silently return if the user doesn't exist, so we don't leak information.
         if (lexAuthUser is null || user?.CanLogin() is not true) return;
-        var (jwt, _) = lexAuthService.GenerateJwt(lexAuthUser, audience: LexboxAudience.ForgotPassword);
+        var (jwt, _) = lexAuthService.GenerateJwt(lexAuthUser, LexboxAudience.ForgotPassword, true);
 
         var email = StartUserEmail(user);
         var httpContext = httpContextAccessor.HttpContext;
@@ -58,10 +58,11 @@ public class EmailService(
     public async Task SendVerifyAddressEmail(User user, string? newEmail = null)
     {
         var (jwt, _) = lexAuthService.GenerateJwt(new LexAuthUser(user)
-        {
-            EmailVerificationRequired = null,
-            Email = newEmail ?? user.Email,
-        });
+            {
+                EmailVerificationRequired = null, Email = newEmail ?? user.Email,
+            },
+            useEmailLifetime: true
+        );
         var email = StartUserEmail(user, newEmail);
         var httpContext = httpContextAccessor.HttpContext;
         ArgumentNullException.ThrowIfNull(httpContext);

--- a/backend/LexBoxApi/Services/UserService.cs
+++ b/backend/LexBoxApi/Services/UserService.cs
@@ -1,26 +1,29 @@
-﻿using LexData;
+﻿using LexBoxApi.Auth;
+using LexCore.Auth;
+using LexData;
 using Microsoft.EntityFrameworkCore;
 
 namespace LexBoxApi.Services;
 
-public class UserService
+public class UserService(LexBoxDbContext dbContext, EmailService emailService, LexAuthService lexAuthService)
 {
-    private readonly LexBoxDbContext _dbContext;
-
-    public UserService(LexBoxDbContext dbContext)
+    public async Task ForgotPassword(string email)
     {
-        _dbContext = dbContext;
+        var (lexAuthUser, user) = await lexAuthService.GetUser(email);
+        // we want to silently return if the user doesn't exist, so we don't leak information.
+        if (lexAuthUser is null || user?.CanLogin() is not true) return;
+        var (jwt, _) = lexAuthService.GenerateJwt(lexAuthUser, audience: LexboxAudience.ForgotPassword);
+        await emailService.SendForgotPasswordEmail(jwt, user);
     }
-
     public async Task UpdateUserLastActive(Guid id)
     {
-        await _dbContext.Users.Where(u => u.Id == id)
+        await dbContext.Users.Where(u => u.Id == id)
             .ExecuteUpdateAsync(c => c.SetProperty(u => u.LastActive, DateTimeOffset.UtcNow));
     }
 
     public async Task<long> GetUserUpdatedDate(Guid id)
     {
-        return (await _dbContext.Users.Where(u => u.Id == id)
+        return (await dbContext.Users.Where(u => u.Id == id)
             .Select(u => u.UpdatedDate)
             .SingleOrDefaultAsync()).ToUnixTimeSeconds();
     }

--- a/backend/LexBoxApi/Services/UserService.cs
+++ b/backend/LexBoxApi/Services/UserService.cs
@@ -9,11 +9,7 @@ public class UserService(LexBoxDbContext dbContext, EmailService emailService, L
 {
     public async Task ForgotPassword(string email)
     {
-        var (lexAuthUser, user) = await lexAuthService.GetUser(email);
-        // we want to silently return if the user doesn't exist, so we don't leak information.
-        if (lexAuthUser is null || user?.CanLogin() is not true) return;
-        var (jwt, _) = lexAuthService.GenerateJwt(lexAuthUser, audience: LexboxAudience.ForgotPassword);
-        await emailService.SendForgotPasswordEmail(jwt, user);
+        await emailService.SendForgotPasswordEmail(email);
     }
     public async Task UpdateUserLastActive(Guid id)
     {

--- a/backend/LexBoxApi/appsettings.json
+++ b/backend/LexBoxApi/appsettings.json
@@ -53,7 +53,7 @@
       "Secret": null,
 //      does not effect jwt used for the cookie
       "Lifetime": "01:00",
-      "EmailJwtLifetime": "1.00:00", //1 day, 0 hours
+      "EmailJwtLifetime": "3.00:00", //3 days, 0 hours
       "RefreshLifetime": "07:00:00",
       "ClockSkew": "00:00:00"
     },

--- a/backend/LexBoxApi/appsettings.json
+++ b/backend/LexBoxApi/appsettings.json
@@ -53,6 +53,7 @@
       "Secret": null,
 //      does not effect jwt used for the cookie
       "Lifetime": "01:00",
+      "EmailJwtLifetime": "1.00:00", //1 day, 0 hours
       "RefreshLifetime": "07:00:00",
       "ClockSkew": "00:00:00"
     },

--- a/backend/Testing/Browser/UserPageTest.cs
+++ b/backend/Testing/Browser/UserPageTest.cs
@@ -1,5 +1,6 @@
 using Testing.Browser.Base;
 using Testing.Browser.Page;
+using Testing.Browser.Page.External;
 
 namespace Testing.Browser;
 
@@ -37,7 +38,8 @@ public class UserPageTest : PageTest
     [Fact]
     public async Task CanResetPassword()
     {
-        await using var userDashboardPage = await RegisterUser("Test: Edit account - reset password", $"{Guid.NewGuid()}@mailinator.com", "test_edit_account_reset_password");
+        var mailinatorId = Guid.NewGuid().ToString();
+        await using var userDashboardPage = await RegisterUser("Test: Edit account - reset password", $"{mailinatorId}@mailinator.com", "test_edit_account_reset_password");
         var user = userDashboardPage.User;
         var userPage = await new UserAccountSettingsPage(Page).Goto();
         var resetPasswordPage = await userPage.ClickResetPassword();
@@ -49,5 +51,10 @@ public class UserPageTest : PageTest
         await loginPage.FillForm(userDashboardPage.User.Email, newPassword);
         await loginPage.Submit();
         await new UserDashboardPage(Page).WaitFor();
+
+        //verify password changed email was received
+        var inboxPage = await MailInboxPage.Get(Page, mailinatorId).Goto();
+        var emailPage = await inboxPage.OpenEmail();
+        await Expect(emailPage.Page.GetByText("Your password was changed").First).ToBeVisibleAsync();
     }
 }

--- a/backend/Testing/LexCore/LexAuthUserTests.cs
+++ b/backend/Testing/LexCore/LexAuthUserTests.cs
@@ -23,7 +23,6 @@ public class LexAuthUserTests
     private readonly LexAuthService _lexAuthService = new LexAuthService(
         new OptionsWrapper<JwtOptions>(JwtOptions.TestingOptions),
         null!,
-        null!,
         null!);
 
     private readonly LexAuthUser _user = new()


### PR DESCRIPTION
closes #145

this changes the lifetime of jwts in emails so that they expire after 24 hours. Also includes some refactoring and makes the jwt generation the responsibility of the email service and not the caller.

Should we mention the expiration time in the email?