### PR TITLE
Only the lexbox pod can access the hg service

### DIFF
--- a/deployment/base/hg-deployment.yaml
+++ b/deployment/base/hg-deployment.yaml
@@ -21,6 +21,31 @@ spec:
 
 ---
 
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: hg-network-policy
+  namespace: languagedepot
+  labels:
+    app: hg
+spec:
+  podSelector:
+    matchLabels:
+      app: hg
+  policyTypes:
+  - Ingress
+  ingress:
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          namespace: languagedepot
+    # Do NOT put a hyphen in front of podSelector on the next line
+      podSelector:
+        matchLabels:
+          app: lexbox
+
+---
+
 # https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#writing-a-deployment-spec
 apiVersion: apps/v1
 kind: Deployment

--- a/deployment/base/hg-deployment.yaml
+++ b/deployment/base/hg-deployment.yaml
@@ -38,7 +38,8 @@ spec:
   - from:
     - namespaceSelector:
         matchLabels:
-          namespace: languagedepot
+          # You'd think namespace: languagedepot would work, but no, that's not valid syntax for NetworkPolicy
+          kubernetes.io/metadata.name: languagedepot
     # Do NOT put a hyphen in front of podSelector on the next line
       podSelector:
         matchLabels:


### PR DESCRIPTION
Fixes #599.

Tested on local dev by verifying that it does not break the project page, which can still load the Mercurial commit graph from hgweb. Have not yet verified that it is actually restricting traffic (i.e., doing its main job) but at least it's not breaking anything. (That is, unless Docker Desktop's Kubernetes implementation ignores NetworkPolicy, in which case we'd have to deploy to develop in order to test this).