### PR TITLE
Have hg command runner stream its output

### DIFF
--- a/backend/LexBoxApi/Controllers/ProjectController.cs
+++ b/backend/LexBoxApi/Controllers/ProjectController.cs
@@ -199,9 +199,10 @@ public class ProjectController(
         var result = await hgService.VerifyRepo(code, HttpContext.RequestAborted);
         // Response.HttpContext.Features.Get<IHttpResponseBodyFeature>()?.DisableBuffering(); // This does nothing????
         var writer = Response.BodyWriter;
+        Response.ContentType = "text/plain; charset=utf-8";
         // await Response.StartAsync();
         // await writer.FlushAsync(); // This does nothing????
-        await Response.WriteAsJsonAsync("Why does this work?\n"); // But this works???!!???
+        // await Response.WriteAsJsonAsync("Why does this work?\n"); // But this works???!!???
         await result.CopyToAsync(writer.AsStream());
         // await Response.CompleteAsync();
         // return new HgCommandResponse(result);

--- a/backend/LexBoxApi/Controllers/ProjectController.cs
+++ b/backend/LexBoxApi/Controllers/ProjectController.cs
@@ -229,6 +229,7 @@ public class ProjectController(
     public async Task StreamHttpResponse(HttpContent hgResult)
     {
         var writer = Response.BodyWriter;
+        //  Browsers want to see a content type or they won't stream the output of the fetch() call
         Response.ContentType = "text/plain; charset=utf-8";
         await hgResult.CopyToAsync(writer.AsStream());
     }

--- a/backend/LexBoxApi/Controllers/ProjectController.cs
+++ b/backend/LexBoxApi/Controllers/ProjectController.cs
@@ -226,6 +226,7 @@ public class ProjectController(
         }
         var result = await hgService.ExecuteHgRecover(code, HttpContext.RequestAborted);
         var writer = Response.BodyWriter;
+        Response.ContentType = "text/plain; charset=utf-8";
         await result.CopyToAsync(writer.AsStream());
     }
 

--- a/backend/LexBoxApi/Controllers/ProjectController.cs
+++ b/backend/LexBoxApi/Controllers/ProjectController.cs
@@ -202,9 +202,7 @@ public class ProjectController(
             return;
         }
         var result = await hgService.VerifyRepo(code, HttpContext.RequestAborted);
-        var writer = Response.BodyWriter;
-        Response.ContentType = "text/plain; charset=utf-8";
-        await result.CopyToAsync(writer.AsStream());
+        await StreamHttpResponse(result);
     }
 
     [HttpGet("hgRecover/{code}")]
@@ -225,9 +223,14 @@ public class ProjectController(
             return;
         }
         var result = await hgService.ExecuteHgRecover(code, HttpContext.RequestAborted);
+        await StreamHttpResponse(result);
+    }
+
+    public async Task StreamHttpResponse(HttpContent hgResult)
+    {
         var writer = Response.BodyWriter;
         Response.ContentType = "text/plain; charset=utf-8";
-        await result.CopyToAsync(writer.AsStream());
+        await hgResult.CopyToAsync(writer.AsStream());
     }
 
     [HttpPost("updateLexEntryCount/{code}")]

--- a/backend/LexBoxApi/Services/HgService.cs
+++ b/backend/LexBoxApi/Services/HgService.cs
@@ -307,30 +307,31 @@ public partial class HgService : IHgService
     }
 
 
-    public async Task<string> VerifyRepo(string code, CancellationToken token)
+    public Task<HttpContent> VerifyRepo(string code, CancellationToken token)
     {
-        return await ExecuteHgCommandServerCommand(code, "verify", token);
+        return ExecuteHgCommandServerCommand(code, "verify", token);
     }
-    public async Task<string> ExecuteHgRecover(string code, CancellationToken token)
+    public async Task<HttpContent> ExecuteHgRecover(string code, CancellationToken token)
     {
         var response = await ExecuteHgCommandServerCommand(code, "recover", token);
-        if (string.IsNullOrWhiteSpace(response)) return "Nothing to recover";
+        // if (string.IsNullOrWhiteSpace(response)) return "Nothing to recover";
         return response;
     }
 
     public async Task<int?> GetLexEntryCount(string code)
     {
-        var str = await ExecuteHgCommandServerCommand(code, "lexentrycount", default);
+        var content = await ExecuteHgCommandServerCommand(code, "lexentrycount", default);
+        var str = await content.ReadAsStringAsync();
         return int.TryParse(str, out int result) ? result : null;
     }
 
