### PR TITLE
Use accept-language header locale if more specific than user locale

### DIFF
--- a/frontend/src/lib/i18n/i18n.test.ts
+++ b/frontend/src/lib/i18n/i18n.test.ts
@@ -1,0 +1,46 @@
+import { buildRegionalLocaleRegex, pickBestLocale } from '.';
+import { describe, expect, it } from 'vitest';
+
+describe('buildRegionalLocaleRegex', () => {
+  it('should find all regional locales for available locales', () => {
+    const acceptLanguageHeader = 'en;q=0.9,fr-CA;q=0.8,fr;q=0.7,de;q=0.6,en-US   ;q=0.5,en-GB,es-419,ja-JP';
+
+    let supportedRegionalLocales = buildRegionalLocaleRegex(['en', 'es', 'de']);
+    let matchedLocales = [...acceptLanguageHeader.matchAll(supportedRegionalLocales)].map(match => match[0]);
+    expect(matchedLocales).toEqual(['en-US', 'en-GB', 'es-419']);
+
+    supportedRegionalLocales = buildRegionalLocaleRegex(['fr', 'es']);
+    matchedLocales = [...acceptLanguageHeader.matchAll(supportedRegionalLocales)].map(match => match[0]);
+    expect(matchedLocales).toEqual(['fr-CA', 'es-419']);
+  });
+});
+
+describe('pickBestLocale', () => {
+  it('should return en by default', () => {
+    expect(pickBestLocale()).toBe('en');
+  });
+
+  it('should return user locale if acceptLanguageHeader is not provided', () => {
+    expect(pickBestLocale('fr')).toBe('fr');
+  });
+
+  it('should return user locale if acceptLanguageHeader does not provide a regional/more specific locale', () => {
+    expect(pickBestLocale('fr', 'en,en-GB,es')).toBe('fr');
+  });
+
+  it('should return user locale if acceptLanguageHeader does not provide a regional/more specific locale with a higher quality rating', () => {
+    expect(pickBestLocale('fr', 'fr,fr-CA;q=0.8,en-GB')).toBe('fr');
+  });
+
+  it('should return regional locale from acceptLanguageHeader if it has a higher quality rating than the regionless locale', () => {
+    expect(pickBestLocale('fr', 'fr-CA,fr;q=0.8,en-GB')).toBe('fr-CA');
+  });
+
+  it('should return supported locale from acceptLanguageHeader with highest quality rating if no user locale is provided', () => {
+    expect(pickBestLocale(undefined, 'fr-CA,fr;q=0.8,en-GB')).toBe('fr-CA');
+  });
+
+  it('should return en if no user locale is provided and acceptLanguageHeader does not have any supported locales', () => {
+    expect(pickBestLocale(undefined, 'ja-JP')).toBe('en');
+  });
+});

--- a/frontend/src/lib/i18n/index.ts
+++ b/frontend/src/lib/i18n/index.ts
@@ -17,10 +17,12 @@ import type { Get } from 'type-fest';
 import { defineContext } from '$lib/util/context';
 import { browser } from '$app/environment';
 
-const englishLocalesInChrome = ['en-US', 'en-GB', 'en-AU', 'en-CA', 'en-IN', 'en-IE', 'en-NZ', 'en-ZA'];
-const frenchLocalesInChrome = ['fr-FR', 'fr-CA', 'fr-CH'];
-const spanishLocalesInChrome = ['es-AR', 'es-CL', 'es-CO', 'es-CR', 'es-HN', 'es-419', 'es-MX', 'es-PE', 'es-ES', 'es-US', 'es-UY', 'es-VE'];
-const supportedLocales = [...availableLocales, ...englishLocalesInChrome, ...frenchLocalesInChrome, ...spanishLocalesInChrome];
+export function buildRegionalLocaleRegex(supportedLocales: string[]): RegExp {
+  return RegExp(`\\b(${supportedLocales.join('|')})[-a-zA-Z0-9]+`, 'g');
+}
+
+const acceptLanguageHeaderSupportedRegionalLocalesRegex = buildRegionalLocaleRegex(availableLocales);
+
 export function getLanguageCodeFromNavigator(): string | undefined {
   // Keep the language code. Discard the country code.
   return getLocaleFromNavigator()?.split('-')[0];
@@ -28,6 +30,9 @@ export function getLanguageCodeFromNavigator(): string | undefined {
 
 function getLocaleFromAcceptLanguageHeader(acceptLanguageHeader?: string | null): string | undefined {
   if (!acceptLanguageHeader) return undefined;
+
+  const regionalLocales = [...acceptLanguageHeader.matchAll(acceptLanguageHeaderSupportedRegionalLocalesRegex)].map(match => match[0]);
+  const supportedLocales = [...availableLocales, ...regionalLocales];
   // replaceAll works around: https://github.com/cibernox/precompile-intl-runtime/issues/45
   return _getLocaleFromAcceptLanguageHeader(acceptLanguageHeader.replaceAll(' ', ''), supportedLocales);
 }


### PR DESCRIPTION
Resolves #647

Prefer using the accept-language header locale for i18n if it's more specific than the locale we have persisted for the user.

I know this isn't highest priority, but I needed the joy of a quick win.

This is somewhat hacky, but for such a small change I think it gets us a really long way.

I tested French and English. Here's English:

en[-US]:
![image](https://github.com/sillsdev/languageforge-lexbox/assets/12587509/def2d719-aff7-4e99-a80a-e5ab8e2973ce)

en-GB:
![image](https://github.com/sillsdev/languageforge-lexbox/assets/12587509/93fd53ab-37df-4ab7-9079-abb468766ecc)
