### PR TITLE
Show-password icon on password fields

### DIFF
--- a/frontend/src/lib/forms/Input.svelte
+++ b/frontend/src/lib/forms/Input.svelte
@@ -2,6 +2,7 @@
   import { randomFormId } from './utils';
   import PlainInput from './PlainInput.svelte';
   import FormField from './FormField.svelte';
+  import Icon from '$lib/icons/Icon.svelte';
 
   export let id = randomFormId();
   export let label: string;
@@ -15,8 +16,29 @@
   // Despite the compatibility table, 'new-password' seems to work well in Chrome, Edge & Firefox
   // https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/autocomplete#browser_compatibility
   export let autocomplete: 'new-password' | 'current-password' | undefined = undefined;
+
+  let currentType = type;
+  if (type == 'password') console.log('Password field displaying');
+
 </script>
 
 <FormField {id} {error} {label} {autofocus} {description}>
-  <PlainInput {id} bind:value {type} {autofocus} {readonly} {error} {placeholder} {autocomplete} />
+  {#if (type == 'password')}
+  <div class="container">
+    <PlainInput {id} bind:value type={currentType} {autofocus} {readonly} {error} {placeholder} {autocomplete} />
+    <span class="eye"><Icon icon="i-mdi-eye" size="text-md"></Icon></span>
+  </div>
+  {:else}
+    <PlainInput {id} bind:value {type} {autofocus} {readonly} {error} {placeholder} {autocomplete} />
+  {/if}
 </FormField>
+
+<style>
+  .eye {
+    position: absolute;
+    right: 1px;
+  }
+  .container {
+    position: relative;
+  }
+</style>

--- a/frontend/src/lib/forms/Input.svelte
+++ b/frontend/src/lib/forms/Input.svelte
@@ -2,7 +2,7 @@
   import { randomFormId } from './utils';
   import PlainInput from './PlainInput.svelte';
   import FormField from './FormField.svelte';
-  import Icon from '$lib/icons/Icon.svelte';
+  import IconButton from '$lib/components/IconButton.svelte';
 
   export let id = randomFormId();
   export let label: string;
@@ -18,15 +18,20 @@
   export let autocomplete: 'new-password' | 'current-password' | undefined = undefined;
 
   let currentType = type;
-  if (type == 'password') console.log('Password field displaying');
+
+  function togglePasswordVisibility(): void {
+    if (type == 'password') {
+      currentType = (currentType == 'password') ? 'text' : 'password';
+    }
+  }
 
 </script>
 
 <FormField {id} {error} {label} {autofocus} {description}>
   {#if (type == 'password')}
   <div class="container">
-    <PlainInput {id} bind:value type={currentType} {autofocus} {readonly} {error} {placeholder} {autocomplete} />
-    <span class="eye"><Icon icon="i-mdi-eye" size="text-md"></Icon></span>
+    <PlainInput {id} bind:value type={currentType} {autofocus} {readonly} {error} {placeholder} {autocomplete} style="w-full" />
+    <span class="eye"><IconButton variant="btn-ghost" icon={currentType == 'password' ? 'i-mdi-eye' : 'i-mdi-eye-off'} on:click={togglePasswordVisibility} /></span>
   </div>
   {:else}
     <PlainInput {id} bind:value {type} {autofocus} {readonly} {error} {placeholder} {autocomplete} />


### PR DESCRIPTION
Any password field now gets an icon to show or hide the password.

Fixes #466.

Hidden mode:

![image](https://github.com/sillsdev/languageforge-lexbox/assets/90762/a3658399-da63-4ffc-b5c2-3fe201492fb0)

Reveal mode:

![image](https://github.com/sillsdev/languageforge-lexbox/assets/90762/d1b0f969-b2d5-4de1-9c6f-b0dd5388dfe4)