-    private async Task<string> ExecuteHgCommandServerCommand(string code, string command, CancellationToken token)
+    private async Task<HttpContent> ExecuteHgCommandServerCommand(string code, string command, CancellationToken token)
     {
         var httpClient = _hgClient.Value;
         var baseUri = _options.Value.HgCommandServer;
-        var response = await httpClient.GetAsync($"{baseUri}{code}/{command}", token);
+        var response = await httpClient.GetAsync($"{baseUri}{code}/{command}", HttpCompletionOption.ResponseHeadersRead, token);
         response.EnsureSuccessStatusCode();
-        return await response.Content.ReadAsStringAsync();
+        return response.Content;
     }
 
     private static readonly string[] InvalidRepoNames = { DELETED_REPO_FOLDER, "api" };

--- a/backend/LexBoxApi/Services/HgService.cs
+++ b/backend/LexBoxApi/Services/HgService.cs
@@ -314,6 +314,7 @@ public partial class HgService : IHgService
     public async Task<HttpContent> ExecuteHgRecover(string code, CancellationToken token)
     {
         var response = await ExecuteHgCommandServerCommand(code, "recover", token);
+        // Can't do this with a streamed response, unfortunately. Will have to do it client-side.
         // if (string.IsNullOrWhiteSpace(response)) return "Nothing to recover";
         return response;
     }

--- a/backend/LexCore/ServiceInterfaces/IHgService.cs
+++ b/backend/LexCore/ServiceInterfaces/IHgService.cs
@@ -15,8 +15,8 @@ public interface IHgService
     Task ResetRepo(string code);
     Task<bool> MigrateRepo(Project project, CancellationToken cancellationToken);
     Task FinishReset(string code, Stream zipFile);
-    Task<string> VerifyRepo(string code, CancellationToken token);
+    Task<HttpContent> VerifyRepo(string code, CancellationToken token);
     Task<int?> GetLexEntryCount(string code);
     Task<string?> GetRepositoryIdentifier(Project project);
-    Task<string> ExecuteHgRecover(string code, CancellationToken token);
+    Task<HttpContent> ExecuteHgRecover(string code, CancellationToken token);
 }

--- a/frontend/src/routes/(authenticated)/project/[project_code]/+page.svelte
+++ b/frontend/src/routes/(authenticated)/project/[project_code]/+page.svelte
@@ -222,14 +222,14 @@
     if (body == null) return;
     const reader = body.getReader();
     const decoder = new TextDecoder();
-    await reader.read().then(function pump ({ done, value }): Promise<null> | null {
+    await reader.read().then(function handleChunk ({ done, value }): Promise<null> | null {
       // The {stream: true} is important here; without it, in theory the output could be
       // broken in the middle of a UTF-8 byte sequence and get garbled. But with stream: true,
       // TextDecoder() will know to expect more output, so if the stream returns a partial
       // UTF-8 sequence, TextDecoder() will return everything except that sequence and wait
       // for more bytes before decoding that sequence.
       hgCommandResponse += decoder.decode(value, {stream: true});
-      return done ? null : reader.read().then(pump);
+      return done ? null : reader.read().then(handleChunk);
     });
   }
 

--- a/frontend/src/routes/(authenticated)/project/[project_code]/+page.svelte
+++ b/frontend/src/routes/(authenticated)/project/[project_code]/+page.svelte
@@ -227,15 +227,17 @@
     // }
     // But that only works on Firefox. So until Chrome implements that, we have to do this:
     const reader = body.getReader();
-    await reader.read().then(function handleChunk ({ done, value }): Promise<null> | null {
+    let done = false;
+    while (!done) {
+      let result = await reader.read();
+      done = result.done;
       // The {stream: true} is important here; without it, in theory the output could be
       // broken in the middle of a UTF-8 byte sequence and get garbled. But with stream: true,
       // TextDecoder() will know to expect more output, so if the stream returns a partial
       // UTF-8 sequence, TextDecoder() will return everything except that sequence and wait
       // for more bytes before decoding that sequence.
-      hgCommandResponse += decoder.decode(value, {stream: true});
-      return done ? null : reader.read().then(handleChunk);
-    });
+      if (result.value) hgCommandResponse += decoder.decode(result.value, {stream: true});
+    }
   }
 
   async function hgCommand(execute: ()=> Promise<Response>): Promise<void> {

--- a/frontend/src/routes/(authenticated)/project/[project_code]/+page.svelte
+++ b/frontend/src/routes/(authenticated)/project/[project_code]/+page.svelte
@@ -238,9 +238,8 @@
     void hgCommandResultModal.openModal(true, true);
     let response = await execute();
     await streamHgCommandResponse(response.body);
-    // hgCommandResponse = await response.text();
-    // let json = await response.json() as { response: string } | undefined;
-    // hgCommandResponse = json?.response ?? 'No response';
+    // Some commands, like hg recover, return nothing if there's nothing to be done
+    if (hgCommandResponse == '') hgCommandResponse = 'No response';
   }
 
   let openInFlexModal: OpenInFlexModal;

