### PR TITLE
Fix login form overflowing and adjust mobile styling

### DIFF
--- a/frontend/src/lib/i18n/locales/en.json
+++ b/frontend/src/lib/i18n/locales/en.json
@@ -109,8 +109,8 @@
     "password_missing": "Password missing",
     "password_reset": "Your password has been reset",
     "link_expired": "The email you clicked has expired. Please request a new one.",
-    "welcome": "### Welcome to Language Depot!\n\
-Language Depot is a hosting service for [FieldWorks (FLEx)](https://software.sil.org/fieldworks/), \
+    "welcome_header": "### Welcome to Language Depot\n",
+    "welcome": "Language Depot is a hosting service for [FieldWorks (FLEx)](https://software.sil.org/fieldworks/), \
 [Language Forge](https://languageforge.org/), [OneStory Editor](https://onestory.org/) and [WeSay](https://software.sil.org/wesay/) projects. \
 It is provided as a service to language communities by [SIL Language Technology](https://software.sil.org/) and \
 the [Linguistics Institute at Payap University](https://li.payap.ac.th/) in Chiang Mai, Thailand."

--- a/frontend/src/routes/(unauthenticated)/login/+page.svelte
+++ b/frontend/src/routes/(unauthenticated)/login/+page.svelte
@@ -44,26 +44,9 @@
 </script>
 
 <div class="hero flex-grow">
-  <div class="hero-content flex-col lg:flex-row-reverse gap-16">
-    <div class="prose text-lg flex-shrink-0">
-      <Markdown md={$t('login.welcome')} />
-      <div class="flex gap-4 not-prose justify-center">
-        <a href="https://software.sil.org/fieldworks/">
-          <img src={flexLogo} class="h-12" height="48" alt="FLEx Logo">
-        </a>
-        <a href="https://languageforge.org/">
-          <img src={lfLogo} class="h-12" height="48" alt="Language Forge Logo">
-        </a>
-        <a href="https://software.sil.org/onestoryeditor/">
-          <img src={oneStoryEditorLogo} class="h-12" height="48" alt="OneStory Editor Logo">
-        </a>
-        <a href="https://software.sil.org/wesay/">
-          <img src={weSayLogo} class="h-12" height="48" alt="WeSay Logo">
-        </a>
-      </div>
-    </div>
-    <div class="card flex-shrink-0 w-full max-w-md shadow-2xl bg-base-200">
-      <div class="card-body">
+  <div class="hero-content flex-col lg:flex-row gap-8">
+    <div class="card flex-shrink-0 w-full max-w-md sm:shadow-2xl sm:bg-base-200">
+      <div class="card-body sm-only:p-0">
         <PageTitle title={$t('login.title')} />
 
         <Form {enhance}>
@@ -97,6 +80,28 @@
 
           <a class="btn btn-primary" href="/register">{$t('register.title')}</a>
         </Form>
+      </div>
+    </div>
+
+    <div class="flex flex-col gap-8 lg:flex-col-reverse">
+      <div class="flex gap-4 not-prose justify-center">
+        <a href="https://software.sil.org/fieldworks/">
+          <img src={flexLogo} class="h-12" height="48" alt="FLEx Logo">
+        </a>
+        <a href="https://languageforge.org/">
+          <img src={lfLogo} class="h-12" height="48" alt="Language Forge Logo">
+        </a>
+        <a href="https://software.sil.org/onestoryeditor/">
+          <img src={oneStoryEditorLogo} class="h-12" height="48" alt="OneStory Editor Logo">
+        </a>
+        <a href="https://software.sil.org/wesay/">
+          <img src={weSayLogo} class="h-12" height="48" alt="WeSay Logo">
+        </a>
+      </div>
+
+      <div class="prose text-lg">
+        <Markdown md={$t('login.welcome_header')} />
+        <Markdown md={$t('login.welcome')} />
       </div>
     </div>
   </div>

--- a/frontend/tailwind.config.cjs
+++ b/frontend/tailwind.config.cjs
@@ -13,5 +13,12 @@ module.exports = {
         themes: ['winter', 'business'],
         darkTheme: 'business',
         logs: false
+  },
+  theme: {
+    extend: {
+      screens: {
+        'sm-only': {'max': '639px'},
+      },
     },
+  },
 };


### PR DESCRIPTION
Resolves #489 

This is what it looks like now immediately before it collapses into a single column:
![image](https://github.com/sillsdev/languageforge-lexbox/assets/12587509/0ff7783e-9d03-4e5f-9384-725ee00ba085)

I also made some changes for mobile:
- The welcome message is underneath the form, so that the form is more available
- The product icons are now directly below the form, so they're still visible
- The form doesn't look like a card on mobile, so we can use more horizontal space

![image](https://github.com/sillsdev/languageforge-lexbox/assets/12587509/1031e280-8a57-4219-824b-7943e89b92da)
