### PR TITLE
Don't let user accidentally close edited form

### DIFF
--- a/frontend/src/lib/components/modals/FormModal.svelte
+++ b/frontend/src/lib/components/modals/FormModal.svelte
@@ -27,7 +27,7 @@
   export let schema: Schema;
 
   const superForm = lexSuperForm(schema, () => modal.submitModal());
-  const { form: _form, errors, reset, message, enhance, formState } = superForm;
+  const { form: _form, errors, reset, message, enhance, formState, tainted } = superForm;
   let modal: Modal;
   let done = false;
 
@@ -84,7 +84,7 @@
   }
 </script>
 
-<Modal bind:this={modal} on:close={() => reset()} bottom>
+<Modal bind:this={modal} on:close={() => reset()} bottom closeOnClickOutside={!$tainted}>
   <Form id="modalForm" {enhance}>
     <p class="mb-4"><slot name="title" /></p>
     <slot errors={$errors} />


### PR DESCRIPTION
This is to try to prevent users from accidentally losing work.
It currently also happens to prevent the Bulk add modal from being closed on the results page.