--- a/frontend/src/routes/(authenticated)/project/[project_code]/+page.svelte
+++ b/frontend/src/routes/(authenticated)/project/[project_code]/+page.svelte
@@ -223,6 +223,11 @@
     const reader = body.getReader();
     const decoder = new TextDecoder();
     await reader.read().then(function pump ({ done, value }): Promise<null> | null {
+      // The {stream: true} is important here; without it, in theory the output could be
+      // broken in the middle of a UTF-8 byte sequence and get garbled. But with stream: true,
+      // TextDecoder() will know to expect more output, so if the stream returns a partial
+      // UTF-8 sequence, TextDecoder() will return everything except that sequence and wait
+      // for more bytes before decoding that sequence.
       hgCommandResponse += decoder.decode(value, {stream: true});
       console.log('Response so far:', hgCommandResponse);
       return done ? null : reader.read().then(pump);

--- a/frontend/src/routes/(authenticated)/project/[project_code]/+page.svelte
+++ b/frontend/src/routes/(authenticated)/project/[project_code]/+page.svelte
@@ -220,8 +220,13 @@
 
   async function streamHgCommandResponse(body: ReadableStream<Uint8Array> | null): Promise<void> {
     if (body == null) return;
-    const reader = body.getReader();
     const decoder = new TextDecoder();
+    // Would be nice to just do this:
+    // for await (const chunk of body) {
+    //   hgCommandResponse += decoder.decode(chunk, {stream: true});
+    // }
+    // But that only works on Firefox. So until Chrome implements that, we have to do this:
+    const reader = body.getReader();
     await reader.read().then(function handleChunk ({ done, value }): Promise<null> | null {
       // The {stream: true} is important here; without it, in theory the output could be
       // broken in the middle of a UTF-8 byte sequence and get garbled. But with stream: true,

--- a/frontend/src/routes/(authenticated)/project/[project_code]/+page.svelte
+++ b/frontend/src/routes/(authenticated)/project/[project_code]/+page.svelte
@@ -228,15 +228,15 @@
     // But that only works on Firefox. So until Chrome implements that, we have to do this:
     const reader = body.getReader();
     let done = false;
+    let value;
     while (!done) {
-      let result = await reader.read();
-      done = result.done;
+      ({done, value} = await reader.read());
       // The {stream: true} is important here; without it, in theory the output could be
       // broken in the middle of a UTF-8 byte sequence and get garbled. But with stream: true,
       // TextDecoder() will know to expect more output, so if the stream returns a partial
       // UTF-8 sequence, TextDecoder() will return everything except that sequence and wait
       // for more bytes before decoding that sequence.
-      if (result.value) hgCommandResponse += decoder.decode(result.value, {stream: true});
+      if (value) hgCommandResponse += decoder.decode(value, {stream: true});
     }
   }
 

--- a/frontend/src/routes/(authenticated)/project/[project_code]/+page.svelte
+++ b/frontend/src/routes/(authenticated)/project/[project_code]/+page.svelte
@@ -229,7 +229,6 @@
       // UTF-8 sequence, TextDecoder() will return everything except that sequence and wait
       // for more bytes before decoding that sequence.
       hgCommandResponse += decoder.decode(value, {stream: true});
-      console.log('Response so far:', hgCommandResponse);
       return done ? null : reader.read().then(pump);
     });
   }

--- a/hgweb/command-runner.sh
+++ b/hgweb/command-runner.sh
@@ -46,6 +46,21 @@ case $command_name in
         chg tip --template '{node}'
         ;;
 
+    verify)
+        # Slowly stream a response
+        echo "Line 1/5"
+        sleep 1s
+        echo "Line 2/5"
+        sleep 1s
+        echo "Line 3/5"
+        # sleep 1s
+        echo "Line 4/5"
+        sleep 1s
+        echo "Line 5/5"
+        # sleep 1s
+        echo "Done"
+        ;;
+
     *)
         chg $command_name 2>&1
         ;;

