### PR TITLE
don't crash frontend on gql 500

### DIFF
--- a/backend/LexBoxApi/GraphQL/LexQueries.cs
+++ b/backend/LexBoxApi/GraphQL/LexQueries.cs
@@ -74,4 +74,9 @@ public class LexQueries
     {
         return loggedInContext.User;
     }
+
+    public LexAuthUser TestingThrowsError()
+    {
+        throw new Exception("This is a test error");
+    }
 }

--- a/frontend/schema.graphql
+++ b/frontend/schema.graphql
@@ -185,6 +185,7 @@ type Query {
   users(skip: Int take: Int where: UserFilterInput orderBy: [UserSortInput!]): UsersCollectionSegment @authorize(policy: "AdminRequiredPolicy")
   me: MeDto
   meAuth: LexAuthUser!
+  testingThrowsError: LexAuthUser!
   isAdmin: IsAdminResponse! @authorize(policy: "AdminRequiredPolicy")
 }
 

--- a/frontend/src/lib/error/UnexpectedError.svelte
+++ b/frontend/src/lib/error/UnexpectedError.svelte
@@ -4,6 +4,7 @@
   import { useError } from '.';
   import t from '$lib/i18n';
   import { derived } from 'svelte/store';
+  import { onDestroy } from 'svelte';
 
   let alertMessageElem: HTMLElement | undefined;
   let traceIdElem: HTMLElement;
@@ -27,10 +28,16 @@
     const subject = `Language Depot - Unexpected error`;
     return `?subject=${subject}&body=${body}`;
   });
