### PR TITLE
Fix updateLexEntryCount failing during SSR

### DIFF
--- a/backend/LexBoxApi/Controllers/ProjectController.cs
+++ b/backend/LexBoxApi/Controllers/ProjectController.cs
@@ -226,8 +226,8 @@ public class ProjectController(
     [AdminRequired]
     public async Task<ActionResult> UpdateAllLexEntryCounts(bool onlyUnknown)
     {
-        var projects = lexBoxDbContext.Projects.Where(p => p.Type == ProjectType.FLEx && (!onlyUnknown || p.FlexProjectMetadata == null)).AsAsyncEnumerable();
-        await foreach (var project in projects)
+        var projects = lexBoxDbContext.Projects.Where(p => p.Type == ProjectType.FLEx && (!onlyUnknown || p.FlexProjectMetadata == null)).ToArray();
+        foreach (var project in projects)
         {
             await projectService.UpdateLexEntryCount(project.Code);
         }

--- a/backend/LexBoxApi/Controllers/ProjectController.cs
+++ b/backend/LexBoxApi/Controllers/ProjectController.cs
@@ -224,14 +224,16 @@ public class ProjectController(
 
     [HttpPost("updateAllLexEntryCounts")]
     [AdminRequired]
-    public async Task<ActionResult> UpdateAllLexEntryCounts(bool onlyUnknown)
+    public async Task<ActionResult<int>> UpdateAllLexEntryCounts(bool onlyUnknown = true, int limit = 100)
     {
-        var projects = lexBoxDbContext.Projects.Where(p => p.Type == ProjectType.FLEx && (!onlyUnknown || p.FlexProjectMetadata == null)).ToArray();
+        var projects = lexBoxDbContext.Projects.Where(p => p.Type == ProjectType.FLEx && (!onlyUnknown || p.FlexProjectMetadata == null)).Take(limit).ToArray();
+        var completed = 0;
         foreach (var project in projects)
         {
             await projectService.UpdateLexEntryCount(project.Code);
+            completed++;
         }
-        return Ok();
+        return Ok(completed);
     }
 
     [HttpPost("queueUpdateProjectMetadataTask")]

--- a/backend/LexBoxApi/Controllers/ProjectController.cs
+++ b/backend/LexBoxApi/Controllers/ProjectController.cs
@@ -224,7 +224,7 @@ public class ProjectController(
 
     [HttpPost("updateAllLexEntryCounts")]
     [AdminRequired]
-    public async Task<ActionResult<int>> UpdateAllLexEntryCounts(bool onlyUnknown = true, int limit = 100)
+    public async Task<ActionResult<int>> UpdateAllLexEntryCounts(bool onlyUnknown = true, int limit = 100, int delayMs = 10)
     {
         var projects = lexBoxDbContext.Projects.Where(p => p.Type == ProjectType.FLEx && (!onlyUnknown || p.FlexProjectMetadata == null)).Take(limit).ToArray();
         var completed = 0;
@@ -232,6 +232,7 @@ public class ProjectController(
         {
             await projectService.UpdateLexEntryCount(project.Code);
             completed++;
+            if (delayMs > 0) await Task.Delay(delayMs);
         }
         return Ok(completed);
     }

--- a/backend/LexBoxApi/Controllers/ProjectController.cs
+++ b/backend/LexBoxApi/Controllers/ProjectController.cs
@@ -222,6 +222,18 @@ public class ProjectController(
         return result is null ? NotFound() : result;
     }
 
+    [HttpPost("updateAllLexEntryCounts")]
+    [AdminRequired]
+    public async Task<ActionResult> UpdateAllLexEntryCounts(bool onlyUnknown)
+    {
+        var projects = lexBoxDbContext.Projects.Where(p => p.Type == ProjectType.FLEx && (!onlyUnknown || p.FlexProjectMetadata == null)).AsAsyncEnumerable();
+        await foreach (var project in projects)
+        {
+            await projectService.UpdateLexEntryCount(project.Code);
+        }
+        return Ok();
+    }
+
     [HttpPost("queueUpdateProjectMetadataTask")]
     public async Task<ActionResult> QueueUpdateProjectMetadataTask(string projectCode)
     {

--- a/backend/LexBoxApi/GraphQL/LexQueries.cs
+++ b/backend/LexBoxApi/GraphQL/LexQueries.cs
@@ -29,11 +29,11 @@ public class LexQueries
     {
         if (withDeleted)
         {
-            return context.Projects.Include(p => p.FlexProjectMetadata).IgnoreQueryFilters();
+            return context.Projects.IgnoreQueryFilters();
         }
         else
         {
-            return context.Projects.Include(p => p.FlexProjectMetadata);
+            return context.Projects;
         }
     }
 

--- a/backend/LexBoxApi/GraphQL/LexQueries.cs
+++ b/backend/LexBoxApi/GraphQL/LexQueries.cs
@@ -29,11 +29,11 @@ public class LexQueries
     {
         if (withDeleted)
         {
-            return context.Projects.IgnoreQueryFilters();
+            return context.Projects.Include(p => p.FlexProjectMetadata).IgnoreQueryFilters();
         }
         else
         {
-            return context.Projects;
+            return context.Projects.Include(p => p.FlexProjectMetadata);
         }
     }
 

--- a/backend/LexBoxApi/Services/HgService.cs
+++ b/backend/LexBoxApi/Services/HgService.cs
@@ -25,15 +25,12 @@ public partial class HgService : IHgService
     private readonly IOptions<HgConfig> _options;
     private readonly Lazy<HttpClient> _hgClient;
     private readonly ILogger<HgService> _logger;
-    // TEMPORARY CHANGE, revert this once we finish running the "update all lex entry counts" migration
-    private readonly IHttpClientFactory _clientFactory;
 
     public HgService(IOptions<HgConfig> options, IHttpClientFactory clientFactory, ILogger<HgService> logger)
     {
         _options = options;
         _logger = logger;
         _hgClient = new(() => clientFactory.CreateClient("HgWeb"));
-        _clientFactory = clientFactory;
     }
 
     [GeneratedRegex(Project.ProjectCodeRegex)]
@@ -329,11 +326,9 @@ public partial class HgService : IHgService
 
     private async Task<string> ExecuteHgCommandServerCommand(string code, string command, CancellationToken token)
     {
-        // var httpClient = _hgClient.Value;
-        // TEMPORARY CHANGE, revert this once we finish running the "update all lex entry counts" migration
-        var httpClient = _clientFactory.CreateClient("HgWeb");
-        httpClient.BaseAddress = new Uri(_options.Value.HgCommandServer);
-        var response = await httpClient.GetAsync($"{code}/{command}", token);
+        var httpClient = _hgClient.Value;
+        var baseUri = _options.Value.HgCommandServer;
+        var response = await httpClient.GetAsync($"{baseUri}{code}/{command}", token);
         response.EnsureSuccessStatusCode();
         return await response.Content.ReadAsStringAsync();
     }

--- a/backend/LexBoxApi/Services/HgService.cs
+++ b/backend/LexBoxApi/Services/HgService.cs
@@ -25,12 +25,15 @@ public partial class HgService : IHgService
     private readonly IOptions<HgConfig> _options;
     private readonly Lazy<HttpClient> _hgClient;
     private readonly ILogger<HgService> _logger;
+    // TEMPORARY CHANGE, revert this once we finish running the "update all lex entry counts" migration
+    private readonly IHttpClientFactory _clientFactory;
 
     public HgService(IOptions<HgConfig> options, IHttpClientFactory clientFactory, ILogger<HgService> logger)
     {
         _options = options;
         _logger = logger;
         _hgClient = new(() => clientFactory.CreateClient("HgWeb"));
+        _clientFactory = clientFactory;
     }
 
     [GeneratedRegex(Project.ProjectCodeRegex)]
@@ -326,7 +329,9 @@ public partial class HgService : IHgService
 
     private async Task<string> ExecuteHgCommandServerCommand(string code, string command, CancellationToken token)
     {
-        var httpClient = _hgClient.Value;
+        // var httpClient = _hgClient.Value;
+        // TEMPORARY CHANGE, revert this once we finish running the "update all lex entry counts" migration
+        var httpClient = _clientFactory.CreateClient("HgWeb");
         httpClient.BaseAddress = new Uri(_options.Value.HgCommandServer);
         var response = await httpClient.GetAsync($"{code}/{command}", token);
         response.EnsureSuccessStatusCode();

--- a/frontend/src/routes/(authenticated)/admin/AdminProjects.svelte
+++ b/frontend/src/routes/(authenticated)/admin/AdminProjects.svelte
@@ -51,7 +51,7 @@
     }
   }
 
-  async function updateAllLexEntryCounts() {
+  async function updateAllLexEntryCounts(): Promise<void> {
     var count = await fetch(`/api/project/updateAllLexEntryCounts?onlyUnknown=true`, {method: 'POST'});
     notifySuccess(`{count} projects updated` + (Number(count) == 0 ? `. You're all done!` : ''));
   }

--- a/frontend/src/routes/(authenticated)/admin/AdminProjects.svelte
+++ b/frontend/src/routes/(authenticated)/admin/AdminProjects.svelte
@@ -22,7 +22,7 @@
   $: filters = queryParams.queryParamValues;
   $: filterDefaults = queryParams.defaultQueryParamValues;
 
-  const { notifyWarning } = useNotifications();
+  const { notifyWarning, notifySuccess } = useNotifications();
 
   const serverSideProjectFilterKeys = (['showDeletedProjects'] as const satisfies Readonly<(keyof ProjectFilters)[]>);
 
@@ -52,7 +52,8 @@
   }
 
   async function updateAllLexEntryCounts() {
-    await fetch(`/api/project/updateAllLexEntryCounts?onlyUnknown=true`, {method: 'POST'});
+    var count = await fetch(`/api/project/updateAllLexEntryCounts?onlyUnknown=true`, {method: 'POST'});
+    notifySuccess(`{count} projects updated` + (Number(count) == 0 ? `. You're all done!` : ''));
   }
 </script>
 

--- a/frontend/src/routes/(authenticated)/admin/AdminProjects.svelte
+++ b/frontend/src/routes/(authenticated)/admin/AdminProjects.svelte
@@ -49,6 +49,10 @@
       notifyWarning($t('delete_project_modal.success', { name: project.name, code: project.code }));
     }
   }
+
+  async function updateAllLexEntryCounts() {
+    await fetch(`/api/project/updateAllLexEntryCounts?onlyUnknown=true`, {method: 'POST'});
+  }
 </script>
 
 <ConfirmDeleteModal bind:this={deleteProjectModal} i18nScope="delete_project_modal" />
@@ -113,4 +117,6 @@
       <RefineFilterMessage total={filteredProjects.length} showing={shownProjects.length} />
     {/if}
   {/if}
+
+  <p><span class="text-bold">TEMPORARY:</span> <button class="btn btn-warning" on:click={updateAllLexEntryCounts}> Update all lex entry counts </button>
 </div>

--- a/frontend/src/routes/(authenticated)/admin/AdminProjects.svelte
+++ b/frontend/src/routes/(authenticated)/admin/AdminProjects.svelte
@@ -15,6 +15,7 @@
   import type { QueryParams } from '$lib/util/query-params';
   import { derived } from 'svelte/store';
   import type { AdminSearchParams } from './+page';
+  import DevContent from '$lib/layout/DevContent.svelte';
 
   export let projects: ProjectItem[];
   export let queryParams: QueryParams<AdminSearchParams>;
@@ -118,5 +119,7 @@
     {/if}
   {/if}
 
+<DevContent>
   <p><span class="text-bold">TEMPORARY:</span> <button class="btn btn-warning" on:click={updateAllLexEntryCounts}> Update all lex entry counts </button>
+</DevContent>
 </div>

--- a/frontend/src/routes/(authenticated)/project/[project_code]/+page.svelte
+++ b/frontend/src/routes/(authenticated)/project/[project_code]/+page.svelte
@@ -39,7 +39,6 @@
   import SendReceiveUrlField from './SendReceiveUrlField.svelte';
   import {isDev} from '$lib/layout/DevContent.svelte';
   import UserModal from '$lib/components/Users/UserModal.svelte';
-  import { derived, type Readable } from 'svelte/store';
   import IconButton from '$lib/components/IconButton.svelte';
   import { delay } from '$lib/util/time';
 
@@ -55,7 +54,7 @@
     return a.user.name.localeCompare(b.user.name);
   });
 
-  let lexEntryCount: Readable<number | Promise<number>> | undefined;
+  $: lexEntryCount = data.lexEntryCount;
 
   const TRUNCATED_MEMBER_COUNT = 5;
   let showAllMembers = false;
@@ -179,22 +178,6 @@
     if (migrationStatus === ProjectMigrationStatus.Migrating) {
       void watchMigrationStatus();
     }
-
-    lexEntryCount = derived(projectStore, p => {
-      if (p.type === ProjectType.FlEx) {
-        if (p.flexProjectMetadata?.lexEntryCount != null) {
-          return p.flexProjectMetadata?.lexEntryCount;
-        } else {
-          return fetch(`/api/project/updateLexEntryCount/${p.code}`, {method: 'POST'})
-          .then(x => x.text())
-          .then(s => parseInt(s))
-          .catch(() => 0);
-        }
-      } else {
-        return 0;
-      }
-    });
-
   });
 
   async function watchMigrationStatus(): Promise<void> {
@@ -358,7 +341,6 @@
         {#if project.type === ProjectType.FlEx}
         <div class="text-lg">
           {$t('project_page.num_entries')}:
-          {#if lexEntryCount}
           <span class="text-secondary">
             {#if ($lexEntryCount instanceof Promise)}
             {#await $lexEntryCount then num_entries}
@@ -368,7 +350,6 @@
               {$number($lexEntryCount)}
             {/if}
           </span>
-          {/if}
         </div>
         {/if}
         <div class="text-lg">{$t('project_page.description')}:</div>

--- a/frontend/src/routes/(authenticated)/project/[project_code]/+page.svelte
+++ b/frontend/src/routes/(authenticated)/project/[project_code]/+page.svelte
@@ -54,6 +54,7 @@
     return a.user.name.localeCompare(b.user.name);
   });
 
+  let lexEntryCount: number | string | null | undefined = undefined;
   $: lexEntryCount = project.flexProjectMetadata?.lexEntryCount;
 
   const TRUNCATED_MEMBER_COUNT = 5;
@@ -74,6 +75,14 @@
     copyingToClipboard = false;
     await delay();
     copiedToClipboard = false;
+  }
+
+  let loadingEntryCount = false;
+  async function updateEntryCount(): Promise<void> {
+    loadingEntryCount = true;
+    const response = await fetch(`/api/project/updateLexEntryCount/${project.code}`, {method: 'POST'});
+    lexEntryCount = await response.text();
+    loadingEntryCount = false;
   }
 
   let changeMemberRoleModal: ChangeMemberRoleModal;
@@ -344,6 +353,16 @@
           <span class="text-secondary">
             {$number(lexEntryCount)}
           </span>
+          <AdminContent>
+            <IconButton
+              loading={loadingEntryCount}
+              icon="i-mdi-refresh"
+              size="btn-sm"
+              variant="btn-ghost"
+              outline={false}
+              on:click={updateEntryCount}
+            />
+          </AdminContent>
         </div>
         {/if}
         <div class="text-lg">{$t('project_page.description')}:</div>

--- a/frontend/src/routes/(authenticated)/project/[project_code]/+page.svelte
+++ b/frontend/src/routes/(authenticated)/project/[project_code]/+page.svelte
@@ -39,6 +39,7 @@
   import SendReceiveUrlField from './SendReceiveUrlField.svelte';
   import {isDev} from '$lib/layout/DevContent.svelte';
   import UserModal from '$lib/components/Users/UserModal.svelte';
+  import { derived, type Readable } from 'svelte/store';
 
   export let data: PageData;
   $: user = data.user;
@@ -52,7 +53,7 @@
     return a.user.name.localeCompare(b.user.name);
   });
 
