### PR TITLE
add hg recover command

### DIFF
--- a/backend/LexCore/ServiceInterfaces/IHgService.cs
+++ b/backend/LexCore/ServiceInterfaces/IHgService.cs
@@ -17,4 +17,5 @@ public interface IHgService
     Task<string> VerifyRepo(string code);
     Task<int?> GetLexEntryCount(string code);
     Task<string?> GetRepositoryIdentifier(Project project);
+    Task<string> ExecuteHgRecover(string code);
 }

--- a/frontend/src/routes/(authenticated)/project/[project_code]/+page.svelte
+++ b/frontend/src/routes/(authenticated)/project/[project_code]/+page.svelte
@@ -185,15 +185,23 @@
     await watchMigrationStatus();
   }
 
-  let verifyModal: Modal;
-  let verifyResponse = '';
+  let hgCommandResultModal: Modal;
+  let hgCommandResponse = '';
 
   async function verify(): Promise<void> {
-    verifyResponse = '';
-    void verifyModal.openModal(true, true);
-    let response = await fetch(`/api/project/hgVerify/${project.code}`);
+    await hgCommand(async () => fetch(`/api/project/hgVerify/${project.code}`));
+  }
+
+  async function recover(): Promise<void> {
+    await hgCommand(async () => fetch(`/api/project/hgRecover/${project.code}`));
+  }
+
+  async function hgCommand(execute: ()=> Promise<Response>): Promise<void> {
+    hgCommandResponse = '';
+    void hgCommandResultModal.openModal(true, true);
+    let response = await execute();
     let json = await response.json() as { response: string } | undefined;
-    verifyResponse = json?.response ?? 'No response';
+    hgCommandResponse = json?.response ?? 'No response';
   }
 
   let openInFlexModal: OpenInFlexModal;
@@ -425,13 +433,14 @@
             {/if}
             {#if migrationStatus === ProjectMigrationStatus.Migrated}
               <Button on:click={verify}>Verify Repository</Button>
-              <Modal bind:this={verifyModal} closeOnClickOutside={false}>
+              <Button on:click={recover}>HG Recover</Button>
+              <Modal bind:this={hgCommandResultModal} closeOnClickOutside={false}>
                 <div class="card">
                   <div class="card-body">
-                    {#if verifyResponse === ''}
+                    {#if hgCommandResponse === ''}
                       <span class="loading loading-ring loading-lg"></span>
                     {:else}
-                      <pre>{verifyResponse}</pre>
+                      <pre>{hgCommandResponse}</pre>
                     {/if}
                   </div>
                 </div>

--- a/hgweb/command-runner.sh
+++ b/hgweb/command-runner.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # Define the list of allowed commands
-allowed_commands=("verify" "tip" "lexentrycount")
+allowed_commands=("verify" "tip" "lexentrycount" "recover")
 
 # Get the project code and command name from the URL
 IFS='/' read -ra PATH_SEGMENTS <<< "$PATH_INFO"


### PR DESCRIPTION
this is related to #540 and allows admins to recover from aborted transactions which happens if there's a network interruption or if the hg server crashes for some reason. Running hg verify first will notify you that you need to run recover on the repo.