### PR TITLE
Project invitation emails also register new users

### DIFF
--- a/backend/LexBoxApi/Controllers/LoginController.cs
+++ b/backend/LexBoxApi/Controllers/LoginController.cs
@@ -72,21 +72,7 @@ public class LoginController(
 
         var userId = loggedInContext.User.Id;
         var user = await lexBoxDbContext.Users.FindAsync(userId);
-        if (user == null)
-        {
-            var jwtUser = loggedInContext.User;
-            user = new LexCore.Entities.User
-            {
-                Name = jwtUser.Name,
-                Email = jwtUser.Email,
-                PasswordHash = "", // New users get sent to forgot-password page next
-                Salt = "",
-                EmailVerified = true,
-                CanCreateProjects = false,
-                IsAdmin = false,
-                Locked = false,
-            };
-        }
+        if (user == null) return NotFound();
         //users can verify their email even if the updated date is out of sync when not changing their email
         //this is to prevent some edge cases where changing their name and then using an old verify email link would fail
         if (user.Email != loggedInContext.User.Email &&

--- a/backend/LexBoxApi/Controllers/LoginController.cs
+++ b/backend/LexBoxApi/Controllers/LoginController.cs
@@ -73,26 +73,7 @@ public class LoginController(
 
         var userId = loggedInContext.User.Id;
         var user = await lexBoxDbContext.Users.FindAsync(userId);
-        if (user == null)
-        {
-            user = new User
-            {
-                Id = userId,
-                Name = "",
-                Email = loggedInContext.User.Email,
-                PasswordHash = "", // New users get sent to forgot-password page next
-                Salt = "",
-                EmailVerified = true,
-                CanCreateProjects = false,
-                IsAdmin = false,
-                Locked = false,
-            };
-            if (loggedInContext.User.Projects.Length > 0)
-            {
-                Console.WriteLine("Adding user to projects...");
-                user.Projects = loggedInContext.User.Projects.Select(p => new ProjectUsers { Role = p.Role, ProjectId = p.ProjectId }).ToList();
-            }
-        }
+        if (user == null) return NotFound();
         //users can verify their email even if the updated date is out of sync when not changing their email
         //this is to prevent some edge cases where changing their name and then using an old verify email link would fail
         if (user.Email != loggedInContext.User.Email &&
@@ -135,7 +116,6 @@ public class LoginController(
         };
         if (loggedInContext.User.Projects.Length > 0)
         {
-            Console.WriteLine("Adding user {0} to projects...", userId);
             user.Projects = loggedInContext.User.Projects.Select(p => new ProjectUsers { Role = p.Role, ProjectId = p.ProjectId }).ToList();
         }
 

--- a/backend/LexBoxApi/Controllers/LoginController.cs
+++ b/backend/LexBoxApi/Controllers/LoginController.cs
@@ -14,6 +14,7 @@ using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.ModelBinding;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.AspNetCore.Http;
+using LexCore.Entities;
 
 namespace LexBoxApi.Controllers;
 
@@ -74,8 +75,9 @@ public class LoginController(
         var user = await lexBoxDbContext.Users.FindAsync(userId);
         if (user == null)
         {
-            user = new LexCore.Entities.User
+            user = new User
             {
+                Id = userId,
                 Name = "",
                 Email = loggedInContext.User.Email,
                 PasswordHash = "", // New users get sent to forgot-password page next
@@ -85,6 +87,11 @@ public class LoginController(
                 IsAdmin = false,
                 Locked = false,
             };
+            if (loggedInContext.User.Projects.Length > 0)
+            {
+                Console.WriteLine("Adding user to projects...");
+                user.Projects = loggedInContext.User.Projects.Select(p => new ProjectUsers { Role = p.Role, ProjectId = p.ProjectId }).ToList();
+            }
         }
         //users can verify their email even if the updated date is out of sync when not changing their email
         //this is to prevent some edge cases where changing their name and then using an old verify email link would fail

--- a/backend/LexBoxApi/Controllers/LoginController.cs
+++ b/backend/LexBoxApi/Controllers/LoginController.cs
@@ -72,7 +72,20 @@ public class LoginController(
 
         var userId = loggedInContext.User.Id;
         var user = await lexBoxDbContext.Users.FindAsync(userId);
-        if (user == null) return NotFound();
+        if (user == null)
+        {
+            user = new LexCore.Entities.User
+            {
+                Name = "",
+                Email = loggedInContext.User.Email,
+                PasswordHash = "", // New users get sent to forgot-password page next
+                Salt = "",
+                EmailVerified = true,
+                CanCreateProjects = false,
+                IsAdmin = false,
+                Locked = false,
+            };
+        }
         //users can verify their email even if the updated date is out of sync when not changing their email
         //this is to prevent some edge cases where changing their name and then using an old verify email link would fail
         if (user.Email != loggedInContext.User.Email &&

--- a/backend/LexBoxApi/Controllers/LoginController.cs
+++ b/backend/LexBoxApi/Controllers/LoginController.cs
@@ -72,7 +72,21 @@ public class LoginController(
 
         var userId = loggedInContext.User.Id;
         var user = await lexBoxDbContext.Users.FindAsync(userId);
-        if (user == null) return NotFound();
+        if (user == null)
+        {
+            var jwtUser = loggedInContext.User;
+            user = new LexCore.Entities.User
+            {
+                Name = jwtUser.Name,
+                Email = jwtUser.Email,
+                PasswordHash = "", // New users get sent to forgot-password page next
+                Salt = "",
+                EmailVerified = true,
+                CanCreateProjects = false,
+                IsAdmin = false,
+                Locked = false,
+            };
+        }
         //users can verify their email even if the updated date is out of sync when not changing their email
         //this is to prevent some edge cases where changing their name and then using an old verify email link would fail
         if (user.Email != loggedInContext.User.Email &&

--- a/backend/LexBoxApi/Controllers/LoginController.cs
+++ b/backend/LexBoxApi/Controllers/LoginController.cs
@@ -42,10 +42,14 @@ public class LoginController(
         string returnTo)
     {
         var user = loggedInContext.User;
-        var userUpdatedDate = await userService.GetUserUpdatedDate(user.Id);
-        if (userUpdatedDate != user.UpdatedDate)
+        // A RegisterAccount token means there's no user account yet, so checking UpdatedDate makes no sense
+        if (user.Audience != LexboxAudience.RegisterAccount)
         {
-            return await EmailLinkExpired();
+            var userUpdatedDate = await userService.GetUserUpdatedDate(user.Id);
+            if (userUpdatedDate != user.UpdatedDate)
+            {
+                return await EmailLinkExpired();
+            }
         }
         await HttpContext.SignInAsync(User,
             new AuthenticationProperties { IsPersistent = true });
@@ -87,44 +91,6 @@ public class LoginController(
         user.UpdateUpdatedDate();
         await lexBoxDbContext.SaveChangesAsync();
         await RefreshJwt();
-        return Redirect(returnTo);
-    }
-
-    [HttpGet("joinProject")]
-    [ProducesResponseType(StatusCodes.Status200OK)]
-    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
-    [ProducesResponseType(StatusCodes.Status404NotFound)]
-    public async Task<ActionResult<LexAuthUser>> JoinProject(
-        string jwt, // This is required because auth looks for a jwt in the query string
-        string returnTo)
-    {
-        var userId = loggedInContext.User.Id;
-        // Ensure we're not registering a user ID twice
-        var user = await lexBoxDbContext.Users.FindAsync(userId);
-        if (user != null) return Unauthorized(); // TODO: Maybe just add them to the project and move on?
-        user = new User
-        {
-            Id = userId,
-            Name = "",
-            Email = loggedInContext.User.Email,
-            PasswordHash = "", // New users get sent to forgot-password page next
-            Salt = "",
-            EmailVerified = true,
-            CanCreateProjects = false,
-            IsAdmin = false,
-            Locked = false,
-        };
-        if (loggedInContext.User.Projects.Length > 0)
-        {
-            user.Projects = loggedInContext.User.Projects.Select(p => new ProjectUsers { Role = p.Role, ProjectId = p.ProjectId }).ToList();
-        }
-
-        user.Email = loggedInContext.User.Email;
-        user.EmailVerified = true;
-        user.UpdateUpdatedDate();
-        await lexBoxDbContext.SaveChangesAsync();
-        await HttpContext.SignInAsync(User,
-            new AuthenticationProperties { IsPersistent = true });
         return Redirect(returnTo);
     }
 

--- a/backend/LexBoxApi/Controllers/UserController.cs
+++ b/backend/LexBoxApi/Controllers/UserController.cs
@@ -50,12 +50,15 @@ public class UserController : ControllerBase
     {
         using var registerActivity = LexBoxActivitySource.Get().StartActivity("Register");
         var validToken = await _turnstileService.IsTokenValid(accountInput.TurnstileToken, accountInput.Email);
+        var jwtUser = _loggedInContext.MaybeUser;
         registerActivity?.AddTag("app.turnstile_token_valid", validToken);
         if (!validToken)
         {
             ModelState.AddModelError<RegisterAccountInput>(r => r.TurnstileToken, "token invalid");
             return ValidationProblem(ModelState);
         }
+
+        var emailVerified = jwtUser?.Email == accountInput.Email;
 
         var hasExistingUser = await _lexBoxDbContext.Users.FilterByEmail(accountInput.Email).AnyAsync();
         registerActivity?.AddTag("app.email_available", !hasExistingUser);
@@ -75,19 +78,24 @@ public class UserController : ControllerBase
             Salt = salt,
             PasswordHash = PasswordHashing.HashPassword(accountInput.PasswordHash, salt, true),
             IsAdmin = false,
-            EmailVerified = false,
+            EmailVerified = emailVerified,
             Locked = false,
             CanCreateProjects = false
         };
         registerActivity?.AddTag("app.user.id", userEntity.Id);
         _lexBoxDbContext.Users.Add(userEntity);
+        if (jwtUser is not null && jwtUser.Projects.Length > 0)
+        {
+            _lexBoxDbContext.ProjectUsers.AddRange(jwtUser.Projects.Select(p =>
+                new ProjectUsers { Role = p.Role, ProjectId = p.ProjectId, UserId = jwtUser.Id }));
+        }
         await _lexBoxDbContext.SaveChangesAsync();
 
         var user = new LexAuthUser(userEntity);
         await HttpContext.SignInAsync(user.GetPrincipal("Registration"),
             new AuthenticationProperties { IsPersistent = true });
 
-        await _emailService.SendVerifyAddressEmail(userEntity);
+        if (!emailVerified) await _emailService.SendVerifyAddressEmail(userEntity);
         return Ok(user);
     }
 

--- a/backend/LexBoxApi/Controllers/UserController.cs
+++ b/backend/LexBoxApi/Controllers/UserController.cs
@@ -86,8 +86,7 @@ public class UserController : ControllerBase
         _lexBoxDbContext.Users.Add(userEntity);
         if (jwtUser is not null && jwtUser.Projects.Length > 0)
         {
-            _lexBoxDbContext.ProjectUsers.AddRange(jwtUser.Projects.Select(p =>
-                new ProjectUsers { Role = p.Role, ProjectId = p.ProjectId, UserId = jwtUser.Id }));
+            userEntity.Projects = jwtUser.Projects.Select(p => new ProjectUsers { Role = p.Role, ProjectId = p.ProjectId }).ToList();
         }
         await _lexBoxDbContext.SaveChangesAsync();
 

--- a/backend/LexBoxApi/Controllers/UserController.cs
+++ b/backend/LexBoxApi/Controllers/UserController.cs
@@ -71,7 +71,7 @@ public class UserController : ControllerBase
         var salt = Convert.ToHexString(RandomNumberGenerator.GetBytes(SHA1.HashSizeInBytes));
         var userEntity = new User
         {
-            Id = jwtUser?.Id ?? Guid.NewGuid(),
+            Id = Guid.NewGuid(),
             Name = accountInput.Name,
             Email = accountInput.Email,
             LocalizationCode = accountInput.Locale,

--- a/backend/LexBoxApi/Controllers/UserController.cs
+++ b/backend/LexBoxApi/Controllers/UserController.cs
@@ -71,7 +71,7 @@ public class UserController : ControllerBase
         var salt = Convert.ToHexString(RandomNumberGenerator.GetBytes(SHA1.HashSizeInBytes));
         var userEntity = new User
         {
-            Id = Guid.NewGuid(),
+            Id = jwtUser?.Id ?? Guid.NewGuid(),
             Name = accountInput.Name,
             Email = accountInput.Email,
             LocalizationCode = accountInput.Locale,

--- a/backend/LexBoxApi/GraphQL/ProjectMutations.cs
+++ b/backend/LexBoxApi/GraphQL/ProjectMutations.cs
@@ -68,8 +68,9 @@ public class ProjectMutations
         var user = await dbContext.Users.FindByEmail(input.UserEmail);
         if (user is null)
         {
-            // TODO: Modify input to have an optional name for those times when the user doesn't exist and we're sending an invitation email
-            await emailService.SendCreateAccountEmail(input.UserEmail, input.UserEmail, input.ProjectId, input.Role);
+            await emailService.SendCreateAccountEmail(input.UserEmail, input.ProjectId, input.Role);
+            // TODO: Create new exception to throw here
+            throw new ProjectMembersMustBeVerified("Invitation email sent");
         }
         if (!user.EmailVerified) throw new ProjectMembersMustBeVerified("Member must verify email first");
         user.UpdateCreateProjectsPermission(input.Role);

--- a/backend/LexBoxApi/GraphQL/ProjectMutations.cs
+++ b/backend/LexBoxApi/GraphQL/ProjectMutations.cs
@@ -56,6 +56,7 @@ public class ProjectMutations
     [Error<NotFoundException>]
     [Error<DbError>]
     [Error<ProjectMembersMustBeVerified>]
+    [Error<ProjectMemberInvitedByEmail>]
     [UseMutationConvention]
     [UseFirstOrDefault]
     [UseProjection]
@@ -69,8 +70,7 @@ public class ProjectMutations
         if (user is null)
         {
             await emailService.SendCreateAccountEmail(input.UserEmail, input.ProjectId, input.Role);
-            // TODO: Create new exception to throw here
-            throw new ProjectMembersMustBeVerified("Invitation email sent");
+            throw new ProjectMemberInvitedByEmail("Invitation email sent");
         }
         if (!user.EmailVerified) throw new ProjectMembersMustBeVerified("Member must verify email first");
         user.UpdateCreateProjectsPermission(input.Role);

--- a/backend/LexBoxApi/Services/Email/EmailTemplates.cs
+++ b/backend/LexBoxApi/Services/Email/EmailTemplates.cs
@@ -27,7 +27,7 @@ public record ForgotPasswordEmail(string Name, string ResetUrl) : EmailTemplateB
 public record VerifyAddressEmail(string Name, string VerifyUrl, bool newAddress) : EmailTemplateBase(EmailTemplate.VerifyEmailAddress);
 
 // TODO: For better email body, will want project name here too, and maybe name of person inviting the user?
-public record ProjectInviteEmail(string Email, string ProjectId, string VerifyUrl) : EmailTemplateBase(EmailTemplate.CreateAccountRequest);
+public record ProjectInviteEmail(string Email, string ProjectId, string ManagerName, string ProjectName, string VerifyUrl) : EmailTemplateBase(EmailTemplate.CreateAccountRequest);
 
 public record PasswordChangedEmail(string Name) : EmailTemplateBase(EmailTemplate.PasswordChanged);
 

--- a/backend/LexBoxApi/Services/Email/EmailTemplates.cs
+++ b/backend/LexBoxApi/Services/Email/EmailTemplates.cs
@@ -27,7 +27,7 @@ public record ForgotPasswordEmail(string Name, string ResetUrl) : EmailTemplateB
 public record VerifyAddressEmail(string Name, string VerifyUrl, bool newAddress) : EmailTemplateBase(EmailTemplate.VerifyEmailAddress);
 
 // TODO: For better email body, will want project name here too, and maybe name of person inviting the user?
-public record ProjectInviteEmail(string Name, string Email, string ProjectId) : EmailTemplateBase(EmailTemplate.CreateAccountRequest);
+public record ProjectInviteEmail(string Email, string ProjectId) : EmailTemplateBase(EmailTemplate.CreateAccountRequest);
 
 public record PasswordChangedEmail(string Name) : EmailTemplateBase(EmailTemplate.PasswordChanged);
 

--- a/backend/LexBoxApi/Services/Email/EmailTemplates.cs
+++ b/backend/LexBoxApi/Services/Email/EmailTemplates.cs
@@ -26,6 +26,7 @@ public record ForgotPasswordEmail(string Name, string ResetUrl) : EmailTemplateB
 
 public record VerifyAddressEmail(string Name, string VerifyUrl, bool newAddress) : EmailTemplateBase(EmailTemplate.VerifyEmailAddress);
 
+// TODO: For better email body, will want project name here too, and maybe name of person inviting the user?
 public record ProjectInviteEmail(string Name, string Email, string ProjectId) : EmailTemplateBase(EmailTemplate.CreateAccountRequest);
 
 public record PasswordChangedEmail(string Name) : EmailTemplateBase(EmailTemplate.PasswordChanged);

--- a/backend/LexBoxApi/Services/Email/EmailTemplates.cs
+++ b/backend/LexBoxApi/Services/Email/EmailTemplates.cs
@@ -18,12 +18,15 @@ public enum EmailTemplate
     ForgotPassword,
     VerifyEmailAddress,
     PasswordChanged,
+    CreateAccountRequest,
     CreateProjectRequest
 }
 
 public record ForgotPasswordEmail(string Name, string ResetUrl) : EmailTemplateBase(EmailTemplate.ForgotPassword);
 
 public record VerifyAddressEmail(string Name, string VerifyUrl, bool newAddress) : EmailTemplateBase(EmailTemplate.VerifyEmailAddress);
+
+public record ProjectInviteEmail(string Name, string Email, string ProjectId) : EmailTemplateBase(EmailTemplate.CreateAccountRequest);
 
 public record PasswordChangedEmail(string Name) : EmailTemplateBase(EmailTemplate.PasswordChanged);
 

--- a/backend/LexBoxApi/Services/Email/EmailTemplates.cs
+++ b/backend/LexBoxApi/Services/Email/EmailTemplates.cs
@@ -27,7 +27,7 @@ public record ForgotPasswordEmail(string Name, string ResetUrl) : EmailTemplateB
 public record VerifyAddressEmail(string Name, string VerifyUrl, bool newAddress) : EmailTemplateBase(EmailTemplate.VerifyEmailAddress);
 
 // TODO: For better email body, will want project name here too, and maybe name of person inviting the user?
-public record ProjectInviteEmail(string Email, string ProjectId) : EmailTemplateBase(EmailTemplate.CreateAccountRequest);
+public record ProjectInviteEmail(string Email, string ProjectId, string VerifyUrl) : EmailTemplateBase(EmailTemplate.CreateAccountRequest);
 
 public record PasswordChangedEmail(string Name) : EmailTemplateBase(EmailTemplate.PasswordChanged);
 

--- a/backend/LexBoxApi/Services/Email/EmailTemplates.cs
+++ b/backend/LexBoxApi/Services/Email/EmailTemplates.cs
@@ -26,7 +26,6 @@ public record ForgotPasswordEmail(string Name, string ResetUrl) : EmailTemplateB
 
 public record VerifyAddressEmail(string Name, string VerifyUrl, bool newAddress) : EmailTemplateBase(EmailTemplate.VerifyEmailAddress);
 
-// TODO: For better email body, will want project name here too, and maybe name of person inviting the user?
 public record ProjectInviteEmail(string Email, string ProjectId, string ManagerName, string ProjectName, string VerifyUrl) : EmailTemplateBase(EmailTemplate.CreateAccountRequest);
 
 public record PasswordChangedEmail(string Name) : EmailTemplateBase(EmailTemplate.PasswordChanged);

--- a/backend/LexBoxApi/Services/EmailService.cs
+++ b/backend/LexBoxApi/Services/EmailService.cs
@@ -108,7 +108,7 @@ public class EmailService(
         var queryString = QueryString.Create("email", emailAddress);
         var returnTo = new UriBuilder() { Path = "/register", Query = queryString.Value };
         var registerLink = _linkGenerator.GetUriByAction(httpContext,
-            "VerifyEmail",
+            "JoinProject",
             "Login",
             new { jwt, returnTo });
         ArgumentException.ThrowIfNullOrEmpty(registerLink);

--- a/backend/LexBoxApi/Services/EmailService.cs
+++ b/backend/LexBoxApi/Services/EmailService.cs
@@ -84,13 +84,13 @@ public class EmailService(
     /// <param name="emailAddress">The email address to send the invitation to</param>
     /// <param name="projectId">The GUID of the project the user is being invited to</param>
     /// <param name="language">The language in which the invitation email should be sent (default English)</param>
-    public async Task SendCreateAccountEmail(string name, string emailAddress, Guid projectId, ProjectRole role, string language = null)
+    public async Task SendCreateAccountEmail(string emailAddress, Guid projectId, ProjectRole role, string language = null)
     {
         language ??= User.DefaultLocalizationCode;
         var (jwt, _) = lexAuthService.GenerateJwt(new LexAuthUser()
             {
                 Id = new Guid(),
-                Name = name,
+                Name = "",
                 Email = emailAddress,
                 EmailVerificationRequired = null,
                 Role = UserRole.user,
@@ -102,7 +102,7 @@ public class EmailService(
             },
             useEmailLifetime: true
         );
-        var email = StartUserEmail(name, emailAddress);
+        var email = StartUserEmail(name: "", emailAddress);
         var httpContext = httpContextAccessor.HttpContext;
         ArgumentNullException.ThrowIfNull(httpContext);
         var queryParam = "verifiedEmail";
@@ -112,7 +112,7 @@ public class EmailService(
             new { jwt, returnTo = $"/user?emailResult={queryParam}", email = emailAddress });
         ArgumentException.ThrowIfNullOrEmpty(verifyLink);
         // TODO: Get project name and include it in the RenderEmail parameters
-        await RenderEmail(email, new ProjectInviteEmail(name, emailAddress, projectId.ToString()), language);
+        await RenderEmail(email, new ProjectInviteEmail(emailAddress, projectId.ToString()), language);
         await SendEmailAsync(email);
     }
 

--- a/backend/LexBoxApi/Services/EmailService.cs
+++ b/backend/LexBoxApi/Services/EmailService.cs
@@ -105,12 +105,10 @@ public class EmailService(
         var email = StartUserEmail(name: "", emailAddress);
         var httpContext = httpContextAccessor.HttpContext;
         ArgumentNullException.ThrowIfNull(httpContext);
-        var queryString = new QueryString();
-        queryString.Add("email", emailAddress);
-        queryString.Add("returnTo", "/register");
-        var returnTo = new UriBuilder() { Path = "/register", Query = queryString.ToString() };
+        var queryString = QueryString.Create("email", emailAddress);
+        var returnTo = new UriBuilder() { Path = "/register", Query = queryString.Value };
         var registerLink = _linkGenerator.GetUriByAction(httpContext,
-            "LoginRedirect",
+            "VerifyEmail",
             "Login",
             new { jwt, returnTo });
         ArgumentException.ThrowIfNullOrEmpty(registerLink);

--- a/backend/LexBoxApi/Services/EmailService.cs
+++ b/backend/LexBoxApi/Services/EmailService.cs
@@ -184,9 +184,7 @@ public class EmailService(
 
     private static MimeMessage StartUserEmail(User user, string? email = null)
     {
-        var message = new MimeMessage();
-        message.To.Add(new MailboxAddress(user.Name, email ?? user.Email));
-        return message;
+        return StartUserEmail(user.Name, email ?? user.Email);
     }
 
     private static MimeMessage StartUserEmail(string name, string email)

--- a/backend/LexBoxApi/Services/EmailService.cs
+++ b/backend/LexBoxApi/Services/EmailService.cs
@@ -105,19 +105,17 @@ public class EmailService(
         var email = StartUserEmail(name: "", emailAddress);
         var httpContext = httpContextAccessor.HttpContext;
         ArgumentNullException.ThrowIfNull(httpContext);
-        var queryParam = "verifiedEmail";
-        // var verifyLink = new UriBuilder()
-        // {
-        //     Host = "localhost", // TODO
-        //     Path = "/register",
-        //     Query = new QueryBuilder(new { jwt, returnTo = $"/user?emailResult={queryParam}", email = newEmail ?? user.Email, });
-        // }
-        // var verifyLink = _linkGenerator.GetUriByName(httpContext, "/register", new { jwt, returnTo = $"/user?emailResult={queryParam}", email = newEmail ?? user.Email, });
-        // TODO: How do I get LinkGenerator to create a frontend link for me, rather than a backend API link?
-        var verifyLink = $"/register?jwt={jwt}&email={emailAddress}&returnTo=/project/{projectId}";
-        ArgumentException.ThrowIfNullOrEmpty(verifyLink);
+        var queryString = new QueryString();
+        queryString.Add("email", emailAddress);
+        queryString.Add("returnTo", "/register");
+        var returnTo = new UriBuilder() { Path = "/register", Query = queryString.ToString() };
+        var registerLink = _linkGenerator.GetUriByAction(httpContext,
+            "LoginRedirect",
+            "Login",
+            new { jwt, returnTo });
+        ArgumentException.ThrowIfNullOrEmpty(registerLink);
         // TODO: Get project name and include it in the RenderEmail parameters
-        await RenderEmail(email, new ProjectInviteEmail(emailAddress, projectId.ToString(), verifyLink), language);
+        await RenderEmail(email, new ProjectInviteEmail(emailAddress, projectId.ToString(), registerLink), language);
         await SendEmailAsync(email);
     }
 

--- a/backend/LexBoxApi/Services/EmailService.cs
+++ b/backend/LexBoxApi/Services/EmailService.cs
@@ -84,7 +84,7 @@ public class EmailService(
     /// <param name="emailAddress">The email address to send the invitation to</param>
     /// <param name="projectId">The GUID of the project the user is being invited to</param>
     /// <param name="language">The language in which the invitation email should be sent (default English)</param>
-    public async Task SendCreateAccountEmail(string emailAddress, Guid projectId, ProjectRole role, string language = null)
+    public async Task SendCreateAccountEmail(string emailAddress, Guid projectId, ProjectRole role, string managerName, string projectName, string language = null)
     {
         language ??= User.DefaultLocalizationCode;
         var (jwt, _) = lexAuthService.GenerateJwt(new LexAuthUser()
@@ -113,7 +113,7 @@ public class EmailService(
             new { jwt, returnTo });
         ArgumentException.ThrowIfNullOrEmpty(registerLink);
         // TODO: Get project name and include it in the RenderEmail parameters
-        await RenderEmail(email, new ProjectInviteEmail(emailAddress, projectId.ToString(), registerLink), language);
+        await RenderEmail(email, new ProjectInviteEmail(emailAddress, projectId.ToString(), managerName, projectName, registerLink), language);
         await SendEmailAsync(email);
     }
 

--- a/backend/LexBoxApi/Services/EmailService.cs
+++ b/backend/LexBoxApi/Services/EmailService.cs
@@ -89,7 +89,7 @@ public class EmailService(
         language ??= User.DefaultLocalizationCode;
         var (jwt, _) = lexAuthService.GenerateJwt(new LexAuthUser()
             {
-                Id = new Guid(),
+                Id = Guid.NewGuid(),
                 Name = "",
                 Email = emailAddress,
                 EmailVerificationRequired = null,

--- a/backend/LexBoxApi/Services/EmailService.cs
+++ b/backend/LexBoxApi/Services/EmailService.cs
@@ -106,13 +106,18 @@ public class EmailService(
         var httpContext = httpContextAccessor.HttpContext;
         ArgumentNullException.ThrowIfNull(httpContext);
         var queryParam = "verifiedEmail";
-        var verifyLink = _linkGenerator.GetUriByAction(httpContext,
-            "RegisterAccount",
-            "User",
-            new { jwt, returnTo = $"/user?emailResult={queryParam}", email = emailAddress });
+        // var verifyLink = new UriBuilder()
+        // {
+        //     Host = "localhost", // TODO
+        //     Path = "/register",
+        //     Query = new QueryBuilder(new { jwt, returnTo = $"/user?emailResult={queryParam}", email = newEmail ?? user.Email, });
+        // }
+        // var verifyLink = _linkGenerator.GetUriByName(httpContext, "/register", new { jwt, returnTo = $"/user?emailResult={queryParam}", email = newEmail ?? user.Email, });
+        // TODO: How do I get LinkGenerator to create a frontend link for me, rather than a backend API link?
+        var verifyLink = $"/register?jwt={jwt}&email={emailAddress}&returnTo=/project/{projectId}";
         ArgumentException.ThrowIfNullOrEmpty(verifyLink);
         // TODO: Get project name and include it in the RenderEmail parameters
-        await RenderEmail(email, new ProjectInviteEmail(emailAddress, projectId.ToString()), language);
+        await RenderEmail(email, new ProjectInviteEmail(emailAddress, projectId.ToString(), verifyLink), language);
         await SendEmailAsync(email);
     }
 

--- a/backend/LexBoxApi/Services/EmailService.cs
+++ b/backend/LexBoxApi/Services/EmailService.cs
@@ -111,6 +111,7 @@ public class EmailService(
             "User",
             new { jwt, returnTo = $"/user?emailResult={queryParam}", email = emailAddress });
         ArgumentException.ThrowIfNullOrEmpty(verifyLink);
+        // TODO: Get project name and include it in the RenderEmail parameters
         await RenderEmail(email, new ProjectInviteEmail(name, emailAddress, projectId.ToString()), language);
         await SendEmailAsync(email);
     }

--- a/backend/LexBoxApi/Services/EmailService.cs
+++ b/backend/LexBoxApi/Services/EmailService.cs
@@ -90,6 +90,7 @@ public class EmailService(
         var (jwt, _) = lexAuthService.GenerateJwt(new LexAuthUser()
             {
                 Id = Guid.NewGuid(),
+                Audience = LexboxAudience.RegisterAccount,
                 Name = "",
                 Email = emailAddress,
                 EmailVerificationRequired = null,
@@ -108,7 +109,7 @@ public class EmailService(
         var queryString = QueryString.Create("email", emailAddress);
         var returnTo = new UriBuilder() { Path = "/register", Query = queryString.Value };
         var registerLink = _linkGenerator.GetUriByAction(httpContext,
-            "JoinProject",
+            "LoginRedirect",
             "Login",
             new { jwt, returnTo });
         ArgumentException.ThrowIfNullOrEmpty(registerLink);

--- a/backend/LexBoxApi/Services/EmailService.cs
+++ b/backend/LexBoxApi/Services/EmailService.cs
@@ -112,7 +112,6 @@ public class EmailService(
             "Login",
             new { jwt, returnTo });
         ArgumentException.ThrowIfNullOrEmpty(registerLink);
-        // TODO: Get project name and include it in the RenderEmail parameters
         await RenderEmail(email, new ProjectInviteEmail(emailAddress, projectId.ToString(), managerName, projectName, registerLink), language);
         await SendEmailAsync(email);
     }

--- a/backend/LexBoxApi/Services/EmailService.cs
+++ b/backend/LexBoxApi/Services/EmailService.cs
@@ -86,7 +86,7 @@ public class EmailService(
     /// <param name="language">The language in which the invitation email should be sent (default English)</param>
     public async Task SendCreateAccountEmail(string name, string emailAddress, Guid projectId, ProjectRole role, string language = null)
     {
-        language = language ?? User.DefaultLocalizationCode;
+        language ??= User.DefaultLocalizationCode;
         var (jwt, _) = lexAuthService.GenerateJwt(new LexAuthUser()
             {
                 Id = new Guid(),
@@ -107,11 +107,11 @@ public class EmailService(
         ArgumentNullException.ThrowIfNull(httpContext);
         var queryParam = "verifiedEmail";
         var verifyLink = _linkGenerator.GetUriByAction(httpContext,
-            "VerifyEmail",
-            "Login",
+            "RegisterAccount",
+            "User",
             new { jwt, returnTo = $"/user?emailResult={queryParam}", email = emailAddress });
         ArgumentException.ThrowIfNullOrEmpty(verifyLink);
-        await RenderEmail(email, new VerifyAddressEmail(name, verifyLink, !string.IsNullOrEmpty(emailAddress)), language); // TODO: Write new email text, use VerifyAddress for testing
+        await RenderEmail(email, new ProjectInviteEmail(name, emailAddress, projectId.ToString()), language);
         await SendEmailAsync(email);
     }
 

--- a/backend/LexCore/Auth/LexboxAudience.cs
+++ b/backend/LexCore/Auth/LexboxAudience.cs
@@ -9,6 +9,7 @@ public enum LexboxAudience
     Unknown,
     //these names are converted to strings and are used in jwt tokens, if the name is changed that will invalidate all existing tokens
     LexboxApi,
+    RegisterAccount,
     ForgotPassword,
     SendAndReceive,
     SendAndReceiveRefresh,

--- a/backend/LexCore/Exceptions/ProjectMemberInvitedByEmail.cs
+++ b/backend/LexCore/Exceptions/ProjectMemberInvitedByEmail.cs
@@ -1,0 +1,8 @@
+﻿namespace LexCore.Exceptions;
+
+public class ProjectMemberInvitedByEmail : Exception
+{
+    public ProjectMemberInvitedByEmail(string message) : base(message)
+    {
+    }
+}

--- a/frontend/schema.graphql
+++ b/frontend/schema.graphql
@@ -158,6 +158,10 @@ type Project {
   updatedDate: DateTime!
 }
 
+type ProjectMemberInvitedByEmail implements Error {
+  message: String!
+}
+
 type ProjectMembersMustBeVerified implements Error {
   message: String!
 }
@@ -230,7 +234,7 @@ type UsersCollectionSegment {
   totalCount: Int!
 }
 
-union AddProjectMemberError = NotFoundError | DbError | ProjectMembersMustBeVerified
+union AddProjectMemberError = NotFoundError | DbError | ProjectMembersMustBeVerified | ProjectMemberInvitedByEmail
 
 union ChangeProjectDescriptionError = NotFoundError | DbError
 

--- a/frontend/src/lib/email/CreateAccountRequest.svelte
+++ b/frontend/src/lib/email/CreateAccountRequest.svelte
@@ -3,9 +3,11 @@
   import t from '$lib/i18n';
 
   export let verifyUrl: string;
+  export let projectName: string;
+  export let managerName: string;
 </script>
 
-<Email subject={$t('emails.create_account_request_email.subject'/*, {projectName: projectName}*/)} name="">
-  <mj-text>{$t('emails.create_account_request_email.body', {name: 'Hello, '})}</mj-text>
+<Email subject={$t('emails.create_account_request_email.subject', {projectName})} name="">
+  <mj-text>{$t('emails.create_account_request_email.body', {managerName, projectName})}</mj-text>
   <mj-button href={verifyUrl}>{$t('emails.create_account_request_email.join_button')}</mj-button>
 </Email>

--- a/frontend/src/lib/email/CreateAccountRequest.svelte
+++ b/frontend/src/lib/email/CreateAccountRequest.svelte
@@ -6,6 +6,6 @@
 </script>
 
 <Email subject={$t('emails.create_account_request_email.subject'/*, {projectName: projectName}*/)} name="">
-  <mj-text>{$t('emails.create_account_request_email.body')}</mj-text>
+  <mj-text>{$t('emails.create_account_request_email.body', {name: 'Hello, '})}</mj-text>
   <mj-button href={verifyUrl}>{$t('emails.create_account_request_email.join_button')}</mj-button>
 </Email>

--- a/frontend/src/lib/email/CreateAccountRequest.svelte
+++ b/frontend/src/lib/email/CreateAccountRequest.svelte
@@ -2,11 +2,10 @@
   import Email from '$lib/email/Email.svelte';
   import t from '$lib/i18n';
 
-  export let name: string;
   export let verifyUrl: string;
 </script>
 
-<Email subject={$t('emails.create_account_request_email.subject'/*, {projectName: projectName}*/)} {name}>
+<Email subject={$t('emails.create_account_request_email.subject'/*, {projectName: projectName}*/)} name="">
   <mj-text>{$t('emails.create_account_request_email.body')}</mj-text>
   <mj-button href={verifyUrl}>{$t('emails.create_account_request_email.join_button')}</mj-button>
 </Email>

--- a/frontend/src/lib/email/CreateAccountRequest.svelte
+++ b/frontend/src/lib/email/CreateAccountRequest.svelte
@@ -1,0 +1,12 @@
+<script lang="ts">
+  import Email from '$lib/email/Email.svelte';
+  import t from '$lib/i18n';
+
+  export let name: string;
+  export let verifyUrl: string;
+</script>
+
+<Email subject={$t('emails.create_account_request_email.subject'/*, {projectName: projectName}*/)} {name}>
+  <mj-text>{$t('emails.create_account_request_email.body')}</mj-text>
+  <mj-button href={verifyUrl}>{$t('emails.create_account_request_email.join_button')}</mj-button>
+</Email>

--- a/frontend/src/lib/email/Email.svelte
+++ b/frontend/src/lib/email/Email.svelte
@@ -23,7 +23,11 @@
     <mj-section>
       <mj-column>
         <mj-text font-size="20px">
-          {$t('emails.shared.greeting', { name })}
+          {#if name}
+            {$t('emails.shared.greeting', { name })}
+          {:else}
+            {$t('emails.shared.greeting_noname')}
+          {/if}
         </mj-text>
         <mj-divider border-color="black" />
         <slot />

--- a/frontend/src/lib/i18n/locales/en.json
+++ b/frontend/src/lib/i18n/locales/en.json
@@ -362,7 +362,8 @@ If you don't see a dialog or already closed it, click the button below:",
       "body": "We're writing to confirm that your password was just changed."
     },
     "shared": {
-      "greeting": "Hello {name}!"
+      "greeting": "Hello {name}!",
+      "greeting_noname": "Hello!"
     },
     "create_account_request_email": {
       "subject": "You've been invited to join a language project",

--- a/frontend/src/lib/i18n/locales/en.json
+++ b/frontend/src/lib/i18n/locales/en.json
@@ -176,6 +176,7 @@ the [Linguistics Institute at Payap University](https://li.payap.ac.th/) in Chia
       "email_required": "Email required",
       "modal_title": "Add a Member to this project",
       "submit_button": "Add Member",
+      "project_not_found": "Project not found. Please refresh the page.",
       "user_not_found": "No user was found with this email address",
       "user_not_verified": "User has not verified their email address",
       "user_needs_to_relogin": "Added members will need to log out and back in again before they see the new project.",
@@ -367,8 +368,8 @@ If you don't see a dialog or already closed it, click the button below:",
       "greeting_noname": "Hello!"
     },
     "create_account_request_email": {
-      "subject": "You've been invited to join a language project",
-      "body": "{name} A project manager has invited you to join a language project. Click below to join.",
+      "subject": "You've been invited to join the {projectName} language project",
+      "body": "{managerName} has invited you to join the {projectName} language project. Click below to join.",
       "join_button": "Join project"
     },
     "create_project_request_email": {

--- a/frontend/src/lib/i18n/locales/en.json
+++ b/frontend/src/lib/i18n/locales/en.json
@@ -372,7 +372,7 @@ If you don't see a dialog or already closed it, click the button below:",
       // TODO also: Better email body
       "body": "{name} has invited you to join a language project. Click here to join.",
       "join_button": "Join project"
-    }
+    },
     "create_project_request_email": {
       "subject": "Project request: {projectName}",
       "heading": "User {name} ({email}) requested that a project be created for them. Details below:"

--- a/frontend/src/lib/i18n/locales/en.json
+++ b/frontend/src/lib/i18n/locales/en.json
@@ -364,6 +364,14 @@ If you don't see a dialog or already closed it, click the button below:",
     "shared": {
       "greeting": "Hello {name}!"
     },
+    "create_account_request_email": {
+      "subject": "You've been invited to join a language project",
+      // TODO: Have email request provide the projectName to fill in, then use this version instead
+      // "subject": "You've been invited to join the {projectName} project",
+      // TODO also: Better email body
+      "body": "{name} has invited you to join a language project. Click here to join.",
+      "join_button": "Join project"
+    }
     "create_project_request_email": {
       "subject": "Project request: {projectName}",
       "heading": "User {name} ({email}) requested that a project be created for them. Details below:"

--- a/frontend/src/lib/i18n/locales/en.json
+++ b/frontend/src/lib/i18n/locales/en.json
@@ -216,7 +216,8 @@ the [Linguistics Institute at Payap University](https://li.payap.ac.th/) in Chia
       "user_delete": "{name} has been removed.",
       "rename_project": "Project name set to {name}.",
       "describe": "Project description has been updated.",
-      "add_member": "{email} has been added to project."
+      "add_member": "{email} has been added to project.",
+      "member_invited": "{email} has been sent an invitation email to join the project."
     },
     "project_name_empty_error": "Project name cannot be empty",
     "confirm_remove": "Would you like to remove {userName} from this project?",

--- a/frontend/src/lib/i18n/locales/en.json
+++ b/frontend/src/lib/i18n/locales/en.json
@@ -367,10 +367,7 @@ If you don't see a dialog or already closed it, click the button below:",
     },
     "create_account_request_email": {
       "subject": "You've been invited to join a language project",
-      // TODO: Have email request provide the projectName to fill in, then use this version instead
-      // "subject": "You've been invited to join the {projectName} project",
-      // TODO also: Better email body
-      "body": "{name} has invited you to join a language project. Click here to join.",
+      "body": "{name} A project manager has invited you to join a language project. Click below to join.",
       "join_button": "Join project"
     },
     "create_project_request_email": {

--- a/frontend/src/lib/i18n/locales/en.json
+++ b/frontend/src/lib/i18n/locales/en.json
@@ -218,7 +218,7 @@ the [Linguistics Institute at Payap University](https://li.payap.ac.th/) in Chia
       "rename_project": "Project name set to {name}.",
       "describe": "Project description has been updated.",
       "add_member": "{email} has been added to project.",
-      "member_invited": "{email} has been sent an invitation email to join the project."
+      "member_invited": "{email} has been sent an invitation email to register and join the project."
     },
     "project_name_empty_error": "Project name cannot be empty",
     "confirm_remove": "Would you like to remove {userName} from this project?",
@@ -368,7 +368,7 @@ If you don't see a dialog or already closed it, click the button below:",
       "greeting_noname": "Hello!"
     },
     "create_account_request_email": {
-      "subject": "You've been invited to join the {projectName} language project",
+      "subject": "Project invitation: {projectName}",
       "body": "{managerName} has invited you to join the {projectName} language project. Click below to join.",
       "join_button": "Join project"
     },

--- a/frontend/src/lib/user.ts
+++ b/frontend/src/lib/user.ts
@@ -80,11 +80,10 @@ export async function login(userId: string, password: string): Promise<LoginResu
 }
 
 type RegisterResponse = { error?: { turnstile: boolean, accountExists: boolean }, user?: LexAuthUser };
-export async function register(password: string, name: string, email: string, locale: string, turnstileToken: string, jwt?: string): Promise<RegisterResponse> {
+export async function register(password: string, name: string, email: string, locale: string, turnstileToken: string): Promise<RegisterResponse> {
   const headers: Record<string,string> = {
     'content-type': 'application/json',
   };
-  if (jwt) headers['authorization'] = `Bearer ${jwt}`;
 
   const response = await fetch('/api/User/registerAccount', {
     method: 'post',

--- a/frontend/src/lib/user.ts
+++ b/frontend/src/lib/user.ts
@@ -81,13 +81,11 @@ export async function login(userId: string, password: string): Promise<LoginResu
 
 type RegisterResponse = { error?: { turnstile: boolean, accountExists: boolean }, user?: LexAuthUser };
 export async function register(password: string, name: string, email: string, locale: string, turnstileToken: string): Promise<RegisterResponse> {
-  const headers: Record<string,string> = {
-    'content-type': 'application/json',
-  };
-
   const response = await fetch('/api/User/registerAccount', {
     method: 'post',
-    headers,
+    headers: {
+      'content-type': 'application/json',
+    },
     body: JSON.stringify({
       name,
       email,

--- a/frontend/src/lib/user.ts
+++ b/frontend/src/lib/user.ts
@@ -80,12 +80,15 @@ export async function login(userId: string, password: string): Promise<LoginResu
 }
 
 type RegisterResponse = { error?: { turnstile: boolean, accountExists: boolean }, user?: LexAuthUser };
-export async function register(password: string, name: string, email: string, locale: string, turnstileToken: string): Promise<RegisterResponse> {
+export async function register(password: string, name: string, email: string, locale: string, turnstileToken: string, jwt?: string): Promise<RegisterResponse> {
+  const headers: Record<string,string> = {
+    'content-type': 'application/json',
+  };
+  if (jwt) headers['authorization'] = `Bearer ${jwt}`;
+
   const response = await fetch('/api/User/registerAccount', {
     method: 'post',
-    headers: {
-      'content-type': 'application/json',
-    },
+    headers,
     body: JSON.stringify({
       name,
       email,

--- a/frontend/src/routes/(authenticated)/project/[project_code]/AddProjectMember.svelte
+++ b/frontend/src/routes/(authenticated)/project/[project_code]/AddProjectMember.svelte
@@ -11,8 +11,6 @@
   export let projectId: string;
   const schema = z.object({
     email: z.string().email($t('project_page.add_user.email_required')),
-    // TODO: Add optional name, required only if user email not found
-    // TODO: Any way of looking that up beforehand?
     role: z.enum([ProjectRole.Editor, ProjectRole.Manager]).default(ProjectRole.Editor),
   });
   let formModal: FormModal<typeof schema>;

--- a/frontend/src/routes/(authenticated)/project/[project_code]/AddProjectMember.svelte
+++ b/frontend/src/routes/(authenticated)/project/[project_code]/AddProjectMember.svelte
@@ -28,7 +28,7 @@
       });
 
       if (error?.byType('NotFoundError')) {
-        return { email: [$t('project_page.add_user.user_not_found')] };
+        return { email: [$t('project_page.add_user.project_not_found')] };
       }
       if (error?.byType('ProjectMembersMustBeVerified')) {
         return { email: [$t('project_page.add_user.user_not_verified')] };

--- a/frontend/src/routes/(authenticated)/project/[project_code]/AddProjectMember.svelte
+++ b/frontend/src/routes/(authenticated)/project/[project_code]/AddProjectMember.svelte
@@ -11,6 +11,8 @@
   export let projectId: string;
   const schema = z.object({
     email: z.string().email($t('project_page.add_user.email_required')),
+    // TODO: Add optional name, required only if user email not found
+    // TODO: Any way of looking that up beforehand?
     role: z.enum([ProjectRole.Editor, ProjectRole.Manager]).default(ProjectRole.Editor),
   });
   let formModal: FormModal<typeof schema>;

--- a/frontend/src/routes/(authenticated)/project/[project_code]/AddProjectMember.svelte
+++ b/frontend/src/routes/(authenticated)/project/[project_code]/AddProjectMember.svelte
@@ -19,6 +19,7 @@
   const { notifySuccess } = useNotifications();
 
   async function openModal(): Promise<void> {
+    let userInvited = false;
     const { response, formState } = await formModal.open(async () => {
       const { error } = await _addProjectMember({
         projectId,
@@ -32,11 +33,16 @@
       if (error?.byType('ProjectMembersMustBeVerified')) {
         return { email: [$t('project_page.add_user.user_not_verified')] };
       }
+      if (error?.byType('ProjectMemberInvitedByEmail')) {
+        userInvited = true;
+        return undefined; // Close modal as if success
+      }
 
       return error?.message;
     });
     if (response === DialogResponse.Submit) {
-      notifySuccess($t('project_page.notifications.add_member', { email: formState.email.currentValue }));
+      const message = userInvited ? 'member_invited' : 'add_member';
+      notifySuccess($t(`project_page.notifications.${message}`, { email: formState.email.currentValue }));
     }
   }
 </script>

--- a/frontend/src/routes/(unauthenticated)/register/+page.svelte
+++ b/frontend/src/routes/(unauthenticated)/register/+page.svelte
@@ -12,7 +12,6 @@
     name: string;
     email: string;
     locale: string;
-    jwt: string;
   };
   let turnstileToken = '';
   // $locale is the locale that our i18n is using for them (i.e. the best available option we have for them)
@@ -23,11 +22,10 @@
     email: z.string().email($t('register.email')),
     password: passwordFormRules($t),
     locale: z.string().min(2).default(userLocale),
-    jwt: z.string(),
   });
 
   let { form, errors, message, enhance, submitting } = lexSuperForm(formSchema, async () => {
-    const { user, error } = await register($form.password, $form.name, $form.email, $form.locale, turnstileToken, $form.jwt);
+    const { user, error } = await register($form.password, $form.name, $form.email, $form.locale, turnstileToken);
     if (error) {
       if (error.turnstile) {
         $message = $t('turnstile.invalid');
@@ -49,7 +47,6 @@
       if (urlValues.name) form.name = urlValues.name;
       if (urlValues.email) form.email = urlValues.email;
       if (urlValues.locale) form.locale = urlValues.locale;
-      if (urlValues.jwt) form.jwt = urlValues.jwt;
       return form;
     }, { taint: false });
   });
@@ -76,11 +73,6 @@
     />
     <DisplayLanguageSelect
       bind:value={$form.locale}
-    />
-    <input
-      id="jwt"
-      type="hidden"
-      bind:value={$form.jwt}
     />
     <FormError error={$message} />
     <SubmitButton loading={$submitting}>{$t('register.button_register')}</SubmitButton>

--- a/frontend/src/routes/(unauthenticated)/register/+page.svelte
+++ b/frontend/src/routes/(unauthenticated)/register/+page.svelte
@@ -42,9 +42,7 @@
   onMount(() => { // query params not available during SSR
     const urlValues = getSearchParamValues<RegisterPageQueryParams>();
     form.update((form) => {
-      if (urlValues.name) form.name = urlValues.name;
       if (urlValues.email) form.email = urlValues.email;
-      if (urlValues.locale) form.locale = urlValues.locale;
       return form;
     }, { taint: true });
   });

--- a/frontend/src/routes/(unauthenticated)/register/+page.svelte
+++ b/frontend/src/routes/(unauthenticated)/register/+page.svelte
@@ -9,7 +9,6 @@
   import { z } from 'zod';
 
   type RegisterPageQueryParams = {
-    name: string;
     email: string;
   };
   let turnstileToken = '';

--- a/frontend/src/routes/(unauthenticated)/register/+page.svelte
+++ b/frontend/src/routes/(unauthenticated)/register/+page.svelte
@@ -11,7 +11,6 @@
   type RegisterPageQueryParams = {
     name: string;
     email: string;
-    locale: string;
   };
   let turnstileToken = '';
   // $locale is the locale that our i18n is using for them (i.e. the best available option we have for them)
@@ -48,7 +47,7 @@
       if (urlValues.email) form.email = urlValues.email;
       if (urlValues.locale) form.locale = urlValues.locale;
       return form;
-    }, { taint: false });
+    }, { taint: true });
   });
 </script>
 

--- a/frontend/src/routes/email/emails.ts
+++ b/frontend/src/routes/email/emails.ts
@@ -38,7 +38,8 @@ interface VerifyEmailAddressProps extends EmailTemplatePropsBase<EmailTemplate.V
 }
 
 interface CreateAccountProps extends EmailTemplatePropsBase<EmailTemplate.CreateAccountRequest> {
-  name: string;
+  managerName: string;
+  projectName: string;
   verifyUrl: string;
 }
 

--- a/frontend/src/routes/email/emails.ts
+++ b/frontend/src/routes/email/emails.ts
@@ -2,6 +2,7 @@ import ForgotPassword from '$lib/email/ForgotPassword.svelte';
 import type {ComponentType} from 'svelte';
 import VerifyEmailAddress from '$lib/email/VerifyEmailAddress.svelte';
 import PasswordChanged from '$lib/email/PasswordChanged.svelte';
+import CreateAccountRequest from '$lib/email/CreateAccountRequest.svelte';
 import CreateProjectRequest from '$lib/email/CreateProjectRequest.svelte';
 import type {CreateProjectInput} from '$lib/gql/generated/graphql';
 
@@ -9,6 +10,7 @@ export const enum EmailTemplate {
     ForgotPassword = 'FORGOT_PASSWORD',
     VerifyEmailAddress = 'VERIFY_EMAIL_ADDRESS',
     PasswordChanged = 'PASSWORD_CHANGED',
+    CreateAccountRequest = 'CREATE_ACCOUNT_REQUEST',
     CreateProjectRequest = 'CREATE_PROJECT_REQUEST',
 }
 
@@ -16,8 +18,8 @@ export const componentMap = {
     [EmailTemplate.ForgotPassword]: ForgotPassword,
     [EmailTemplate.VerifyEmailAddress]: VerifyEmailAddress,
     [EmailTemplate.PasswordChanged]: PasswordChanged,
+    [EmailTemplate.CreateAccountRequest]: CreateAccountRequest,
     [EmailTemplate.CreateProjectRequest]: CreateProjectRequest,
-    // TODO: Create ProjectInviteEmail template
 } satisfies Record<EmailTemplate, ComponentType>;
 
 interface EmailTemplatePropsBase<T extends EmailTemplate> {
@@ -35,6 +37,11 @@ interface VerifyEmailAddressProps extends EmailTemplatePropsBase<EmailTemplate.V
     newAddress: boolean;
 }
 
+interface CreateAccountProps extends EmailTemplatePropsBase<EmailTemplate.CreateAccountRequest> {
+  name: string;
+  verifyUrl: string;
+}
+
 interface CreateProjectProps extends EmailTemplatePropsBase<EmailTemplate.CreateProjectRequest> {
     project: CreateProjectInput;
     user: { name: string, email: string };
@@ -43,5 +50,6 @@ interface CreateProjectProps extends EmailTemplatePropsBase<EmailTemplate.Create
 export type EmailTemplateProps =
     ForgotPasswordProps
     | VerifyEmailAddressProps
+    | CreateAccountProps
     | CreateProjectProps
     | EmailTemplatePropsBase<EmailTemplate>;

--- a/frontend/src/routes/email/emails.ts
+++ b/frontend/src/routes/email/emails.ts
@@ -17,6 +17,7 @@ export const componentMap = {
     [EmailTemplate.VerifyEmailAddress]: VerifyEmailAddress,
     [EmailTemplate.PasswordChanged]: PasswordChanged,
     [EmailTemplate.CreateProjectRequest]: CreateProjectRequest,
+    // TODO: Create ProjectInviteEmail template
 } satisfies Record<EmailTemplate, ComponentType>;
 
 interface EmailTemplatePropsBase<T extends EmailTemplate> {

--- a/frontend/src/routes/email/tester/+page@.svelte
+++ b/frontend/src/routes/email/tester/+page@.svelte
@@ -27,6 +27,12 @@
             newAddress: true,
         },
         {
+            label: 'Create Account Request',
+            name: 'Bob',
+            template: EmailTemplate.CreateAccountRequest,
+            verifyUrl: absoluteUrl('register?name=Bob'), // TODO: Get correct URL
+        },
+        {
             label: 'Create Project Request',
             name: 'Admin',
             baseUrl: location.origin,


### PR DESCRIPTION
Project managers who want to invite new users can click one button and send an invitation email.

We could almost reuse the "Verify email" flow, except for one problem: new users won't have a password. We could send them to the forgot-password page next, but that's not great UX. Better to create a new flow that they will land on, which asks them to choose a password then brings them to their home page.

Will fix #239 once completed.