-  $: lexEntryCount = data.lexEntryCount;
+  let lexEntryCount: Readable<number | Promise<number>> | undefined;
 
   const TRUNCATED_MEMBER_COUNT = 5;
   let showAllMembers = false;
@@ -164,6 +165,22 @@
     if (migrationStatus === ProjectMigrationStatus.Migrating) {
       void watchMigrationStatus();
     }
+
+    lexEntryCount = derived(projectStore, p => {
+      if (p.type === ProjectType.FlEx) {
+        if (p.flexProjectMetadata?.lexEntryCount != null) {
+          return p.flexProjectMetadata?.lexEntryCount;
+        } else {
+          return fetch(`/api/project/updateLexEntryCount/${p.code}`, {method: 'POST'})
+          .then(x => x.text())
+          .then(s => parseInt(s))
+          .catch(() => 0);
+        }
+      } else {
+        return 0;
+      }
+    });
+
   });
 
   async function watchMigrationStatus(): Promise<void> {
@@ -311,6 +328,7 @@
         {#if project.type === ProjectType.FlEx}
         <div class="text-lg">
           {$t('project_page.num_entries')}:
+          {#if lexEntryCount}
           <span class="text-secondary">
             {#if ($lexEntryCount instanceof Promise)}
             {#await $lexEntryCount then num_entries}
@@ -320,6 +338,7 @@
               {$number($lexEntryCount)}
             {/if}
           </span>
+          {/if}
         </div>
         {/if}
         <div class="text-lg">{$t('project_page.description')}:</div>

--- a/frontend/src/routes/(authenticated)/project/[project_code]/+page.svelte
+++ b/frontend/src/routes/(authenticated)/project/[project_code]/+page.svelte
@@ -39,7 +39,6 @@
   import SendReceiveUrlField from './SendReceiveUrlField.svelte';
   import {isDev} from '$lib/layout/DevContent.svelte';
   import UserModal from '$lib/components/Users/UserModal.svelte';
-  import { derived, type Readable } from 'svelte/store';
   import IconButton from '$lib/components/IconButton.svelte';
   import { delay } from '$lib/util/time';
 
@@ -55,7 +54,7 @@
     return a.user.name.localeCompare(b.user.name);
   });
 
-  let lexEntryCount: Readable<number | Promise<number>> | undefined;
+  $: lexEntryCount = project.flexProjectMetadata?.lexEntryCount;
 
   const TRUNCATED_MEMBER_COUNT = 5;
   let showAllMembers = false;
@@ -179,22 +178,6 @@
     if (migrationStatus === ProjectMigrationStatus.Migrating) {
       void watchMigrationStatus();
     }
-
-    lexEntryCount = derived(projectStore, p => {
-      if (p.type === ProjectType.FlEx) {
-        if (p.flexProjectMetadata?.lexEntryCount != null) {
-          return p.flexProjectMetadata?.lexEntryCount;
-        } else {
-          return fetch(`/api/project/updateLexEntryCount/${p.code}`, {method: 'POST'})
-          .then(x => x.text())
-          .then(s => parseInt(s))
-          .catch(() => 0);
-        }
-      } else {
-        return 0;
-      }
-    });
-
   });
 
   async function watchMigrationStatus(): Promise<void> {
@@ -358,17 +341,9 @@
         {#if project.type === ProjectType.FlEx}
         <div class="text-lg">
           {$t('project_page.num_entries')}:
-          {#if lexEntryCount}
           <span class="text-secondary">
-            {#if ($lexEntryCount instanceof Promise)}
-            {#await $lexEntryCount then num_entries}
-              {num_entries}
-            {/await}
-            {:else}
-              {$number($lexEntryCount)}
-            {/if}
+            {$number(lexEntryCount)}
           </span>
-          {/if}
         </div>
         {/if}
         <div class="text-lg">{$t('project_page.description')}:</div>

--- a/frontend/src/routes/(authenticated)/project/[project_code]/+page.ts
+++ b/frontend/src/routes/(authenticated)/project/[project_code]/+page.ts
@@ -11,6 +11,7 @@ import type {
   DeleteProjectUserMutation,
   ProjectPageQuery,
 } from '$lib/gql/types';
+import { ProjectType } from '$lib/gql/generated/graphql';
 import { derived } from 'svelte/store';
 import { getClient, graphql } from '$lib/gql';
 
@@ -18,6 +19,7 @@ import type { PageLoadEvent } from './$types';
 import { error } from '@sveltejs/kit';
 import { isAdmin } from '$lib/user';
 import { tryMakeNonNullable } from '$lib/util/store';
+import { browser } from '$app/environment';
 
 export type Project = NonNullable<ProjectPageQuery['projectByCode']>;
 export type ProjectUser = Project['users'][number];
@@ -97,8 +99,24 @@ export async function load(event: PageLoadEvent) {
 
   event.depends(`project:${projectCode}`);
 
+  const lexEntryCount = derived(nonNullableProject, p => {
+    if (p.type === ProjectType.FlEx) {
+      if (Number.isInteger(p.flexProjectMetadata?.lexEntryCount)) {
+        return p.flexProjectMetadata?.lexEntryCount;
+      } else {
+        return !browser ? undefined : event.fetch(`/api/project/updateLexEntryCount/${p.code}`, {method: 'POST'})
+        .then(x => x.text())
+        .then(s => parseInt(s))
+        .catch(() => undefined);
+      }
+    } else {
+      return undefined;
+    }
+  });
+
   return {
     project: nonNullableProject,
+    lexEntryCount,
     changesets: derived(changesetResultStore, result => ({
       fetching: result.fetching,
       changesets: result.data?.projectByCode?.changesets ?? [],

--- a/frontend/src/routes/(authenticated)/project/[project_code]/+page.ts
+++ b/frontend/src/routes/(authenticated)/project/[project_code]/+page.ts
@@ -11,8 +11,7 @@ import type {
   DeleteProjectUserMutation,
   ProjectPageQuery,
 } from '$lib/gql/types';
-import { ProjectType } from '$lib/gql/generated/graphql';
-import { derived, type Readable } from 'svelte/store';
+import { derived } from 'svelte/store';
 import { getClient, graphql } from '$lib/gql';
 
 import type { PageLoadEvent } from './$types';
@@ -98,27 +97,8 @@ export async function load(event: PageLoadEvent) {
 
   event.depends(`project:${projectCode}`);
 
-  // eslint thinks this cast is unnecessary, but if it's removed then type-checking on `p.type` below fails
-  // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion
-  const project = projectResult.projectByCode as Readable<Project>;
-  const lexEntryCount = derived(project, p => {
-    if (p.type === ProjectType.FlEx) {
-      if (p.flexProjectMetadata?.lexEntryCount != null) {
-        return p.flexProjectMetadata?.lexEntryCount;
-      } else {
-        return event.fetch(`/api/project/updateLexEntryCount/${p.code}`, {method: 'POST'})
-        .then(x => x.text())
-        .then(s => parseInt(s))
-        .catch(() => 0);
-      }
-    } else {
-      return 0;
-    }
-  });
-
   return {
     project: nonNullableProject,
-    lexEntryCount,
     changesets: derived(changesetResultStore, result => ({
       fetching: result.fetching,
       changesets: result.data?.projectByCode?.changesets ?? [],


### PR DESCRIPTION
Fix #551.

The probable cause of the updateLexEntryCount failures is a race condition between server-side rendering calling `fetch` and the client-side rendered page calling the same `fetch` again, which sometimes causes two serer processes to get into a race condition where they check for the FlexProjectMetadata table row, don't find it, and both try to create it with the same ProjectId value.

We catch the DbError on the server, and at the same time, we move the updateLexEntryCount call onto the client (inside onMount) to avoid the race condition ever happening in the first place.