### PR TITLE
Use Mercurial 3 and 6 in unit testing

### DIFF
--- a/.github/workflows/integration-test.yaml
+++ b/.github/workflows/integration-test.yaml
@@ -14,6 +14,11 @@ on:
         description: 'The domain to use for hg'
         required: true
         type: string
+      hg-version:
+        description: 'The version of hg to test (3 or 6, default 3)'
+        required: false
+        default: '3'
+        type: string
       http-scheme:
         description: 'The scheme to use for http tests'
         type: string
@@ -31,6 +36,11 @@ on:
       hg-domain:
         description: 'The domain to use for hg'
         required: true
+        type: string
+      hg-version:
+        description: 'The version of hg to test (3 or 6, default 3)'
+        required: false
+        default: '3'
         type: string
       http-scheme:
         description: 'The scheme to use for http tests'
@@ -67,6 +77,10 @@ jobs:
       - name: Playwright setup
         working-directory: backend/Testing
         run: pwsh "$(dotnet msbuild --getProperty:OutputPath)playwright.ps1" install
+      - name: Build for tests
+        run: "dotnet build /p:MercurialVersion=$MERCURIAL_VERSION"
+        env:
+          MERCURIAL_VERSION: ${{ inputs.hg-version }}
       - name: Integration tests
         env:
           TEST_SERVER_HOSTNAME: ${{ inputs.test-domain }}

--- a/.github/workflows/integration-test.yaml
+++ b/.github/workflows/integration-test.yaml
@@ -50,7 +50,7 @@ on:
 jobs:
   test:
     timeout-minutes: 60
-    name: Test ${{ inputs.runs-on }} on ${{ inputs.test-domain }}
+    name: Test ${{ inputs.runs-on }} for Mercurial ${{ inputs.hg-version }} on ${{ inputs.test-domain }}
     permissions:
       checks: write
     environment:
@@ -101,7 +101,7 @@ jobs:
         uses: EnricoMi/publish-unit-test-result-action/composite@v2
         if: always() && !env.act
         with:
-          check_name: Integration Tests ${{ inputs.runs-on }}
+          check_name: Integration Tests ${{ inputs.runs-on }} for Mercurial ${{ inputs.hg-version }}
           files: ./test-results/*.trx
       - name: Upload playwright results
         if: always()

--- a/.github/workflows/release-pipeline.yaml
+++ b/.github/workflows/release-pipeline.yaml
@@ -72,6 +72,7 @@ jobs:
     secrets: inherit
     with:
       runs-on: ${{ matrix.runs-on }}
+      hg-version: ${{ matrix.hg-version }}
       test-domain: staging.languagedepot.org
       hg-domain: hg-staging.languageforge.org
 

--- a/.github/workflows/release-pipeline.yaml
+++ b/.github/workflows/release-pipeline.yaml
@@ -63,6 +63,9 @@ jobs:
         runs-on:
           - ubuntu-latest
           - windows-latest
+        hg-version:
+          - '3'
+          - '6'
     needs: deploy
     permissions:
       checks: write

--- a/backend/Testing/Testing.csproj
+++ b/backend/Testing/Testing.csproj
@@ -7,6 +7,8 @@
 
         <IsPackable>false</IsPackable>
         <Mercurial4ChorusDestDir>$(MSBuildProjectDirectory)</Mercurial4ChorusDestDir>
+        <!-- To switch Mercurial versions, do dotnet build /p:MercurialVersion=6 followed by dotnet test -->
+        <!-- Note that if you run dotnet test /p:MercurialVersion=6 it will not work as expected; you must run dotnet build first in order to switch Mercurial versions -->
         <MercurialVersion Condition=" '$(MercurialVersion)' == '' ">3</MercurialVersion>
     </PropertyGroup>
 

--- a/backend/Testing/Testing.csproj
+++ b/backend/Testing/Testing.csproj
@@ -7,8 +7,23 @@
 
         <IsPackable>false</IsPackable>
         <Mercurial4ChorusDestDir>$(MSBuildProjectDirectory)</Mercurial4ChorusDestDir>
+        <MercurialVersion Condition=" '$(MercurialVersion)' == '' ">3</MercurialVersion>
     </PropertyGroup>
 
+    <Choose>
+        <When Condition=" '$(MercurialVersion)' == '6' ">
+            <ItemGroup>
+                <PackageReference Include="SIL.Chorus.LibChorus" Version="6.0.0-beta0043" />
+                <PackageReference Include="SIL.Chorus.Mercurial" Version="6.5.1.22" />
+            </ItemGroup>
+        </When>
+        <Otherwise>
+            <ItemGroup>
+                <PackageReference Include="SIL.Chorus.LibChorus" Version="6.0.0-beta0041" />
+                <PackageReference Include="SIL.Chorus.Mercurial" Version="3.0.3.11" />
+            </ItemGroup>
+        </Otherwise>
+    </Choose>
     <ItemGroup>
         <PackageReference Include="Microsoft.Extensions.Configuration" Version="8.0.0" />
         <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0" />
@@ -18,8 +33,6 @@
         <PackageReference Include="Microsoft.Playwright.TestAdapter" Version="1.41.2" />
         <PackageReference Include="Moq" Version="4.20.70" />
         <PackageReference Include="Shouldly" Version="4.2.1" />
-        <PackageReference Include="SIL.Chorus.LibChorus" Version="6.0.0-beta0041" />
-        <PackageReference Include="SIL.Chorus.Mercurial" Version="3.0.3.11" />
         <PackageReference Include="SIL.ChorusPlugin.LfMergeBridge" Version="4.1.0" />
         <PackageReference Include="SIL.Core" Version="13.0.0-beta0074" />
         <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="7.3.0" />


### PR DESCRIPTION
Fix #487.

Currently, to get the correct version of Mercurial running the tests, you have to run `dotnet build /p:MercurialVersion=N` (either 3 or 6) followed by `dotnet test /p:MercurialVersion=N`. If you omit the build step and just run the tests, the currently-installed Mercurial version gets run regardless of the version you specified in the `/p` flag. This has something to do with how the Chorus NuGet package copies the Mercurial package into the build folder, but I haven't tracked it down yet.