### PR TITLE
Bug: auth issues on reset password page just send the user home or to login without any message about an error

### DIFF
--- a/frontend/src/app.d.ts
+++ b/frontend/src/app.d.ts
@@ -10,6 +10,14 @@ declare global {
     lexbox: { fetchProxy: Fetch }
   }
 
+  type LexboxResponseHandlingConfig = {
+    disableRedirectOnAuthError?: true;
+  }
+
+  interface RequestInit {
+    lexboxResponseHandlingConfig?: LexboxResponseHandlingConfig;
+  }
+
   namespace App {
     interface Locals {
       client: Client;

--- a/frontend/src/hooks.client.ts
+++ b/frontend/src/hooks.client.ts
@@ -67,7 +67,8 @@ handleFetch(async ({ fetch, args }) => {
 
     validateFetchResponse(response,
       location.pathname === '/login',
-      location.pathname === '/' || location.pathname === '/home' || location.pathname === '/admin');
+      location.pathname === '/' || location.pathname === '/home' || location.pathname === '/admin',
+      args[1]?.lexboxResponseHandlingConfig);
 
     return response;
   });

--- a/frontend/src/hooks.client.ts
+++ b/frontend/src/hooks.client.ts
@@ -66,7 +66,6 @@ handleFetch(async ({ fetch, args }) => {
     const response = await fetch(...args);
 
     validateFetchResponse(response,
-      location.pathname === '/login',
       location.pathname === '/' || location.pathname === '/home' || location.pathname === '/admin',
       args[1]?.lexboxResponseHandlingConfig);
 

--- a/frontend/src/hooks.server.ts
+++ b/frontend/src/hooks.server.ts
@@ -63,7 +63,6 @@ export const handleFetch: HandleFetch = async ({ event, request, fetch }) => {
 
     const routeId = event.route.id ?? '';
     validateFetchResponse(response,
-      routeId.endsWith('/login'),
       routeId.endsWith(AUTHENTICATED_ROOT) || routeId.endsWith('/home') || routeId.endsWith('/admin'));
 
     return response;

--- a/frontend/src/hooks.shared.ts
+++ b/frontend/src/hooks.shared.ts
@@ -20,7 +20,12 @@ export function getErrorMessage(error: unknown): string {
   );
 }
 
-export function validateFetchResponse(response: Response, isAtLogin: boolean, isHome: boolean): void {
+export function validateFetchResponse(
+  response: Response, isAtLogin: boolean, isHome: boolean, config?: LexboxResponseHandlingConfig): void {
+  if (config?.disableRedirectOnAuthError && [401, 403].includes(response.status)) {
+    return;
+  }
+
   if (response.status === 401 && !isAtLogin) {
     throw redirect(307, '/logout');
   }

--- a/frontend/src/hooks.shared.ts
+++ b/frontend/src/hooks.shared.ts
@@ -21,12 +21,12 @@ export function getErrorMessage(error: unknown): string {
 }
 
 export function validateFetchResponse(
-  response: Response, isAtLogin: boolean, isHome: boolean, config?: LexboxResponseHandlingConfig): void {
+  response: Response, isHome: boolean, config?: LexboxResponseHandlingConfig): void {
   if (config?.disableRedirectOnAuthError && [401, 403].includes(response.status)) {
     return;
   }
 
-  if (response.status === 401 && !isAtLogin) {
+  if (response.status === 401) {
     throw redirect(307, '/logout');
   }
 

--- a/frontend/src/lib/i18n/locales/en.json
+++ b/frontend/src/lib/i18n/locales/en.json
@@ -275,6 +275,7 @@ the [Linguistics Institute at Payap University](https://li.payap.ac.th/) in Chia
     "new_password": "New Password",
     "submit": "Reset Password",
     "password_reset": "Your password has been reset",
+    "failed": "Resetting your password failed. Did you use an expired link? ({statusText})",
   },
   "retention_policy": {
     "dev": "Software Developer",

--- a/frontend/src/lib/i18n/locales/en.json
+++ b/frontend/src/lib/i18n/locales/en.json
@@ -107,7 +107,6 @@
     "missing_user_info": "User info missing",
     "title": "Log in",
     "password_missing": "Password missing",
-    "password_reset": "Your password has been reset",
     "link_expired": "The email you clicked has expired. Please request a new one.",
     "welcome": "### Welcome to Language Depot!\n\
 Language Depot is a hosting service for [FieldWorks (FLEx)](https://software.sil.org/fieldworks/), \
@@ -274,7 +273,8 @@ the [Linguistics Institute at Payap University](https://li.payap.ac.th/) in Chia
   "reset_password": {
     "title": "Reset Password",
     "new_password": "New Password",
-    "submit": "Reset Password"
+    "submit": "Reset Password",
+    "password_reset": "Your password has been reset",
   },
   "retention_policy": {
     "dev": "Software Developer",

--- a/frontend/src/lib/user.ts
+++ b/frontend/src/lib/user.ts
@@ -60,6 +60,9 @@ export async function login(userId: string, password: string): Promise<boolean> 
       password: await hash(password),
       preHashedPassword: true,
     }),
+    lexboxResponseHandlingConfig: {
+      disableRedirectOnAuthError: true,
+    },
   })
   return response.ok;
 }

--- a/frontend/src/routes/(authenticated)/resetPassword/+page.svelte
+++ b/frontend/src/routes/(authenticated)/resetPassword/+page.svelte
@@ -24,7 +24,7 @@
     if (!response.ok) {
       return response.statusText;
     }
-    notifySuccess($t('login.password_reset'));
+    notifySuccess($t('reset_password.password_reset'));
     await goto(data.home);
   });
 </script>

--- a/frontend/src/routes/(authenticated)/resetPassword/+page.svelte
+++ b/frontend/src/routes/(authenticated)/resetPassword/+page.svelte
@@ -20,9 +20,12 @@
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ passwordHash: await hash($form.password) }),
+      lexboxResponseHandlingConfig: {
+        disableRedirectOnAuthError: true,
+      },
     });
     if (!response.ok) {
-      return response.statusText;
+      return $t('reset_password.failed', {statusText: response.statusText});
     }
     notifySuccess($t('reset_password.password_reset'));
     await goto(data.home);


### PR DESCRIPTION
Resolves #465 

Here's what happens now if you get a 403 when trying to reset your password:
![image](https://github.com/sillsdev/languageforge-lexbox/assets/12587509/86c8410d-6800-491a-81fe-6db867aa0288)

I also tried to show a message in cases where we do end up redirecting users to the login screen, but I got stuck when I discovered that we can't pass query-params when we `throw redirect(...)`, because whatever we pass in as a url gets URL-encoded.

@hahn-kev what do you think?