### PR TITLE
Bug: project page missing ssr data

### DIFF
--- a/frontend/src/lib/app.postcss
+++ b/frontend/src/lib/app.postcss
@@ -130,8 +130,7 @@ table tr:nth-last-child(-n + 2):not(:nth-child(-n + 2)) .dropdown {
 
 .hydrating {
   .input,
-  input,
-  button {
+  input {
     visibility: hidden;
   }
 

--- a/frontend/src/lib/layout/AppBar.svelte
+++ b/frontend/src/lib/layout/AppBar.svelte
@@ -2,10 +2,9 @@
   import { env } from '$env/dynamic/public';
   import t from '$lib/i18n';
   import { AuthenticatedUserIcon, UserAddOutline } from '$lib/icons';
-  import {createEventDispatcher, onMount} from 'svelte';
-  import type {LexAuthUser} from '$lib/user';
-  import { Button } from '$lib/forms';
-  import {page} from '$app/stores';
+  import { onMount } from 'svelte';
+  import type { LexAuthUser } from '$lib/user';
+  import { page } from '$app/stores';
 
   onMount(() => {
     isPlaywright = localStorage.getItem('isPlaywright') === 'true';
@@ -13,7 +12,6 @@
   });
   let isPlaywright = false;
   let environmentName = env.PUBLIC_ENV_NAME?.toLowerCase();
-  const dispatch = createEventDispatcher();
   export let user: LexAuthUser | undefined;
   $: loggedIn = !!user;
 </script>
@@ -32,10 +30,11 @@
     </a>
     <div>
       {#if user}
-        <Button on:click={() => dispatch('menuopen')} class="btn-primary normal-case px-2">
+        <!-- using a label means it works before hydration is complete -->
+        <label for="drawer-toggle" class="btn btn-primary px-2">
           {user.name}
           <AuthenticatedUserIcon size="text-4xl" />
-        </Button>
+        </label>
       {:else}
         {#if $page.url.pathname !== '/login'}
           <a href="/login" class="btn btn-primary">

--- a/frontend/src/lib/layout/Layout.svelte
+++ b/frontend/src/lib/layout/Layout.svelte
@@ -13,16 +13,12 @@
   $: data = $page.data as LayoutData;
   $: user = data.user;
 
-  function open(): void {
-    menuToggle = true;
-  }
-
   function close(): void {
     menuToggle = false;
   }
 
   function closeOnEscape(event: KeyboardEvent): void {
-    event.key === 'Escape' && close();
+    if (event.key === 'Escape') close();
   }
   onMount(() => {
     if (user) ensureClientMatchesUser(user);
@@ -37,10 +33,10 @@
 
 {#if user}
   <div class="drawer drawer-end">
-    <input type="checkbox" checked={menuToggle} class="drawer-toggle" />
+    <input id="drawer-toggle" type="checkbox" bind:checked={menuToggle} class="drawer-toggle" />
 
     <div class="drawer-content max-w-[100vw]">
-      <AppBar on:menuopen={open} {user} />
+      <AppBar {user} />
       <div class="bg-neutral text-neutral-content p-2 md:px-6 flex justify-between items-center">
         <Breadcrumbs />
         <AdminContent>
@@ -62,7 +58,8 @@
       </Content>
     </div>
     <div class="drawer-side z-10">
-      <button class="drawer-overlay" on:click={close} on:keydown={close} />
+      <!-- using a label means it works before hydration is complete -->
+      <label for="drawer-toggle" class="drawer-overlay" />
       <AppMenu {user} serverVersion={data.serverVersion} apiVersion={data.apiVersion} />
     </div>
   </div>

--- a/frontend/src/routes/+layout.svelte
+++ b/frontend/src/routes/+layout.svelte
@@ -46,7 +46,7 @@
   {/if}
 </svelte:head>
 
-{#if $loading}
+{#if $loading || hydrating}
   <progress class="progress progress-info block fixed z-50 h-[3px] rounded-none bg-transparent"></progress>
 {/if}
 


### PR DESCRIPTION
Resolves #499 

3 improvements:
- Stop hiding buttons during hydration (this is harmless, because users obviously can't make changes with buttons that will get lost after hydration. Buttons tend to do nothing until hydration is complete.)
- Add loading indicator while hydrating, so users can see that the page isn't necessarily ready
- Used labels as much as possible for toggling the drawer, so that it works (and users can navigate to a different page) before hydration is complete.

Recording of hydration:
https://github.com/sillsdev/languageforge-lexbox/assets/12587509/e2ce39aa-5fe9-4e9d-97a5-6174de9e8703

