### PR TITLE
Add revision number to project history log

### DIFF
--- a/backend/LexCore/Entities/Project.cs
+++ b/backend/LexCore/Entities/Project.cs
@@ -74,6 +74,7 @@ public enum ProjectType
 public class Changeset
 {
     public string Node { get; set; }
+    public int Rev { get; set; }
     public double[] Date { get; set; }
     public string Desc { get; set; }
 

--- a/frontend/schema.graphql
+++ b/frontend/schema.graphql
@@ -48,6 +48,7 @@ type ChangeUserAccountBySelfPayload {
 
 type Changeset {
   node: String!
+  rev: Int!
   date: [Float!]!
   desc: String!
   branch: String!

--- a/frontend/src/lib/components/HgLogView.svelte
+++ b/frontend/src/lib/components/HgLogView.svelte
@@ -121,7 +121,8 @@
 <table class="table table-zebra">
   <thead>
     <tr class="sticky top-0 z-[1] bg-base-100">
-      <th></th>
+      <th></th> <!-- No header on train-tracks column -->
+      <th></th> <!-- No header on revision-number column -->
       <th>{$t('project_page.hg.date_header')}</th>
       <th>{$t('project_page.hg.author_header')}</th>
       <th>{$t('project_page.hg.log_header')}</th>
@@ -136,6 +137,7 @@
               <TrainTracks {circles} {paths} rowHeights={heights} />
             </td>
           {/if}
+          <td>{log.rev}</td>
           <td bind:offsetHeight={heights[idx]}>{$date(log.date[0] * 1000)}</td>
           <td>{log.user}</td>
           <td>{log.trimmedLog}</td>

--- a/frontend/src/lib/components/HgLogView.svelte
+++ b/frontend/src/lib/components/HgLogView.svelte
@@ -21,6 +21,7 @@
 
   export let logEntries: LogEntries;
   export let loading: boolean;
+  export let projectCode: string;
 
   function assignRowsAndColumns(entries: ExpandedLogEntry[]): void {
     // Walk the log top-down (most recent entry first) and assign circle locations for each log entry ("node")
@@ -137,7 +138,7 @@
               <TrainTracks {circles} {paths} rowHeights={heights} />
             </td>
           {/if}
-          <td>{log.rev}</td>
+          <td><a href="/hg/{projectCode}/file/{log.node}">{log.rev}</a></td>
           <td bind:offsetHeight={heights[idx]}>{$date(log.date[0] * 1000)}</td>
           <td>{log.user}</td>
           <td>{log.trimmedLog}</td>

--- a/frontend/src/lib/components/HgLogView.svelte
+++ b/frontend/src/lib/components/HgLogView.svelte
@@ -122,7 +122,7 @@
   <thead>
     <tr class="sticky top-0 z-[1] bg-base-100">
       <th></th> <!-- No header on train-tracks column -->
-      <th></th> <!-- No header on revision-number column -->
+      <th>#</th> <!-- "Revision" is too long -->
       <th>{$t('project_page.hg.date_header')}</th>
       <th>{$t('project_page.hg.author_header')}</th>
       <th>{$t('project_page.hg.log_header')}</th>

--- a/frontend/src/routes/(authenticated)/project/[project_code]/+page.svelte
+++ b/frontend/src/routes/(authenticated)/project/[project_code]/+page.svelte
@@ -408,7 +408,7 @@
         </p>
 
         <div class="max-h-[75vh] overflow-auto border-b border-base-200">
-          <HgLogView logEntries={$changesetStore.changesets} loading={$changesetStore.fetching} />
+          <HgLogView logEntries={$changesetStore.changesets} loading={$changesetStore.fetching} projectCode={project.code} />
         </div>
       </div>
 

--- a/frontend/src/routes/(authenticated)/project/[project_code]/+page.ts
+++ b/frontend/src/routes/(authenticated)/project/[project_code]/+page.ts
@@ -79,6 +79,7 @@ export async function load(event: PageLoadEvent) {
             code
             changesets {
               node
+              rev
               parents
               date
               user

--- a/hgweb/json-lex/map
+++ b/hgweb/json-lex/map
@@ -1,2 +1,15 @@
 ﻿__base__ = ../json/map
 notfound = '\{"error": "not found"}'
+changelistentry = '\{
+  "node": {node|json},
+  "rev": {rev|json},
+  "date": {date|json},
+  "desc": {desc|utf8|json},
+  "branch": {if(branch, branch%changesetbranch, "default"|json)},
+  "bookmarks": [{join(bookmarks%changelistentryname, ", ")}],
+  "tags": [{join(tags%changelistentryname, ", ")}],
+  "user": {author|utf8|json},
+  "phase": {phase|json},
+  "parents": [{if(allparents, join(allparents%changesetparent, ", "),
+                  join(parent%changesetparent, ", "))}]
+  }'


### PR DESCRIPTION
Fixes #393.

Fixing this required editing the `json-lex` style definition for hgweb, to add "rev" to the changelistentry definition (it wasn't there by default in the json style). Note that with hgweb's templating system, you can't inherit-and-modify a single template item like changelistentry, so I couldn't just add "rev" to it and inherit the rest of the properties from the json style. I had to copy the entire changelistentry definition in order to add "rev" to it. Which means that in theory, our json-lex style could get out-of-sync with the json style if Mercurial ever adds anything else to the changelistentry definition. In practice, the odds of Mercurial changing the changelistentry output of `json` are pretty much zero, though, so it won't be a problem.

- [ ] update the json-lex style in redmine before merging in this PR, but after it's been approved.