### PR TITLE
Allow 2-letter language codes

### DIFF
--- a/frontend/src/lib/i18n/locales/en.json
+++ b/frontend/src/lib/i18n/locales/en.json
@@ -142,7 +142,7 @@ the [Linguistics Institute at Payap University](https://li.payap.ac.th/) in Chia
       "description_missing": "Description required",
       "language_code": "Language Code",
       "language_code_description": "Preferably an [Ethnologue code](https://www.ethnologue.com)",
-      "language_code_too_short": "Language code must be at least 3 characters",
+      "language_code_too_short": "Language code must be at least 2 characters",
       "language_code_invalid": "Language code can only include lowercase a-z, digits and '-'",
       "name": "Name",
       "name_description": "E.g. the name of the language you're working on",

--- a/frontend/src/lib/i18n/locales/es.json
+++ b/frontend/src/lib/i18n/locales/es.json
@@ -131,7 +131,7 @@ el [Linguistics Institute at Payap University](https://li.payap.ac.th/) en Chian
       "description_missing": "Descripción requerida",
       "language_code": "Código de Idioma",
       "language_code_description": "Preferiblemente un código [Ethnologue](https://www.ethnologue.com)",
-      "language_code_too_short": "El código de idioma debe tener al menos 3 caracteres",
+      "language_code_too_short": "El código de idioma debe tener al menos 2 caracteres",
       "language_code_invalid": "El código de idioma solo puede incluir minúsculas a-z, dígitos y '-'",
       "name": "Nombre",
       "name_description": "Por ejemplo, el nombre del idioma en el que estás trabajando",

--- a/frontend/src/lib/i18n/locales/fr.json
+++ b/frontend/src/lib/i18n/locales/fr.json
@@ -131,7 +131,7 @@ le [Linguistics Institute at Payap University](https://li.payap.ac.th/) à Chian
       "description_missing": "Description requise",
       "language_code": "Code de langue",
       "language_code_description": "De préférence, un [code Ethnologue](https://www.ethnologue.com)",
-      "language_code_too_short": "Le code de langue doit comporter au moins 3 caractères",
+      "language_code_too_short": "Le code de langue doit comporter au moins 2 caractères",
       "language_code_invalid": "Le code de langue ne peut contenir que des minuscules a-z, des chiffres et '-'",
       "name": "Nom",
       "name_description": "Par exemple, le nom de la langue sur laquelle vous travaillez",

--- a/frontend/src/routes/(authenticated)/project/create/+page.svelte
+++ b/frontend/src/routes/(authenticated)/project/create/+page.svelte
@@ -35,7 +35,7 @@
     retentionPolicy: z.nativeEnum(RetentionPolicy).default(RetentionPolicy.Training),
     languageCode: z
       .string()
-      .min(3, $t('project.create.language_code_too_short'))
+      .min(2, $t('project.create.language_code_too_short'))
       .regex(/^[a-z-\d]+$/, $t('project.create.language_code_invalid')),
     code: codeValidation,
     customCode: z.boolean().default(false),


### PR DESCRIPTION
Fix #380.

After discussion, we decided to simply allow two-letter language codes. We do not require that they be valid language codes, any more than we were requiring that the 3-letter codes be valid ISO-639-3 codes before this change.