### PR TITLE
Feat: organize project member list

### DIFF
--- a/frontend/src/lib/components/Badges/ActionBadge.svelte
+++ b/frontend/src/lib/components/Badges/ActionBadge.svelte
@@ -3,7 +3,7 @@
   import { createEventDispatcher } from 'svelte';
   export let disabled = false;
   export let actionIcon: IconString;
-  export let variant: 'btn-neutral' | 'btn-primary' = 'btn-neutral';
+  export let variant: 'btn-neutral' | 'btn-primary' | 'btn-secondary' = 'btn-neutral';
   $: iconHoverColor = variant === 'btn-neutral' ? 'group-hover:bg-base-200' : 'group-hover:bg-neutral/50';
 
   const dispatch = createEventDispatcher<{

--- a/frontend/src/lib/components/Badges/BadgeList.svelte
+++ b/frontend/src/lib/components/Badges/BadgeList.svelte
@@ -1,3 +1,13 @@
-<span class="inline-flex flex-wrap gap-3">
+<script lang="ts">
+  export let grid = false;
+</script>
+
+<span class:grid class:inline-flex={!grid} class="badge-list flex-wrap gap-3 justify-items-stretch">
   <slot />
 </span>
+
+<style>
+  .badge-list {
+    grid-template-columns: repeat(auto-fill, minmax(250px, 1fr));
+  }
+</style>

--- a/frontend/src/lib/components/Badges/MemberBadge.svelte
+++ b/frontend/src/lib/components/Badges/MemberBadge.svelte
@@ -1,13 +1,15 @@
 <script lang="ts">
-  import type { ProjectRole } from '$lib/gql/types';
+  import { ProjectRole } from '$lib/gql/types';
   import FormatUserProjectRole from '../FormatUserProjectRole.svelte';
   import ActionBadge from './ActionBadge.svelte';
   import Badge from './Badge.svelte';
   export let member: { name: string; role: ProjectRole };
   export let canManage = false;
+
+  let variant = member.role === ProjectRole.Manager ? 'btn-primary' as const : 'btn-secondary' as const;
 </script>
 
-<ActionBadge actionIcon="i-mdi-dots-vertical" variant="btn-primary" disabled={!canManage}>
+<ActionBadge actionIcon="i-mdi-dots-vertical" {variant} disabled={!canManage}>
   <span class="pr-3 whitespace-nowrap overflow-ellipsis overflow-hidden" title={member.name}>
     {member.name}
   </span>

--- a/frontend/src/lib/components/Badges/MemberBadge.svelte
+++ b/frontend/src/lib/components/Badges/MemberBadge.svelte
@@ -8,9 +8,12 @@
 </script>
 
 <ActionBadge actionIcon="i-mdi-dots-vertical" variant="btn-primary" disabled={!canManage}>
-  <span class="pr-3 whitespace-nowrap">
+  <span class="pr-3 whitespace-nowrap overflow-ellipsis overflow-hidden" title={member.name}>
     {member.name}
   </span>
+
+  <!-- justify the name left and the role right -->
+  <span class="flex-grow" />
 
   <Badge>
     <FormatUserProjectRole projectRole={member.role} />

--- a/frontend/src/lib/components/Dropdown.svelte
+++ b/frontend/src/lib/components/Dropdown.svelte
@@ -4,9 +4,16 @@
   export let disabled = false;
 </script>
 
-<div class="inline-grid" use:overlay={{disabled}}>
+<div class="dropdown-container inline-flex" use:overlay={{ disabled }}>
   <slot />
   <div class="overlay-content">
     <slot name="content" />
   </div>
 </div>
+
+<style>
+  :global(.dropdown-container > *) {
+    max-width: 100%;
+    flex-grow: 1;
+  }
+</style>

--- a/frontend/src/lib/forms/Button.svelte
+++ b/frontend/src/lib/forms/Button.svelte
@@ -2,13 +2,14 @@
   import Loader from '$lib/components/Loader.svelte';
 
   export let loading = false;
-  export let style: 'btn-primary' | 'btn-success' | 'btn-error' | undefined = undefined;
+  export let style: 'btn-primary' | 'btn-success' | 'btn-error' | 'btn-outline' | undefined = undefined;
   export let type: undefined | 'submit' = undefined;
+  export let size: undefined | 'btn-sm' = undefined;
   export let disabled = false;
 </script>
 
 <!-- https://daisyui.com/components/button -->
-<button on:click {...$$restProps} class="btn whitespace-nowrap {style ?? ''} {$$restProps.class ?? ''}" {type} {disabled}>
+<button on:click {...$$restProps} class="btn whitespace-nowrap {style ?? ''} {$$restProps.class ?? ''} {size ?? ''}" {type} {disabled}>
   <Loader {loading} />
   <slot />
 </button>

--- a/frontend/src/lib/i18n/locales/en.json
+++ b/frontend/src/lib/i18n/locales/en.json
@@ -208,7 +208,11 @@ the [Linguistics Institute at Payap University](https://li.payap.ac.th/) in Chia
     "summary": "Summary",
     "description": "Description",
     "last_commit": "Last Commit",
-    "members": "Members",
+    "members": {
+      "title": "Members",
+      "show_all": "Show all...",
+      "show_less": "Show less",
+    },
     "add_description": "Add description...",
     "remove_project_user_title": "Member",
     "remove_user": "Remove",

--- a/frontend/src/routes/(authenticated)/project/[project_code]/+page.svelte
+++ b/frontend/src/routes/(authenticated)/project/[project_code]/+page.svelte
@@ -324,7 +324,7 @@
           {$t('project_page.members.title')}
         </p>
 
-        <BadgeList grid>
+        <BadgeList grid={showMembers.length > TRUNCATED_MEMBER_COUNT}>
           {#each showMembers as member}
             {@const canManageMember = canManage && (member.user.id !== userId || isAdmin(user))}
             <Dropdown disabled={!canManageMember}>

--- a/frontend/src/routes/(authenticated)/project/[project_code]/+page.svelte
+++ b/frontend/src/routes/(authenticated)/project/[project_code]/+page.svelte
@@ -314,7 +314,7 @@
           {$t('project_page.members')}
         </p>
 
-        <BadgeList>
+        <BadgeList grid>
           {#each project.users as member}
             {@const canManageMember = canManage && (member.user.id !== userId || isAdmin(user))}
             <Dropdown disabled={!canManageMember}>
@@ -336,7 +336,9 @@
             </Dropdown>
           {/each}
           {#if canManage}
-            <AddProjectMember projectId={project.id} />
+            <div class="place-self-end" style="grid-column: -2 / -1">
+              <AddProjectMember projectId={project.id} />
+            </div>
           {/if}
 
           <ChangeMemberRoleModal projectId={project.id} bind:this={changeMemberRoleModal} />

--- a/frontend/src/routes/(authenticated)/project/[project_code]/+page.svelte
+++ b/frontend/src/routes/(authenticated)/project/[project_code]/+page.svelte
@@ -15,7 +15,7 @@
     _changeProjectName,
     _deleteProjectUser,
     _refreshProjectMigrationStatusAndRepoInfo,
-    type ProjectUser
+    type ProjectUser,
   } from './+page';
   import AddProjectMember from './AddProjectMember.svelte';
   import ChangeMemberRoleModal from './ChangeMemberRoleModal.svelte';
@@ -183,7 +183,7 @@
     const response = await result.json();
     if (response) {
       migrationStatus = ProjectMigrationStatus.Migrated;
-      await _refreshProjectMigrationStatusAndRepoInfo(project.code)
+      await _refreshProjectMigrationStatusAndRepoInfo(project.code);
     }
   }
 
@@ -201,10 +201,10 @@
   <HeaderPage wide title={project.name}>
     <svelte:fragment slot="banner">
       {#if migrationStatus === ProjectMigrationStatus.Migrating}
-            <div class="alert alert-warning mb-4">
-              <span class="i-mdi-alert text-2xl" />
-              <span>This project is currently being migrated. Some features may not work as expected.</span>
-            </div>
+        <div class="alert alert-warning mb-4">
+          <span class="i-mdi-alert text-2xl" />
+          <span>This project is currently being migrated. Some features may not work as expected.</span>
+        </div>
       {/if}
     </svelte:fragment>
     <svelte:fragment slot="actions">


### PR DESCRIPTION
Resolves #379 

Waiting for #286 

Here's what I came up with based on @hahn-kev's suggestion to use a grid:
https://github.com/sillsdev/languageforge-lexbox/assets/12587509/7f83ae15-817f-47ef-8d4b-dc89dc929c40

And if there are less than 5 members:
![image](https://github.com/sillsdev/languageforge-lexbox/assets/12587509/0dba9c46-dfb1-4a6f-9ec6-edc7e9596f79)
