### PR TITLE
Fix S/R tests with Mercurial 6

### DIFF
--- a/.github/workflows/integration-test.yaml
+++ b/.github/workflows/integration-test.yaml
@@ -139,6 +139,10 @@ jobs:
         env:
           ZIP_PASSWORD: ${{ secrets.TEST_USER_PASSWORD }}
         run: 7z a ./playwright-traces.7z -mx=0 -mmt=off ./frontend/test-results -p"$ZIP_PASSWORD"
+      - name: Set up python3-venv
+        # Needed by publish-unit-test-result-action on ubuntu-22.04
+        run: sudo apt install python3-venv
+        if: ${{ always() && !env.act }}
       - name: Publish unit test results
         uses: EnricoMi/publish-unit-test-result-action/composite@v2
         if: ${{ always() && !env.act }}

--- a/.github/workflows/integration-test.yaml
+++ b/.github/workflows/integration-test.yaml
@@ -57,7 +57,7 @@ jobs:
         if: ${{ inputs.runs-on == 'self-hosted' }}
         run: |
           sudo apt-get update
-          sudo apt-get install -y p7zip-full wget zlib1g-dev libssl-dev #needed by setup python
+          sudo apt-get install -y p7zip-full iputils-ping wget zlib1g-dev libssl-dev #needed by setup python
           wget -q https://github.com/PowerShell/PowerShell/releases/download/v7.4.1/powershell_7.4.1-1.deb_amd64.deb
           sudo dpkg -i powershell_7.4.1-1.deb_amd64.deb
           sudo apt-get install -f

--- a/.github/workflows/integration-test.yaml
+++ b/.github/workflows/integration-test.yaml
@@ -57,7 +57,7 @@ jobs:
         if: ${{ inputs.runs-on == 'self-hosted' }}
         run: |
           sudo apt-get update
-          sudo apt-get install -y p7zip-full iputils-ping wget zlib1g-dev libssl-dev #needed by setup python
+          sudo apt-get install -y p7zip-full iputils-ping python3-venv wget zlib1g-dev libssl-dev #needed by setup python
           wget -q https://github.com/PowerShell/PowerShell/releases/download/v7.4.1/powershell_7.4.1-1.deb_amd64.deb
           sudo dpkg -i powershell_7.4.1-1.deb_amd64.deb
           sudo apt-get install -f
@@ -139,10 +139,6 @@ jobs:
         env:
           ZIP_PASSWORD: ${{ secrets.TEST_USER_PASSWORD }}
         run: 7z a ./playwright-traces.7z -mx=0 -mmt=off ./frontend/test-results -p"$ZIP_PASSWORD"
-      - name: Set up python3-venv
-        # Needed by publish-unit-test-result-action on ubuntu-22.04
-        run: sudo apt install -y python3-venv
-        if: ${{ always() && !env.act && inputs.hg-version == '6' }}
       - name: Publish unit test results
         uses: EnricoMi/publish-unit-test-result-action/composite@v2
         if: ${{ always() && !env.act }}

--- a/.github/workflows/integration-test.yaml
+++ b/.github/workflows/integration-test.yaml
@@ -141,8 +141,8 @@ jobs:
         run: 7z a ./playwright-traces.7z -mx=0 -mmt=off ./frontend/test-results -p"$ZIP_PASSWORD"
       - name: Set up python3-venv
         # Needed by publish-unit-test-result-action on ubuntu-22.04
-        run: sudo apt install python3-venv
-        if: ${{ always() && !env.act }}
+        run: sudo apt install -y python3-venv
+        if: ${{ always() && !env.act && inputs.hg-version == '6' }}
       - name: Publish unit test results
         uses: EnricoMi/publish-unit-test-result-action/composite@v2
         if: ${{ always() && !env.act }}

--- a/backend/Testing/LexCore/Services/HgServiceTests.cs
+++ b/backend/Testing/LexCore/Services/HgServiceTests.cs
@@ -83,7 +83,7 @@ public class HgServiceTests
     [InlineData("-xy")]
     [InlineData("-x-y-z")]
     [InlineData("-123")]
-    private async void ProjectCodesMayNotStartWithHyphen(string code)
+    private async Task ProjectCodesMayNotStartWithHyphen(string code)
     {
         await Assert.ThrowsAsync<ArgumentException>(() => _hgService.InitRepo(code));
     }

--- a/backend/Testing/SyncReverseProxy/SendReceiveServiceTests.cs
+++ b/backend/Testing/SyncReverseProxy/SendReceiveServiceTests.cs
@@ -235,8 +235,8 @@ query projectLastCommit {
             UserName = auth.Username,
             Password = auth.Password
         };
-        HgRunner.Run($"hg clone {hgwebUrl}{origProjectCode} {sourceProjectDir}", "", 15, progress);
-        HgRunner.Run($"hg push {hgwebUrl}{newProjectCode}", sourceProjectDir, 15, progress);
+        HgRunner.Run($"hg clone {hgwebUrl}{origProjectCode} {sourceProjectDir}", "", 45, progress);
+        HgRunner.Run($"hg push {hgwebUrl}{newProjectCode}", sourceProjectDir, 45, progress);
 
         // Sleep 5 seconds to ensure hgweb picks up newly-pushed commits
         await Task.Delay(TimeSpan.FromSeconds(5));

--- a/backend/Testing/SyncReverseProxy/SendReceiveServiceTests.cs
+++ b/backend/Testing/SyncReverseProxy/SendReceiveServiceTests.cs
@@ -235,8 +235,8 @@ query projectLastCommit {
             UserName = auth.Username,
             Password = auth.Password
         };
-        HgRunner.Run($"hg clone {hgwebUrl}{origProjectCode} {sourceProjectDir}", "", 45, progress);
-        HgRunner.Run($"hg push {hgwebUrl}{newProjectCode}", sourceProjectDir, 45, progress);
+        HgRunner.Run($"hg clone {hgwebUrl}{origProjectCode} {sourceProjectDir}", "", 15, progress);
+        HgRunner.Run($"hg push {hgwebUrl}{newProjectCode}", sourceProjectDir, 15, progress);
 
         // Sleep 5 seconds to ensure hgweb picks up newly-pushed commits
         await Task.Delay(TimeSpan.FromSeconds(5));

--- a/backend/Testing/Testing.csproj
+++ b/backend/Testing/Testing.csproj
@@ -15,8 +15,8 @@
     <Choose>
         <When Condition=" '$(MercurialVersion)' == '6' ">
             <ItemGroup>
-                <PackageReference Include="SIL.Chorus.LibChorus" Version="6.0.0-beta0043" />
-                <PackageReference Include="SIL.Chorus.Mercurial" Version="6.5.1.22" />
+                <PackageReference Include="SIL.Chorus.LibChorus" Version="6.0.0-beta0044" />
+                <PackageReference Include="SIL.Chorus.Mercurial" Version="6.5.1.25" />
             </ItemGroup>
         </When>
         <Otherwise>


### PR DESCRIPTION
Linked to #710, but not yet a fix for it (maybe) — self-hosted runner still isn't passing the SendReceiveAfterProjectReset test, so I can't prove whether this is actualy a fix for issue #710 or not.

We update Chorus to the latest version, which has some bugfixes to the Linux Mercurial package. This makes the SendReceiveAfterProjectReset test pass on my machine. If it fails when run against develop or staging, then there might be something else going on as well.

