### PR TITLE
track abandoned transactions

### DIFF
--- a/backend/LexBoxApi/Services/HgService.cs
+++ b/backend/LexBoxApi/Services/HgService.cs
@@ -271,6 +271,11 @@ public partial class HgService : IHgService
         return Path.Exists(Path.Combine(_options.Value.RepoPath, projectCode, ".hg", "store", "journal"));
     }
 
+    public bool RepoIsLocked(string projectCode)
+    {
+        return Path.Exists(Path.Combine(_options.Value.RepoPath, projectCode, ".hg", "store", "lock"));
+    }
+
     public async Task<string?> GetRepositoryIdentifier(Project project)
     {
         var json = await GetCommit(project.Code, project.MigrationStatus, "0");

--- a/backend/LexBoxApi/Services/HgService.cs
+++ b/backend/LexBoxApi/Services/HgService.cs
@@ -266,6 +266,11 @@ public partial class HgService : IHgService
         }
     }
 
+    public bool HasAbandonedTransactions(string projectCode)
+    {
+        return Path.Exists(Path.Combine(_options.Value.RepoPath, projectCode, ".hg", "store", "journal"));
+    }
+
     public async Task<string?> GetRepositoryIdentifier(Project project)
     {
         var json = await GetCommit(project.Code, project.MigrationStatus, "0");

--- a/backend/LexCore/Entities/Project.cs
+++ b/backend/LexCore/Entities/Project.cs
@@ -44,6 +44,11 @@ public class Project : EntityBase
             return await hgService.GetChangesets(Code, MigrationStatus);
         }
     }
+
+    public bool GetHasAbandonedTransactions(IHgService hgService)
+    {
+        return hgService.HasAbandonedTransactions(Code);
+    }
 }
 
 public enum ProjectMigrationStatus

--- a/backend/LexCore/ServiceInterfaces/IHgService.cs
+++ b/backend/LexCore/ServiceInterfaces/IHgService.cs
@@ -19,4 +19,5 @@ public interface IHgService
     Task<int?> GetLexEntryCount(string code);
     Task<string?> GetRepositoryIdentifier(Project project);
     Task<HttpContent> ExecuteHgRecover(string code, CancellationToken token);
+    bool HasAbandonedTransactions(string projectCode);
 }

--- a/backend/SyncReverseProxy/ProxyKernel.cs
+++ b/backend/SyncReverseProxy/ProxyKernel.cs
@@ -83,6 +83,7 @@ public static class ProxyKernel
         var httpClient = context.RequestServices.GetRequiredService<HttpMessageInvoker>();
         var forwarder = context.RequestServices.GetRequiredService<IHttpForwarder>();
         var eventsService = context.RequestServices.GetRequiredService<ProxyEventsService>();
+        var hgService = context.RequestServices.GetRequiredService<IHgService>();
         var lexProxyService = context.RequestServices.GetRequiredService<ILexProxyService>();
         var repoMigrationService = context.RequestServices.GetRequiredService<IRepoMigrationService>();
         var hgType = context.GetEndpoint()?.Metadata.OfType<HgType>().FirstOrDefault() ?? throw new ArgumentException("Unknown HG request type");
@@ -123,6 +124,9 @@ public static class ProxyKernel
                     await eventsService.OnResumableRequest(context);
                     break;
             }
+
+            if (hgService.HasAbandonedTransactions(projectCode))
+                Activity.Current?.AddTag("app.abandoned_transaction_detected", true);
         }
         catch (Exception e)
         {


### PR DESCRIPTION
closes #617

also makes the check avalible via gql, it's just a filesystem call so I don't see a need to ever cache it in the db