### PR TITLE
Forbid colon from appearing in passwords

### DIFF
--- a/frontend/src/lib/forms/utils.ts
+++ b/frontend/src/lib/forms/utils.ts
@@ -14,7 +14,7 @@ export function tryParse<T, ValidT>(zodType: ZodType<ValidT>, value: T): ValidT 
 export function passwordFormRules($t: Translater): z.ZodString {
   return z.string()
     .min(4, $t('form.password.too_short'))
-    .regex(/^[^&%+]+$/, $t('form.password.forbidden_characters'));
+    .regex(/^[^&%:+]+$/, $t('form.password.forbidden_characters'));
 }
 
 export function emptyString(): z.ZodString {

--- a/frontend/src/lib/i18n/locales/en.json
+++ b/frontend/src/lib/i18n/locales/en.json
@@ -345,7 +345,7 @@ the [Linguistics Institute at Payap University](https://li.payap.ac.th/) in Chia
   },
   "form": {
     "password": {
-      "forbidden_characters": "The symbols &, +, and % are not allowed in passwords",
+      "forbidden_characters": "The symbols &, +, :, and % are not allowed in passwords",
       "too_short": "Must be at least 4 characters"
     }
   },


### PR DESCRIPTION
Colon (:) can, if not quoted properly, confuse HTTP URLs with user:pass.

Fixes #255.