### PR TITLE
order admin projects by most recently created.

### DIFF
--- a/frontend/src/lib/components/Projects/ProjectTable.svelte
+++ b/frontend/src/lib/components/Projects/ProjectTable.svelte
@@ -47,7 +47,6 @@
         {#if isColumnVisible('lastChange')}
           <th>
             {$t('project.table.last_change')}
-            <span class="i-mdi-sort-ascending text-xl align-[-5px] ml-2" />
           </th>
         {/if}
         {#if isColumnVisible('migrated')}

--- a/frontend/src/routes/(authenticated)/+page.ts
+++ b/frontend/src/routes/(authenticated)/+page.ts
@@ -8,7 +8,9 @@ export async function load(event: PageLoadEvent) {
   //language=GraphQL
   const results = await client.awaitedQueryStore(event.fetch, graphql(`
         query loadProjects {
-            myProjects {
+            myProjects(orderBy: [
+                {code: ASC }
+            ]) {
                 code
                 id
                 name

--- a/frontend/src/routes/(authenticated)/admin/+page.ts
+++ b/frontend/src/routes/(authenticated)/admin/+page.ts
@@ -39,11 +39,11 @@ export async function load(event: PageLoadEvent) {
 
   //language=GraphQL
   const projectResultsPromise = client.awaitedQueryStore(event.fetch, graphql(`
-        query loadAdminDashboardProjects($withDeletedProjects: Boolean, $filter: ProjectFilterInput) {
+        query loadAdminDashboardProjects($withDeletedProjects: Boolean!, $filter: ProjectFilterInput) {
             projects(
               where: $filter,
               orderBy: [
-                {lastCommit: ASC},
+                {createdDate: DESC},
                 {name: ASC}
             ], withDeleted: $withDeletedProjects) {
               code


### PR DESCRIPTION
closes #150 

just sorting by created date, I removed the sorting indicator on the project table because it's no longer sorted by last updated and we don't show the created date. Not my favorite solution but we don't really have space to add another column.