### PR TITLE
Lock when initializing template repo

### DIFF
--- a/backend/Testing/Fixtures/IntegrationFixture.cs
+++ b/backend/Testing/Fixtures/IntegrationFixture.cs
@@ -15,7 +15,6 @@ public class IntegrationFixture : IAsyncLifetime
     public static readonly FileInfo TemplateRepoZip = new(TemplateRepoZipName);
     public static readonly DirectoryInfo TemplateRepo = new(Path.Join(BasePath, "_template-repo_"));
     public ApiTestBase AdminApiTester { get; private set; } = new();
-    private string AdminJwt = string.Empty;
 
     public async Task InitializeAsync(ApiTestBase apiTester)
     {
@@ -28,7 +27,7 @@ public class IntegrationFixture : IAsyncLifetime
         DeletePreviousTestFiles();
         Directory.CreateDirectory(BasePath);
         InitTemplateRepo();
-        AdminJwt = await AdminApiTester.LoginAs(AdminAuth.Username, AdminAuth.Password);
+        await AdminApiTester.LoginAs(AdminAuth.Username, AdminAuth.Password);
     }
 
     public Task DisposeAsync()
@@ -41,13 +40,14 @@ public class IntegrationFixture : IAsyncLifetime
         if (Directory.Exists(BasePath)) Directory.Delete(BasePath, true);
     }
 
-    private void InitTemplateRepo()
+    private static void InitTemplateRepo()
     {
         lock (TemplateRepo)
         {
             if (TemplateRepo.Exists) return;
             using var stream = TemplateRepoZip.OpenRead();
             ZipFile.ExtractToDirectory(stream, TemplateRepo.FullName);
+            TemplateRepo.Refresh();
         }
     }
 

--- a/backend/Testing/Fixtures/IntegrationFixture.cs
+++ b/backend/Testing/Fixtures/IntegrationFixture.cs
@@ -16,6 +16,11 @@ public class IntegrationFixture : IAsyncLifetime
     public static readonly DirectoryInfo TemplateRepo = new(Path.Join(BasePath, "_template-repo_"));
     public ApiTestBase AdminApiTester { get; private set; } = new();
 
+    static IntegrationFixture()
+    {
+        DeletePreviousTestFiles();
+    }
+
     public async Task InitializeAsync(ApiTestBase apiTester)
     {
         AdminApiTester = apiTester;
@@ -24,7 +29,6 @@ public class IntegrationFixture : IAsyncLifetime
 
     public async Task InitializeAsync()
     {
-        DeletePreviousTestFiles();
         Directory.CreateDirectory(BasePath);
         InitTemplateRepo();
         await AdminApiTester.LoginAs(AdminAuth.Username, AdminAuth.Password);

--- a/backend/Testing/Fixtures/IntegrationFixtureTests.cs
+++ b/backend/Testing/Fixtures/IntegrationFixtureTests.cs
@@ -1,7 +1,6 @@
 ﻿using Moq;
 using Shouldly;
 using Testing.ApiTests;
-using Testing.Services;
 
 namespace Testing.Fixtures;
 
@@ -10,10 +9,12 @@ namespace Testing.Fixtures;
 /// </summary>
 public class IntegrationFixtureTests
 {
+    // A static shared instance for the whole test class, because that's how xunit uses fixtures
+    private static readonly IntegrationFixture fixture = new();
+
     [Fact]
     public async Task InitCreatesARepoWithTheProject()
     {
-        var fixture = new IntegrationFixture();
         await fixture.InitializeAsync(Mock.Of<ApiTestBase>());
         IntegrationFixture.TemplateRepo.EnumerateFiles()
             .Select(f => f.Name)
@@ -23,7 +24,6 @@ public class IntegrationFixtureTests
     [Fact]
     public async Task CanFindTheProjectZipFile()
     {
-        var fixture = new IntegrationFixture();
         await fixture.InitializeAsync(Mock.Of<ApiTestBase>());
         IntegrationFixture.TemplateRepoZip
             .Directory!.EnumerateFiles().Select(f => f.Name)
@@ -33,23 +33,9 @@ public class IntegrationFixtureTests
     [Fact]
     public async Task CanInitFlexProjectRepo()
     {
-        var fixture = new IntegrationFixture();
         await fixture.InitializeAsync(Mock.Of<ApiTestBase>());
         var projectConfig = fixture.InitLocalFlexProjectWithRepo();
         Directory.EnumerateFiles(projectConfig.Dir)
             .ShouldContain(projectConfig.FwDataFile);
-    }
-
-    [Fact]
-    public async Task InitCleansUpPreviousRun()
-    {
-        var fixture = new IntegrationFixture();
-        await fixture.InitializeAsync(Mock.Of<ApiTestBase>());
-        var filePath = Path.Join(Constants.BasePath, "test.txt");
-        await File.WriteAllTextAsync(filePath, "test");
-        Directory.EnumerateFiles(Constants.BasePath).ShouldContain(filePath);
-
-        await fixture.InitializeAsync();
-        Directory.EnumerateFiles(Constants.BasePath).ShouldNotContain(filePath);
     }
 }

--- a/backend/Testing/Fixtures/IntegrationFixtureTests.cs
+++ b/backend/Testing/Fixtures/IntegrationFixtureTests.cs
@@ -15,7 +15,7 @@ public class IntegrationFixtureTests
     {
         var fixture = new IntegrationFixture();
         await fixture.InitializeAsync(Mock.Of<ApiTestBase>());
-        fixture.TemplateRepo.EnumerateFiles()
+        IntegrationFixture.TemplateRepo.EnumerateFiles()
             .Select(f => f.Name)
             .ShouldContain("kevin-test-01.fwdata");
     }
@@ -25,9 +25,9 @@ public class IntegrationFixtureTests
     {
         var fixture = new IntegrationFixture();
         await fixture.InitializeAsync(Mock.Of<ApiTestBase>());
-        fixture.TemplateRepoZip
+        IntegrationFixture.TemplateRepoZip
             .Directory!.EnumerateFiles().Select(f => f.Name)
-            .ShouldContain(fixture.TemplateRepoZip.Name);
+            .ShouldContain(IntegrationFixture.TemplateRepoZip.Name);
     }
 
     [Fact]


### PR DESCRIPTION
It seems xUnit runs tests [in parallel by default](https://xunit.net/docs/running-tests-in-parallel).

We now have multiple test class uses the fixture that initializes our template repo.

In [one run](https://github.com/sillsdev/languageforge-lexbox/runs/24375914285), all the tests (I think) in 1 class failed.
In [another run](https://github.com/sillsdev/languageforge-lexbox/runs/24377069026), a class with only 1 test failed (SimultaneousResetsDontResultIn404s) with the same reason.

I think this PR is the fix.