### PR TITLE
Add bulk-delete users feature to admin dashboard

### DIFF
--- a/frontend/src/lib/i18n/locales/en.json
+++ b/frontend/src/lib/i18n/locales/en.json
@@ -13,6 +13,7 @@
     "column_edit": "Edit",
     "project_table_title": "Projects",
     "user_table_title": "Users",
+    "selected_label": "{count} selected",
     "is_draft": "Draft",
     "email_not_verified": "Not Verified",
     "notifications": {

--- a/frontend/src/lib/i18n/locales/en.json
+++ b/frontend/src/lib/i18n/locales/en.json
@@ -14,6 +14,7 @@
     "project_table_title": "Projects",
     "user_table_title": "Users",
     "selected_label": "{count} selected",
+    "bulk_delete_users": "Delete {count} {count, plural, one {user} other {users}}",
     "is_draft": "Draft",
     "email_not_verified": "Not Verified",
     "notifications": {

--- a/frontend/src/routes/(authenticated)/admin/+page.svelte
+++ b/frontend/src/routes/(authenticated)/admin/+page.svelte
@@ -57,6 +57,16 @@
   $: filteredUserCount = $userData?.totalCount ?? 0;
   $: shownUsers = lastLoadUsedActiveFilter ? users : users.slice(0, 10);
 
+  let selectedUsers: User[] = [];
+
+  function toggleSelectAllUsers(e): void {
+    if (e.target.checked) {
+      selectedUsers = [...shownUsers];
+    } else {
+      selectedUsers = [];
+    }
+  }
+
   function filterProjectsByUser(user: User): void {
     $queryParamValues.userEmail = user.email ?? undefined;
   }
@@ -130,7 +140,7 @@
         <table class="table table-lg">
           <thead>
             <tr class="bg-base-200">
-              <th class="max-w-4"><input type="checkbox"/></th>
+              <th class="max-w-4"><input type="checkbox" on:change={toggleSelectAllUsers}/></th>
               <th>
                 {$t('admin_dashboard.column_name')}<span class="i-mdi-sort-ascending text-xl align-[-5px] ml-2" />
               </th>
@@ -142,7 +152,7 @@
           <tbody>
             {#each shownUsers as user}
               <tr>
-                <td class="max-w-4"><input type="checkbox"/></td>
+                <td class="max-w-4"><input type="checkbox" bind:group={selectedUsers} value={user}/></td>
                 <td>
                   <div class="flex items-center gap-2">
                     <Button variant="btn-ghost" size="btn-sm" on:click={() => userModal.open(user)}>

--- a/frontend/src/routes/(authenticated)/admin/+page.svelte
+++ b/frontend/src/routes/(authenticated)/admin/+page.svelte
@@ -130,6 +130,7 @@
         <table class="table table-lg">
           <thead>
             <tr class="bg-base-200">
+              <th class="max-w-4"><input type="checkbox"/></th>
               <th>
                 {$t('admin_dashboard.column_name')}<span class="i-mdi-sort-ascending text-xl align-[-5px] ml-2" />
               </th>
@@ -141,6 +142,7 @@
           <tbody>
             {#each shownUsers as user}
               <tr>
+                <td class="max-w-4"><input type="checkbox"/></td>
                 <td>
                   <div class="flex items-center gap-2">
                     <Button variant="btn-ghost" size="btn-sm" on:click={() => userModal.open(user)}>

--- a/frontend/src/routes/(authenticated)/admin/+page.svelte
+++ b/frontend/src/routes/(authenticated)/admin/+page.svelte
@@ -67,6 +67,10 @@
     }
   }
 
+  function deleteSelectedUsers(): void {
+    console.log(`Would delete the following ${selectedUsers.length} users`, selectedUsers);
+  }
+
   function filterProjectsByUser(user: User): void {
     $queryParamValues.userEmail = user.email ?? undefined;
   }
@@ -128,6 +132,12 @@
             {$t('admin_dashboard.selected_label', {count: selectedUsers.length})}
           </span>
         </Badge>
+        <button on:click={deleteSelectedUsers} class="btn btn-sm btn-success max-xs:btn-square">
+          <span class="admin-tabs:hidden">
+            {$t('admin_dashboard.bulk_delete_users', {count: selectedUsers.length})}
+          </span>
+          <span class="i-mdi-trash text-2xl" />
+        </button>
         {/if}
       </AdminTabs>
       <div class="mt-4">

--- a/frontend/src/routes/(authenticated)/admin/+page.svelte
+++ b/frontend/src/routes/(authenticated)/admin/+page.svelte
@@ -122,6 +122,13 @@
             {$number(filteredUserCount)}
           </span>
         </Badge>
+        {#if (selectedUsers?.length)}
+        <Badge>
+          <span class="inline-flex gap-2">
+            {$t('admin_dashboard.selected_label', {count: selectedUsers.length})}
+          </span>
+        </Badge>
+        {/if}
       </AdminTabs>
       <div class="mt-4">
         <FilterBar

--- a/frontend/src/routes/(authenticated)/admin/+page.svelte
+++ b/frontend/src/routes/(authenticated)/admin/+page.svelte
@@ -118,27 +118,33 @@
 
     <div class:admin-tabs:hidden={tab !== 'users'}>
       <AdminTabs activeTab="users" on:clickTab={(event) => $queryParamValues.tab = event.detail}>
-        {$t('admin_dashboard.user_table_title')}
-        <Badge>
-          <span class="inline-flex gap-2">
-            {$number(shownUsers.length)}
-            <span>/</span>
-            {$number(filteredUserCount)}
-          </span>
-        </Badge>
+        <div class="flex gap-4 justify-between grow">
+          <div class="flex gap-4 items-center">
+            {$t('admin_dashboard.user_table_title')}
+            <Badge>
+              <span class="inline-flex gap-2">
+                {$number(shownUsers.length)}
+                <span>/</span>
+                {$number(filteredUserCount)}
+              </span>
+            </Badge>
+          </div>
         {#if (selectedUsers?.length)}
-        <Badge>
-          <span class="inline-flex gap-2">
-            {$t('admin_dashboard.selected_label', {count: selectedUsers.length})}
-          </span>
-        </Badge>
-        <button on:click={deleteSelectedUsers} class="btn btn-sm btn-success max-xs:btn-square">
-          <span class="admin-tabs:hidden">
-            {$t('admin_dashboard.bulk_delete_users', {count: selectedUsers.length})}
-          </span>
-          <span class="i-mdi-trash text-2xl" />
-        </button>
+        <div class="flex gap-4 items-center">
+          <Badge>
+            <span class="inline-flex gap-2">
+              {$t('admin_dashboard.selected_label', {count: selectedUsers.length})}
+            </span>
+          </Badge>
+          <button on:click={deleteSelectedUsers} class="btn btn-sm btn-success max-xs:btn-square">
+            <span class="admin-tabs:hidden">
+              {$t('admin_dashboard.bulk_delete_users', {count: selectedUsers.length})}
+            </span>
+            <span class="i-mdi-trash text-2xl" />
+          </button>
+        </div>
         {/if}
+      </div>
       </AdminTabs>
       <div class="mt-4">
         <FilterBar


### PR DESCRIPTION
Fixes #641.

Have implemented UI, currently non-functional (clicking the Delete button just logs to the JS console which users would have been deleted).

Current UI:

![image](https://github.com/sillsdev/languageforge-lexbox/assets/90762/8b522490-3e43-47b4-9369-b87598413e6b)

UI on small screens:

![image](https://github.com/sillsdev/languageforge-lexbox/assets/90762/e8180b9a-b9f2-4488-8270-ae236cff52d2)

The checkbox in the header is a "Select All" checkbox. I don't think it needs to be labeled as such, because I suspect its behavior is intuitive.

Confirmation popup:

![image](https://github.com/sillsdev/languageforge-lexbox/assets/90762/c3312c97-8f7a-4fb0-9e1c-fd2a72f569ad)

Of course once the backend is implemented, the "Not deleting, simulation only" message will go away.

## Not yet implemented

- Backend API for actually deleting the users
- Backend API needs to confirm that each user is, in fact, deletable (not last user/manager on a project, that sort of thing)

## Design decisions to be made

- If any users can't be deleted because they are the last user/manager on a project, do we delete the rest? (Answer: probably yes)
- If any users can't be deleted, do we return a notification to the admin UI listing which users couldn't be deleted? (Answer: probably yes)