### PR TITLE
Add proof-of-concept tool to make .fwdata files

### DIFF
--- a/backend/MkFwData/MkFwData.csproj
+++ b/backend/MkFwData/MkFwData.csproj
@@ -1,0 +1,17 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <GenerateResourceUsePreserializedResources>true</GenerateResourceUsePreserializedResources>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <!-- TODO: Change to PackageReference once LfMergeBridge has a release with the necessary code included -->
+    <ProjectReference Include="..\..\..\flexbridge\src\LfMergeBridge\LfMergeBridge.csproj" />
+    <PackageReference Include="System.CommandLine" Version="2.0.0-beta4.22272.1" />
+  </ItemGroup>
+
+</Project>

--- a/backend/MkFwData/MkFwData.csproj
+++ b/backend/MkFwData/MkFwData.csproj
@@ -6,12 +6,21 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <GenerateResourceUsePreserializedResources>true</GenerateResourceUsePreserializedResources>
+    <Mercurial4ChorusDestDir>$(MSBuildProjectDirectory)</Mercurial4ChorusDestDir>
   </PropertyGroup>
 
   <ItemGroup>
     <!-- TODO: Change to PackageReference once LfMergeBridge has a release with the necessary code included -->
     <ProjectReference Include="..\..\..\flexbridge\src\LfMergeBridge\LfMergeBridge.csproj" />
+    <!-- <PackageReference Include="SIL.ChorusPlugin.LfMergeBridge" Version="4.x.x" /> TODO: Uncomment once we know what the version will be -->
     <PackageReference Include="System.CommandLine" Version="2.0.0-beta4.22272.1" />
+    <PackageReference Include="SIL.Chorus.LibChorus" Version="6.0.0-beta0045" />
+    <PackageReference Include="SIL.Chorus.Mercurial" Version="6.5.1.29" />
   </ItemGroup>
+
+    <ItemGroup>
+      <Content Include="Mercurial\**" CopyToOutputDirectory="Always" />
+      <Content Include="MercurialExtensions\**" CopyToOutputDirectory="Always" />
+    </ItemGroup>
 
 </Project>

--- a/backend/MkFwData/Program.cs
+++ b/backend/MkFwData/Program.cs
@@ -47,7 +47,7 @@ class Program
         string dir = isDir ? file.FullName : new FileInfo(file.FullName).Directory!.FullName;
         HgRunner.Run($"hg checkout {rev}", dir, 30, progress);
         progress.WriteVerbose("Creating {0} ...", name);
-        LfMergeBridge.LfMergeBridge.PutHumptyTogetherAgain(progress, writeVerbose: true, name);
+        LfMergeBridge.LfMergeBridge.ReassembleFwdataFile(progress, writeVerbose: true, name);
         progress.WriteMessage("Created {0}", name);
     }
 }

--- a/backend/MkFwData/Program.cs
+++ b/backend/MkFwData/Program.cs
@@ -1,0 +1,43 @@
+using SIL.Progress;
+using System.CommandLine;
+
+class Program
+{
+    static async Task Main(string[] args)
+    {
+        var rootCommand = new RootCommand("Make .fwdata file");
+
+        var verboseOption = new Option<bool>(
+            ["--verbose", "-v"],
+            "Display verbose output"
+        );
+        rootCommand.AddGlobalOption(verboseOption);
+
+        var quietOption = new Option<bool>(
+            ["--quiet", "-q"],
+            "Suppress all output (overrides --verbose if present)"
+        );
+        rootCommand.AddGlobalOption(quietOption);
+
+        var file = new Argument<FileSystemInfo>(
+            "file",
+            "Name of .fwdata file to create"
+        );
+        rootCommand.Add(file);
+
+        rootCommand.SetHandler(Run, file, verboseOption, quietOption);
+
+        await rootCommand.InvokeAsync(args);
+    }
+
+    static void Run(FileSystemInfo file, bool verbose, bool quiet)
+    {
+        IProgress progress = quiet ? new NullProgress() : new ConsoleProgress();
+        progress.ShowVerbose = verbose;
+        bool isDir = file.Exists && (file.Attributes & FileAttributes.Directory) != 0;
+        string name = isDir ? Path.Join(file.FullName, file.Name + ".fwdata") : file.FullName;
+        progress.WriteVerbose("Creating {0} ...", name);
+        LfMergeBridge.LfMergeBridge.PutHumptyTogetherAgain(progress, writeVerbose: true, name);
+        progress.WriteMessage("Created {0}", name);
+    }
+}


### PR DESCRIPTION
WIP. Will fix #631 when complete.

Tool will be used to create .fwdata files on demand, allowing us to implement several different features we might want on the backend.

Currently this is a separate binary so as not to pull in a bunch of dependencies into the LexBoxApi project. But we could fold it into LexBoxApi if we want to.

## How to test

Will require https://github.com/sillsdev/flexbridge/pull/398 to be merged (and released) in order to work. To test this PR branch before that FLExBridge PR is merged, do the following:

1. Clone https://github.com/sillsdev/flexbridge/ in a sibling directory to where you have lexbox checked out.
2. Check out the `feature/lfmergebridge-create-fwdata` branch in the flexbridge repo.
    * You can do this in a single step by running `git clone https://github.com/sillsdev/flexbridge/ -b feature/lfmergebridge-create-fwdata`
3. In flexbridge, run `dotnet build` and make sure it's working
    * I had to add `<GenerateResourceUsePreserializedResources>true</GenerateResourceUsePreserializedResources>` to several .csproj files in the flexbridge repo in order to build, but I think that's Linux-only and you won't have that problem on a Windows machine. So I haven't (yet) included that change in https://github.com/sillsdev/flexbridge/pull/398
4. Clone a Mercurial repo, let's say sena-3, somewhere
5. In the sena-3 repo, run `hg update tip`
6. `cd backend/MkFwData`
7. `dotnet run -- /path/to/sena-3`

If all goes well, you should see "Created /path/to/sena-3/sena-3.fwdata" and you should now have a sena-3.fwdata file.

## Planned development

I plan to add an option to the MkFwData command to optionally check out the `tip` revision, or any specified revision, automatically, so that you don't have to do so as a separate step. Then after the .fwdata file is created, we would run something like `hg checkout null` which is Mercurial syntax for "Dispose of the working tree, please, I no longer want it". (This does not delete unversioned files, such as the .fwdata file just created by the tool). That way we won't leave lots of working trees taking up space in our data volume.

## Potential uses

This could be used to easily download an .fwdata file. There's potential for using it for more advanced features, such as checking out two different revisions of a project, creating two .fwdata files, using liblcm to load them, and then comparing the two revisions using liblcm in order to present a much nicer UI to the user when they say "What changed in this project between (date) and now?" I.e. instead of Mercurial diffs, we could tell them "The definition of word X was changed from Y to Z" and so on.

This could also be used as the basis of a liblcm-based viewer. And, if the "split .fwdata file up" operation was implemented, potentially an editor as well.