### PR TITLE
Add go home button to error alert that always works

### DIFF
--- a/frontend/src/lib/error/UnexpectedErrorAlert.svelte
+++ b/frontend/src/lib/error/UnexpectedErrorAlert.svelte
@@ -37,8 +37,15 @@
 <dialog bind:this={dialog} class="modal">
   <div class="modal-box bg-error text-error-content max-w-[95vw] w-[unset]">
     <UnexpectedError />
-    <div class="flex justify-end modal-action">
-      <button on:click={dismissClick} class="btn btn-ghost self-end">{$t('modal.dismiss')}</button>
+    <div class="flex justify-end gap-4 modal-action">
+      <a class="btn btn-outline" href="/" rel="external">
+        {$t('errors.go_home')}
+        <span class="i-mdi-home-outline text-xl"></span>
+      </a>
+      <button on:click={dismissClick} class="btn btn-outline self-end">
+        {$t('modal.dismiss')}
+        <span class="i-mdi-close text-xl"></span>
+      </button>
     </div>
   </div>
 </dialog>

--- a/frontend/src/routes/(unauthenticated)/sandbox/+page.svelte
+++ b/frontend/src/routes/(unauthenticated)/sandbox/+page.svelte
@@ -46,6 +46,8 @@ function preFillForm(): void {
 <h2 class="text-lg">Sandbox</h2>
 <div class="grid gap-2 grid-cols-3">
   <div class="card w-96 bg-base-200 shadow-lg">
+    <a rel="external" class="btn" href="/">Go home</a>
+    <div class="divider"/>
     <a rel="external" class="btn" href="/sandbox/403">Goto page load 403</a>
     <a rel="external" target="_blank" class="btn" href="/sandbox/403">Goto page load 403 new tab</a>
     <a rel="external" class="btn" href="/api/AuthTesting/403">Goto API 403</a>

--- a/frontend/src/routes/+error.svelte
+++ b/frontend/src/routes/+error.svelte
@@ -26,7 +26,7 @@
         <UnexpectedError />
       {/if}
       <div class="mt-8 text-center">
-        <a class="btn btn-success" href="/">{$t('errors.go_home')} <span class="i-mdi-home-outline text-xl"></span></a>
+        <a class="btn btn-success" href="/" rel="external">{$t('errors.go_home')} <span class="i-mdi-home-outline text-xl"></span></a>
       </div>
     </div>
   </Page>


### PR DESCRIPTION
I even tested it out when the app is broken and it works 😉.

![image](https://github.com/sillsdev/languageforge-lexbox/assets/12587509/df057d20-4eb7-4315-997d-8eac6d8adc49)
