### PR TITLE
Use correct audience for invitation-email and make API unambiguous

### DIFF
--- a/backend/LexBoxApi/Auth/LexAuthService.cs
+++ b/backend/LexBoxApi/Auth/LexAuthService.cs
@@ -131,18 +131,17 @@ public class LexAuthService
     }
 
     public (string token, DateTime expiresAt) GenerateJwt(LexAuthUser user,
-        LexboxAudience audience = LexboxAudience.LexboxApi,
         bool useEmailLifetime = false)
     {
         var options = _userOptions.Value;
-        var lifetime = (audience, useEmailLifetime) switch
+        var lifetime = (user.Audience, useEmailLifetime) switch
         {
             (_, true) => options.EmailJwtLifetime,
             (LexboxAudience.SendAndReceive, _) => options.SendReceiveJwtLifetime,
             (LexboxAudience.SendAndReceiveRefresh, _) => options.SendReceiveRefreshJwtLifetime,
             _ => options.Lifetime
         };
-        return GenerateToken(user, audience, lifetime);
+        return GenerateToken(user, user.Audience, lifetime);
     }
 
     private (string token, DateTime expiresAt) GenerateToken(LexAuthUser user,

--- a/backend/LexBoxApi/Controllers/IntegrationController.cs
+++ b/backend/LexBoxApi/Controllers/IntegrationController.cs
@@ -68,12 +68,18 @@ public class IntegrationController(
         var user = loggedInContext.User;
         //generates a short lived token only useful for S&R of this one project
         var (projectToken, projectTokenExpiresAt) = authService.GenerateJwt(
-            user with { Projects = user.Projects.Where(p => p.ProjectId == projectId).ToArray() },
-            LexboxAudience.SendAndReceive);
+            user with
+            {
+                Projects = user.Projects.Where(p => p.ProjectId == projectId).ToArray(),
+                Audience = LexboxAudience.SendAndReceiveRefresh,
+            });
 
         //refresh long lived token used to get new tokens
-        var (flexToken, flexTokenExpiresAt) =
-            authService.GenerateJwt(user with { Projects = [] }, LexboxAudience.SendAndReceiveRefresh);
+        var (flexToken, flexTokenExpiresAt) = authService.GenerateJwt(user with
+        {
+            Projects = [],
+            Audience = LexboxAudience.SendAndReceiveRefresh,
+        });
         return new RefreshResponse(projectToken, projectTokenExpiresAt, flexToken, flexTokenExpiresAt);
     }
 }

--- a/backend/LexBoxApi/Controllers/IntegrationController.cs
+++ b/backend/LexBoxApi/Controllers/IntegrationController.cs
@@ -71,7 +71,7 @@ public class IntegrationController(
             user with
             {
                 Projects = user.Projects.Where(p => p.ProjectId == projectId).ToArray(),
-                Audience = LexboxAudience.SendAndReceiveRefresh,
+                Audience = LexboxAudience.SendAndReceive,
             });
 
         //refresh long lived token used to get new tokens

--- a/backend/LexBoxApi/Controllers/TestingController.cs
+++ b/backend/LexBoxApi/Controllers/TestingController.cs
@@ -40,7 +40,7 @@ public class TestingController : ControllerBase
         var user = await _lexBoxDbContext.Users.Include(u => u.Projects).ThenInclude(p => p.Project)
             .FindByEmailOrUsername(usernameOrEmail);
         if (user is null) return NotFound();
-        var (token, _) = _lexAuthService.GenerateJwt(new LexAuthUser(user) { Role = userRole }, audience: audience);
+        var (token, _) = _lexAuthService.GenerateJwt(new LexAuthUser(user) { Role = userRole, Audience = audience });
         return token;
     }
 

--- a/backend/LexBoxApi/Services/EmailService.cs
+++ b/backend/LexBoxApi/Services/EmailService.cs
@@ -35,7 +35,7 @@ public class EmailService(
         var (lexAuthUser, user) = await lexAuthService.GetUser(emailAddress);
         // we want to silently return if the user doesn't exist, so we don't leak information.
         if (lexAuthUser is null || user?.CanLogin() is not true) return;
-        var (jwt, _) = lexAuthService.GenerateJwt(lexAuthUser, LexboxAudience.ForgotPassword, true);
+        var (jwt, _) = lexAuthService.GenerateJwt(lexAuthUser with { Audience = LexboxAudience.ForgotPassword }, true);
 
         var email = StartUserEmail(user);
         if (email is null) return;

--- a/backend/Testing/LexCore/LexAuthUserTests.cs
+++ b/backend/Testing/LexCore/LexAuthUserTests.cs
@@ -201,7 +201,7 @@ public class LexAuthUserTests
     [Fact]
     public void CanRoundTripThroughRefresh()
     {
-        var (forgotJwt, _) = _lexAuthService.GenerateJwt(_user, audience: LexboxAudience.ForgotPassword);
+        var (forgotJwt, _) = _lexAuthService.GenerateJwt(_user with { Audience = LexboxAudience.ForgotPassword });
         //simulate parsing the token into a claims principal
         var tokenHandler = new JwtSecurityTokenHandler();
         var forgotPrincipal =


### PR DESCRIPTION
Fixes #656 

Kind of looks like this feature was never tested 😬

Turns out the API for generating JWT's was ambiguous and **always** used a seperate audience parameter instead of the `LexAuthUser.Audience`.
So, I improved it.

Afterwards I tested the email workflows: invite new user, forgot password, change email