### PR TITLE
Allow counting lex entries for WeSay projects too

### DIFF
--- a/backend/LexBoxApi/Controllers/ProjectController.cs
+++ b/backend/LexBoxApi/Controllers/ProjectController.cs
@@ -236,7 +236,7 @@ public class ProjectController(
     [AdminRequired]
     public async Task<ActionResult<int>> UpdateAllLexEntryCounts(bool onlyUnknown = true, int limit = 100, int delayMs = 10)
     {
-        var projects = lexBoxDbContext.Projects.Where(p => p.Type == ProjectType.FLEx && (!onlyUnknown || p.FlexProjectMetadata == null)).Take(limit).ToArray();
+        var projects = lexBoxDbContext.Projects.Where(p => (p.Type == ProjectType.FLEx || p.Type == ProjectType.WeSay) && (!onlyUnknown || p.FlexProjectMetadata == null)).Take(limit).ToArray();
         var completed = 0;
         foreach (var project in projects)
         {

--- a/backend/LexBoxApi/Services/HgService.cs
+++ b/backend/LexBoxApi/Services/HgService.cs
@@ -252,9 +252,16 @@ public partial class HgService : IHgService
         return response;
     }
 
-    public async Task<int?> GetLexEntryCount(string code)
+    public async Task<int?> GetLexEntryCount(string code, ProjectType projectType)
     {
-        var content = await ExecuteHgCommandServerCommand(code, "lexentrycount", default);
+        var command = projectType switch
+        {
+            ProjectType.FLEx => "lexentrycount",
+            ProjectType.WeSay => "wesaylexentrycount",
+            _ => null
+        };
+        if (command is null) return null;
+        var content = await ExecuteHgCommandServerCommand(code, command, default);
         var str = await content.ReadAsStringAsync();
         return int.TryParse(str, out int result) ? result : null;
     }

--- a/backend/LexBoxApi/Services/ProjectService.cs
+++ b/backend/LexBoxApi/Services/ProjectService.cs
@@ -112,9 +112,9 @@ public class ProjectService(LexBoxDbContext dbContext, IHgService hgService, IOp
             .Include(p => p.FlexProjectMetadata)
             .FirstOrDefaultAsync(p => p.Code == projectCode);
         if (project is null) return;
-        if (hgConfig.Value.AutoUpdateLexEntryCountOnSendReceive && project is { Type: ProjectType.FLEx })
+        if (hgConfig.Value.AutoUpdateLexEntryCountOnSendReceive && project is { Type: ProjectType.FLEx } or { Type: ProjectType.WeSay })
         {
-            var count = await hgService.GetLexEntryCount(projectCode);
+            var count = await hgService.GetLexEntryCount(projectCode, project.Type);
             if (project.FlexProjectMetadata is null)
             {
                 project.FlexProjectMetadata = new FlexProjectMetadata { LexEntryCount = count };
@@ -142,8 +142,8 @@ public class ProjectService(LexBoxDbContext dbContext, IHgService hgService, IOp
     public async Task<int?> UpdateLexEntryCount(string projectCode)
     {
         var project = await dbContext.Projects.Include(p => p.FlexProjectMetadata).FirstOrDefaultAsync(p => p.Code == projectCode);
-        if (project?.Type is not ProjectType.FLEx) return null;
-        var count = await hgService.GetLexEntryCount(projectCode);
+        if (project?.Type is not (ProjectType.FLEx or ProjectType.WeSay)) return null;
+        var count = await hgService.GetLexEntryCount(projectCode, project.Type);
         if (project.FlexProjectMetadata is null)
         {
             project.FlexProjectMetadata = new FlexProjectMetadata { LexEntryCount = count };

--- a/backend/LexCore/ServiceInterfaces/IHgService.cs
+++ b/backend/LexCore/ServiceInterfaces/IHgService.cs
@@ -15,7 +15,7 @@ public interface IHgService
     Task ResetRepo(string code);
     Task FinishReset(string code, Stream zipFile);
     Task<HttpContent> VerifyRepo(string code, CancellationToken token);
-    Task<int?> GetLexEntryCount(string code);
+    Task<int?> GetLexEntryCount(string code, ProjectType projectType);
     Task<string?> GetRepositoryIdentifier(Project project);
     Task<HttpContent> ExecuteHgRecover(string code, CancellationToken token);
     bool HasAbandonedTransactions(string projectCode);

--- a/frontend/src/routes/(authenticated)/project/[project_code]/+page.svelte
+++ b/frontend/src/routes/(authenticated)/project/[project_code]/+page.svelte
@@ -320,7 +320,7 @@
           {$t('project_page.last_commit')}:
           <span class="text-secondary">{$date(project.lastCommit)}</span>
         </div>
-        {#if project.type === ProjectType.FlEx}
+        {#if project.type === ProjectType.FlEx || project.type === ProjectType.WeSay}
         <div class="text-lg inline-flex items-center gap-1">
           {$t('project_page.num_entries')}:
           <span class="text-secondary">

--- a/hgweb/command-runner.sh
+++ b/hgweb/command-runner.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # Define the list of allowed commands
-allowed_commands=("verify" "tip" "lexentrycount" "recover")
+allowed_commands=("verify" "tip" "wesaylexentrycount" "lexentrycount" "recover")
 
 # Get the project code and command name from the URL
 IFS='/' read -ra PATH_SEGMENTS <<< "$PATH_INFO"

--- a/hgweb/command-runner.sh
+++ b/hgweb/command-runner.sh
@@ -43,6 +43,13 @@ case $command_name in
         chg cat -r tip Linguistics/Lexicon/Lexicon_{01,02,03,04,05,06,07,08,09,10}.lexdb | grep -c '<LexEntry\b'
         ;;
 
+    wesaylexentrycount)
+        # Can't predict .lift filename, but we can ask Mercurial for it
+        LIFTFILE=$(chg manifest -r tip | grep '\.lift$' | head -n 1)
+        # The \b for word boundary is not necessary for .lift files
+        [ -n "${LIFTFILE}" ] && chg cat -r tip "${LIFTFILE}" | grep -c '<entry'
+        ;;
+
     tip)
         chg tip --template '{node}'
         ;;

--- a/hgweb/command-runner.sh
+++ b/hgweb/command-runner.sh
@@ -47,7 +47,7 @@ case $command_name in
         # Can't predict .lift filename, but we can ask Mercurial for it
         LIFTFILE=$(chg manifest -r tip | grep '\.lift$' | head -n 1)
         # The \b for word boundary is not necessary for .lift files
-        [ -n "${LIFTFILE}" ] && chg cat -r tip "${LIFTFILE}" | grep -c '<entry'
+        [ -n "${LIFTFILE}" ] && (chg cat -r tip "${LIFTFILE}" | grep -c '<entry') || echo 0
         ;;
 
     tip)


### PR DESCRIPTION
WIP. Will fix #547 when complete.

This expands the HgService.GetLexEntryCount method to be able to handle WeSay projects as well.

I have currently implemented this in the simplest way possible, using the FlexProjectMetadata table to store the LexEntryCount for WeSay projects as well as FLEx projects. This would mean that we'd want to rename that table to LexProjectMetadata, because FlexProjectMetadata would become a misnomer. (If table-rename migrations aren't possible, or aren't easy, with EF Core, then we could just live with the slight misnomer of a name). Or we could migrate that table to become a generic ProjectMetadata table, with nullable fields for every type of metadata that might be used in one or another type of project. E.g., LexEntryCount would apply to both FLEx and WeSay, OneStory projects might someday acquire a StoryCount or CoveredVerseCount field (which would be null for FLEx and WeSay projects), and so on.

The alternative is to create a WeSayProjectMetadata table and update all the code that touches LexEntryCount to create the appropriate table, include the appropriate table in queries, and so on. Then if we add metadata for OneStory, we'd have a third type of table.

My preference is to have just one type of metadata table, whose semantics would be determined by the application rather than enforced by the database. But if we want the semantics of the table enforced by the database (e.g., OneStory projects will never have a LexEntryCount) then we'd need to create multiple metadata tables with distinct names. (And we'd still be in a situation where the semantics would be enforced by the application and not the database, unless Postgres lets you create foreign key checks like "ProjectID must reference a GUID from the Projects table where the ProjectType field is equal to FLEx").