### PR TITLE
Feat/405 dont add admins to projects they create

### DIFF
--- a/backend/LexBoxApi/Models/Project/CreateProjectInput.cs
+++ b/backend/LexBoxApi/Models/Project/CreateProjectInput.cs
@@ -10,5 +10,6 @@ public record CreateProjectInput(
     [property: MinLength(4), RegularExpression(LexCore.Entities.Project.ProjectCodeRegex)]
     string Code,
     ProjectType Type,
-    RetentionPolicy RetentionPolicy
+    RetentionPolicy RetentionPolicy,
+    Guid? ProjectManagerId
 );

--- a/backend/LexBoxApi/Services/ProjectService.cs
+++ b/backend/LexBoxApi/Services/ProjectService.cs
@@ -10,7 +10,7 @@ namespace LexBoxApi.Services;
 
 public class ProjectService(LexBoxDbContext dbContext, IHgService hgService, IRepoMigrationService migrationService, IMemoryCache memoryCache)
 {
-    public async Task<Guid> CreateProject(CreateProjectInput input, Guid userId)
+    public async Task<Guid> CreateProject(CreateProjectInput input)
     {
         await using var transaction = await dbContext.Database.BeginTransactionAsync();
         var projectId = input.Id ?? Guid.NewGuid();
@@ -26,7 +26,7 @@ public class ProjectService(LexBoxDbContext dbContext, IHgService hgService, IRe
                 Type = input.Type,
                 LastCommit = null,
                 RetentionPolicy = input.RetentionPolicy,
-                Users = new List<ProjectUsers> { new() { UserId = userId, Role = ProjectRole.Manager } }
+                Users = input.ProjectManagerId.HasValue ? [new() { UserId = input.ProjectManagerId.Value, Role = ProjectRole.Manager }] : [],
             });
         await dbContext.SaveChangesAsync();
         await hgService.InitRepo(input.Code);

--- a/backend/LexCore/Auth/LexAuthUser.cs
+++ b/backend/LexCore/Auth/LexAuthUser.cs
@@ -116,6 +116,9 @@ public record LexAuthUser
     public required UserRole Role { get; set; }
 
     [JsonIgnore]
+    public bool IsAdmin => Role == UserRole.admin;
+
+    [JsonIgnore]
     public AuthUserProject[] Projects { get; set; } = Array.Empty<AuthUserProject>();
 
     [JsonPropertyName(LexAuthConstants.ProjectsClaimType)]

--- a/backend/Testing/LexCore/Services/ProjectServiceTest.cs
+++ b/backend/Testing/LexCore/Services/ProjectServiceTest.cs
@@ -33,9 +33,7 @@ public class ProjectServiceTest
     public async Task CanCreateProject()
     {
         var projectId = await _projectService.CreateProject(
-            new(null, "TestProject", "Test", "test", ProjectType.FLEx, RetentionPolicy.Test),
-            SeedingData.TestAdminId
-        );
+            new(null, "TestProject", "Test", "test", ProjectType.FLEx, RetentionPolicy.Test, null));
         projectId.ShouldNotBe(default);
     }
 
@@ -44,13 +42,10 @@ public class ProjectServiceTest
     {
         //first project should be created
         await _projectService.CreateProject(
-            new(null, "TestProject", "Test", "test-dup-code", ProjectType.FLEx, RetentionPolicy.Test),
-            SeedingData.TestAdminId
-        );
+            new(null, "TestProject", "Test", "test-dup-code", ProjectType.FLEx, RetentionPolicy.Test, null));
 
         var exception = await _projectService.CreateProject(
-            new(null, "Test2", "Test desc", "test-dup-code", ProjectType.Unknown, RetentionPolicy.Dev),
-            SeedingData.TestAdminId
+            new(null, "Test2", "Test desc", "test-dup-code", ProjectType.Unknown, RetentionPolicy.Dev, null)
         ).ShouldThrowAsync<DbUpdateException>();
 
         exception.InnerException.ShouldBeOfType<PostgresException>()

