### PR TITLE
Fix i18n for emails

### DIFF
--- a/frontend/src/app.d.ts
+++ b/frontend/src/app.d.ts
@@ -22,6 +22,7 @@ declare global {
     interface Locals {
       client: Client;
       getUser: (() => LexAuthUser | null);
+      requestedLocale?: string;
     }
 
     interface Error {

--- a/frontend/src/routes/+layout.server.ts
+++ b/frontend/src/routes/+layout.server.ts
@@ -2,12 +2,9 @@ import { APP_VERSION, apiVersion } from '$lib/util/version';
 
 import type { LayoutServerLoadEvent } from './$types'
 import { USER_LOAD_KEY } from '$lib/user';
-import { availableLocales } from '$locales';
-import { getLocaleFromAcceptLanguageHeader } from 'svelte-intl-precompile';
 import { getRootTraceparent } from '$lib/otel/otel.server'
 
-export async function load({ locals, depends, fetch, request }: LayoutServerLoadEvent) {
-  const requestLang = getLocaleFromAcceptLanguageHeader(request.headers.get('Accept-Language'), availableLocales);
+export async function load({ locals, depends, fetch }: LayoutServerLoadEvent) {
   const user = locals.getUser();
   const traceParent = getRootTraceparent()
 
@@ -20,7 +17,7 @@ export async function load({ locals, depends, fetch, request }: LayoutServerLoad
   }
   return {
     user,
-    locale: user?.locale ?? requestLang,
+    locale: user?.locale ?? locals.requestedLocale,
     traceParent,
     serverVersion: APP_VERSION,
     apiVersion: apiVersion.value

--- a/frontend/src/routes/+layout.ts
+++ b/frontend/src/routes/+layout.ts
@@ -1,10 +1,13 @@
 import type { LayoutLoadEvent } from './$types';
+import { browser } from '$app/environment';
 import { loadI18n } from '$lib/i18n';
 
 //setting this to false can help diagnose requests to the api as you can see them in the browser instead of sveltekit
 export const ssr = true;
 
 export async function load(event: LayoutLoadEvent) {
-  await loadI18n(event.data.locale);
+  if (browser) { // i18n is initialized on the server in hooks.server.ts
+    await loadI18n(event.data.locale);
+  }
   return event.data;
 }


### PR DESCRIPTION
Resolves #534 

Init i18n for emails and send Accept-Language header to svelte when rendering emails.

I also opened a [tiny PR upstream](https://github.com/cibernox/precompile-intl-runtime/pull/46) that would let us tidy up the .NET code a tad.