### PR TITLE
Enable filtering for unknown project type

### DIFF
--- a/frontend/src/lib/components/ProjectType/ProjectTypeIcon.svelte
+++ b/frontend/src/lib/components/ProjectType/ProjectTypeIcon.svelte
@@ -33,5 +33,5 @@
 {#if src}
   <img {src} alt={$t('project_type.logo', { type: type ?? ProjectType.Unknown })} class={size}>
 {:else if type}
-  <span class="i-mdi-help-circle-outline text-xl mb-[-2px]" />
+  <span class="i-mdi-help-circle-outline text-2xl" />
 {/if}

--- a/frontend/src/lib/components/Projects/ProjectFilter.svelte
+++ b/frontend/src/lib/components/Projects/ProjectFilter.svelte
@@ -114,7 +114,7 @@
     {/if}
     {#if filterEnabled('projectType')}
       <div class="form-control">
-        <ProjectTypeSelect bind:value={$filters.projectType} undefinedOptionLabel={$t('project_type.any')} />
+        <ProjectTypeSelect bind:value={$filters.projectType} undefinedOptionLabel={$t('common.any')} includeUnknown />
       </div>
     {/if}
     {#if filterEnabled('showDeletedProjects')}

--- a/frontend/src/lib/components/Projects/ProjectTable.svelte
+++ b/frontend/src/lib/components/Projects/ProjectTable.svelte
@@ -104,7 +104,7 @@
           {/if}
           {#if isColumnVisible('type')}
             <td>
-              <span class="tooltip align-bottom" data-tip={$t(getProjectTypeI18nKey(project.type))}>
+              <span class="tooltip align-bottom shrink-0 leading-0" data-tip={$t(getProjectTypeI18nKey(project.type))}>
                 <ProjectTypeIcon type={project.type} />
               </span>
             </td>

--- a/frontend/src/lib/forms/ProjectTypeSelect.svelte
+++ b/frontend/src/lib/forms/ProjectTypeSelect.svelte
@@ -7,13 +7,14 @@
   export let value: ProjectType | undefined;
   export let error: string | string[] | undefined = undefined;
   export let undefinedOptionLabel: string | undefined = undefined;
-let types = [
-  ProjectType.FlEx,
-  ProjectType.WeSay,
-  ProjectType.OneStoryEditor,
-  ProjectType.OurWord,
-  ProjectType.AdaptIt
-];
+  export let includeUnknown = false;
+  const types = [
+    ProjectType.FlEx,
+    ProjectType.WeSay,
+    ProjectType.OneStoryEditor,
+    ProjectType.OurWord,
+    ProjectType.AdaptIt
+  ];
 </script>
 <div class="relative">
   <Select id="type" label={$t('project_type.type')} bind:value {error} on:change>
@@ -23,8 +24,11 @@ let types = [
     {#each types as type}
       <option value={type}><FormatProjectType {type}/></option>
     {/each}
-   </Select>
-  <span class="absolute right-10 top-11 pointer-events-none">
+    {#if includeUnknown}
+      <option value={ProjectType.Unknown}><FormatProjectType type={ProjectType.Unknown}/></option>
+    {/if}
+  </Select>
+  <span class="absolute right-10 top-[3.75rem] -translate-y-1/2 pointer-events-none leading-0">
     <ProjectTypeIcon type={value} size="h-8" />
   </span>
 </div>

--- a/frontend/src/lib/i18n/locales/en.json
+++ b/frontend/src/lib/i18n/locales/en.json
@@ -323,7 +323,6 @@ If you don't see a dialog or already closed it, click the button below:",
   },
   "project_type": {
     "type": "Project type",
-    "any": "Any",
     "adaptIt": "Adapt It",
     "flex": "FLEx",
     "oneStoryEditor": "OneStory Editor",
@@ -476,5 +475,6 @@ If you don't see a dialog or already closed it, click the button below:",
     "no": "No",
     "none": "None",
     "or": "Or",
+    "any": "Any",
   }
 }


### PR DESCRIPTION
This seemed like a missing easy-win. I noticed that it wasn't there as I added an "Unknown confidentiality" filter option.

![image](https://github.com/sillsdev/languageforge-lexbox/assets/12587509/bed2fd4a-70ea-4a38-866c-06d756e6e084)
