### PR TITLE
Determine project type from files in repo

### DIFF
--- a/backend/LexBoxApi/Controllers/ProjectController.cs
+++ b/backend/LexBoxApi/Controllers/ProjectController.cs
@@ -78,8 +78,7 @@ public class ProjectController : ControllerBase
         if (project is null) return NotFound();
         if (project.Type == ProjectType.Unknown)
         {
-            var hgService = HttpContext.RequestServices.GetRequiredService<IHgService>();
-            project.Type = await hgService.DetermineProjectType(project.Code, project.MigrationStatus);
+            project.Type = await _hgService.DetermineProjectType(project.Code, project.MigrationStatus);
             await _lexBoxDbContext.SaveChangesAsync();
         }
         return project;

--- a/backend/LexBoxApi/Controllers/ProjectController.cs
+++ b/backend/LexBoxApi/Controllers/ProjectController.cs
@@ -68,6 +68,23 @@ public class ProjectController : ControllerBase
         return updatedCount;
     }
 
+    [HttpPost("updateProjectType/{id}")]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    [AdminRequired]
+    public async Task<ActionResult<Project>> UpdateProjectType(Guid id)
+    {
+        var project = await _lexBoxDbContext.Projects.FindAsync(id);
+        if (project is null) return NotFound();
+        if (project.Type == ProjectType.Unknown)
+        {
+            var hgService = HttpContext.RequestServices.GetRequiredService<IHgService>();
+            project.Type = await hgService.DetermineProjectType(project.Code, project.MigrationStatus);
+            await _lexBoxDbContext.SaveChangesAsync();
+        }
+        return project;
+    }
+
     [HttpPost("addLexboxPostfix")]
     [AdminRequired]
     public async Task<ActionResult<int>> AddLexboxSuffix()

--- a/backend/LexBoxApi/Controllers/ProjectController.cs
+++ b/backend/LexBoxApi/Controllers/ProjectController.cs
@@ -85,6 +85,17 @@ public class ProjectController : ControllerBase
         return project;
     }
 
+    [HttpGet("determineProjectType/{id}")]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    [AdminRequired]
+    public async Task<ActionResult<ProjectType>> DetermineProjectType(Guid id)
+    {
+        var project = await _lexBoxDbContext.Projects.FindAsync(id);
+        if (project is null) return NotFound();
+        return await _hgService.DetermineProjectType(project.Code, project.MigrationStatus);
+    }
+
     [HttpPost("updateProjectTypesForUnknownProjects")]
     [ProducesResponseType(StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status404NotFound)]

--- a/backend/LexBoxApi/Services/HgService.cs
+++ b/backend/LexBoxApi/Services/HgService.cs
@@ -293,7 +293,7 @@ public class HgService : IHgService
 
     public async Task<ProjectType> DetermineProjectType(string projectCode, ProjectMigrationStatus migrationStatus)
     {
-        var response = await GetClient(migrationStatus, projectCode).GetAsync($"{projectCode}/file/tip?style=json");
+        var response = await GetClient(migrationStatus, projectCode).GetAsync($"{projectCode}/file/tip?style=json-lex");
         response.EnsureSuccessStatusCode();
         var parsed = await response.Content.ReadFromJsonAsync<BrowseResponse>();
         // TODO: Move the heuristics below to a ProjectHeuristics class?

--- a/backend/LexBoxApi/Services/HgService.cs
+++ b/backend/LexBoxApi/Services/HgService.cs
@@ -296,6 +296,7 @@ public class HgService : IHgService
         var response = await GetClient(migrationStatus, projectCode).GetAsync($"{projectCode}/file/tip?style=json-lex");
         response.EnsureSuccessStatusCode();
         var parsed = await response.Content.ReadFromJsonAsync<BrowseResponse>();
+        bool hasDotSettingsFolder = false;
         // TODO: Move the heuristics below to a ProjectHeuristics class?
         foreach (var file in parsed?.Files ?? [])
         {
@@ -321,9 +322,17 @@ public class HgService : IHgService
                 {
                     return ProjectType.WeSay;
                 }
-                // TODO: Determine how to detect ProjectType.OurWord
+                //OurWord projects have a .Settings folder, but that might not be super reliable
+                //so we only use it as a last resort if we didn't match any other project type.
+                if (name.Equals(".Settings", StringComparison.OrdinalIgnoreCase))
+                {
+                    hasDotSettingsFolder = true;
+                }
             }
         }
+
+        //if we didn't find any of the above files, check for a .Settings folder
+        if (hasDotSettingsFolder) return ProjectType.OurWord;
         return ProjectType.Unknown;
     }
 

--- a/backend/LexCore/ServiceInterfaces/IHgService.cs
+++ b/backend/LexCore/ServiceInterfaces/IHgService.cs
@@ -7,6 +7,7 @@ public interface IHgService
     Task InitRepo(string code);
     Task<DateTimeOffset?> GetLastCommitTimeFromHg(string projectCode, ProjectMigrationStatus migrationStatus);
     Task<Changeset[]> GetChangesets(string projectCode, ProjectMigrationStatus migrationStatus);
+    Task<ProjectType> DetermineProjectType(string projectCode, ProjectMigrationStatus migrationStatus);
     Task DeleteRepo(string code);
     Task SoftDeleteRepo(string code, string deletedRepoSuffix);
     Task<string?> BackupRepo(string code);

--- a/frontend/src/routes/(authenticated)/project/[project_code]/+page.svelte
+++ b/frontend/src/routes/(authenticated)/project/[project_code]/+page.svelte
@@ -122,11 +122,6 @@
     copiedToClipboard = false;
   }
 
-  async function lookupProject(): Promise<void> {
-    const result = await fetch(`/api/project/determineProjectType/${project.id}`);
-    console.log(await result.text());
-  }
-
   let deleteProjectModal: ConfirmDeleteModal;
 
   async function softDeleteProject(): Promise<void> {
@@ -267,7 +262,6 @@
     <svelte:fragment slot="header-content">
       <BadgeList>
         <ProjectTypeBadge type={project.type} />
-        <button on:click={lookupProject}>Lookup</button>
         <Badge>
           <FormatRetentionPolicy policy={project.retentionPolicy} />
         </Badge>

--- a/frontend/src/routes/(authenticated)/project/[project_code]/+page.svelte
+++ b/frontend/src/routes/(authenticated)/project/[project_code]/+page.svelte
@@ -122,6 +122,11 @@
     copiedToClipboard = false;
   }
 
+  async function lookupProject(): Promise<void> {
+    const result = await fetch(`/api/project/determineProjectType/${project.id}`);
+    console.log(await result.text());
+  }
+
   let deleteProjectModal: ConfirmDeleteModal;
 
   async function softDeleteProject(): Promise<void> {
@@ -262,6 +267,7 @@
     <svelte:fragment slot="header-content">
       <BadgeList>
         <ProjectTypeBadge type={project.type} />
+        <button on:click={lookupProject}>Lookup</button>
         <Badge>
           <FormatRetentionPolicy policy={project.retentionPolicy} />
         </Badge>


### PR DESCRIPTION
This uses the hgweb URL for browsing the files in the repo's tip to get a list of files, and uses a filename-based heuristic to determine the project type from the list of files in the repo.

Fixes #199.