### PR TITLE
Fix PowerShell error during initial `task setup`

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -37,7 +37,7 @@ tasks:
   setup-win:
     platforms: [ windows ]
     cmds:
-      - cmd: powershell if (test-path {{.HG_REPO_DIR}}/sena-3) { rm -r {{.HG_REPO_DIR}}/sena-3 }
+      - cmd: powershell "if (test-path {{.HG_REPO_DIR}}/sena-3) { rm -r {{.HG_REPO_DIR}}/sena-3 }"
         ignore_error: true
         silent: true
       - powershell -Command "Invoke-WebRequest 'https://drive.google.com/uc?export=download&id=1I-hwc0RHoQqW774gbS5qR-GHa1E7BlsS' -OutFile sena-3.zip"

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -37,7 +37,7 @@ tasks:
   setup-win:
     platforms: [ windows ]
     cmds:
-      - cmd: powershell rm -r {{.HG_REPO_DIR}}/sena-3
+      - cmd: powershell if (test-path {{.HG_REPO_DIR}}/sena-3) { rm -r {{.HG_REPO_DIR}}/sena-3 }
         ignore_error: true
         silent: true
       - powershell -Command "Invoke-WebRequest 'https://drive.google.com/uc?export=download&id=1I-hwc0RHoQqW774gbS5qR-GHa1E7BlsS' -OutFile sena-3.zip"


### PR DESCRIPTION
Fixes #773.

PowerShell doesn't have an equivalent of the Linux `rm -rf` that ignores errors if the file doesn't exist. So we test if the directory exists first, and then if it exists, delete it.