### PR TITLE
Capture hg verify error output (which contains detected corruption)

### DIFF
--- a/hgweb/command-runner.sh
+++ b/hgweb/command-runner.sh
@@ -43,7 +43,7 @@ case $command_name in
         ;;
 
     *)
-        command_output=$(chg $command_name)
+        command_output=$(chg $command_name 2>&1)
         ;;
 esac
 


### PR DESCRIPTION
So, sadly it turns out that our hg verify button has not worked well so far. The error output is where the juicy stuff is.

When capturing error output:
![image](https://github.com/sillsdev/languageforge-lexbox/assets/12587509/8d946a2d-443b-4100-849e-82f917eb0e2e)

Without error output:
![image](https://github.com/sillsdev/languageforge-lexbox/assets/12587509/9bd464d7-dea0-4e35-ad6a-05172c87355e)
