### PR TITLE
Bug/533 fetching  _app/version.json sometimes fails

### DIFF
--- a/frontend/src/hooks.client.ts
+++ b/frontend/src/hooks.client.ts
@@ -59,7 +59,7 @@ function shouldTryAutoReload(updateDetected: boolean): boolean {
  * This is obviously NOT a SvelteKit handler/feature. It just mimics the `handleFetch` in hooks.server.ts.
  */
 handleFetch(async ({ fetch, args }) => {
-  const response = await traceFetch(async () => {
+  const response = await traceFetch(args, async () => {
     const response = await fetch(...args);
 
     validateFetchResponse(response,

--- a/frontend/src/lib/otel/otel.server.ts
+++ b/frontend/src/lib/otel/otel.server.ts
@@ -94,12 +94,12 @@ export async function traceFetch(
     fetch: () => Promise<Response>,
     event?: RequestEvent | NavigationEvent | Event
 ): Promise<Response> {
-  return _traceFetch(() => tracer()
+  return _traceFetch([request], () => tracer()
       .startActiveSpan(`${request.method} ${request.url}`, async (span) => {
         try {
           span.setAttributes({
             [SemanticAttributes.HTTP_METHOD]: request.method,
-            [SemanticAttributes.HTTP_TARGET]: request.url,
+            [SemanticAttributes.HTTP_URL]: request.url,
           });
           traceHeaders(span, 'request', request.headers);
           const traceparent = buildTraceparent(span);

--- a/frontend/svelte.config.js
+++ b/frontend/svelte.config.js
@@ -8,7 +8,7 @@ const config = {
   },
   kit: {
     version: {
-      pollInterval: 60000 * 3, // 3m
+      pollInterval: 0,
     },
     adapter: adapter({
       precompress: true


### PR DESCRIPTION
Resolves #533 

1bc7bb998a1bc3d149d9f72db6c91259728a35ef adds a tiny bit of really useful context to our root fetch span so that we can corrolate `error = true` and `http.url` or `http.status_code` in Honeycomb without digging.

37022f44935c91b837cdd0162b442e574fca1219 turns off version polling. I don't think it's a super valuable feature and the alternative of filtering out these errors just adds more complexity. I think this is the smartest choice, but I'm open to discussion of course. Interestingly, we explicitly fetch the version in our error handlers, which results in the `updated` store emitting. So, on an error caused by a version update a user can still get notified that a newer version is available. Version polling is about trying to make sure the user doesn't trip over updates that put their client out of sync with the server, so showing them that message when an error occurs (and we even have some reload logic in place) should still get us pretty much all the way there.