### PR TITLE
Fix URL for populating test repos

### DIFF
--- a/deployment/develop/hg-deployment-patch.yaml
+++ b/deployment/develop/hg-deployment-patch.yaml
@@ -18,7 +18,7 @@ spec:
                 unzip -q sena-3.zip -d /repos/
               fi
               if [ ! -d /repos/elawa-dev-flex ]; then
-                wget -O elawa.zip 'https://drive.google.com/uc?export=download&id=1Jk-eSDho8ATBMS-Kmfatwi-MWQth26ro&confirm=t'
+                wget -O elawa.zip 'https://drive.usercontent.google.com/download?export=download&id=1Jk-eSDho8ATBMS-Kmfatwi-MWQth26ro&confirm=t'
                 unzip -q elawa.zip -d /repos/
               fi
           volumeMounts:

--- a/deployment/init-repos/hg-deployment-patch.yaml
+++ b/deployment/init-repos/hg-deployment-patch.yaml
@@ -21,7 +21,7 @@ spec:
                 unzip -q /tmp/sena-3.zip -d /repos/
               fi
               if [ ! -d /repos/elawa-dev-flex ]; then
-                wget -O /tmp/elawa.zip 'https://drive.google.com/uc?export=download&id=1Jk-eSDho8ATBMS-Kmfatwi-MWQth26ro&confirm=t'
+                wget -O /tmp/elawa.zip 'https://drive.usercontent.google.com/download?export=download&id=1Jk-eSDho8ATBMS-Kmfatwi-MWQth26ro&confirm=t'
                 unzip -q /tmp/elawa.zip -d /repos/
               fi
           volumeMounts:


### PR DESCRIPTION
Google Drive changed something internal and the URL we used to use for downloading the elawa.zip repo no longer works. The new URL is drive.usercontent.google.com/download rather than drive.google.com/uc.

Fixes #494.