### PR TITLE
Otel/552 svelte client can create a lot of otel events

### DIFF
--- a/frontend/src/lib/otel/otel.client.ts
+++ b/frontend/src/lib/otel/otel.client.ts
@@ -1,9 +1,9 @@
 import { BatchSpanProcessor, WebTracerProvider } from '@opentelemetry/sdk-trace-web'
+import {SERVICE_NAME, traceUserAttributes} from '.';
 
 import { APP_VERSION } from '$lib/util/version';
 import { OTLPTraceExporterBrowserWithXhrRetry } from './trace-exporter-browser-with-xhr-retry';
 import { Resource } from '@opentelemetry/resources'
-import {SERVICE_NAME, traceUserAttributes} from '.';
 import { SemanticResourceAttributes } from '@opentelemetry/semantic-conventions'
 import { ZoneContextManager } from '@opentelemetry/context-zone'
 import { getWebAutoInstrumentations } from '@opentelemetry/auto-instrumentations-web'
@@ -14,7 +14,15 @@ export * from '.';
 
 instrumentGlobalFetch(() => {
   registerInstrumentations({
-    instrumentations: [getWebAutoInstrumentations()],
+    instrumentations: [getWebAutoInstrumentations({
+      '@opentelemetry/instrumentation-document-load': {
+        // note: disabling this makes the traceParent in our root layout meaningless
+        enabled: false,
+      },
+      '@opentelemetry/instrumentation-user-interaction': {
+        enabled: false,
+      },
+    })],
   });
 });
 


### PR DESCRIPTION
Resolves #552.
We don't have to do it this way, but...here's a PR if we decide to 😉.

- turns off document-load instrumentation
- turns off user-interaction instrumentation
- fixes overlay global listener handling

Here's what a page load looks like with document-load instrumentation disabled. We just have all the juicy stuff:
https://ui.honeycomb.io/sil-language-forge/environments/test/result/kE3WyuHsWFF/trace/DFSDihZQwLT?fields[]=s_serviceName&fields[]=s_name&span=aa1f9ef7a92fa4ab
![image](https://github.com/sillsdev/languageforge-lexbox/assets/12587509/6a6a01ff-6ae4-4629-bdcb-4cf966340309)

And clicks just don't create spans/traces anymore.