### PR TITLE
Bug/730 invalid email in addinvite member results in 500

### DIFF
--- a/frontend/src/lib/forms/utils.ts
+++ b/frontend/src/lib/forms/utils.ts
@@ -20,3 +20,7 @@ export function passwordFormRules($t: Translater): z.ZodString {
 export function emptyString(): z.ZodString {
   return z.string().length(0);
 }
+
+export function isEmail(value: string): boolean {
+  return !!tryParse(z.string().email(), value);
+}

--- a/frontend/src/lib/i18n/locales/en.json
+++ b/frontend/src/lib/i18n/locales/en.json
@@ -198,6 +198,7 @@ the [Linguistics Institute at Payap University](https://li.payap.ac.th/) in Chia
       "shared_password": "Shared Password",
       "usernames": "Logins/usernames (one per line)",
       "usernames_alphanum_only": "Logins/usernames must contain only letters, numbers, and underscore (_) characters",
+      "empty_user_field": "Please enter email addresses and/or logins",
       "creator_must_have_email": "You must have an email address in order to create a project.",
       "members_added": "{addedCount} new {addedCount, plural, one {member was} other {members were}} added to project.",
       "existing_added_members": "{existedCount} {existedCount, plural, one {user} other {users}} already existed.",

--- a/frontend/src/lib/i18n/locales/en.json
+++ b/frontend/src/lib/i18n/locales/en.json
@@ -180,6 +180,7 @@ the [Linguistics Institute at Payap University](https://li.payap.ac.th/) in Chia
       "add_button": "Add/Invite Member",
       "modal_title": "Add or invite a Member to this project",
       "submit_button": "Add Member",
+      "empty_user_field": "Please enter an email address or login",
       "submit_button_email": "Add or invite Member",
       "project_not_found": "Project not found. Please refresh the page.",
       "username_not_found": "No user was found with this login",

--- a/frontend/src/routes/(authenticated)/project/[project_code]/+page.svelte
+++ b/frontend/src/routes/(authenticated)/project/[project_code]/+page.svelte
@@ -131,7 +131,7 @@
   $: userId = user.id;
   $: canManage = isAdmin(user) || project?.users.find((u) => u.user.id == userId)?.role == ProjectRole.Manager;
 
-  const projectNameValidation = z.string().min(1, $t('project_page.project_name_empty_error'));
+  const projectNameValidation = z.string().trim().min(1, $t('project_page.project_name_empty_error'));
 
   let deleteProjectModal: ConfirmDeleteModal;
 

--- a/frontend/src/routes/(authenticated)/project/[project_code]/AddProjectMember.svelte
+++ b/frontend/src/routes/(authenticated)/project/[project_code]/AddProjectMember.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import { BadgeButton } from '$lib/components/Badges';
   import { DialogResponse, FormModal } from '$lib/components/modals';
-  import { Input, ProjectRoleSelect } from '$lib/forms';
+  import { Input, ProjectRoleSelect, isEmail } from '$lib/forms';
   import { ProjectRole } from '$lib/gql/types';
   import t from '$lib/i18n';
   import { z } from 'zod';
@@ -10,7 +10,9 @@
 
   export let projectId: string;
   const schema = z.object({
-    usernameOrEmail: z.string(),
+    usernameOrEmail: z.string().trim()
+      .min(1, $t('project_page.add_user.empty_user_field'))
+      .refine((value) => !value.includes('@') || isEmail(value), { message: $t('form.invalid_email') }),
     role: z.enum([ProjectRole.Editor, ProjectRole.Manager]).default(ProjectRole.Editor),
   });
   let formModal: FormModal<typeof schema>;

--- a/frontend/src/routes/(authenticated)/project/[project_code]/BulkAddProjectMembers.svelte
+++ b/frontend/src/routes/(authenticated)/project/[project_code]/BulkAddProjectMembers.svelte
@@ -22,7 +22,7 @@
 
   export let projectId: string;
   const schema = z.object({
-    usernamesText: z.string().min(1, $t('register.name_missing')),
+    usernamesText: z.string().trim().min(1, $t('project_page.bulk_add_members.empty_user_field')),
     password: passwordFormRules($t),
   });
 

--- a/frontend/src/routes/(authenticated)/project/create/+page.svelte
+++ b/frontend/src/routes/(authenticated)/project/create/+page.svelte
@@ -24,8 +24,8 @@
   const { notifySuccess } = useNotifications();
 
   const formSchema = z.object({
-    name: z.string().min(1, $t('project.create.name_missing')),
-    description: z.string().min(1, $t('project.create.description_missing')),
+    name: z.string().trim().min(1, $t('project.create.name_missing')),
+    description: z.string().trim().min(1, $t('project.create.description_missing')),
     type: z.nativeEnum(ProjectType).default(ProjectType.FlEx),
     retentionPolicy: z.nativeEnum(RetentionPolicy).default(RetentionPolicy.Training),
     languageCode: z

--- a/frontend/src/routes/(authenticated)/user/+page.svelte
+++ b/frontend/src/routes/(authenticated)/user/+page.svelte
@@ -36,8 +36,8 @@
 
   const formSchema = z.object({
     email: z.string().email($t('form.invalid_email')).nullish(),
-    name: z.string(),
-    locale: z.string().min(2),
+    name: z.string().trim().min(1, $t('register.name_missing')),
+    locale: z.string().trim().min(2),
   });
 
   let { form, errors, enhance, message, submitting, formState } = lexSuperForm(formSchema, async () => {

--- a/frontend/src/routes/(unauthenticated)/login/+page.svelte
+++ b/frontend/src/routes/(unauthenticated)/login/+page.svelte
@@ -17,7 +17,7 @@
   import DevContent from '$lib/layout/DevContent.svelte';
 
   const formSchema = z.object({
-    email: z.string().min(1, $t('login.missing_user_info')),
+    email: z.string().trim().min(1, $t('login.missing_user_info')),
     password: z.string().min(1, $t('login.password_missing')),
   });
   let { form, errors, message, enhance, submitting } = lexSuperForm(

--- a/frontend/src/routes/(unauthenticated)/register/+page.svelte
+++ b/frontend/src/routes/(unauthenticated)/register/+page.svelte
@@ -18,11 +18,11 @@
   // getLanguageCodeFromNavigator() gives us the language/locale they probably actually want. Maybe we'll support it in the future.
   const userLocale = getLanguageCodeFromNavigator() ?? $locale;
   const formSchema = z.object({
-    name: z.string().min(1, $t('register.name_missing')),
+    name: z.string().trim().min(1, $t('register.name_missing')),
     email: z.string().email($t('form.invalid_email')),
     password: passwordFormRules($t),
     score: z.number(),
-    locale: z.string().min(2).default(userLocale),
+    locale: z.string().trim().min(2).default(userLocale),
   });
 
   let { form, errors, message, enhance, submitting } = lexSuperForm(formSchema, async () => {

--- a/frontend/src/routes/(unauthenticated)/sandbox/+page.svelte
+++ b/frontend/src/routes/(unauthenticated)/sandbox/+page.svelte
@@ -25,7 +25,7 @@
   }
   const formSchema = z.object(
     {
-      name: z.string().min(3).max(255),
+      name: z.string().trim().min(3).max(255),
       lastName: z.string().min(3).max(255),
     }
   );
@@ -124,7 +124,7 @@ let deleteModal: DeleteModal;
         />
         <Input
           id="lastName"
-          label="Last Name"
+          label="Last Name (allows only white space)"
           type="text"
           error={$errors.lastName}
           bind:value={$form.lastName}


### PR DESCRIPTION
Resolves #730 

- [I've asked](https://github.com/sillsdev/languageforge-lexbox/pull/697#discussion_r1568597159) @rmunn to add server-side validation, because he essentially already has the code to do so in an open PR

I also realized that we allow only whitespace (client-side at least) for a number of required fields. So, I fixed that too.