### PR TITLE
set the application group to prevent crash

### DIFF
--- a/hgweb/hg.conf
+++ b/hgweb/hg.conf
@@ -13,6 +13,7 @@ ServerName localhost
     eviction-timeout=0 restart-interval=0 shutdown-timeout=5 maximum-requests=0
 
     WSGIProcessGroup hgweb
+    WSGIApplicationGroup %{GLOBAL}
 
     WSGIScriptAlias /hg /usr/local/www/wsgi-scripts/hgweb.wsgi
     <Directory /usr/local/www/wsgi-scripts>


### PR DESCRIPTION
in staging I was running into this error on the hgweb container when trying to do S&R. Adding the application group back fixed it
```
[Mon Apr 08 23:20:40.482380 2024] [otel_apache:error] [pid 12:tid 139661531936448] mod_opentelemetry_webserver_sdk: initialize_opentelemetry: config retrieved from process memory pool
[Mon Apr 08 23:20:40.482418 2024] [otel_apache:error] [pid 12:tid 139661531936448] mod_opentelemetry_webserver_sdk: otel_hook_header_parser_begin: lexbox:hgweb:v2024-04-08-d468b58b
[Mon Apr 08 23:20:40.482567 2024] [otel_apache:error] [pid 12:tid 139661531936448] mod_opentelemetry_webserver_sdk: otel_hook_header_parser_begin: request begin successful
[Mon Apr 08 23:20:40.482602 2024] [otel_apache:error] [pid 12:tid 139661531936448] mod_opentelemetry_webserver_sdk: otel_stopInteraction: result code: 25
[Mon Apr 08 23:20:40.482639 2024] [otel_apache:error] [pid 12:tid 139661531936448] mod_opentelemetry_webserver_sdk: otel_payload_decorator: correlation information : "tracestate" : ""
[Mon Apr 08 23:20:40.482648 2024] [otel_apache:error] [pid 12:tid 139661531936448] mod_opentelemetry_webserver_sdk: otel_payload_decorator: correlation information : "traceparent" : "00-a4fb96051ad24772709bd608433a1d13-d40230a0998c2488-01"
[Mon Apr 08 23:20:40.482650 2024] [otel_apache:error] [pid 12:tid 139661531936448] mod_opentelemetry_webserver_sdk: mod_cgid.c: interaction begin successful
[Mon Apr 08 23:20:40.482682 2024] [otel_apache:error] [pid 12:tid 139661531936448] mod_opentelemetry_webserver_sdk: otel_payload_decorator: correlation information : "tracestate" : ""
[Mon Apr 08 23:20:40.482690 2024] [otel_apache:error] [pid 12:tid 139661531936448] mod_opentelemetry_webserver_sdk: otel_payload_decorator: correlation information : "traceparent" : "00-a4fb96051ad24772709bd608433a1d13-dd61dfeaaa60041c-01"
[Mon Apr 08 23:20:40.482692 2024] [otel_apache:error] [pid 12:tid 139661531936448] mod_opentelemetry_webserver_sdk: mod_wsgi.c: interaction begin successful
[Mon Apr 08 23:20:40.487913 2024] [wsgi:info] [pid 9:tid 139661641295552] mod_wsgi (pid=9): Create interpreter 'localhost:5158|/hg'.
[Mon Apr 08 23:20:40.492481 2024] [wsgi:info] [pid 9:tid 139661641295552] [remote 10.42.3.188:33740] mod_wsgi (pid=9, process='hgweb', application='localhost:5158|/hg'): Loading Python script file '/usr/local/www/wsgi-scripts/hgweb.wsgi'.
[Mon Apr 08 23:20:40.548979 2024] [wsgi:error] [pid 9:tid 139661641295552] [remote 10.42.3.188:33740] mod_wsgi (pid=9): Failed to exec Python script file '/usr/local/www/wsgi-scripts/hgweb.wsgi'.
[Mon Apr 08 23:20:40.549005 2024] [wsgi:error] [pid 9:tid 139661641295552] [remote 10.42.3.188:33740] mod_wsgi (pid=9): Exception occurred processing WSGI script '/usr/local/www/wsgi-scripts/hgweb.wsgi'.
[Mon Apr 08 23:20:40.550110 2024] [wsgi:error] [pid 9:tid 139661641295552] [remote 10.42.3.188:33740] Traceback (most recent call last):
[Mon Apr 08 23:20:40.550410 2024] [wsgi:error] [pid 9:tid 139661641295552] [remote 10.42.3.188:33740] File "/usr/local/www/wsgi-scripts/hgweb.wsgi", line 28, in <module>
[Mon Apr 08 23:20:40.550423 2024] [wsgi:error] [pid 9:tid 139661641295552] [remote 10.42.3.188:33740] from opentelemetry.exporter.otlp.proto.grpc.trace_exporter import OTLPSpanExporter
[Mon Apr 08 23:20:40.550430 2024] [wsgi:error] [pid 9:tid 139661641295552] [remote 10.42.3.188:33740] File "/usr/lib/python3/dist-packages/opentelemetry/exporter/otlp/proto/grpc/trace_exporter/__init__.py", line 22, in <module>
[Mon Apr 08 23:20:40.550431 2024] [wsgi:error] [pid 9:tid 139661641295552] [remote 10.42.3.188:33740] from grpc import ChannelCredentials, Compression
[Mon Apr 08 23:20:40.550436 2024] [wsgi:error] [pid 9:tid 139661641295552] [remote 10.42.3.188:33740] File "/usr/lib/python3/dist-packages/grpc/__init__.py", line 22, in <module>
[Mon Apr 08 23:20:40.550438 2024] [wsgi:error] [pid 9:tid 139661641295552] [remote 10.42.3.188:33740] from grpc import _compression
[Mon Apr 08 23:20:40.550445 2024] [wsgi:error] [pid 9:tid 139661641295552] [remote 10.42.3.188:33740] File "/usr/lib/python3/dist-packages/grpc/_compression.py", line 20, in <module>
[Mon Apr 08 23:20:40.550454 2024] [wsgi:error] [pid 9:tid 139661641295552] [remote 10.42.3.188:33740] from grpc._cython import cygrpc
[Mon Apr 08 23:20:40.550467 2024] [wsgi:error] [pid 9:tid 139661641295552] [remote 10.42.3.188:33740] ImportError: Interpreter change detected - this module can only be loaded into one interpreter per process.
10.42.3.188 - - [08/Apr/2024:23:20:40 +0000] "GET /hg/e/elawa-dev-flex?cmd=capabilities HTTP/1.1" 500 528
[Mon Apr 08 23:20:40.550796 2024] [otel_apache:error] [pid 12:tid 139661531936448] mod_opentelemetry_webserver_sdk: otel_hook_log_transaction_end: request end successful (HTTP status=500)
```

from the stack it looks like the error is due to the otel tracing we added into wsgi, this would be why it wasn't an issue before