### PR TITLE
Retry sending emails a few times before giving up

### DIFF
--- a/backend/LexBoxApi/Jobs/RetryEmailJob.cs
+++ b/backend/LexBoxApi/Jobs/RetryEmailJob.cs
@@ -1,0 +1,50 @@
+﻿using LexBoxApi.Services;
+using MimeKit;
+using Quartz;
+
+namespace LexBoxApi.Jobs;
+
+public class RetryEmailJob(EmailService emailService) : LexJob
+{
+    public static async Task Queue(ISchedulerFactory schedulerFactory,
+        MimeMessage email,
+        int retryCount = 3,
+        int retryWaitSeconds = 5 * 60,
+        CancellationToken cancellationToken = default)
+    {
+        var memory = new MemoryStream();
+        await email.WriteToAsync(memory, cancellationToken);
+        await QueueJob(schedulerFactory,
+            Key,
+            new JobDataMap {
+                { nameof(SerializedEmail), memory.ToArray() },
+                { nameof(RetryCount), retryCount },
+                { nameof(RetryWaitSeconds), retryWaitSeconds },
+            },
+            cancellationToken);
+    }
+
+    public static JobKey Key { get; } = new("RetryEmailJob", "RetryingJobs");
+    public byte[]? SerializedEmail { get; set; }
+    public int RetryCount { get; set; }
+    public int RetryWaitSeconds { get; set; }
+
+    protected override async Task ExecuteJob(IJobExecutionContext context)
+    {
+        if (SerializedEmail is null) throw new ArgumentNullException("email");
+        var memory = new MemoryStream(SerializedEmail, writable: false);
+        var email = await MimeMessage.LoadAsync(memory);
+        while (RetryCount > 0)
+        {
+            try
+            {
+                await emailService.SendEmailAsync(email);
+            }
+            catch
+            {
+                RetryCount -= 1;
+                await Task.Delay(TimeSpan.FromSeconds(RetryWaitSeconds));
+            }
+        }
+    }
+}

--- a/backend/LexBoxApi/ScheduledTasksKernel.cs
+++ b/backend/LexBoxApi/ScheduledTasksKernel.cs
@@ -39,6 +39,7 @@ public static class ScheduledTasksKernel
             //Setup jobs
             q.AddJob<CleanupResetBackupJob>(CleanupResetBackupJob.Key);
             q.AddJob<UpdateProjectMetadataJob>(UpdateProjectMetadataJob.Key, j => j.StoreDurably());
+            q.AddJob<RetryEmailJob>(RetryEmailJob.Key, j => j.StoreDurably());
             q.AddTrigger(opts => opts.ForJob(CleanupResetBackupJob.Key)
                 .WithIdentity("WeeklyCleanupTrigger")
                 //every sunday at 2am

--- a/backend/LexBoxApi/Services/EmailService.cs
+++ b/backend/LexBoxApi/Services/EmailService.cs
@@ -47,7 +47,7 @@ public class EmailService(
             new { jwt, returnTo = "/resetPassword" });
         ArgumentException.ThrowIfNullOrEmpty(forgotLink);
         await RenderEmail(email, new ForgotPasswordEmail(user.Name, forgotLink), user.LocalizationCode);
-        await SendEmailWithRetriesAsync(email);
+        await SendEmailWithRetriesAsync(email, retryCount:5, retryWaitSeconds:30);
     }
 
     /// <summary>

--- a/backend/LexBoxApi/Services/EmailService.cs
+++ b/backend/LexBoxApi/Services/EmailService.cs
@@ -4,6 +4,7 @@ using System.Text.Json;
 using System.Text.Json.Serialization;
 using LexBoxApi.Auth;
 using LexBoxApi.Config;
+using LexBoxApi.Jobs;
 using LexBoxApi.Models.Project;
 using LexBoxApi.Otel;
 using LexBoxApi.Services.Email;
@@ -23,6 +24,7 @@ public class EmailService(
     IHttpClientFactory clientFactory,
     LexboxLinkGenerator linkGenerator,
     IHttpContextAccessor httpContextAccessor,
+    Quartz.ISchedulerFactory schedulerFactory,
     LexAuthService lexAuthService)
 {
     private readonly EmailConfig _emailConfig = emailConfig.Value;
@@ -45,7 +47,7 @@ public class EmailService(
             new { jwt, returnTo = "/resetPassword" });
         ArgumentException.ThrowIfNullOrEmpty(forgotLink);
         await RenderEmail(email, new ForgotPasswordEmail(user.Name, forgotLink), user.LocalizationCode);
-        await SendEmailAsync(email);
+        await SendEmailWithRetriesAsync(email);
     }
 
     /// <summary>
@@ -74,14 +76,14 @@ public class EmailService(
             new { jwt, returnTo = $"/user?emailResult={queryParam}", email = newEmail ?? user.Email, });
         ArgumentException.ThrowIfNullOrEmpty(verifyLink);
         await RenderEmail(email, new VerifyAddressEmail(user.Name, verifyLink, !string.IsNullOrEmpty(newEmail)), user.LocalizationCode);
-        await SendEmailAsync(email);
+        await SendEmailWithRetriesAsync(email);
     }
 
     public async Task SendPasswordChangedEmail(User user)
     {
         var email = StartUserEmail(user);
         await RenderEmail(email, new PasswordChangedEmail(user.Name), user.LocalizationCode);
-        await SendEmailAsync(email);
+        await SendEmailWithRetriesAsync(email);
     }
 
     public async Task SendCreateProjectRequestEmail(LexAuthUser user, CreateProjectInput projectInput)
@@ -90,10 +92,10 @@ public class EmailService(
         email.To.Add(new MailboxAddress("Admin", _emailConfig.CreateProjectEmailDestination));
         await RenderEmail(email,
             new CreateProjectRequestEmail("Admin", new CreateProjectRequestUser(user.Name, user.Email), projectInput), "en");
-        await SendEmailAsync(email);
+        await SendEmailWithRetriesAsync(email);
     }
 
-    private async Task SendEmailAsync(MimeMessage message)
+    public async Task SendEmailAsync(MimeMessage message)
     {
         message.From.Add(MailboxAddress.Parse(_emailConfig.From));
         using var activity = LexBoxActivitySource.Get().StartActivity();
@@ -115,6 +117,17 @@ public class EmailService(
             activity?.RecordException(e);
             activity?.SetStatus(ActivityStatusCode.Error);
             throw;
+        }
+    }
+     private async Task SendEmailWithRetriesAsync(MimeMessage message, int retryCount = 3, int retryWaitSeconds = 5 * 60)
+    {
+        try
+        {
+            await SendEmailAsync(message);
+        }
+        catch
+        {
+            await RetryEmailJob.Queue(schedulerFactory, message, retryCount, retryWaitSeconds);
         }
     }
 


### PR DESCRIPTION
Fix #276.

Emails are tried once the normal way, and if they go through, there's no need to create a job for them. If they fail with any exception, a Quartz job is created allowing them to be retried later. Default is to retry every 5 minutes and retry 3 times before giving up, but those defaults are parameters in the SendEmailWithRetriesAsync method so they're easy to change.