### PR TITLE
Allow hg pod access from dev and non-dev namespaces

### DIFF
--- a/deployment/base/hg-deployment.yaml
+++ b/deployment/base/hg-deployment.yaml
@@ -44,6 +44,13 @@ spec:
       podSelector:
         matchLabels:
           app: lexbox
+    - namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: languagedepot-dev
+    # Do NOT put a hyphen in front of podSelector on the next line
+      podSelector:
+        matchLabels:
+          app: lexbox
 
 ---
 


### PR DESCRIPTION
Should fix #783.

Note that the namespace tag of the network policy remains `languagedepot`. That tag *should* be adjusted by the Fleet deployment just the same as the namespace tags in all the other Kubernetes configs; it's the `namespaceSelector`s that weren't adjusted.