### PR TITLE
Bug/278 project type icon shows old icon after type change

### DIFF
--- a/frontend/src/lib/components/ProjectType/ProjectTypeIcon.svelte
+++ b/frontend/src/lib/components/ProjectType/ProjectTypeIcon.svelte
@@ -4,12 +4,18 @@
   import oneStoryLogo from '$lib/assets/onestory-editor-logo.svg';
   import weSayLogo from '$lib/assets/we-say-logo.png';
   import ourWordLogo from '$lib/assets/our-word-logo.png';
+  import { browser } from '$app/environment';
+  import { preloadImage } from '$lib/util/image';
 
   export function getProjectTypeIcon(type?: ProjectType): string | undefined {
     return type === ProjectType.FlEx ? flexLogo
     : type === ProjectType.OneStoryEditor ? oneStoryLogo
     : type === ProjectType.WeSay ? weSayLogo
     : type === ProjectType.OurWord ? ourWordLogo : undefined;
+  }
+
+  if (browser) {
+    [flexLogo, oneStoryLogo, weSayLogo, ourWordLogo].map(preloadImage);
   }
 </script>
 

--- a/frontend/src/lib/email/Email.svelte
+++ b/frontend/src/lib/email/Email.svelte
@@ -30,11 +30,12 @@
       </mj-column>
     </mj-section>
     <mj-section>
-      <mj-column vertical-align="middle">
-        <mj-text align="right" font-size="15px"> Language Depot </mj-text>
-      </mj-column>
-      <mj-column vertical-align="middle" width="50px" padding="0px">
-        <mj-image src={silLogo} padding="0px" alt="SIL Logo" height="50px" width="50px" />
+      <mj-column>
+        <mj-social font-size="15px" icon-size="40px" icon-padding="8px">
+          <mj-social-element href="https://languagedepot.org" src={silLogo} alt="SIL Logo">
+            Language Depot
+          </mj-social-element>
+        </mj-social>
       </mj-column>
     </mj-section>
   </mj-body>

--- a/frontend/src/lib/util/image.ts
+++ b/frontend/src/lib/util/image.ts
@@ -1,0 +1,7 @@
+export function preloadImage(src: string): Promise<void> {
+  return new Promise((resolve) => {
+    const img = new Image();
+    img.src = src;
+    img.onload = () => resolve();
+  });
+}


### PR DESCRIPTION
Fixes #278 

Thanks ChatGPT (verified on [StackOverflow](https://stackoverflow.com/questions/3646036/preloading-images-with-javascript), but I was not finding this answer myself).

There is still sort of a tiny delay, because we're still using a dynamic src tag that loads the image when it changes, but it will always hit the browser cache, so it's not really noticeable.