### PR TITLE
Bug/permission issues

### DIFF
--- a/backend/LexBoxApi/Services/HgService.cs
+++ b/backend/LexBoxApi/Services/HgService.cs
@@ -239,12 +239,11 @@ public partial class HgService : IHgService
 
     private static void CopyFilesRecursively(DirectoryInfo source, DirectoryInfo target)
     {
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+            target.UnixFileMode = Permissions;
         foreach (var dir in source.EnumerateDirectories())
         {
-            var directoryInfo = target.CreateSubdirectory(dir.Name);
-            if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
-                directoryInfo.UnixFileMode = Permissions;
-            CopyFilesRecursively(dir, directoryInfo);
+            CopyFilesRecursively(dir, target.CreateSubdirectory(dir.Name));
         }
 
         foreach (var file in source.EnumerateFiles())

--- a/backend/LexBoxApi/Services/HgService.cs
+++ b/backend/LexBoxApi/Services/HgService.cs
@@ -181,7 +181,7 @@ public partial class HgService : IHgService
             RedirectStandardOutput = false,
             //.hg/cache is excluded since there can be issues reading and it's not required
             Arguments = $"""
-                         -c "rsync -axhAXP --del --exclude=.hg/cache lexbox@{remoteHost}:{remotePath} {repoPath}"
+                         -c "rsync -axhAXP --del --groupmap=hg:www-data --exclude=.hg/cache lexbox@{remoteHost}:{remotePath} {repoPath}"
                          """,
         });
         if (process is null)

--- a/backend/LexBoxApi/Services/HgService.cs
+++ b/backend/LexBoxApi/Services/HgService.cs
@@ -223,7 +223,9 @@ public partial class HgService : IHgService
         await Task.Run(() =>
         {
             var deletedRepoPath = Path.Combine(_options.Value.RepoPath, DELETED_REPO_FOLDER);
-            Directory.CreateDirectory(deletedRepoPath);
+            var directory = Directory.CreateDirectory(deletedRepoPath);
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+                directory.UnixFileMode = Permissions;
             Directory.Move(
                 Path.Combine(_options.Value.RepoPath, code),
                 Path.Combine(deletedRepoPath, deletedRepoName));
@@ -257,6 +259,7 @@ public partial class HgService : IHgService
     private static void SetPermissionsRecursively(DirectoryInfo rootDir)
     {
         if (!RuntimeInformation.IsOSPlatform(OSPlatform.Linux)) return;
+        rootDir.UnixFileMode = Permissions;
 
         foreach (var dir in rootDir.EnumerateDirectories())
         {


### PR DESCRIPTION
closes #541 and #539

We're now setting permissions when creating the root folder for a reset, and we're mapping the hg group to www-data when doing a migration