--- a/frontend/schema.graphql
+++ b/frontend/schema.graphql
@@ -102,6 +102,7 @@ type LexAuthUser {
   email: String!
   name: String!
   role: UserRole!
+  isAdmin: Boolean!
   projects: [AuthUserProject!]!
   projectsJson: String!
   locked: Boolean
@@ -297,6 +298,7 @@ input CreateProjectInput {
   code: String!
   type: ProjectType!
   retentionPolicy: RetentionPolicy!
+  projectManagerId: UUID
 }
 
 input DateTimeOperationFilterInput {

--- a/frontend/src/lib/components/Badges/MemberBadge.svelte
+++ b/frontend/src/lib/components/Badges/MemberBadge.svelte
@@ -6,10 +6,13 @@
   export let member: { name: string; role: ProjectRole };
   export let canManage = false;
 
+  export let type: 'existing' | 'new' = 'existing';
+  $: actionIcon = (type === 'existing' ? 'i-mdi-dots-vertical' as const : 'i-mdi-close' as const);
+
   $: variant = member.role === ProjectRole.Manager ? 'btn-primary' as const : 'btn-secondary' as const;
 </script>
 
-<ActionBadge actionIcon="i-mdi-dots-vertical" {variant} disabled={!canManage}>
+<ActionBadge {actionIcon} {variant} disabled={!canManage} on:action>
   <span class="pr-3 whitespace-nowrap overflow-ellipsis overflow-x-clip" title={member.name}>
     {member.name}
   </span>

--- a/frontend/src/lib/components/Badges/MemberBadge.svelte
+++ b/frontend/src/lib/components/Badges/MemberBadge.svelte
@@ -10,7 +10,7 @@
 </script>
 
 <ActionBadge actionIcon="i-mdi-dots-vertical" {variant} disabled={!canManage}>
-  <span class="pr-3 whitespace-nowrap overflow-ellipsis overflow-hidden" title={member.name}>
+  <span class="pr-3 whitespace-nowrap overflow-ellipsis overflow-x-clip" title={member.name}>
     {member.name}
   </span>
 

--- a/frontend/src/lib/i18n/locales/en.json
+++ b/frontend/src/lib/i18n/locales/en.json
@@ -415,5 +415,6 @@ If you don't see a dialog or already closed it, click the button below:",
   "common": {
     "yes": "Yes",
     "no": "No",
+    "none": "None",
   }
 }

--- a/frontend/src/lib/util/guid.ts
+++ b/frontend/src/lib/util/guid.ts
@@ -1,0 +1,8 @@
+import type { UUID } from 'crypto';
+
+const guidRegex = /^[0-9a-f]{8}-?[0-9a-f]{4}-?[0-5][0-9a-f]{3}-?[089ab][0-9a-f]{3}-?[0-9a-f]{12}$/i;
+
+export function isGuid(val?: string): val is UUID {
+  // only match strings of the exact length of a GUID, with or without dashes
+  return !!val && (val.length == 32 || val.length == 36) && guidRegex.test(val);
+}

--- a/frontend/src/lib/util/query-params.ts
+++ b/frontend/src/lib/util/query-params.ts
@@ -85,7 +85,7 @@ export function getBoolSearchParam<T extends PrimitiveRecord>(key: keyof Conditi
   }
 }
 
