### PR TITLE
Extend member filter to draft projects

### DIFF
--- a/backend/LexCore/Entities/DraftProject.cs
+++ b/backend/LexCore/Entities/DraftProject.cs
@@ -7,5 +7,6 @@ public class DraftProject : EntityBase
     public required string Code { get; set; }
     public required ProjectType Type { get; set; }
     public required RetentionPolicy RetentionPolicy { get; set; }
+    public User? ProjectManager { get; set; }
     public Guid? ProjectManagerId { get; set; }
 }

--- a/backend/LexData/Entities/DraftProjectEntityConfiguration.cs
+++ b/backend/LexData/Entities/DraftProjectEntityConfiguration.cs
@@ -1,5 +1,6 @@
 using LexCore.Entities;
 using LexData.Configuration;
+using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Metadata.Builders;
 
 namespace LexData.Entities;
@@ -10,5 +11,8 @@ public class DraftProjectEntityConfiguration : EntityBaseConfiguration<DraftProj
     {
         base.Configure(builder);
         builder.HasIndex(p => p.Code).IsUnique();
+        builder.HasOne(p => p.ProjectManager)
+            .WithMany()
+            .OnDelete(DeleteBehavior.Cascade);
     }
 }

--- a/backend/LexData/Migrations/20240422130904_Make DraftFilter.ProjectMangerId a FK.Designer.cs
+++ b/backend/LexData/Migrations/20240422130904_Make DraftFilter.ProjectMangerId a FK.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using LexData;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace LexData.Migrations
 {
     [DbContext(typeof(LexBoxDbContext))]
-    partial class LexBoxDbContextModelSnapshot : ModelSnapshot
+    [Migration("20240422130904_Make DraftFilter.ProjectMangerId a FK")]
+    partial class MakeDraftFilterProjectMangerIdaFK
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/backend/LexData/Migrations/20240422130904_Make DraftFilter.ProjectMangerId a FK.cs
+++ b/backend/LexData/Migrations/20240422130904_Make DraftFilter.ProjectMangerId a FK.cs
@@ -1,0 +1,39 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace LexData.Migrations
+{
+    /// <inheritdoc />
+    public partial class MakeDraftFilterProjectMangerIdaFK : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateIndex(
+                name: "IX_DraftProjects_ProjectManagerId",
+                table: "DraftProjects",
+                column: "ProjectManagerId");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_DraftProjects_Users_ProjectManagerId",
+                table: "DraftProjects",
+                column: "ProjectManagerId",
+                principalTable: "Users",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Cascade);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_DraftProjects_Users_ProjectManagerId",
+                table: "DraftProjects");
+
+            migrationBuilder.DropIndex(
+                name: "IX_DraftProjects_ProjectManagerId",
+                table: "DraftProjects");
+        }
+    }
+}

--- a/frontend/schema.graphql
+++ b/frontend/schema.graphql
@@ -103,6 +103,7 @@ type DraftProject {
   code: String!
   type: ProjectType!
   retentionPolicy: RetentionPolicy!
+  projectManager: User
   projectManagerId: UUID
   id: UUID!
   createdDate: DateTime!
@@ -407,6 +408,7 @@ input DraftProjectFilterInput {
   code: StringOperationFilterInput
   type: ProjectTypeOperationFilterInput
   retentionPolicy: RetentionPolicyOperationFilterInput
+  projectManager: UserFilterInput
   projectManagerId: UuidOperationFilterInput
   id: UuidOperationFilterInput
   createdDate: DateTimeOperationFilterInput
@@ -419,6 +421,7 @@ input DraftProjectSortInput {
   code: SortEnumType
   type: SortEnumType
   retentionPolicy: SortEnumType
+  projectManager: UserSortInput
   projectManagerId: SortEnumType
   id: SortEnumType
   createdDate: SortEnumType


### PR DESCRIPTION
There's the slight risk that a user who created a draft PR has been deleted, in which case the DB migration will fail, but I think we can risk it 😉 

Resolves #747 

Filtered:
![image](https://github.com/sillsdev/languageforge-lexbox/assets/12587509/700cd47e-2fa1-4f8e-a6b9-0926a22f964d)

Unfiltered:
![image](https://github.com/sillsdev/languageforge-lexbox/assets/12587509/36afe757-7e15-4dd1-97bf-e9c480e0b7ca)
