### PR TITLE
Chore/allow setting partial form values

### DIFF
--- a/frontend/src/lib/components/modals/FormModal.svelte
+++ b/frontend/src/lib/components/modals/FormModal.svelte
@@ -29,7 +29,7 @@
 
 
   export async function open(
-    value: FormType | undefined,  //eslint-disable-line @typescript-eslint/no-redundant-type-constituents
+    value: Partial<FormType> | undefined,  //eslint-disable-line @typescript-eslint/no-redundant-type-constituents
     onSubmit: SubmitCallback
   ): Promise<FormModalResult<Schema>>;
   export async function open(onSubmit: SubmitCallback): Promise<FormModalResult<Schema>>;
@@ -42,7 +42,8 @@
 
     reset();
 
-    if (value) _form.set(value, { taint: false });
+    //need to use update otherwise some fields might be undefined since value can be a partial
+    if (value) _form.update(f => ({...f, ...value}), { taint: false });
 
     const response = await openModal(onSubmit);
     const _formState = $formState; // we need to read the form state before the modal closes or it will be reset

--- a/frontend/src/routes/(authenticated)/admin/EditUserAccount.svelte
+++ b/frontend/src/routes/(authenticated)/admin/EditUserAccount.svelte
@@ -16,7 +16,7 @@
   const schema = z.object({
     email: z.string().email(),
     name: z.string(),
-    password: passwordFormRules($t).or(emptyString()),
+    password: passwordFormRules($t).or(emptyString()).default(''),
     role: z.enum([UserRole.User, UserRole.Admin]),
   });
   type Schema = typeof schema;
@@ -31,7 +31,7 @@
   export async function openModal(user: User): Promise<FormModalResult<Schema>> {
     _user = user;
     const role = user.isAdmin ? UserRole.Admin : UserRole.User;
-    return await formModal.open({ name: user.name, email: user.email, role, password: '' }, async () => {
+    return await formModal.open({ name: user.name, email: user.email, role }, async () => {
       const { error, data } = await _changeUserAccountByAdmin({
         userId: user.id,
         email: $form.email,

--- a/frontend/src/routes/(unauthenticated)/sandbox/+page.svelte
+++ b/frontend/src/routes/(unauthenticated)/sandbox/+page.svelte
@@ -1,8 +1,9 @@
 ﻿<script lang="ts">
   import TusUpload from '$lib/components/TusUpload.svelte';
   import Dropdown from '$lib/components/Dropdown.svelte';
-  import { Button } from '$lib/forms';
+  import {Button, Form, Input, lexSuperForm, SubmitButton} from '$lib/forms';
   import { PageBreadcrumb } from '$lib/layout';
+  import z from 'zod';
 
   function uploadFinished(): void {
     alert('upload done!');
@@ -15,6 +16,20 @@
   async function fetch403(): Promise<Response> {
     return fetch('/api/AuthTesting/403');
   }
+  const formSchema = z.object(
+    {
+      name: z.string().min(3).max(255),
+      lastName: z.string().min(3).max(255),
+    }
+  );
+
+  // eslint-disable-next-line @typescript-eslint/require-await
+  let {form, enhance, errors} = lexSuperForm(formSchema, async () => {
+      console.log('submit', $form);
+  });
+function preFillForm(): void {
+  form.update(f => ({...f, name: 'John'}), {taint: false});
+}
 </script>
 <PageBreadcrumb>Hello from sandbox</PageBreadcrumb>
 <PageBreadcrumb>second value</PageBreadcrumb>
@@ -60,6 +75,31 @@
           </ul>
         </Dropdown>
       </div>
+    </div>
+  </div>
+  <div class="card w-96 bg-base-200 shadow-lg">
+    <div class="card-body">
+      <h2 class="card-title">Form Example</h2>
+      <Form {enhance}>
+        <Input
+          id="name"
+          label="Name"
+          type="text"
+          error={$errors.name}
+          bind:value={$form.name}
+          autofocus
+        />
+        <Input
+          id="lastName"
+          label="Last Name"
+          type="text"
+          error={$errors.lastName}
+          bind:value={$form.lastName}
+          autofocus
+        />
+        <SubmitButton>Submit</SubmitButton>
+        <Button style="btn-outline" on:click={preFillForm}>Pre fill</Button>
+      </Form>
     </div>
   </div>
 </div>


### PR DESCRIPTION
Resolves #374 

it turns out that our setup for edit user account was a little more complicated, and required setting a default value for that field. Once I did that and used update instead of set on the store I was able to allow our form modals to accept partial values again.