### PR TITLE
Don't require password, so server returns 403 instead of 400

### DIFF
--- a/backend/LexBoxApi/Controllers/LegacyProjectApiController.cs
+++ b/backend/LexBoxApi/Controllers/LegacyProjectApiController.cs
@@ -24,7 +24,7 @@ public class LegacyProjectApiController : ControllerBase
         _lexProxyService = lexProxyService;
     }
 
-    public record ProjectsInput([Required(AllowEmptyStrings = true)] string Password);
+    public record ProjectsInput(string Password);
 
     [AllowAnonymous]
     [HttpPost("/api/user/{userName}/projects")]


### PR DESCRIPTION
Fixes #419 (found while testing)

Looks like we've tried to solve this several times:
![image](https://github.com/sillsdev/languageforge-lexbox/assets/12587509/3a6ba132-0181-4ace-a28a-f8b6c915f76e)

But it's still happening:
![image](https://github.com/sillsdev/languageforge-lexbox/assets/12587509/bb1cabc7-1c67-4e64-ad3c-da9488103f80)
The spikes of 5 are what LF seems to do.