### PR TITLE
Fixup/bulk add member

### DIFF
--- a/frontend/src/lib/components/Users/UserModal.svelte
+++ b/frontend/src/lib/components/Users/UserModal.svelte
@@ -40,14 +40,18 @@
       <div>
         <h3>{$t('admin_dashboard.column_email')}</h3>
         <p class="value flex items-center gap-2 text-left">
-          {user.email ?? '-'}
-          {#if !user.emailVerified}
-          <span
-            class="tooltip text-warning text-md shrink-0 leading-0"
-            data-tip={$t('admin_dashboard.email_not_verified')}>
-            <span class="i-mdi-help-circle-outline" />
-          </span>
-        {/if}
+          {#if user.email}
+            {user.email}
+            {#if !user.emailVerified}
+              <span
+                class="tooltip text-warning text-md shrink-0 leading-0"
+                data-tip={$t('admin_dashboard.email_not_verified')}>
+                <span class="i-mdi-help-circle-outline" />
+              </span>
+            {/if}
+          {:else}
+            –
+          {/if}
         </p>
       </div>
       <div>

--- a/frontend/src/lib/i18n/locales/en.json
+++ b/frontend/src/lib/i18n/locales/en.json
@@ -14,7 +14,6 @@
     "project_table_title": "Projects",
     "user_table_title": "Users",
     "is_draft": "Draft",
-    "email_is_null": "No Email",
     "email_not_verified": "Not Verified",
     "notifications": {
       "user_deleted": "{name} has been deleted.",
@@ -183,7 +182,7 @@ the [Linguistics Institute at Payap University](https://li.payap.ac.th/) in Chia
       "submit_button": "Add Member",
       "project_not_found": "Project not found. Please refresh the page.",
       "user_not_found": "No user was found with this email address",
-      "user_not_verified": "User has not verified their email address",
+      "user_must_be_verified": "User needs a verified email address",
       "user_needs_to_relogin": "Added members will need to log out and back in again before they see the new project.",
     },
     "bulk_add_members": {

--- a/frontend/src/routes/(authenticated)/admin/+page.svelte
+++ b/frontend/src/routes/(authenticated)/admin/+page.svelte
@@ -170,13 +170,17 @@
                 </td>
                 <td>
                   <span class="inline-flex items-center gap-2 text-left">
-                    {user.email ?? $t('admin_dashboard.email_is_null')}
-                    {#if !user.emailVerified}
-                      <span
-                        class="tooltip text-warning text-xl shrink-0 leading-0"
-                        data-tip={$t('admin_dashboard.email_not_verified')}>
-                        <span class="i-mdi-help-circle-outline" />
-                      </span>
+                    {#if user.email}
+                      {user.email}
+                      {#if !user.emailVerified}
+                        <span
+                          class="tooltip text-warning text-xl shrink-0 leading-0"
+                          data-tip={$t('admin_dashboard.email_not_verified')}>
+                          <span class="i-mdi-help-circle-outline" />
+                        </span>
+                      {/if}
+                    {:else}
+                      –
                     {/if}
                   </span>
                 </td>

--- a/frontend/src/routes/(authenticated)/project/[project_code]/AddProjectMember.svelte
+++ b/frontend/src/routes/(authenticated)/project/[project_code]/AddProjectMember.svelte
@@ -31,7 +31,7 @@
         return { email: [$t('project_page.add_user.project_not_found')] };
       }
       if (error?.byType('ProjectMembersMustBeVerified')) {
-        return { email: [$t('project_page.add_user.user_not_verified')] };
+        return { email: [$t('project_page.add_user.user_must_be_verified')] };
       }
       if (error?.byType('ProjectMemberInvitedByEmail')) {
         userInvited = true;

--- a/frontend/src/routes/(authenticated)/project/[project_code]/BulkAddProjectMembers.svelte
+++ b/frontend/src/routes/(authenticated)/project/[project_code]/BulkAddProjectMembers.svelte
@@ -84,6 +84,7 @@
       <Input
         id="shared_password"
         type="password"
+        autocomplete="new-password"
         label={$t('project_page.bulk_add_members.shared_password')}
         bind:value={$form.password}
         error={errors.password}

--- a/frontend/src/routes/(authenticated)/project/[project_code]/ChangeMemberRoleModal.svelte
+++ b/frontend/src/routes/(authenticated)/project/[project_code]/ChangeMemberRoleModal.svelte
@@ -26,7 +26,7 @@
         role: $form.role,
       });
       if (result.error?.byType('ProjectMembersMustBeVerified')) {
-        return { role: [$t('project_page.add_user.user_not_verified')] };
+        return { role: [$t('project_page.add_user.user_must_be_verified')] };
       }
       return result.error?.message;
     });


### PR DESCRIPTION
Just a few touch ups related to #621 

"–" is what we've used everywhere so far to represent "no value"
`"User has not verified their email address"` was dissatisfying when referring to users that don't have an email address at all
`autocomplete="new-password"` has proven to be valueable when not wanting browsers to autofill password fields