### PR TITLE
Allow deleting draft projects

### DIFF
--- a/frontend/src/lib/gql/gql-client.ts
+++ b/frontend/src/lib/gql/gql-client.ts
@@ -53,6 +53,7 @@ function createGqlClient(_gqlEndpoint?: string): Client {
           Mutation: {
             softDeleteProject: (result, args: SoftDeleteProjectMutationVariables, cache, _info) => {
               cache.invalidate({__typename: 'Project', id: args.input.projectId});
+              cache.invalidate({__typename: 'DraftProject', id: args.input.projectId});
             },
             deleteUserByAdminOrSelf: (result, args: DeleteUserByAdminOrSelfMutationVariables, cache, _info) => {
               cache.invalidate({__typename: 'User', id: args.input.userId});

--- a/frontend/src/routes/(authenticated)/admin/AdminProjects.svelte
+++ b/frontend/src/routes/(authenticated)/admin/AdminProjects.svelte
@@ -57,7 +57,7 @@
   $: shownProjects = limitResults ? limit(filteredProjects, lastLoadUsedActiveFilter ? DEFAULT_PAGE_SIZE : 10) : filteredProjects;
 
   let deleteProjectModal: ConfirmDeleteModal;
-  async function softDeleteProject(project: ProjectItem): Promise<void> {
+  async function softDeleteProject(project: ProjectItemWithDraftStatus): Promise<void> {
     const result = await deleteProjectModal.open(project.name, async () => {
       const { error } = await _deleteProject(project.id);
       return error?.message;
@@ -114,7 +114,7 @@
 
   <ProjectTable projects={shownProjects}>
     <td class="p-0" slot="actions" let:project>
-      {#if !project.isDraft && !project.deletedDate}
+      {#if project.isDraft || !project.deletedDate}
         <Dropdown>
           <button class="btn btn-ghost btn-square">
             <span class="i-mdi-dots-vertical text-lg" />


### PR DESCRIPTION
Fixes #741.

I've allowed the "Delete Project" menu to show up for draft projects as well as real projects, and changed the SoftDeleteProject mutation to delete a draft project if there is no "real" project with that GUID. (Draft projects are hard-deleted, because there's no reason to soft-delete them: they were just project requests, and there is no Mercurial repo attached).

Currently the wording on the modal is exactly the same for deleting a draft project as for deleting a "real" project. I could change it to say "Delete Draft Project" if necessary, but I feel like it's probably good enough as-is.

![image](https://github.com/sillsdev/languageforge-lexbox/assets/90762/5362ad78-8c4e-4ff4-b6f8-e583c2ed6bf9)

![image](https://github.com/sillsdev/languageforge-lexbox/assets/90762/329b6417-0818-4f78-967b-4d702759a2f0)

![image](https://github.com/sillsdev/languageforge-lexbox/assets/90762/dc4884d9-e146-4d09-b069-b36618ab87f6)
