### PR TITLE
Notify current admins when new user becomes admin

### DIFF
--- a/backend/LexBoxApi/GraphQL/UserMutations.cs
+++ b/backend/LexBoxApi/GraphQL/UserMutations.cs
@@ -110,8 +110,8 @@ public class UserMutations
 
         if (wasPromotedToAdmin)
         {
-            var oldAdmins = dbContext.Users.Where(u => u.IsAdmin).AsAsyncEnumerable();
-            await emailService.SendNewAdminEmail(oldAdmins, user.Name, user.Email);
+            var admins = dbContext.Users.Where(u => u.IsAdmin).AsAsyncEnumerable();
+            await emailService.SendNewAdminEmail(admins, user.Name, user.Email);
         }
 
         return user;

--- a/backend/LexBoxApi/Services/Email/EmailTemplates.cs
+++ b/backend/LexBoxApi/Services/Email/EmailTemplates.cs
@@ -16,12 +16,15 @@ public record EmailTemplateBase(EmailTemplate Template)
 public enum EmailTemplate
 {
     ForgotPassword,
+    NewAdmin,
     VerifyEmailAddress,
     PasswordChanged,
     CreateProjectRequest
 }
 
 public record ForgotPasswordEmail(string Name, string ResetUrl) : EmailTemplateBase(EmailTemplate.ForgotPassword);
+
+public record NewAdminEmail(string Name, string AdminName, string AdminEmail) : EmailTemplateBase(EmailTemplate.NewAdmin);
 
 public record VerifyAddressEmail(string Name, string VerifyUrl, bool newAddress) : EmailTemplateBase(EmailTemplate.VerifyEmailAddress);
 

--- a/backend/LexBoxApi/Services/EmailService.cs
+++ b/backend/LexBoxApi/Services/EmailService.cs
@@ -48,12 +48,12 @@ public class EmailService(
         await SendEmailAsync(email);
     }
 
-    public async Task SendNewAdminEmail(IAsyncEnumerable<User> oldAdmins, string newAdminName, string newAdminEmail)
+    public async Task SendNewAdminEmail(IAsyncEnumerable<User> admins, string newAdminName, string newAdminEmail)
     {
-        await foreach (var oldAdmin in oldAdmins)
+        await foreach (var admin in admins)
         {
-            var email = StartUserEmail(oldAdmin);
-            await RenderEmail(email, new NewAdminEmail(oldAdmin.Name, newAdminName, newAdminEmail), oldAdmin.LocalizationCode);
+            var email = StartUserEmail(admin);
+            await RenderEmail(email, new NewAdminEmail(admin.Name, newAdminName, newAdminEmail), admin.LocalizationCode);
             await SendEmailAsync(email);
         }
     }

