### PR TITLE
Asynchronously check for duplicate project codes on creation page

### DIFF
--- a/backend/LexBoxApi/Controllers/ProjectController.cs
+++ b/backend/LexBoxApi/Controllers/ProjectController.cs
@@ -74,6 +74,13 @@ public class ProjectController(
         return project;
     }
 
+    [HttpGet("projectCodeAvailable/{code}")]
+    public async Task<bool> ProjectCodeAvailable(string code)
+    {
+        permissionService.AssertHasProjectCreatePermission();
+        return !await projectService.ProjectExists(code);
+    }
+
     [HttpGet("determineProjectType/{id}")]
     [ProducesResponseType(StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status404NotFound)]

--- a/backend/LexBoxApi/Services/PermissionService.cs
+++ b/backend/LexBoxApi/Services/PermissionService.cs
@@ -74,4 +74,9 @@ public class PermissionService(
     {
         return User is { CanCreateProjects: true } or { Role: UserRole.admin };
     }
+
+    public void AssertHasProjectCreatePermission()
+    {
+        if (!HasProjectCreatePermission()) throw new UnauthorizedAccessException();
+    }
 }

--- a/backend/LexCore/ServiceInterfaces/IPermissionService.cs
+++ b/backend/LexCore/ServiceInterfaces/IPermissionService.cs
@@ -11,5 +11,6 @@ public interface IPermissionService
     void AssertIsAdmin();
     void AssertCanDeleteAccount(Guid userId);
     bool HasProjectCreatePermission();
+    void AssertHasProjectCreatePermission();
     void AssertCanLockOrUnlockUser(Guid userId);
 }

--- a/frontend/src/lib/forms/utils.ts
+++ b/frontend/src/lib/forms/utils.ts
@@ -1,3 +1,4 @@
+import { browser } from '$app/environment';
 import { type Translater } from '$lib/i18n';
 import { z, type ZodDefault, type ZodType } from 'zod';
 
@@ -19,4 +20,31 @@ export function passwordFormRules($t: Translater): z.ZodString {
 
 export function emptyString(): z.ZodString {
   return z.string().length(0);
+}
+
+/**
+ * Debouncind a refine serves 2 purposes:
+ * 1) Debouncing, of course, to avoid (e.g.) making too many requests
+ * 2) Ensuring the validation result is consistent. It seems that the last resolve doesn't always "win".
+ * By making them all resolve to the same value, it doesn't matter which one wins.
+ */
+export function debouncedRefine<T>(refine: (value: T) => Promise<boolean>, debounceTime = 300): (value: T) => Promise<boolean> {
+  // consumers don't expect debounced refines to get called server-side, but they sometimes do,
+  // which can cause problems, e.g. calling fetch with a relative path kills the server
+  if (!browser) return () => Promise.resolve(true);
+
+  let timeout: ReturnType<typeof setTimeout>;
+  let openResolves: ((value: boolean) => void)[] = [];
+  return (value: T) => {
+    clearTimeout(timeout);
+    return new Promise((resolve) => {
+      openResolves.push(resolve);
+      timeout = setTimeout(() => {
+        void refine(value).then((result) => {
+          for (const openResolve of openResolves) openResolve(result);
+          openResolves = [];
+        });
+      }, debounceTime);
+    });
+  };
 }

--- a/frontend/src/lib/user.ts
+++ b/frontend/src/lib/user.ts
@@ -40,7 +40,7 @@ export type LexAuthUser = {
   projects: UserProjects[]
   locked: boolean
   emailVerified: boolean
-  canCreateProject: boolean
+  canCreateProjects: boolean
   locale: string
 }
 type UserProjectRole = 'Manager' | 'Editor' | 'Unknown';
@@ -135,7 +135,7 @@ function jwtToUser(user: JwtTokenUser): LexAuthUser {
     projects: projectsStringToProjects(projectsString),
     locked: user.lock === true,
     emailVerified: !user.unver,
-    canCreateProject: user.mkproj === true,
+    canCreateProjects: user.mkproj === true || role === 'admin',
     locale: user.loc,
   }
 }

--- a/frontend/src/routes/(authenticated)/project/create/+page.svelte
+++ b/frontend/src/routes/(authenticated)/project/create/+page.svelte
@@ -1,11 +1,11 @@
 <script lang="ts">
   import { goto } from '$app/navigation';
-  import { Checkbox, Form, FormError, Input, ProjectTypeSelect, Select, SubmitButton, TextArea, lexSuperForm } from '$lib/forms';
+  import { Checkbox, Form, FormError, Input, ProjectTypeSelect, Select, SubmitButton, TextArea, debouncedRefine, lexSuperForm } from '$lib/forms';
   import { CreateProjectResult, DbErrorCode, ProjectRole, ProjectType, RetentionPolicy, type CreateProjectInput } from '$lib/gql/types';
   import t from '$lib/i18n';
   import { TitlePage } from '$lib/layout';
   import { z } from 'zod';
-  import { _createProject } from './+page';
+  import { _createProject, _projectCodeAvailable } from './+page';
   import AdminContent from '$lib/layout/AdminContent.svelte';
   import { useNotifications } from '$lib/notify';
   import { Duration } from '$lib/util/time';
@@ -20,6 +20,14 @@
 
   const { notifySuccess } = useNotifications();
 
+  let codeValidation: z.ZodType = z.string().toLowerCase()
+    .min(4, $t('project.create.code_too_short'))
+    .refine(debouncedRefine((code) =>
+      // user is not available when defining the schema
+      // || isAdmin will be redundant soon after new JWTs roll out
+      user.canCreateProjects ? _projectCodeAvailable(code) : Promise.resolve(true)),
+      $t('project.create.code_exists'));
+
   const formSchema = z.object({
     name: z.string().min(1, $t('project.create.name_missing')),
     description: z.string().min(1, $t('project.create.description_missing')),
@@ -29,7 +37,7 @@
       .string()
       .min(3, $t('project.create.language_code_too_short'))
       .regex(/^[a-z-\d]+$/, $t('project.create.language_code_invalid')),
-    code: z.string().toLowerCase().min(4, $t('project.create.code_too_short')),
+    code: codeValidation,
     customCode: z.boolean().default(false),
   });
   //random guid
@@ -182,7 +190,7 @@
 
     <FormError error={$message} />
     <SubmitButton loading={$submitting}>
-        {#if data.user.canCreateProject || data.user.role === 'admin'}
+        {#if data.user.canCreateProjects}
             {$t('project.create.submit')}
         {:else}
             {$t('project.create.request')}

--- a/frontend/src/routes/(authenticated)/project/create/+page.ts
+++ b/frontend/src/routes/(authenticated)/project/create/+page.ts
@@ -58,3 +58,9 @@ export async function _createProject(input: CreateProjectInput): $OpResult<Creat
     { input });
   return result;
 }
+
+export async function _projectCodeAvailable(code: string): Promise<boolean> {
+  const result = await fetch(`/api/project/projectCodeAvailable/${code}`);
+  if (!result.ok) throw new Error('Failed to check project code availability');
+  return await result.json() as boolean;
+}


### PR DESCRIPTION
Users would like feedback like "this project code is duplicated" before clicking on the Create Project button.

Draft, just getting started. Only thing here so far is moving the description field down below the rest of the fields so that there's something for the user to be typing into while project-code validation happens in the background.

Once complete, will fix #257.

#257 mentions validating password strength, but as we haven't yet settled on rules for that, that might end up out-of-scope for this PR.