-  $: if ($error) {
-    if (alertMessageElem) alertMessageElem.textContent = $error.message;
-    if (traceIdElem) traceIdElem.textContent = $error.traceId;
-  }
+
+  onDestroy(
+    // subscribe() is more durable than reactive syntax
+    error.subscribe((e) => {
+      if (e) {
+        if (alertMessageElem) alertMessageElem.textContent = e.message;
+        if (traceIdElem) traceIdElem.textContent = e.traceId;
+      }
+    })
+  );
 
   function onTraceIdClick(event: MouseEvent): void {
     if (event.ctrlKey) {

--- a/frontend/src/lib/error/UnexpectedErrorAlert.svelte
+++ b/frontend/src/lib/error/UnexpectedErrorAlert.svelte
@@ -3,20 +3,20 @@
   import {useDismiss, useError} from '.';
   import t from '$lib/i18n';
   import UnexpectedError from './UnexpectedError.svelte';
+  import { onDestroy } from 'svelte';
 
   let dialog: HTMLDialogElement;
   const error = useError();
   const dismiss = useDismiss();
   beforeNavigate(dismiss);
-  $: {
-    if (dialog) {
-      if ($error) {
-        open();
-      } else {
-        close();
-      }
-    }
-  }
+
+  onDestroy(
+    // subscribe() is more durable than reactive syntax
+    error.subscribe((e) => {
+      if (!dialog) return;
+      e ? open() : close();
+    })
+  );
 
   function dismissClick(): void {
     close();

--- a/frontend/src/routes/(unauthenticated)/sandbox/+page.svelte
+++ b/frontend/src/routes/(unauthenticated)/sandbox/+page.svelte
@@ -38,7 +38,6 @@ function preFillForm(): void {
   let disableDropdown = false;
 
   async function gqlThrows500(): Promise<void> {
-    //after calling this the application is dead, the only way to recover is a page reload
     await _gqlThrows500();
   }
 </script>

--- a/frontend/src/routes/(unauthenticated)/sandbox/+page.svelte
+++ b/frontend/src/routes/(unauthenticated)/sandbox/+page.svelte
@@ -2,11 +2,12 @@
   import TusUpload from '$lib/components/TusUpload.svelte';
   import Dropdown from '$lib/components/Dropdown.svelte';
   import {Button, Form, Input, lexSuperForm, SubmitButton} from '$lib/forms';
-  import { PageBreadcrumb } from '$lib/layout';
+  import {PageBreadcrumb} from '$lib/layout';
   import z from 'zod';
   // eslint-disable-next-line no-restricted-imports
-  import { t as otherT } from 'svelte-intl-precompile';
+  import {t as otherT} from 'svelte-intl-precompile';
   import t from '$lib/i18n';
+  import {_gqlThrows500} from './+page';
 
   function uploadFinished(): void {
     alert('upload done!');
@@ -34,7 +35,12 @@ function preFillForm(): void {
   form.update(f => ({...f, name: 'John'}), {taint: false});
 }
 
-let disableDropdown = false;
+  let disableDropdown = false;
+
+  async function gqlThrows500(): Promise<void> {
+    //after calling this the application is dead, the only way to recover is a page reload
+    await _gqlThrows500();
+  }
 </script>
 <PageBreadcrumb>Hello from sandbox</PageBreadcrumb>
 <PageBreadcrumb>second value</PageBreadcrumb>
@@ -47,13 +53,14 @@ let disableDropdown = false;
     <a rel="external" target="_blank" class="btn" href="/api/AuthTesting/403">Goto API 403 new tab</a>
     <button class="btn" on:click={fetch403}>Fetch 403</button>
 
-    <div class="divider" />
+    <div class="divider"/>
 
     <a rel="external" class="btn" href="/sandbox/500">Goto page load 500</a>
     <a rel="external" target="_blank" class="btn" href="/sandbox/500">Goto page load 500 new tab</a>
     <a rel="external" class="btn" href="/api/testing/test500NoException">Goto API 500</a>
     <a rel="external" target="_blank" class="btn" href="/api/testing/test500NoException">Goto API 500 new tab</a>
     <button class="btn" on:click={fetch500}>Fetch 500</button>
+    <button class="btn" on:click={gqlThrows500}>GQL 500</button>
   </div>
   <div class="card w-96 bg-base-200 shadow-lg">
     <div class="card-body">

--- a/frontend/src/routes/(unauthenticated)/sandbox/+page.ts
+++ b/frontend/src/routes/(unauthenticated)/sandbox/+page.ts
@@ -1,11 +1,20 @@
 ﻿import {getClient, graphql} from '$lib/gql';
-import type {SandboxQueryMyselfQuery} from '$lib/gql/generated/graphql';
-import type {Readable} from 'svelte/store';
 
-export async function _gqlThrows500(): Promise<Readable<SandboxQueryMyselfQuery['testingThrowsError']>> {
+import type { PageLoadEvent } from './$types';
+import type {Readable} from 'svelte/store';
+import type {SandboxQueryMyselfQuery} from '$lib/gql/generated/graphql';
+import { browser } from '$app/environment';
+
+export async function load(event: PageLoadEvent) {
+  if (!browser && event.url.searchParams.has('gql-500')) {
+    await _gqlThrows500(event.fetch);
+  }
+}
+
+export async function _gqlThrows500(argFetch?: Fetch): Promise<Readable<SandboxQueryMyselfQuery['testingThrowsError']>> {
   const client = getClient();
   //language=GraphQL
-  const results = await client.awaitedQueryStore(fetch, graphql(`
+  const results = await client.awaitedQueryStore(argFetch ?? fetch, graphql(`
     query sandboxQueryMyself {
       testingThrowsError {
         id

--- a/frontend/src/routes/(unauthenticated)/sandbox/+page.ts
+++ b/frontend/src/routes/(unauthenticated)/sandbox/+page.ts
@@ -6,7 +6,7 @@ import type {SandboxQueryMyselfQuery} from '$lib/gql/generated/graphql';
 import { browser } from '$app/environment';
 
 export async function load(event: PageLoadEvent) {
-  if (!browser && event.url.searchParams.has('gql-500')) {
+  if (!browser && event.url.searchParams.has('ssr-gql-500')) {
     await _gqlThrows500(event.fetch);
   }
 }

--- a/frontend/src/routes/(unauthenticated)/sandbox/+page.ts
+++ b/frontend/src/routes/(unauthenticated)/sandbox/+page.ts
@@ -1,0 +1,16 @@
+﻿import {getClient, graphql} from '$lib/gql';
+import type {SandboxQueryMyselfQuery} from '$lib/gql/generated/graphql';
+import type {Readable} from 'svelte/store';
+
+export async function _gqlThrows500(): Promise<Readable<SandboxQueryMyselfQuery['testingThrowsError']>> {
+  const client = getClient();
+  //language=GraphQL
+  const results = await client.awaitedQueryStore(fetch, graphql(`
+    query sandboxQueryMyself {
+      testingThrowsError {
+        id
+      }
+    }
+  `), {}, {requestPolicy: 'network-only'});
+  return results.testingThrowsError;
+}

--- a/frontend/tests/errorHandling.test.ts
+++ b/frontend/tests/errorHandling.test.ts
@@ -55,6 +55,19 @@ test('catch fetch 500 and error dialog', async ({ page }) => {
   test.fail();
 });
 
+
+//we want to verify that once we get the 500 in GQL we can still navigate to another page
+test('catch gql 500 and go home', async ({ page }) => {
+  await loginAs(page.request, 'admin', testEnv.defaultPassword);
+  await new SandboxPage(page).goto();
+  // Create promise first before triggering the action
+  const responsePromise = page.waitForResponse('/api/graphql');
+  await page.getByText('GQL 500').click();
+  await responsePromise.catch(() => {});// Ignore the error
+  await page.getByText('Language Depot').click();
+  await new UserDashboardPage(page).waitFor();
+});
+
 test('server page load 403 is redirected to login', async ({ context }) => {
   await context.addCookies([{name: testEnv.authCookieName, value: testEnv.invalidJwt, url: testEnv.serverBaseUrl}]);
   const page = await context.newPage();

--- a/frontend/tests/errorHandling.test.ts
+++ b/frontend/tests/errorHandling.test.ts
@@ -1,13 +1,14 @@
-import { expect } from '@playwright/test';
-import { test } from './fixtures';
-import { SandboxPage } from './pages/sandboxPage';
 import * as testEnv from './envVars';
-import { UserDashboardPage } from './pages/userDashboardPage';
-import { LoginPage } from './pages/loginPage';
+
 import { AdminDashboardPage } from './pages/adminDashboardPage';
-import { loginAs } from './utils/authHelpers';
+import { LoginPage } from './pages/loginPage';
+import { SandboxPage } from './pages/sandboxPage';
 import { UserAccountSettingsPage } from './pages/userAccountSettingsPage';
+import { UserDashboardPage } from './pages/userDashboardPage';
+import { expect } from '@playwright/test';
 import { getInbox } from './utils/mailboxHelpers';
+import { loginAs } from './utils/authHelpers';
+import { test } from './fixtures';
 
 test('can catch 500 errors from goto in same tab', async ({ page }) => {
   await new SandboxPage(page).goto();
@@ -55,17 +56,28 @@ test('catch fetch 500 and error dialog', async ({ page }) => {
   test.fail();
 });
 
-
 //we want to verify that once we get the 500 in GQL we can still navigate to another page
-test('catch gql 500 and go home', async ({ page }) => {
+test('client-side gql 500 does not break the application', async ({ page }) => {
   await loginAs(page.request, 'admin', testEnv.defaultPassword);
   await new SandboxPage(page).goto();
   // Create promise first before triggering the action
   const responsePromise = page.waitForResponse('/api/graphql');
   await page.getByText('GQL 500').click();
-  await responsePromise.catch(() => {});// Ignore the error
+  await responsePromise.catch(() => { });// Ignore the error
+  await expect(page.locator(':text-matches("Unexpected response:.*(500)", "g")').first()).toBeVisible();
+  await page.getByRole('button', { name: 'Dismiss' }).click();
   await page.getByText('Language Depot').click();
   await new UserDashboardPage(page).waitFor();
+  test.fail(); // Everything up to here passed, but we expect a soft 500 response assertion to ultimately fail the test
+});
+
+test('server-side gql 500 does not kill the server', async ({ page }) => {
+  await loginAs(page.request, 'admin', testEnv.defaultPassword);
+  await new SandboxPage(page).goto({ urlEnd: '?ssr-gql-500', expectErrorResponse: true });
+  await expect(page.locator(':text-matches("Unexpected response:.*(500)", "g")').first()).toBeVisible();
+  // we've verified that a 500 occured, now we verify that the server is still alive
+  await new AdminDashboardPage(page).goto();
+  test.fail(); // Everything up to here passed, but we expect a soft 500 response assertion to ultimately fail the test
 });
 
 test('server page load 403 is redirected to login', async ({ context }) => {


### PR DESCRIPTION
closes #441 

After some testing I found a reproduction, I've committed that. I played a bit and tried to get a fix but I'm not sure what the right answer is.

There's 2 places that throw errors that cause the problem.
First is here
https://github.com/sillsdev/languageforge-lexbox/blob/7fd6a16bbf384cf277f61b5646a1a08a0491a884/frontend/src/hooks.shared.ts#L43-L45
for this one I tried not throwing if this was a request to the gql endpoint. Then I ran into the second one.

Second is here
https://github.com/sillsdev/languageforge-lexbox/blob/7fd6a16bbf384cf277f61b5646a1a08a0491a884/frontend/src/lib/gql/gql-client.ts#L189-L195
specifically the last lone
If I comment out the throw at the end then the frontend doesn't crash. But then I'm not really sure what the point of even calling `throwAnyUnexpectedErrors` was, and then how do we detect the failure in the calling code? We don't want the calling code to execute because we're not in a valid state, which is why we were throwing an exception.

@myieye you worked on a lot of this gql code, do you have any ideas?