### PR TITLE
Update GHA action versions used in our workflows

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -50,7 +50,7 @@ jobs:
       ui-version: ${{ steps.get-ui-version.outputs.result }}
     steps:
       - name: Checkout lexbox repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@1d96c772d19495a3b5c517cd2bc0cb401ea0529f # v4.1.3
         with:
           path: lexbox
       - name: Run kustomize
@@ -58,7 +58,7 @@ jobs:
         run: |
           kubectl kustomize . -o resources.yaml
       - name: Checkout fleet repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@1d96c772d19495a3b5c517cd2bc0cb401ea0529f # v4.1.3
         with:
           repository: ${{ vars.FLEET_REPO }}
           ssh-key: ${{ secrets.FLEET_REPO_SSH_KEY }}
@@ -68,16 +68,16 @@ jobs:
           cp lexbox/deployment/${{ inputs.k8s-environment }}/resources.yaml fleet/${{ inputs.k8s-environment }}/
       #        this kustomization file is in the fleet repo and only modifies the image versions being used.
       - name: Update image version in fleet kustomization.yaml
-        uses: mikefarah/yq@v4.34.2
+        uses: mikefarah/yq@0b34c9a00de1c575a34eea05af1d956a525c4fc1 # v4.34.2
         with:
           cmd: yq eval -i '(.images.[] | select(.name == "${{ inputs.image }}").newTag) = "${{ inputs.version }}"' "fleet/${{ inputs.k8s-environment }}/kustomization.yaml"
       - name: Get API version
-        uses: mikefarah/yq@v4.34.2
+        uses: mikefarah/yq@0b34c9a00de1c575a34eea05af1d956a525c4fc1 # v4.34.2
         id: get-api-version
         with:
           cmd: yq '.images.[] | select(.name == "ghcr.io/sillsdev/lexbox-api").newTag' "fleet/${{ inputs.k8s-environment }}/kustomization.yaml"
       - name: Get UI version
-        uses: mikefarah/yq@v4.34.2
+        uses: mikefarah/yq@0b34c9a00de1c575a34eea05af1d956a525c4fc1 # v4.34.2
         id: get-ui-version
         with:
           cmd: yq '.images.[] | select(.name == "ghcr.io/sillsdev/lexbox-ui").newTag' "fleet/${{ inputs.k8s-environment }}/kustomization.yaml"

--- a/.github/workflows/develop-ui.yaml
+++ b/.github/workflows/develop-ui.yaml
@@ -65,7 +65,7 @@ jobs:
       - run: pnpm run check --output machine
       - run: pnpm run lint:report
       - name: Annotate Code Linting REsults
-        uses: ataylorme/eslint-annotate-action@2.2.0  # TODO: d57a1193d4c59cbfbf3f86c271f42612f9dbd9e9 (v3.0.0) has breaking changes, update in separate commit
+        uses: ataylorme/eslint-annotate-action@d57a1193d4c59cbfbf3f86c271f42612f9dbd9e9 # v3.0.0
         if: always()
         with:
           report-json: ./frontend/eslint_report.json

--- a/.github/workflows/develop-ui.yaml
+++ b/.github/workflows/develop-ui.yaml
@@ -51,11 +51,11 @@ jobs:
       run:
         working-directory: ./frontend
     steps:
-      - uses: actions/checkout@v3
-      - uses: pnpm/action-setup@v3
+      - uses: actions/checkout@1d96c772d19495a3b5c517cd2bc0cb401ea0529f # v4.1.3
+      - uses: pnpm/action-setup@a3252b78c470c02df07e9d59298aecedc3ccdd6d # v3.0.0
         with:
           package_json_file: 'frontend/package.json'
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # v4.0.2
         with:
           node-version-file: './frontend/package.json'
           cache: 'pnpm'
@@ -65,7 +65,7 @@ jobs:
       - run: pnpm run check --output machine
       - run: pnpm run lint:report
       - name: Annotate Code Linting REsults
