### PR TITLE
Various forgotten fixups necessary for emails being nullable

### DIFF
--- a/backend/LexBoxApi/GraphQL/CustomTypes/MeDto.cs
+++ b/backend/LexBoxApi/GraphQL/CustomTypes/MeDto.cs
@@ -4,6 +4,6 @@ public class MeDto
 {
     public required Guid Id { get; set; }
     public required string Name { get; set; }
-    public required string Email { get; set; }
+    public required string? Email { get; set; }
     public required string Locale { get; set; }
 }

--- a/backend/LexCore/Auth/LexAuthConstants.cs
+++ b/backend/LexCore/Auth/LexAuthConstants.cs
@@ -4,6 +4,7 @@ public static class LexAuthConstants
 {
     public const string RoleClaimType = "role";
     public const string EmailClaimType = "email";
+    public const string UsernameClaimType = "user";
     public const string NameClaimType = "name";
     public const string IdClaimType = "sub";
     public const string AudienceClaimType = "aud";

--- a/backend/LexCore/Auth/LexAuthUser.cs
+++ b/backend/LexCore/Auth/LexAuthUser.cs
@@ -86,6 +86,7 @@ public record LexAuthUser
     {
         Id = user.Id;
         Email = user.Email;
+        Username = user.Username;
         Role = user.IsAdmin ? UserRole.admin : UserRole.user;
         Name = user.Name;
         UpdatedDate = user.UpdatedDate.ToUnixTimeSeconds();
@@ -109,6 +110,9 @@ public record LexAuthUser
 
     [JsonPropertyName(LexAuthConstants.EmailClaimType)]
     public string? Email { get; set; }
+
+    [JsonPropertyName(LexAuthConstants.UsernameClaimType)]
+    public string? Username { get; set; }
 
     [JsonPropertyName(LexAuthConstants.NameClaimType)]
     public required string Name { get; set; }

--- a/frontend/schema.graphql
+++ b/frontend/schema.graphql
@@ -133,6 +133,7 @@ type LexAuthUser {
   updatedDate: Long!
   audience: LexboxAudience!
   email: String
+  username: String
   name: String!
   role: UserRole!
   isAdmin: Boolean!

--- a/frontend/schema.graphql
+++ b/frontend/schema.graphql
@@ -148,7 +148,7 @@ type LexAuthUser {
 type MeDto {
   id: UUID!
   name: String!
-  email: String!
+  email: String
   locale: String!
 }
 
@@ -348,14 +348,14 @@ input ChangeProjectNameInput {
 input ChangeUserAccountByAdminInput {
   role: UserRole!
   userId: UUID!
-  email: String!
+  email: String
   name: String!
 }
 
 input ChangeUserAccountBySelfInput {
   locale: String!
   userId: UUID!
-  email: String!
+  email: String
   name: String!
 }
 

--- a/frontend/src/lib/components/modals/FormModal.svelte
+++ b/frontend/src/lib/components/modals/FormModal.svelte
@@ -62,7 +62,7 @@
     modal.close();
   }
 
-  export function form(): Readable<Readonly<FormType>> {
+  export function form(): Readable<FormType> {
     return superForm.form;
   }
 

--- a/frontend/src/lib/email/EmailVerificationStatus.svelte
+++ b/frontend/src/lib/email/EmailVerificationStatus.svelte
@@ -66,7 +66,7 @@
       </div>
       <span class="i-mdi-email-heart-outline" />
     </div>
-  {:else}
+  {:else if user.email}
     <div class="alert alert-warning" transition:slide|local>
       <span>{$t('account_settings.verify_email.please_verify')}</span>
       <Button loading={sendingVerificationEmail} on:click={sendVerificationEmail}>

--- a/frontend/src/lib/forms/Input.svelte
+++ b/frontend/src/lib/forms/Input.svelte
@@ -7,7 +7,7 @@
   export let id = randomFormId();
   export let label: string;
   export let description: string | undefined = undefined;
-  export let value: string | undefined = undefined;
+  export let value: string | undefined | null = undefined;
   export let type: 'text' | 'email' | 'password' = 'text';
   export let autofocus: true | undefined = undefined;
   export let readonly = false;

--- a/frontend/src/lib/forms/PlainInput.svelte
+++ b/frontend/src/lib/forms/PlainInput.svelte
@@ -10,7 +10,7 @@
   let input: HTMLInputElement;
 
   export let id = randomFormId();
-  export let value: string | undefined = undefined;
+  export let value: string | undefined | null = undefined;
   export let type: 'text' | 'email' | 'password' = 'text';
   export let autofocus: true | undefined = undefined;
   export let readonly = false;
@@ -21,7 +21,7 @@
   export let autocomplete: 'new-password' | 'current-password' | undefined = undefined;
   export let debounce: number | boolean = false;
   export let debouncing = false;
-  export let undebouncedValue: string | undefined = undefined;
+  export let undebouncedValue: string | undefined | null = undefined;
   export let style: string | undefined = undefined;
 
   $: undebouncedValue = value;

--- a/frontend/src/lib/layout/AppMenu.svelte
+++ b/frontend/src/lib/layout/AppMenu.svelte
@@ -15,7 +15,7 @@
 <ul class="menu bg-base-100 min-w-[33%] flex-nowrap overflow-y-auto">
   <header class="prose flex flex-col items-end p-4 mb-4 max-w-full">
     <h2 class="mb-0">{user.name}</h2>
-    <span class="font-light">{user.email}</span>
+    <span class="font-light">{user.email ?? ''}</span>
   </header>
 
   <li>

--- a/frontend/src/lib/layout/AppMenu.svelte
+++ b/frontend/src/lib/layout/AppMenu.svelte
@@ -15,7 +15,7 @@
 <ul class="menu bg-base-100 min-w-[33%] flex-nowrap overflow-y-auto">
   <header class="prose flex flex-col items-end p-4 mb-4 max-w-full">
     <h2 class="mb-0">{user.name}</h2>
-    <span class="font-light">{user.email ?? ''}</span>
+    <span class="font-light">{user.email ?? user.username}</span>
   </header>
 
   <li>

--- a/frontend/src/lib/user.ts
+++ b/frontend/src/lib/user.ts
@@ -24,6 +24,7 @@ type JwtTokenUser = {
   sub: string
   name: string
   email?: string
+  user?: string
   role: 'admin' | 'user'
   proj?: string,
   lock: boolean | undefined,
@@ -37,6 +38,7 @@ export type LexAuthUser = {
   id: string
   name: string
   email?: string
+  username?: string
   role: 'admin' | 'user'
   projects: UserProjects[]
   locked: boolean
@@ -127,12 +129,13 @@ export function getUser(cookies: Cookies): LexAuthUser | null {
 }
 
 function jwtToUser(user: JwtTokenUser): LexAuthUser {
-  const { sub: id, name, email, proj: projectsString, role } = user;
+  const { sub: id, name, email, user: username, proj: projectsString, role } = user;
 
   return {
     id,
     name,
     email,
+    username,
     role,
     projects: projectsStringToProjects(projectsString),
     locked: user.lock === true,

--- a/frontend/src/lib/user.ts
+++ b/frontend/src/lib/user.ts
@@ -23,7 +23,7 @@ type RegisterResponseErrors = {
 type JwtTokenUser = {
   sub: string
   name: string
-  email: string
+  email?: string
   role: 'admin' | 'user'
   proj?: string,
   lock: boolean | undefined,
@@ -36,7 +36,7 @@ type JwtTokenUser = {
 export type LexAuthUser = {
   id: string
   name: string
-  email: string
+  email?: string
   role: 'admin' | 'user'
   projects: UserProjects[]
   locked: boolean

--- a/frontend/src/routes/(authenticated)/+page.svelte
+++ b/frontend/src/routes/(authenticated)/+page.svelte
@@ -84,10 +84,10 @@
     {/if}
   </svelte:fragment>
 
-  {#if !data.user.emailVerified || !$projects.length}
+  {#if !$projects.length}
     <div class="text-lg text-secondary flex gap-4 items-center justify-center">
       <span class="i-mdi-creation-outline text-xl shrink-0" />
-      {#if !data.user.emailVerified}
+      {#if !data.user.emailVerified && !data.user.createdByAdmin}
         {$t('user_dashboard.not_verified')}
       {:else}
         {$t('user_dashboard.no_projects')}

--- a/frontend/src/routes/(authenticated)/admin/+page.svelte
+++ b/frontend/src/routes/(authenticated)/admin/+page.svelte
@@ -79,7 +79,7 @@
       if (formState.name.tainted || formState.password.tainted || formState.role.tainted) {
         notifySuccess($t('admin_dashboard.notifications.user_updated', { name: formState.name.currentValue }));
       }
-      if (formState.email.changed) {
+      if (formState.email.changed && formState.email.currentValue) {
         notifySuccess(
           $t('admin_dashboard.notifications.email_need_verification', {
             name: user.name,

--- a/frontend/src/routes/(authenticated)/admin/EditUserAccount.svelte
+++ b/frontend/src/routes/(authenticated)/admin/EditUserAccount.svelte
@@ -16,7 +16,7 @@
   export let deleteUser: (user: User) => void;
 
   const schema = z.object({
-    email: z.string().email($t('form.invalid_email')),
+    email: z.string().email($t('form.invalid_email')).nullable().default(null),
     name: z.string(),
     password: passwordFormRules($t).or(emptyString()).default(''),
     role: z.enum([UserRole.User, UserRole.Admin]),
@@ -34,7 +34,7 @@
     _user = user;
     userIsLocked = user.locked;
     const role = user.isAdmin ? UserRole.Admin : UserRole.User;
-    return await formModal.open({ name: user.name, email: user.email ?? undefined, role }, async () => {
+    return await formModal.open({ name: user.name, email: user.email ?? null, role }, async () => {
       const { error, data } = await _changeUserAccountByAdmin({
         userId: user.id,
         email: $form.email,

--- a/frontend/src/routes/(authenticated)/admin/EditUserAccount.svelte
+++ b/frontend/src/routes/(authenticated)/admin/EditUserAccount.svelte
@@ -16,7 +16,7 @@
   export let deleteUser: (user: User) => void;
 
   const schema = z.object({
-    email: z.string().email($t('form.invalid_email')).nullable().default(null),
+    email: z.string().email($t('form.invalid_email')).nullish(),
     name: z.string(),
     password: passwordFormRules($t).or(emptyString()).default(''),
     role: z.enum([UserRole.User, UserRole.Admin]),

--- a/frontend/src/routes/(authenticated)/admin/EditUserAccount.svelte
+++ b/frontend/src/routes/(authenticated)/admin/EditUserAccount.svelte
@@ -29,6 +29,10 @@
     formModal.close();
   }
 
+  // This is a bit of a hack to make sure that the email field is not required if the user has no email
+  // even if the user edited the email field
+  $: if(form && $form && !$form.email && _user && !_user.email) $form.email = null;
+
   let _user: User;
   export async function openModal(user: User): Promise<FormModalResult<Schema>> {
     _user = user;

--- a/frontend/src/routes/(authenticated)/project/[project_code]/+page.svelte
+++ b/frontend/src/routes/(authenticated)/project/[project_code]/+page.svelte
@@ -257,7 +257,7 @@
                   <Markdown
                     md={$t('project_page.get_project.instructions_wesay', {
                     code: project.code,
-                    login: encodeURIComponent(user.email),
+                    login: encodeURIComponent(user.email ?? user.username ?? ''),
                     name: project.name,
                   })}
                   />

--- a/frontend/src/routes/(authenticated)/user/+page.svelte
+++ b/frontend/src/routes/(authenticated)/user/+page.svelte
@@ -35,7 +35,7 @@
   }
 
   const formSchema = z.object({
-    email: z.string().email($t('form.invalid_email')).nullable().default(null),
+    email: z.string().email($t('form.invalid_email')).nullish(),
     name: z.string(),
     locale: z.string().min(2),
   });
@@ -55,7 +55,7 @@
       return error.message;
     }
 
-    if ($formState.email.changed) {
+    if ($formState.email.changed && $form.email) {
       requestedEmail.set($form.email);
     }
 

--- a/frontend/src/routes/(authenticated)/user/+page.svelte
+++ b/frontend/src/routes/(authenticated)/user/+page.svelte
@@ -16,7 +16,7 @@
   import { delay } from '$lib/util/time';
 
   export let data: PageData;
-  $: user = data?.account;
+  $: user = data.account;
   let deleteModal: DeleteUserModal;
 
   const emailResult = useEmailResult();
@@ -63,6 +63,11 @@
       notifySuccess($t('account_settings.update_success'));
     }
   });
+
+  // This is a bit of a hack to make sure that the email field is not required if the user has no email
+  // even if the user edited the email field
+  $: if(!$form.email && $user && !$user.email) $form.email = null;
+
   onMount(() => {
     form.set(
       {

--- a/frontend/src/routes/(authenticated)/user/+page.svelte
+++ b/frontend/src/routes/(authenticated)/user/+page.svelte
@@ -35,7 +35,7 @@
   }
 
   const formSchema = z.object({
-    email: z.string().email($t('form.invalid_email')),
+    email: z.string().email($t('form.invalid_email')).nullable().default(null),
     name: z.string(),
     locale: z.string().min(2),
   });
@@ -66,7 +66,7 @@
   onMount(() => {
     form.set(
       {
-        email: $user.email,
+        email: $user.email ?? null,
         name: $user.name,
         locale: $user.locale,
       },


### PR DESCRIPTION
Fixes #657

FYI the form validation change (`.nullable()`) doesn't allow a user to delete an existing email address.
But even if they could the server would ignore it, because it ignores empty values.