-export function getSearchParam<T extends PrimitiveRecord, R = string | undefined>(
+export function getSearchParam<T extends PrimitiveRecord, R = string | undefined | null>(
   key: keyof ConditionalPick<T, (R extends StandardEnum<unknown> ? R[keyof R] : R)> & string,
   params: URLSearchParams): EnumOrString<R> | undefined {
   const value = params.get(key);

--- a/frontend/src/routes/(authenticated)/admin/+page.ts
+++ b/frontend/src/routes/(authenticated)/admin/+page.ts
@@ -4,6 +4,7 @@ import type { PageLoadEvent } from './$types';
 import { isAdmin, type LexAuthUser } from '$lib/user';
 import { redirect } from '@sveltejs/kit';
 import {getBoolSearchParam, getSearchParam} from '$lib/util/query-params';
+import { isGuid } from '$lib/util/guid';
 import type {
   $OpResult,
   ChangeUserAccountByAdminInput,
@@ -100,13 +101,6 @@ export async function load(event: PageLoadEvent) {
     ...projectResults,
     ...userResults,
   }
-}
-
-const guidRegex = /^[0-9a-f]{8}-?[0-9a-f]{4}-?[0-5][0-9a-f]{3}-?[089ab][0-9a-f]{3}-?[0-9a-f]{12}$/i;
-
-function isGuid(val: string): boolean {
-  // only match strings of the exact length of a GUID, with or without dashes
-  return (val.length == 32 || val.length == 36) && guidRegex.test(val);
 }
 
 function requireAdmin(user: LexAuthUser | null): void {

--- a/frontend/src/routes/(authenticated)/project/create/+page.ts
+++ b/frontend/src/routes/(authenticated)/project/create/+page.ts
@@ -1,6 +1,42 @@
 import type { $OpResult, CreateProjectInput, CreateProjectMutation } from '$lib/gql/types';
 import { getClient, graphql } from '$lib/gql';
 
+import type { PageLoadEvent } from './$types';
+import { getSearchParam } from '$lib/util/query-params';
+import { isAdmin } from '$lib/user';
+import { isGuid } from '$lib/util/guid';
+
+export async function load(event: PageLoadEvent) {
+  const userIsAdmin = isAdmin((await event.parent()).user);
+  const requestingUserId = getSearchParam<CreateProjectInput>('projectManagerId', event.url.searchParams);
+  if (userIsAdmin && isGuid(requestingUserId)) {
+    const client = getClient();
+    const userResultsPromise = await client.query(graphql(`
+          query loadRequestingUser($userId: UUID!) {
+              users(
+                where: {id: {eq: $userId}}) {
+                items {
+                  id
+                  name
+                  email
+                  username
+                  isAdmin
+                  emailVerified
+                  createdDate
+                  locked
+                  localizationCode
+                  updatedDate
+                  lastActive
+                  canCreateProjects
+                }
+              }
+          }
+      `), { userId: requestingUserId }, { fetch: event.fetch});
+    const requestingUser = userResultsPromise.data?.users?.items?.[0];
+    return { requestingUser };
+  }
+}
+
 export async function _createProject(input: CreateProjectInput): $OpResult<CreateProjectMutation> {
   const result = await getClient().mutation(
     graphql(`

--- a/frontend/src/routes/email/tester/+page@.svelte
+++ b/frontend/src/routes/email/tester/+page@.svelte
@@ -70,7 +70,8 @@
                 code: 'my-proj-custom-onestory',
                 type: ProjectType.WeSay,
                 description: 'My project description',
-                retentionPolicy: RetentionPolicy.Dev
+                retentionPolicy: RetentionPolicy.Dev,
+                projectManagerId: '703701a8-005c-4747-91f2-ac7650455118', // manager from seeding data
             },
             user: {
                 name: 'Bob',


### PR DESCRIPTION
Resolves #405 

- Admins are now never added to projects when they create them
- When a user requests a project, they are automatically added when the admin create the project unless...
- The admin can remove the user on the "Create Project" page and then decide who to add afterwards

The new members section is `<AdminContent>`, because only admins can create projects with no members and projects for other users.

![image](https://github.com/sillsdev/languageforge-lexbox/assets/12587509/771ae736-0d11-4d78-830a-6553ec3bb206)

![image](https://github.com/sillsdev/languageforge-lexbox/assets/12587509/d108c1f4-dc27-43e8-805a-9c4c9f0a7012)
