### PR TITLE
Try to fix "module has no attribute" errors

### DIFF
--- a/hgweb/hg.conf
+++ b/hgweb/hg.conf
@@ -1,5 +1,6 @@
 LoadModule wsgi_module /usr/lib/apache2/modules/mod_wsgi.so
-WSGIPythonOptimize 1
+WSGIPythonOptimize 0
+WSGILazyInitialization Off
 WSGISocketPrefix logs/wsgi
 LogLevel debug
 ServerName localhost


### PR DESCRIPTION
We're getting the following errors from time to time:

    module 'mercurial.hgweb.request' has no attribute 'parserequestfromenv'

This happens immediately after a Python interpreter is restarted. It's probably related to Mercurial's on-demand module import system. As an attempt to prevent this, we'll try starting the Python interpreter when Apache starts, rather than after the WSGI process forks, to see if that allows the interpreter to fully load the relevant modules.

We also set WSGIPythonOptimize to 0 so that Python assert statements will no longer be compiled away. This may or may not help, but it's possible that it will produce more meaningful error messages.