### PR TITLE
Try to fix reset-project integration test

### DIFF
--- a/backend/Testing/SyncReverseProxy/SendReceiveServiceTests.cs
+++ b/backend/Testing/SyncReverseProxy/SendReceiveServiceTests.cs
@@ -283,6 +283,9 @@ query projectLastCommit {
         await apiTester.HttpClient.PostAsync($"{apiTester.BaseUrl}/api/project/resetProject/{newProjectCode}", null);
         await apiTester.HttpClient.PostAsync($"{apiTester.BaseUrl}/api/project/finishResetProject/{newProjectCode}", null);
 
+        // Sleep 5 seconds to ensure hgweb picks up newly-reset project
+        await Task.Delay(TimeSpan.FromSeconds(5));
+
         // Step 2: verify project is now empty, i.e. tip is "0000000..."
         response = await apiTester.HttpClient.GetAsync(tipUri.Uri);
         jsonResult = await response.Content.ReadFromJsonAsync<JsonObject>();


### PR DESCRIPTION
It appears that the hgweb server might need 5 seconds to pick up on the reset-project change, just like it needs 5 seconds to pick up on new projects. We'll wait 5 seconds so the server can notice the change.

This will hopefully fix the [integration test failures](https://github.com/sillsdev/languageforge-lexbox/actions/runs/8151849655/job/22282722686) we've been seeing against staging. I haven't been able to reproduce the failures locally so I'm not 100% certain that this is the cause, but it's worth trying.