### PR TITLE
stream backup zip, instead of creating tmp zip file first

### DIFF
--- a/backend/LexBoxApi/Controllers/ActionResults/FileCallbackResult.cs
+++ b/backend/LexBoxApi/Controllers/ActionResults/FileCallbackResult.cs
@@ -1,0 +1,50 @@
+﻿using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Infrastructure;
+
+namespace LexBoxApi.Controllers.ActionResults;
+
+/// <summary>
+/// Represents an <see cref="ActionResult"/> that when executed will
+/// execute a callback to write the file content out as a stream.
+/// copied from https://github.com/StephenClearyExamples/AsyncDynamicZip/tree/net6-ziparchive
+/// MIT License
+/// </summary>
+public sealed class FileCallbackResult : FileResult
+{
+    private readonly Func<Stream, ActionContext, Task> _callback;
+
+    /// <summary>
+    /// Creates a new <see cref="FileCallbackResult"/> instance.
+    /// </summary>
+    /// <param name="contentType">The Content-Type header of the response.</param>
+    /// <param name="callback">The stream with the file.</param>
+    public FileCallbackResult(string contentType, Func<Stream, ActionContext, Task> callback)
+        : base(contentType)
+    {
+        _ = callback ?? throw new ArgumentNullException(nameof(callback));
+        _callback = callback;
+    }
+
+    /// <inheritdoc />
+    public override Task ExecuteResultAsync(ActionContext context)
+    {
+        _ = context ?? throw new ArgumentNullException(nameof(context));
+        var executor =
+            new FileCallbackResultExecutor(context.HttpContext.RequestServices.GetRequiredService<ILoggerFactory>());
+        return executor.ExecuteAsync(context, this);
+    }
+
+    private sealed class FileCallbackResultExecutor : FileResultExecutorBase
+    {
+        public FileCallbackResultExecutor(ILoggerFactory loggerFactory)
+            : base(CreateLogger<FileCallbackResultExecutor>(loggerFactory))
+        {
+        }
+
+        public Task ExecuteAsync(ActionContext context, FileCallbackResult result)
+        {
+            SetHeadersAndLog(context, result, fileLength: null, enableRangeProcessing: false);
+            return result._callback(context.HttpContext.Response.BodyWriter.AsStream(), context);
+        }
+    }
+}

--- a/backend/LexBoxApi/Services/HgService.cs
+++ b/backend/LexBoxApi/Services/HgService.cs
@@ -89,10 +89,10 @@ public partial class HgService : IHgService
         {
             return null;
         }
-        return new(stream => Task.Run(() =>
+        return new((stream, token) => Task.Run(() =>
         {
             ZipFile.CreateFromDirectory(repoPath, stream, CompressionLevel.Fastest, false);
-        }));
+        }, token));
     }
 
     public async Task ResetRepo(string code)

--- a/backend/LexBoxApi/Services/ProjectService.cs
+++ b/backend/LexBoxApi/Services/ProjectService.cs
@@ -51,10 +51,13 @@ public class ProjectService(LexBoxDbContext dbContext, IHgService hgService, IRe
         return projectId;
     }
 
-    public async Task<string?> BackupProject(ResetProjectByAdminInput input)
+    public async Task<BackupExecutor?> BackupProject(string code)
     {
-        var backupFile = await hgService.BackupRepo(input.Code);
-        return backupFile;
+        var exists = await dbContext.Projects.Where(p => p.Code == code && p.MigrationStatus == ProjectMigrationStatus.Migrated)
+            .AnyAsync();
+        if (!exists) return null;
+        var backupExecutor = hgService.BackupRepo(code);
+        return backupExecutor;
     }
 
     public async Task ResetProject(ResetProjectByAdminInput input)

--- a/backend/LexCore/ServiceInterfaces/IHgService.cs
+++ b/backend/LexCore/ServiceInterfaces/IHgService.cs
@@ -2,6 +2,7 @@
 
 namespace LexCore.ServiceInterfaces;
 
+public record BackupExecutor(Func<Stream, Task> ExecuteBackup);
 public interface IHgService
 {
     Task InitRepo(string code);
@@ -10,7 +11,7 @@ public interface IHgService
     Task<ProjectType> DetermineProjectType(string projectCode, ProjectMigrationStatus migrationStatus);
     Task DeleteRepo(string code);
     Task SoftDeleteRepo(string code, string deletedRepoSuffix);
-    Task<string?> BackupRepo(string code);
+    BackupExecutor? BackupRepo(string code);
     Task ResetRepo(string code);
     Task<bool> MigrateRepo(Project project, CancellationToken cancellationToken);
     Task FinishReset(string code, Stream zipFile);

--- a/backend/LexCore/ServiceInterfaces/IHgService.cs
+++ b/backend/LexCore/ServiceInterfaces/IHgService.cs
@@ -2,7 +2,7 @@
 
 namespace LexCore.ServiceInterfaces;
 
-public record BackupExecutor(Func<Stream, Task> ExecuteBackup);
+public record BackupExecutor(Func<Stream, CancellationToken, Task> ExecuteBackup);
 public interface IHgService
 {
     Task InitRepo(string code);


### PR DESCRIPTION
this should improve the responsivness to our users, but als prevent request timeout issues due to nothing being sent until the zip process is finished.

closes #563 (hopefully)