--- a/backend/LexBoxApi/Services/EmailService.cs
+++ b/backend/LexBoxApi/Services/EmailService.cs
@@ -51,7 +51,6 @@ public class EmailService(
     public async Task SendNewAdminEmail(IAsyncEnumerable<User> admins, string newAdminName, string newAdminEmail)
     {
         var email = new MimeMessage();
-        email.To.Add(new MailboxAddress("Admins", "nobody@example.com"));
         await foreach (var admin in admins)
         {
             email.Bcc.Add(new MailboxAddress(admin.Name, admin.Email));

--- a/backend/LexBoxApi/Services/EmailService.cs
+++ b/backend/LexBoxApi/Services/EmailService.cs
@@ -50,12 +50,14 @@ public class EmailService(
 
     public async Task SendNewAdminEmail(IAsyncEnumerable<User> admins, string newAdminName, string newAdminEmail)
     {
+        var email = new MimeMessage();
+        email.To.Add(new MailboxAddress("Admins", "nobody@example.com"));
         await foreach (var admin in admins)
         {
-            var email = StartUserEmail(admin);
-            await RenderEmail(email, new NewAdminEmail(admin.Name, newAdminName, newAdminEmail), admin.LocalizationCode);
-            await SendEmailAsync(email);
+            email.Bcc.Add(new MailboxAddress(admin.Name, admin.Email));
         }
+        await RenderEmail(email, new NewAdminEmail("Admin", newAdminName, newAdminEmail), User.DefaultLocalizationCode);
+        await SendEmailAsync(email);
     }
 
     /// <summary>

--- a/backend/LexBoxApi/Services/EmailService.cs
+++ b/backend/LexBoxApi/Services/EmailService.cs
@@ -48,6 +48,16 @@ public class EmailService(
         await SendEmailAsync(email);
     }
 
+    public async Task SendNewAdminEmail(IAsyncEnumerable<User> oldAdmins, string newAdminName, string newAdminEmail)
+    {
+        await foreach (var oldAdmin in oldAdmins)
+        {
+            var email = StartUserEmail(oldAdmin);
+            await RenderEmail(email, new NewAdminEmail(oldAdmin.Name, newAdminName, newAdminEmail), oldAdmin.LocalizationCode);
+            await SendEmailAsync(email);
+        }
+    }
+
     /// <summary>
     /// Sends a verification email to the user for their email address.
     /// </summary>

--- a/frontend/src/lib/email/NewAdmin.svelte
+++ b/frontend/src/lib/email/NewAdmin.svelte
@@ -1,0 +1,12 @@
+<script lang="ts">
+  import Email from '$lib/email/Email.svelte';
+  import t from '$lib/i18n';
+
+  export let name: string;
+  export let adminName: string;
+  export let adminEmail: string;
+</script>
+
+<Email subject={$t('emails.new_admin.subject', {adminName})} {name}>
+  <mj-text>{$t('emails.new_admin.body', {adminName, adminEmail})}</mj-text>
+</Email>

--- a/frontend/src/lib/i18n/locales/en.json
+++ b/frontend/src/lib/i18n/locales/en.json
@@ -346,6 +346,10 @@ If you don't see a dialog or already closed it, click the button below:",
     "close_all": "Close all"
   },
   "emails": {
+    "new_admin": {
+      "subject": "New Language Depot administrator {adminName}",
+      "body": "{adminName} ({adminEmail}) has been made an administrator on Language Depot."
+    },
     "verify_email": {
       "subject": "Verify your e-mail address",
       "to_verify_click": "Click the button below to verify your e-mail address.",

--- a/frontend/src/routes/email/emails.ts
+++ b/frontend/src/routes/email/emails.ts
@@ -1,4 +1,5 @@
 import ForgotPassword from '$lib/email/ForgotPassword.svelte';
+import NewAdmin from '$lib/email/NewAdmin.svelte';
 import type {ComponentType} from 'svelte';
 import VerifyEmailAddress from '$lib/email/VerifyEmailAddress.svelte';
 import PasswordChanged from '$lib/email/PasswordChanged.svelte';
@@ -6,6 +7,7 @@ import CreateProjectRequest from '$lib/email/CreateProjectRequest.svelte';
 import type {CreateProjectInput} from '$lib/gql/generated/graphql';
 
 export const enum EmailTemplate {
+    NewAdmin = 'NEW_ADMIN',
     ForgotPassword = 'FORGOT_PASSWORD',
     VerifyEmailAddress = 'VERIFY_EMAIL_ADDRESS',
     PasswordChanged = 'PASSWORD_CHANGED',
@@ -14,6 +16,7 @@ export const enum EmailTemplate {
 
 export const componentMap = {
     [EmailTemplate.ForgotPassword]: ForgotPassword,
+    [EmailTemplate.NewAdmin]: NewAdmin,
     [EmailTemplate.VerifyEmailAddress]: VerifyEmailAddress,
     [EmailTemplate.PasswordChanged]: PasswordChanged,
     [EmailTemplate.CreateProjectRequest]: CreateProjectRequest,
@@ -29,6 +32,11 @@ interface ForgotPasswordProps extends EmailTemplatePropsBase<EmailTemplate.Forgo
     resetUrl: string;
 }
 
+interface NewAdminProps extends EmailTemplatePropsBase<EmailTemplate.NewAdmin> {
+  adminName: string;
+  adminEmail: string;
+}
+
 interface VerifyEmailAddressProps extends EmailTemplatePropsBase<EmailTemplate.VerifyEmailAddress> {
     verifyUrl: string;
     newAddress: boolean;
@@ -41,6 +49,7 @@ interface CreateProjectProps extends EmailTemplatePropsBase<EmailTemplate.Create
 
 export type EmailTemplateProps =
     ForgotPasswordProps
+    | NewAdminProps
     | VerifyEmailAddressProps
     | CreateProjectProps
     | EmailTemplatePropsBase<EmailTemplate>;


### PR DESCRIPTION
Current logic is to send notification email to all current admins (including the user who was just promoted to admin, because why not). In the future we might choose to make it a configuration parameter so that we can include certain non-admin emails, or exclude some admins who ask to stop receiving those notifications. But for now, the logic is deliberately very simple.

Fixes #394.