### PR TITLE
Instructions for empty projects

### DIFF
--- a/frontend/src/lib/i18n/locales/en.json
+++ b/frontend/src/lib/i18n/locales/en.json
@@ -271,7 +271,7 @@ the [Linguistics Institute at Payap University](https://li.payap.ac.th/) in Chia
       "log_header": "Message"
     },
     "get_project": {
-      "instructions_header": "To open the project with {type, select, FL_EX { FLEx } WE_SAY { WeSay } other { (e.g.) FLEx } } {mode, select, manual { manually} other { }}",
+      "instructions_header": "To {isEmpty, select, true { set up } other { get } } this project with {type, select, FL_EX { FLEx } WE_SAY { WeSay } other { (e.g.) FLEx } } {mode, select, manual { manually} other { }}",
       "instructions_flex": "1. In the \"Send/Receive\" menu click \"Get Project from colleague…\"\n\
 1. In the \"Receive project\" dialog box, click \"Internet\"\n\
 1. In the \"Get Project From Internet\" dialog box, enter your \"Login\" and \"Password\" for Language Depot and click \"Log in\"\n\
@@ -282,7 +282,7 @@ the [Linguistics Institute at Payap University](https://li.payap.ac.th/) in Chia
 1. Fill in the required information: name of project, name for the folder (e.g. \"{name}\"), etc. Then click \"Finish\".\n\
 1. After the new project opens, click on \"Send/Receive\" -> \"Send this Project for the first time\".\n\
 1. Click on \"OK (I have the master project)\".\n\
-1. Click on \"Settings...\" and enter your LanguageDepot login credentials.\n\
+1. Click on \"Settings...\" and enter your Language Depot login credentials.\n\
 1. Click Log in, then select the Project ID ({code}) from the drop-down menu.\n\
 1. Click on Internet. This will initiate the first Send/Receive.",
       "instructions_wesay": "1. Launch 'WeSay Configuration Tool'\n\
@@ -304,7 +304,7 @@ the [Linguistics Institute at Payap University](https://li.payap.ac.th/) in Chia
 1. In the \"Password\" field type your password\n\
 1. Click on \"OK\" to close the \"Settings...\" dialog\n\
 1. Click on \"Internet\". This will initiate the first Send/Receive.",
-      "label": "Get project",
+      "label": "{isEmpty, select, true { Set up } other { Get } } project",
       "send_receive_url": "Send/Receive URL",
     },
     "promote_project": {

--- a/frontend/src/lib/i18n/locales/en.json
+++ b/frontend/src/lib/i18n/locales/en.json
@@ -292,6 +292,16 @@ the [Linguistics Institute at Payap University](https://li.payap.ac.th/) in Chia
 1. In the 'Password' field type your password\n\
 1. Enter a \"Name for the folder on your computer\" (e.g. \"{name}\")\n\
 1. Click 'Download'",
+      "instructions_wesay_empty": "1. [Download WeSay](https://software.sil.org/wesay/download/) onto your computer.\n\
+1. Open WeSay and select \"Create a new blank project...\".\n\
+1. Fill in the required information: project language and name of project (e.g. \"{name}\"), etc. Then click \"Finish\".\n\
+1. Add some words if you want\n\
+1. Click \"Send/Receive\"\n\
+1. Click on \"Settings...\"\n\
+1. In the \"Project ID\" field type: \"{code}\"\n\
+1. In the \"Login\" field type: \"{login}\"\ Note: A bug in WeSay means you can't type the @ symbol for an email.  The workaround is to type %40 in place of @. \n\
+1. In the \"Password\" field type your password\n\
+1. Click on \"Internet\". This will initiate the first Send/Receive.",
       "label": "Get project",
       "send_receive_url": "Send/Receive URL",
     },

--- a/frontend/src/lib/i18n/locales/en.json
+++ b/frontend/src/lib/i18n/locales/en.json
@@ -277,6 +277,14 @@ the [Linguistics Institute at Payap University](https://li.payap.ac.th/) in Chia
 1. In the \"Get Project From Internet\" dialog box, enter your \"Login\" and \"Password\" for Language Depot and click \"Log in\"\n\
 1. In the \"Project ID\" field that appears, select \"{code}\"\n\
 1. Enter a \"Name for the folder on your computer\" (e.g. \"{name}\")",
+      "instructions_flex_empty": "1. [Download FLEx](https://software.sil.org/fieldworks/download/) onto your computer.\n\
+1. Open the FLEx application and select \"Create a new project...\".\n\
+1. Fill in the required information: name of project, name for the folder (e.g. \"{name}\"), etc. Then click \"Finish\".\n\
+1. After the new project opens, click on \"Send/Receive\" -> \"Send this Project for the first time\".\n\
+1. Click on \"OK (I have the master project)\".\n\
+1. Click on \"Settings...\" and enter your LanguageDepot login credentials.\n\
+1. Click Log in, then select the Project ID ({code}) from the drop-down menu.\n\
+1. Click on Internet. This will initiate the first Send/Receive.",
       "instructions_wesay": "1. Launch 'WeSay Configuration Tool'\n\
 1. Click 'Get from Internet'\n\
 1. In the 'Project ID' field type: \"{code}\"\n\

--- a/frontend/src/lib/i18n/locales/en.json
+++ b/frontend/src/lib/i18n/locales/en.json
@@ -298,9 +298,11 @@ the [Linguistics Institute at Payap University](https://li.payap.ac.th/) in Chia
 1. Add some words if you want\n\
 1. Click \"Send/Receive\"\n\
 1. Click on \"Settings...\"\n\
+1. In the \"Name to show in change history\" field make sure your name is spelled correctly\n\
 1. In the \"Project ID\" field type: \"{code}\"\n\
 1. In the \"Login\" field type: \"{login}\"\ Note: A bug in WeSay means you can't type the @ symbol for an email.  The workaround is to type %40 in place of @. \n\
 1. In the \"Password\" field type your password\n\
+1. Click on \"OK\" to close the \"Settings...\" dialog\n\
 1. Click on \"Internet\". This will initiate the first Send/Receive.",
       "label": "Get project",
       "send_receive_url": "Send/Receive URL",

--- a/frontend/src/routes/(authenticated)/project/[project_code]/+page.svelte
+++ b/frontend/src/routes/(authenticated)/project/[project_code]/+page.svelte
@@ -49,6 +49,7 @@
   $: changesetStore = data.changesets;
   let isEmpty: boolean = false;
   $: isEmpty = project?.lastCommit == null;
+  // TODO: Once we've stabilized the lastCommit issue with project reset, get rid of the next line
   $: if (! $changesetStore.fetching) isEmpty = $changesetStore.changesets.length === 0;
   $: members = project.users.sort((a, b) => {
     if (a.role !== b.role) {
@@ -237,13 +238,13 @@
       {:else}
         <Dropdown>
           <button class="btn btn-primary">
-            {$t('project_page.get_project.label')}
+            {$t('project_page.get_project.label', {isEmpty: isEmpty ? 'true' : 'false'})}
             <span class="i-mdi-dots-vertical text-2xl" />
           </button>
           <div slot="content" class="card w-[calc(100vw-1rem)] sm:max-w-[35rem]">
             <div class="card-body max-sm:p-4">
               <div class="prose">
-                <h3>{$t('project_page.get_project.instructions_header', {type: project.type, mode: 'normal'})}</h3>
+                <h3>{$t('project_page.get_project.instructions_header', {type: project.type, mode: 'normal', isEmpty: isEmpty ? 'true' : 'false'})}</h3>
                 {#if project.type === ProjectType.WeSay}
                   {#if isEmpty}
                     <Markdown

--- a/frontend/src/routes/(authenticated)/project/[project_code]/+page.svelte
+++ b/frontend/src/routes/(authenticated)/project/[project_code]/+page.svelte
@@ -238,13 +238,13 @@
       {:else}
         <Dropdown>
           <button class="btn btn-primary">
-            {$t('project_page.get_project.label', {isEmpty: isEmpty ? 'true' : 'false'})}
+            {$t('project_page.get_project.label', {isEmpty: isEmpty.toString()})}
             <span class="i-mdi-dots-vertical text-2xl" />
           </button>
           <div slot="content" class="card w-[calc(100vw-1rem)] sm:max-w-[35rem]">
             <div class="card-body max-sm:p-4">
               <div class="prose">
-                <h3>{$t('project_page.get_project.instructions_header', {type: project.type, mode: 'normal', isEmpty: isEmpty ? 'true' : 'false'})}</h3>
+                <h3>{$t('project_page.get_project.instructions_header', {type: project.type, mode: 'normal', isEmpty: isEmpty.toString()})}</h3>
                 {#if project.type === ProjectType.WeSay}
                   {#if isEmpty}
                     <Markdown

--- a/frontend/src/routes/(authenticated)/project/[project_code]/+page.svelte
+++ b/frontend/src/routes/(authenticated)/project/[project_code]/+page.svelte
@@ -245,13 +245,23 @@
               <div class="prose">
                 <h3>{$t('project_page.get_project.instructions_header', {type: project.type, mode: 'normal'})}</h3>
                 {#if project.type === ProjectType.WeSay}
-                  <Markdown
-                    md={$t('project_page.get_project.instructions_wesay', {
-                    code: project.code,
-                    login: encodeURIComponent(user.email ?? user.username ?? ''),
-                    name: project.name,
-                  })}
-                  />
+                  {#if isEmpty}
+                    <Markdown
+                        md={$t('project_page.get_project.instructions_wesay_empty', {
+                        code: project.code,
+                        login: encodeURIComponent(user.email ?? user.username ?? ''),
+                        name: project.name,
+                      })}
+                    />
+                  {:else}
+                    <Markdown
+                        md={$t('project_page.get_project.instructions_wesay', {
+                        code: project.code,
+                        login: encodeURIComponent(user.email ?? user.username ?? ''),
+                        name: project.name,
+                      })}
+                    />
+                  {/if}
                 {:else}
                   {#if isEmpty}
                   <Markdown

--- a/frontend/src/routes/(authenticated)/project/[project_code]/+page.svelte
+++ b/frontend/src/routes/(authenticated)/project/[project_code]/+page.svelte
@@ -47,6 +47,9 @@
   let projectStore = data.project;
   $: project = $projectStore;
   $: changesetStore = data.changesets;
+  let isEmpty: boolean = false;
+  $: isEmpty = project?.lastCommit == null;
+  $: if (! $changesetStore.fetching) isEmpty = $changesetStore.changesets.length === 0;
   $: members = project.users.sort((a, b) => {
     if (a.role !== b.role) {
       return a.role === ProjectRole.Manager ? -1 : 1;
@@ -250,12 +253,21 @@
                   })}
                   />
                 {:else}
+                  {#if isEmpty}
+                  <Markdown
+                    md={$t('project_page.get_project.instructions_flex_empty', {
+                    code: project.code,
+                    name: project.name,
+                  })}
+                  />
+                  {:else}
                   <Markdown
                     md={$t('project_page.get_project.instructions_flex', {
                     code: project.code,
                     name: project.name,
                   })}
                   />
+                  {/if}
                 {/if}
               </div>
               <SendReceiveUrlField projectCode={project.code} />


### PR DESCRIPTION
Will fix #686 when completed.

Currently shows instructions for empty FLEx projects. Still need to write up instructions for empty WeSay projects, and possibly instructions for both empty and non-empty OneStory Editor projects.

Screenshot of instructions (as they currently are) on an empty FLEx project:

![image](https://github.com/sillsdev/languageforge-lexbox/assets/90762/24ffd50f-edde-4cb9-96b0-b6f3e2cfe97d)

Same, for an empty WeSay project:

![image](https://github.com/sillsdev/languageforge-lexbox/assets/90762/644ccf7d-0c62-4f8e-8838-9b2808940f6d)
