### PR TITLE
Reduce resumable memory by 200Mb

### DIFF
--- a/deployment/production/hg-deployment.yaml
+++ b/deployment/production/hg-deployment.yaml
@@ -16,6 +16,6 @@ spec:
         - name: hgresumable
           resources:
             requests:
-              memory: 1000Mi
+              memory: 800Mi
             limits:
-              memory: 1000Mi
+              memory: 800Mi


### PR DESCRIPTION
I don't know if this is what we actually want to do, but it's what [I did](https://github.com/sillsdev/languagedepot-deploy/commit/d33655a11d6397bde13443268a18cbdb86294e7e) in order to get the new hgweb image deployed in aws.

@hahn-kev I think you were planning on talking to TechOps about how much memory we can/should use, right?