### PR TITLE
Improve error message when reset-password fails

### DIFF
--- a/frontend/src/lib/i18n/locales/en.json
+++ b/frontend/src/lib/i18n/locales/en.json
@@ -303,7 +303,7 @@ If you don't see a dialog or already closed it, click the button below:",
     "new_password": "New Password",
     "submit": "Reset Password",
     "password_reset": "Your password has been reset",
-    "failed": "Resetting your password failed. Did you use an expired link? ({statusText})",
+    "failed": "Resetting your password failed. Did you use an expired link? ({errorMessage})",
   },
   "retention_policy": {
     "dev": "Software Developer",

--- a/frontend/src/lib/i18n/locales/es.json
+++ b/frontend/src/lib/i18n/locales/es.json
@@ -285,7 +285,7 @@ el [Linguistics Institute at Payap University](https://li.payap.ac.th/) en Chian
     "new_password": "Nueva contraseña",
     "submit": "Restablecer contraseña",
     "password_reset": "Se ha restablecido su contraseña",
-    "failed": "Error al restablecer su contraseña. ¿Usó un enlace caducado? ({statusText})",
+    "failed": "Error al restablecer su contraseña. ¿Usó un enlace caducado? ({errorMessage})",
   },
   "retention_policy": {
     "dev": "Desarrollador de software",

--- a/frontend/src/lib/i18n/locales/fr.json
+++ b/frontend/src/lib/i18n/locales/fr.json
@@ -285,7 +285,7 @@ le [Linguistics Institute at Payap University](https://li.payap.ac.th/) à Chian
     "new_password": "Nouveau mot de passe",
     "submit": "Réinitialiser le mot de passe",
     "password_reset": "Votre mot de passe a été réinitialisé",
-    "failed": "Échec de la réinitialisation du mot de passe. Avez-vous utilisé un lien expiré ? ({statusText})",
+    "failed": "Échec de la réinitialisation du mot de passe. Avez-vous utilisé un lien expiré ? ({errorMessage})",
   },
   "retention_policy": {
     "dev": "Développeur logiciel",

--- a/frontend/src/lib/util/asp-response.ts
+++ b/frontend/src/lib/util/asp-response.ts
@@ -1,0 +1,22 @@
+/* See: builder.Services.AddProblemDetails. More specifically the ProblemDetails type. */
+export type AspProblemDetails = {
+  type?: string,
+  title?: string,
+  status?: number,
+}
+
+export async function getAspResponseErrorMessage(response: Response): Promise<string> {
+  if (response.statusText) return response.statusText;
+  const { responseJson, responseText } = await tryGetJson<AspProblemDetails>(response);
+  return responseJson?.title ?? responseJson?.status?.toString() ?? responseText;
+}
+
+async function tryGetJson<T extends object = object>(response: Response): Promise<{ responseJson: T | undefined, responseText: string }> {
+  const responseText = await response.text();
+  let responseJson: T | undefined = undefined;
+  try {
+    responseJson = JSON.parse(responseText) as T;
+  } catch { /* empty */ }
+
+  return { responseJson, responseText };
+}

--- a/frontend/src/routes/(authenticated)/resetPassword/+page.svelte
+++ b/frontend/src/routes/(authenticated)/resetPassword/+page.svelte
@@ -7,6 +7,7 @@
   import { z } from 'zod';
   import { useNotifications } from '$lib/notify';
   import type { PageData } from './$types';
+  import { getAspResponseErrorMessage } from '$lib/util/asp-response';
 
   export let data: PageData;
 
@@ -25,7 +26,8 @@
       },
     });
     if (!response.ok) {
-      return $t('reset_password.failed', {statusText: response.statusText});
+      let errorMessage = await getAspResponseErrorMessage(response);
+      return $t('reset_password.failed', { errorMessage });
     }
     notifySuccess($t('reset_password.password_reset'));
     await goto(data.home);


### PR DESCRIPTION
Follow up of PR #505 after testing #465

The error message I displayed when reset-password fails, was sometimes empty. So, this PR reads the ASP ProblemDetails, which I seem to get as a response now.