### PR TITLE
Bump SIL.Chorus.Mercurial package to fix Linux bug

### DIFF
--- a/backend/Testing/Testing.csproj
+++ b/backend/Testing/Testing.csproj
@@ -15,8 +15,8 @@
     <Choose>
         <When Condition=" '$(MercurialVersion)' == '6' ">
             <ItemGroup>
-                <PackageReference Include="SIL.Chorus.LibChorus" Version="6.0.0-beta0044" />
-                <PackageReference Include="SIL.Chorus.Mercurial" Version="6.5.1.25" />
+                <PackageReference Include="SIL.Chorus.LibChorus" Version="6.0.0-beta0045" />
+                <PackageReference Include="SIL.Chorus.Mercurial" Version="6.5.1.29" />
             </ItemGroup>
         </When>
         <Otherwise>


### PR DESCRIPTION
Fixes #754.

This will get #735 unstuck. But there's no reason to wait for #735 before merging this, as it also pulls in [a Chorus bugfix](https://github.com/sillsdev/chorus/pull/336) that we'll benefit from when running the integration tests.