### PR TITLE
Center email footer on desktop and mobile

### DIFF
--- a/frontend/src/lib/email/Email.svelte
+++ b/frontend/src/lib/email/Email.svelte
@@ -30,11 +30,12 @@
       </mj-column>
     </mj-section>
     <mj-section>
-      <mj-column vertical-align="middle">
-        <mj-text align="right" font-size="15px"> Language Depot </mj-text>
-      </mj-column>
-      <mj-column vertical-align="middle" width="50px" padding="0px">
-        <mj-image src={silLogo} padding="0px" alt="SIL Logo" height="50px" width="50px" />
+      <mj-column>
+        <mj-social font-size="15px" icon-size="40px" icon-padding="8px">
+          <mj-social-element href="https://languagedepot.org" src={silLogo} alt="SIL Logo">
+            Language Depot
+          </mj-social-element>
+        </mj-social>
       </mj-column>
     </mj-section>
   </mj-body>


### PR DESCRIPTION
Fixes #476

Who would have thought that Language Depot was just longing to be a social media platform 😆.

Desktop:
![image](https://github.com/sillsdev/languageforge-lexbox/assets/12587509/ef6ab6ab-ad9e-409a-83da-067b95f69539)

Mobile:
![image](https://github.com/sillsdev/languageforge-lexbox/assets/12587509/651804b4-35d3-4992-babd-747a549a43c9)
