### PR TITLE
New project managers also gain CreateProject rights

### DIFF
--- a/backend/LexBoxApi/Services/ProjectService.cs
+++ b/backend/LexBoxApi/Services/ProjectService.cs
@@ -32,6 +32,12 @@ public class ProjectService(LexBoxDbContext dbContext, IHgService hgService, IOp
             });
         // Also delete draft project, if any
         await dbContext.DraftProjects.Where(dp => dp.Id == projectId).ExecuteDeleteAsync();
+        if (input.ProjectManagerId.HasValue)
+        {
+            var manager = await dbContext.Users.FindAsync(input.ProjectManagerId.Value);
+            manager?.UpdateCreateProjectsPermission(ProjectRole.Manager);
+
+        }
         await dbContext.SaveChangesAsync();
         await hgService.InitRepo(input.Code);
         await transaction.CommitAsync();


### PR DESCRIPTION
Fixes #751.

If the admin accepts the project creation request and creates the draft project, the new project manager should also gain CreateProject rights just like existing managers have.

Currently does not have a unit test. Do we feel it needs one?