-        uses: ataylorme/eslint-annotate-action@2.2.0
+        uses: ataylorme/eslint-annotate-action@2.2.0  # TODO: d57a1193d4c59cbfbf3f86c271f42612f9dbd9e9 (v3.0.0) has breaking changes, update in separate commit
         if: always()
         with:
           report-json: ./frontend/eslint_report.json

--- a/.github/workflows/integration-test.yaml
+++ b/.github/workflows/integration-test.yaml
@@ -52,7 +52,7 @@ jobs:
       name: ${{ inputs.environment }}
     runs-on: ${{ inputs.runs-on }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@1d96c772d19495a3b5c517cd2bc0cb401ea0529f # v4.1.3
       - name: Setup self-hosted dependencies
         if: ${{ inputs.runs-on == 'self-hosted' }}
         run: |
@@ -64,28 +64,28 @@ jobs:
           rm powershell_7.4.1-1.deb_amd64.deb
           pwsh #validate that powershell installed correctly
       # First we need to setup Node...
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # v4.0.2
         if: ${{ inputs.run-playwright }}
         with:
           node-version-file: 'frontend/package.json'
       # Then we can set up pnpm...
-      - uses: pnpm/action-setup@v3
+      - uses: pnpm/action-setup@a3252b78c470c02df07e9d59298aecedc3ccdd6d # v3.0.0
         if: ${{ inputs.run-playwright }}
         with:
           package_json_file: 'frontend/package.json'
       # Then we can have Noede set up package caching
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # v4.0.2
         if: ${{ inputs.run-playwright }}
         with:
           node-version-file: 'frontend/package.json'
           cache: 'pnpm'
           cache-dependency-path: 'frontend/pnpm-lock.yaml'
-      - uses: actions/setup-dotnet@v3
+      - uses: actions/setup-dotnet@4d6c8fcf3c8f7a60068d26b594648e99df24cee3 # v4.0.0
         env:
           DOTNET_INSTALL_DIR: ${{ inputs.runs-on == 'self-hosted' && '/opt/hostedtoolcache/dotnet' || '' }} #poor man's conditional
         with:
           dotnet-version: '8.x'
-      - uses: MatteoH2O1999/setup-python@v3.0.0
+      - uses: MatteoH2O1999/setup-python@429b7dee8a48c31eb72ce0b420ea938ff51c2f11 # v3.2.1
         id: python
         if: ${{ inputs.runs-on != 'windows-latest' && !env.act && inputs.hg-version == '3' }}
         with:
@@ -143,14 +143,14 @@ jobs:
           ZIP_PASSWORD: ${{ secrets.TEST_USER_PASSWORD }}
         run: 7z a ./playwright-traces.7z -mx=0 -mmt=off ./frontend/test-results -p"$ZIP_PASSWORD"
       - name: Publish unit test results
-        uses: EnricoMi/publish-unit-test-result-action/composite@v2
+        uses: EnricoMi/publish-unit-test-result-action/composite@8885e273a4343cd7b48eaa72428dea0c3067ea98 # v2.14.0
         if: ${{ always() && !env.act }}
         with:
           check_name: Integration Tests ${{ inputs.runs-on }} for Mercurial ${{ inputs.hg-version }}
           files: ./test-results/*.trx
       - name: Upload playwright results
         if: ${{ always() && steps.password_protect_test_results.outcome == 'success' }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@1746f4ab65b179e0ea60a494b83293b640dd5bba # v4.3.2
         with:
           name: playwright-traces-${{ inputs.runs-on }}-hg-${{ inputs.hg-version }}
           path: ./playwright-traces.7z

--- a/.github/workflows/lexbox-api.yaml
+++ b/.github/workflows/lexbox-api.yaml
@@ -44,8 +44,8 @@ jobs:
       DOCKER_BUILDKIT: 1
 
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-dotnet@v3
+      - uses: actions/checkout@1d96c772d19495a3b5c517cd2bc0cb401ea0529f # v4.1.3
+      - uses: actions/setup-dotnet@4d6c8fcf3c8f7a60068d26b594648e99df24cee3 # v4.0.0
         with:
           dotnet-version: '8.x'
       - name: Dotnet build
@@ -53,14 +53,14 @@ jobs:
       - name: Unit tests
         run: dotnet test --logger xunit --results-directory ./test-results --filter "Category!=Integration" --blame-hang-timeout 10m
       - name: Publish unit test results
-        uses: EnricoMi/publish-unit-test-result-action@v2
+        uses: EnricoMi/publish-unit-test-result-action@8885e273a4343cd7b48eaa72428dea0c3067ea98 # v2.14.0
         if: always()
         with:
           check_name: C# Unit Tests
           files: ./test-results/*.xml
       - name: Upload test results
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@1746f4ab65b179e0ea60a494b83293b640dd5bba # v4.3.2
         with:
           name: dotnet-unit-test-results
           path: ./test-results
@@ -68,7 +68,7 @@ jobs:
       - name: Docker meta
         id: meta
         if: ${{ !env.ACT }}
-        uses: docker/metadata-action@v4
+        uses: docker/metadata-action@8e5442c4ef9f78752691e2d8f8d19755c6f78e81 # v5.5.1
         with:
           images: ${{ env.IMAGE_NAME }}
           tags: |
@@ -78,14 +78,14 @@ jobs:
             type=raw,value=${{ inputs.version }}
 
       - name: ghcr.io login
-        uses: docker/login-action@v2
+        uses: docker/login-action@e92390c5fb421da1463c202d546fed0ec5c39f20 # v3.1.0
         if: ${{ !env.ACT }}
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - uses: docker/build-push-action@v4
+      - uses: docker/build-push-action@2cdde995de11925a030ce8070c3d77a52ffcf1c0 # v5.3.0
         with:
           context: backend
           build-args: |

--- a/.github/workflows/lexbox-hasura.yaml
+++ b/.github/workflows/lexbox-hasura.yaml
@@ -29,7 +29,7 @@ jobs:
 
     steps:
       -
-        uses: actions/checkout@v3
+        uses: actions/checkout@1d96c772d19495a3b5c517cd2bc0cb401ea0529f # v4.1.3
       - name: Set Version
         id: setVersion
         # set version to date in vYYYY-MM-DD format
@@ -39,7 +39,7 @@ jobs:
       - name: Docker meta
         id: meta
         if: ${{ !env.ACT }}
-        uses: docker/metadata-action@v4
+        uses: docker/metadata-action@8e5442c4ef9f78752691e2d8f8d19755c6f78e81 # v5.5.1
         with:
           images: ghcr.io/sillsdev/lexbox-hasura
           tags: |
@@ -48,13 +48,13 @@ jobs:
             type=raw,enable=${{ env.PROD_RELEASE }},value=latest
             type=raw,enable=${{ env.PROD_RELEASE }},value=${{ env.VERSION }}
       -
-        uses: docker/login-action@v2
+        uses: docker/login-action@e92390c5fb421da1463c202d546fed0ec5c39f20 # v3.1.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
       -
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@2cdde995de11925a030ce8070c3d77a52ffcf1c0 # v5.3.0
         with:
           context: hasura
           push: ${{ !env.ACT }}

--- a/.github/workflows/lexbox-hgweb.yaml
+++ b/.github/workflows/lexbox-hgweb.yaml
@@ -42,7 +42,7 @@ jobs:
 
     steps:
       -
-        uses: actions/checkout@v3
+        uses: actions/checkout@1d96c772d19495a3b5c517cd2bc0cb401ea0529f # v4.1.3
       - name: Set Version
         id: setVersion
         if: ${{ !env.VERSION }}
@@ -55,7 +55,7 @@ jobs:
       - name: Docker meta
         id: meta
         if: ${{ !env.ACT }}
-        uses: docker/metadata-action@v4
+        uses: docker/metadata-action@8e5442c4ef9f78752691e2d8f8d19755c6f78e81 # v5.5.1
         with:
           images: ${{ env.IMAGE_NAME }}
           tags: |
@@ -64,13 +64,13 @@ jobs:
             type=raw,enable=${{ env.PROD_RELEASE }},value=latest
             type=raw,value=${{ env.VERSION }}
       -
-        uses: docker/login-action@v2
+        uses: docker/login-action@e92390c5fb421da1463c202d546fed0ec5c39f20 # v3.1.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
       -
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@2cdde995de11925a030ce8070c3d77a52ffcf1c0 # v5.3.0
         with:
           context: hgweb
           build-args: |

--- a/.github/workflows/lexbox-ui.yaml
+++ b/.github/workflows/lexbox-ui.yaml
@@ -25,8 +25,8 @@ jobs:
       DOCKER_BUILDKIT: 1
 
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@1d96c772d19495a3b5c517cd2bc0cb401ea0529f # v4.1.3
+      - uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # v4.0.2
         with:
           node-version-file: './frontend/package.json'
       - name: pnpm install
@@ -39,7 +39,7 @@ jobs:
         run: |
           pnpm run test:unit --reporter=default --reporter=junit --outputFile.junit=test-results/vitest-results.xml
       - name: Publish unit test results
-        uses: EnricoMi/publish-unit-test-result-action@v2
+        uses: EnricoMi/publish-unit-test-result-action@8885e273a4343cd7b48eaa72428dea0c3067ea98 # v2.14.0
         if: always()
         with:
           check_name: UI unit Tests
@@ -49,7 +49,7 @@ jobs:
       - name: Docker meta
         id: meta
         if: ${{ !env.ACT }}
-        uses: docker/metadata-action@v4
+        uses: docker/metadata-action@8e5442c4ef9f78752691e2d8f8d19755c6f78e81 # v5.5.1
         with:
           images: ${{ env.IMAGE_NAME }}
           tags: |
@@ -58,13 +58,13 @@ jobs:
             type=raw,enable=${{ inputs.label-latest }},value=latest
             type=raw,value=${{ inputs.version }}
 
-      - uses: docker/login-action@v2
+      - uses: docker/login-action@e92390c5fb421da1463c202d546fed0ec5c39f20 # v3.1.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - uses: docker/build-push-action@v4
+      - uses: docker/build-push-action@2cdde995de11925a030ce8070c3d77a52ffcf1c0 # v5.3.0
         with:
           context: frontend
           build-args: |

--- a/.github/workflows/package-cleanup.yaml
+++ b/.github/workflows/package-cleanup.yaml
@@ -12,7 +12,7 @@ jobs:
           - 'lexbox-api'
           - 'lexbox-hgweb'
     steps:
-      - uses: actions/delete-package-versions@v4.1.1
+      - uses: actions/delete-package-versions@ve5bc658cc4c965c472efe991f8beea3981499c55 # v5.0.0
         with:
           package-name: ${{ matrix.package-name }}
           package-type: 'container'

--- a/.github/workflows/release-pipeline.yaml
+++ b/.github/workflows/release-pipeline.yaml
@@ -104,7 +104,7 @@ jobs:
       contents: write
     steps:
       - name: Release
-        uses: softprops/action-gh-release@v0.1.15
+        uses: softprops/action-gh-release@a6c7483a42ee9d5daced968f6c217562cd680f7f # v2.0.0
         with:
           tag_name: ${{ needs.set-version.outputs.version }}
           target_commitish: ${{ github.sha }}


### PR DESCRIPTION
Many of the GHA actions we reference in our workflows are using Node 16 and need to be updated to Node 20; others simply haven't been updated in a while and should be updated to the latest version.

Fixes #606.

Note: Using SHAs rather than version tags as this is [GitHub's recommended best practice](https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-third-party-actions) for third-party actions, and there's no particular reason not to do so for official GitHub-created actions either.