### PR TITLE
Preload AdaptIt img and use well-known affix as project-code suffix

### DIFF
--- a/frontend/src/lib/components/ProjectType/ProjectTypeIcon.svelte
+++ b/frontend/src/lib/components/ProjectType/ProjectTypeIcon.svelte
@@ -17,7 +17,7 @@
   }
 
   if (browser) {
-    void [flexLogo, oneStoryLogo, weSayLogo, ourWordLogo].map(preloadImage);
+    void [flexLogo, oneStoryLogo, weSayLogo, ourWordLogo, adaptItLogo].map(preloadImage);
   }
 </script>
 

--- a/frontend/src/routes/(authenticated)/project/create/+page.svelte
+++ b/frontend/src/routes/(authenticated)/project/create/+page.svelte
@@ -83,6 +83,7 @@
     [ProjectType.WeSay]: 'dictionary',
     [ProjectType.OneStoryEditor]: 'onestory',
     [ProjectType.OurWord]: 'ourword',
+    [ProjectType.AdaptIt]: 'aikb',
   };
 
   const policyCodeMap: Partial<Record<RetentionPolicy, string | undefined>> = {


### PR DESCRIPTION
Found these while testing #589

aikb (Adapt It Knowledge Base?) is **by far** the most standard affix used in prod. They've used it as a prefix until now, but..... 🤷 😬 

Almost all AdaptIt projects:
![image](https://github.com/sillsdev/languageforge-lexbox/assets/12587509/b8e75c88-6b16-41cf-87bb-2f32b37500c8)

Projects that use 'aikb' in the code:
![image](https://github.com/sillsdev/languageforge-lexbox/assets/12587509/a5bdcce8-d213-43e0-bb5d-3c2a83f2d39d)

Projects that use 'adaptit' in the code:
![image](https://github.com/sillsdev/languageforge-lexbox/assets/12587509/5e80ac8f-645b-4ee1-8fd5-448ccfcdf5e4)
