### PR TITLE
Pass isConfidential: false in dotnet test

### DIFF
--- a/backend/Testing/ApiTests/NewProjectRaceCondition.cs
+++ b/backend/Testing/ApiTests/NewProjectRaceCondition.cs
@@ -40,6 +40,7 @@ public class NewProjectRaceCondition : ApiTestBase
                     type: FL_EX,
                     id: "{{id}}",
                     code: "{{id}}",
+                    isConfidential: false,
                     description: "this is just a testing project for testing a race condition",
                     retentionPolicy: DEV
                 }) {

--- a/backend/Testing/Services/Utils.cs
+++ b/backend/Testing/Services/Utils.cs
@@ -43,6 +43,7 @@ public static class Utils
                     type: FL_EX,
                     id: "{{config.Id}}",
                     code: "{{config.Code}}",
+                    isConfidential: false,
                     description: "Project created by an integration test",
                     retentionPolicy: DEV
                 }) {


### PR DESCRIPTION
Now that `isConfidential` is required in GraphQL project creation, we need it in the dotnet test methods that create projects via GQL mutations.

Fixes #791.