### PR TITLE
add specific instructions for using WeSay to S&R a project

### DIFF
--- a/frontend/src/lib/i18n/locales/en.json
+++ b/frontend/src/lib/i18n/locales/en.json
@@ -249,7 +249,7 @@ the [Linguistics Institute at Payap University](https://li.payap.ac.th/) in Chia
 1. In the \"Project ID\" field that appears, select \"{code}\"\n\
 1. Enter a \"Name for the folder on your computer\" (e.g. \"{name}\")",
       "instructions_wesay": "1. Launch 'WeSay Configuration Tool'\n\
-1. Click 'Get Project from Internet'\n\
+1. Click 'Get from Internet'\n\
 1. In the 'Project ID' field type: \"{code}\"\n\
 1. In the 'Login' field type: \"{login}\"\ Note: there is a bug in WeSay that means you can't type the @ symbol for an email, this is a workaround \n\
 1. In the 'Password' field type your password\n\

--- a/frontend/src/lib/i18n/locales/en.json
+++ b/frontend/src/lib/i18n/locales/en.json
@@ -251,7 +251,7 @@ the [Linguistics Institute at Payap University](https://li.payap.ac.th/) in Chia
       "instructions_wesay": "1. Launch 'WeSay Configuration Tool'\n\
 1. Click 'Get from Internet'\n\
 1. In the 'Project ID' field type: \"{code}\"\n\
-1. In the 'Login' field type: \"{login}\"\ Note: there is a bug in WeSay that means you can't type the @ symbol for an email, this is a workaround \n\
+1. In the 'Login' field type: \"{login}\"\ Note: A bug in WeSay means you can't type the @ symbol for an email.  The workaround is to type %40 in place of @. \n\
 1. In the 'Password' field type your password\n\
 1. Enter a \"Name for the folder on your computer\" (e.g. \"{name}\")\n\
 1. Click 'Download'",

--- a/frontend/src/lib/i18n/locales/en.json
+++ b/frontend/src/lib/i18n/locales/en.json
@@ -242,12 +242,19 @@ the [Linguistics Institute at Payap University](https://li.payap.ac.th/) in Chia
       "log_header": "Message"
     },
     "get_project": {
-      "instructions_header": "To open the project with{type, select, FL_EX { } other { (e.g.) }}FLEx{mode, select, manual { manually} other { }}",
-      "instructions": "1. In the \"Send/Receive\" menu click \"Get Project from colleague…\"\n\
+      "instructions_header": "To open the project with {type, select, FL_EX { FLEx } WE_SAY { WeSay } other { (e.g.) FLEx } } {mode, select, manual { manually} other { }}",
+      "instructions_flex": "1. In the \"Send/Receive\" menu click \"Get Project from colleague…\"\n\
 1. In the \"Receive project\" dialog box, click \"Internet\"\n\
 1. In the \"Get Project From Internet\" dialog box, enter your \"Login\" and \"Password\" for Language Depot and click \"Log in\"\n\
 1. In the \"Project ID\" field that appears, select \"{code}\"\n\
 1. Enter a \"Name for the folder on your computer\" (e.g. \"{name}\")",
+      "instructions_wesay": "1. Launch 'WeSay Configuration Tool'\n\
+1. Click 'Get Project from Internet'\n\
+1. In the 'Project ID' field type: \"{code}\"\n\
+1. In the 'Login' field type: \"{login}\"\ Note: there is a bug in WeSay that means you can't type the @ symbol for an email, this is a workaround \n\
+1. In the 'Password' field type your password\n\
+1. Enter a \"Name for the folder on your computer\" (e.g. \"{name}\")\n\
+1. Click 'Download'",
       "label": "Get project",
       "send_receive_url": "Send/Receive URL",
     },

--- a/frontend/src/routes/(authenticated)/project/[project_code]/+page.svelte
+++ b/frontend/src/routes/(authenticated)/project/[project_code]/+page.svelte
@@ -224,13 +224,23 @@
             <div slot="content" class="card w-[calc(100vw-1rem)] sm:max-w-[35rem]">
               <div class="card-body max-sm:p-4">
                 <div class="prose">
-                  <h3>{$t('project_page.get_project.instructions_header', { type: project.type, mode: 'normal' })}</h3>
-                  <Markdown
-                    md={$t('project_page.get_project.instructions', {
+                  <h3>{$t('project_page.get_project.instructions_header', {type: project.type, mode: 'normal'})}</h3>
+                  {#if project.type === ProjectType.WeSay}
+                    <Markdown
+                      md={$t('project_page.get_project.instructions_wesay', {
+                      code: project.code,
+                      login: encodeURIComponent(user.email),
+                      name: project.name,
+                    })}
+                    />
+                  {:else}
+                    <Markdown
+                      md={$t('project_page.get_project.instructions_flex', {
                       code: project.code,
                       name: project.name,
                     })}
-                  />
+                    />
+                  {/if}
                 </div>
                 <SendReceiveUrlField projectCode={project.code} />
               </div>

--- a/frontend/src/routes/+layout.ts
+++ b/frontend/src/routes/+layout.ts
@@ -2,7 +2,7 @@ import type { LayoutLoadEvent } from './$types';
 import { loadI18n } from '$lib/i18n';
 
 //setting this to false can help diagnose requests to the api as you can see them in the browser instead of sveltekit
-export const ssr = true;
+export const ssr = false;
 
 export async function load(event: LayoutLoadEvent) {
   await loadI18n(event.data.locale);

--- a/frontend/src/routes/+layout.ts
+++ b/frontend/src/routes/+layout.ts
@@ -2,7 +2,7 @@ import type { LayoutLoadEvent } from './$types';
 import { loadI18n } from '$lib/i18n';
 
 //setting this to false can help diagnose requests to the api as you can see them in the browser instead of sveltekit
-export const ssr = false;
+export const ssr = true;
 
 export async function load(event: LayoutLoadEvent) {
   await loadI18n(event.data.locale);


### PR DESCRIPTION
closes #360 the main use for this is to encode the users email address for them so they can still use wesay without a username.

Preview: 
![image](https://github.com/sillsdev/languageforge-lexbox/assets/4575355/0b8d7af4-6938-463f-a931-226d9e06549f)
edit: changed "Get Project From Internet" to "Get from Internet" to match what WeSay actually says

open to suggestions for changing the wording.