### PR TITLE
add a qa user to our db seeding code

### DIFF
--- a/backend/LexData/Configuration/DbConfig.cs
+++ b/backend/LexData/Configuration/DbConfig.cs
@@ -7,4 +7,5 @@ public class DbConfig
     [Required]
     public required string LexBoxConnectionString { get; set; }
     public string DefaultSeedUserPassword { get; init; } = "pass";
+    public string QaAdminEmail { get; init; } = "qa@test.com";
 }

--- a/backend/LexData/SeedingData.cs
+++ b/backend/LexData/SeedingData.cs
@@ -2,25 +2,19 @@ using LexCore;
 using LexCore.Entities;
 using LexData.Configuration;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Options;
 
 namespace LexData;
 
-public class SeedingData
+public class SeedingData(LexBoxDbContext lexBoxDbContext, IOptions<DbConfig> dbConfig, IHostEnvironment environment)
 {
     public static readonly Guid TestAdminId = new("cf430ec9-e721-450a-b6a1-9a853212590b");
-    private readonly LexBoxDbContext _lexBoxDbContext;
-    private readonly IOptions<DbConfig> _dbConfig;
-
-    public SeedingData(LexBoxDbContext lexBoxDbContext, IOptions<DbConfig> dbConfig)
-    {
-        _lexBoxDbContext = lexBoxDbContext;
-        _dbConfig = dbConfig;
-    }
+    public static readonly Guid QaAdminId = new("99b00c58-0dc7-4fe4-b6f2-c27b828811e0");
 
     public async Task SeedIfNoUsers(CancellationToken cancellationToken = default)
     {
-        if (await _lexBoxDbContext.Users.CountAsync(cancellationToken) > 0)
+        if (await lexBoxDbContext.Users.CountAsync(cancellationToken) > 0)
         {
             return;
         }
@@ -32,12 +26,13 @@ public class SeedingData
 
     public async Task SeedDatabase(CancellationToken cancellationToken = default)
     {
+        if (environment.IsProduction()) return;
         //NOTE: When seeding make sure you provide a constant Id like I have done here,
         // this will allow us to call seed multiple times without creating new entities each time.
-        if (string.IsNullOrEmpty(_dbConfig.Value.DefaultSeedUserPassword))
+        if (string.IsNullOrEmpty(dbConfig.Value.DefaultSeedUserPassword))
             throw new Exception("DefaultSeedUserPassword is not set");
-        var passwordHash = PasswordHashing.HashPassword(_dbConfig.Value.DefaultSeedUserPassword, PwSalt, false);
-        _lexBoxDbContext.Attach(new User
+        var passwordHash = PasswordHashing.HashPassword(dbConfig.Value.DefaultSeedUserPassword, PwSalt, false);
+        lexBoxDbContext.Attach(new User
         {
             Id = TestAdminId,
             Email = "admin@test.com",
@@ -49,8 +44,23 @@ public class SeedingData
             EmailVerified = true,
             CanCreateProjects = true,
         });
+        if (!string.IsNullOrEmpty(dbConfig.Value.QaAdminEmail))
+        {
+            lexBoxDbContext.Attach(new User
+            {
+                Id = QaAdminId,
+                Email = dbConfig.Value.QaAdminEmail,
+                Name = "Qa Admin",
+                Username = null,
+                Salt = PwSalt,
+                PasswordHash = passwordHash,
+                IsAdmin = true,
+                EmailVerified = true,
+                CanCreateProjects = true
+            });
+        }
 
-        _lexBoxDbContext.Attach(new User
+        lexBoxDbContext.Attach(new User
         {
             Id = new Guid("79198d79-3f69-4de5-914f-96c336e58f94"),
             Email = "user@test.com",
@@ -63,7 +73,7 @@ public class SeedingData
             CanCreateProjects = false,
         });
 
-        _lexBoxDbContext.Attach(new Project
+        lexBoxDbContext.Attach(new Project
         {
             Id = new Guid("0ebc5976-058d-4447-aaa7-297f8569f968"),
             Name = "Sena 3",
@@ -110,7 +120,7 @@ public class SeedingData
                 },
             }
         });
-        _lexBoxDbContext.Attach(new Project
+        lexBoxDbContext.Attach(new Project
         {
             Id = new Guid("9e972940-8a8e-4b29-a609-bdc2f93b3507"),
             Name = "Elawa",
@@ -123,18 +133,18 @@ public class SeedingData
             Users = new()
         });
 
-        foreach (var entry in _lexBoxDbContext.ChangeTracker.Entries())
+        foreach (var entry in lexBoxDbContext.ChangeTracker.Entries())
         {
             var exists = await entry.GetDatabaseValuesAsync(cancellationToken) is not null;
             entry.State = exists ? EntityState.Modified : EntityState.Added;
         }
 
-        await _lexBoxDbContext.SaveChangesAsync(cancellationToken);
+        await lexBoxDbContext.SaveChangesAsync(cancellationToken);
     }
 
     public async Task CleanUpSeedData()
     {
-        await _lexBoxDbContext.Users.Where(u => u.Salt == PwSalt).ExecuteDeleteAsync();
-        await _lexBoxDbContext.Projects.Where(p => p.Code == "sena-3").ExecuteDeleteAsync();
+        await lexBoxDbContext.Users.Where(u => u.Salt == PwSalt).ExecuteDeleteAsync();
+        await lexBoxDbContext.Projects.Where(p => p.Code == "sena-3").ExecuteDeleteAsync();
     }
 }

--- a/deployment/base/lexbox-deployment.yaml
+++ b/deployment/base/lexbox-deployment.yaml
@@ -107,6 +107,12 @@ spec:
                   key: SEED_USER_PASSWORD
                   name: db
                   optional: true
+          - name: DbConfig__QaAdminEmail
+            valueFrom:
+              secretKeyRef:
+                  key: QA_ADMIN_EMAIL
+                  name: db
+                  optional: true
           - name: DbConfig__LexBoxConnectionString
             value: Host=db;Port=5432;Username=postgres;Password=$(POSTGRES_PASSWORD);Database=$(POSTGRES_DB)
           - name: LfClassicConfig__ConnectionString

--- a/deployment/base/secrets.yaml
+++ b/deployment/base/secrets.yaml
@@ -9,6 +9,7 @@ stringData:
   POSTGRES_DB: 'lexbox'
   POSTGRES_PASSWORD: ''
   SEED_USER_PASSWORD: ''
+  QA_ADMIN_EMAIL: ''
 
 ---
 


### PR DESCRIPTION
close #743

we need a consistent qa admin for the test team. This PR adds a new admin user with an email determined by a config value. In staging I've set that config value to the appropriate email address, this will allow the admin to recover that account even if they don't know the password.