### PR TITLE
Disable Browse button during upload

### DIFF
--- a/frontend/src/lib/components/TusUpload.svelte
+++ b/frontend/src/lib/components/TusUpload.svelte
@@ -145,6 +145,7 @@
           type="file"
           {accept}
           class="file-input file-input-bordered file-input-primary grow"
+          disabled={percent > 0 && !uploadError}
           bind:this={fileInput}
           on:cancel|stopPropagation
           on:change={fileChanged}

--- a/frontend/src/lib/components/TusUpload.svelte
+++ b/frontend/src/lib/components/TusUpload.svelte
@@ -145,7 +145,7 @@
           type="file"
           {accept}
           class="file-input file-input-bordered file-input-primary grow"
-          disabled={percent > 0 && !uploadError}
+          disabled={status === UploadStatus.Uploading || status === UploadStatus.Complete}
           bind:this={fileInput}
           on:cancel|stopPropagation
           on:change={fileChanged}


### PR DESCRIPTION
Fix #618.

Before uploading, button is enabled:

![image](https://github.com/sillsdev/languageforge-lexbox/assets/90762/f5cb08f2-1f3b-47de-9bee-6c8b9d29cded)

While uploading, button is disabled:

![image](https://github.com/sillsdev/languageforge-lexbox/assets/90762/509677e1-a285-475a-8c1d-33a06536c06e)

If uploaded zip file was invalid, button gets re-enabled:

![image](https://github.com/sillsdev/languageforge-lexbox/assets/90762/f1ece27f-1dfa-4004-9cab-2c8a214736c5)

