### PR TITLE
Bug/638 uncaught typeerror cannot redefine property googletag

### DIFF
--- a/frontend/src/lib/error/UnexpectedError.svelte
+++ b/frontend/src/lib/error/UnexpectedError.svelte
@@ -54,6 +54,8 @@
       return 'prod';
     } else if (_env.includes('stag')) {
       return 'staging';
+    } else if (_env.includes('develop')) {
+      return 'develop';
     } else {
       return 'test';
     }

--- a/frontend/src/lib/error/index.ts
+++ b/frontend/src/lib/error/index.ts
@@ -56,7 +56,8 @@ function setupGlobalErrorHandlers(error: Writable<App.Error | null>): void {
       {
         ['app.error.source']: handler,
         ['app.error.show_user']: showToUser,
-      }
+      },
+      !showToUser,
     );
 
     if (!showToUser) return;
@@ -94,7 +95,8 @@ function setupGlobalErrorHandlers(error: Writable<App.Error | null>): void {
         ['app.error.source']: handler,
         ['app.error.keys']: keysForMissingMessageError,
         ['app.error.show_user']: showToUser,
-      }
+      },
+      !showToUser,
     );
 
     if (!showToUser) return;

--- a/frontend/src/lib/error/index.ts
+++ b/frontend/src/lib/error/index.ts
@@ -106,6 +106,13 @@ function setupGlobalErrorHandlers(error: Writable<App.Error | null>): void {
   function errorIsFromExtension(error: Error): boolean {
     return !!error.stack &&
       // tested on Chrome, Edge, Firefox and Brave
-      (error.stack.includes('chrome-extension://') || error.stack.includes('moz-extension://'));
+      (error.stack.includes('chrome-extension://') || error.stack.includes('moz-extension://')
+      || originatesFromAnonymousScript(error.stack));
+  }
+
+  function originatesFromAnonymousScript(stack: string): boolean {
+    // VM/anonymous code errors are almost certainly not from our code
+    const lastLine = stack.split('\n').pop() ?? '';
+    return lastLine.includes('at <anonymous>');
   }
 }


### PR DESCRIPTION
Resolves #638

Other than filtering out the specific error message (which I would find somewhat dissatisfying, because another error message could become problematic any time), I think filtering out errors from anonymous code is pretty much the only way to not show them to users.

So far [this is the only error](https://ui.honeycomb.io/sil-language-forge/environments/prod?query=%7B%22time_range%22%3A5184000%2C%22granularity%22%3A0%2C%22breakdowns%22%3A%5B%22exception.stacktrace%22%5D%2C%22calculations%22%3A%5B%7B%22op%22%3A%22COUNT%22%7D%5D%2C%22filters%22%3A%5B%7B%22column%22%3A%22exception.stacktrace%22%2C%22op%22%3A%22contains%22%2C%22value%22%3A%22at%20%3Canonymous%3E%22%7D%5D%2C%22filter_combination%22%3A%22AND%22%2C%22orders%22%3A%5B%7B%22op%22%3A%22COUNT%22%2C%22order%22%3A%22descending%22%7D%5D%2C%22havings%22%3A%5B%5D%2C%22limit%22%3A100%7D) we've had that originated from anonymous code:
![image](https://github.com/sillsdev/languageforge-lexbox/assets/12587509/6d9824bb-9eaf-4c64-a40b-47cea6710e03)

I think that showing users every browser error is somewhat of an extreme practice. I like it, because it makes us aim for an error-less experience. But because we're somewhat extreme, I think relaxing in this one small way is ok and worth it.

I've also changed our error-tracing to ensure that we always trace app.error.show_user = false so that we can keep track of errors that we don't show to the user.