--- a/hgweb/command-runner.sh
+++ b/hgweb/command-runner.sh
@@ -46,6 +46,13 @@ case $command_name in
         chg tip --template '{node}'
         ;;
 
+    verify)
+        # Env var PYTHONUNBUFFERED required for commands like verify and recover, so that output can stream back to the project page
+        export PYTHONUNBUFFERED=1
+        # Need a timeout so hg verify won't take forever on the "checking files" step
+        timeout 5 chg verify
+        ;;
+
     *)
         # Env var PYTHONUNBUFFERED required for commands like verify and recover, so that output can stream back to the project page
         PYTHONUNBUFFERED=1 chg $command_name

--- a/hgweb/command-runner.sh
+++ b/hgweb/command-runner.sh
@@ -29,25 +29,24 @@ if [[ ! " ${allowed_commands[@]} " =~ " ${command_name} " ]]; then
     exit 1
 fi
 
-# Run the hg command
+# Start outputting the result right away so the HTTP connection won't be timed out
+echo "Content-type: text/plain"
+echo ""
+
+# Run the hg command, simply output to stdout
 cd /var/hg/repos/$project_code
 case $command_name in
 
     lexentrycount)
         # The \b for word boundary is necessary to distinguish LexEntry from LexEntryType and similar
-        command_output=$(chg cat -r tip Linguistics/Lexicon/Lexicon_{01,02,03,04,05,06,07,08,09,10}.lexdb | grep -c '<LexEntry\b')
+        chg cat -r tip Linguistics/Lexicon/Lexicon_{01,02,03,04,05,06,07,08,09,10}.lexdb | grep -c '<LexEntry\b'
         ;;
 
     tip)
-        command_output=$(chg tip --template '{node}')
+        chg tip --template '{node}'
         ;;
 
     *)
-        command_output=$(chg $command_name 2>&1)
+        chg $command_name 2>&1
         ;;
 esac
-
-# Output the result
-echo "Content-type: text/plain"
-echo ""
-echo "$command_output"

--- a/hgweb/command-runner.sh
+++ b/hgweb/command-runner.sh
@@ -46,22 +46,8 @@ case $command_name in
         chg tip --template '{node}'
         ;;
 
-    verify)
-        # Slowly stream a response
-        echo "Line 1/5"
-        sleep 1s
-        echo "Line 2/5"
-        sleep 1s
-        echo "Line 3/5"
-        # sleep 1s
-        echo "Line 4/5"
-        sleep 1s
-        echo "Line 5/5"
-        # sleep 1s
-        echo "Done"
-        ;;
-
     *)
-        chg $command_name 2>&1
+        # Env var PYTHONUNBUFFERED required for commands like verify and recover, so that output can stream back to the project page
+        PYTHONUNBUFFERED=1 chg $command_name
         ;;
 esac


### PR DESCRIPTION
If we delay writing anything to stdout, CloudFlare will time out the connection after 100 seconds. But if we start writing to stdout and keep writing to it, then CloudFlare will see an ongoing active connection and won't time it out.

This may fix #615 with no advanced configuration changes needed. Let's try it.