### PR TITLE
Query if projects are in LF

### DIFF
--- a/backend/LexBoxApi/GraphQL/CustomTypes/IsLanguageForgeProjectDataLoader.cs
+++ b/backend/LexBoxApi/GraphQL/CustomTypes/IsLanguageForgeProjectDataLoader.cs
@@ -1,0 +1,30 @@
+using LexCore.ServiceInterfaces;
+using LfClassicData;
+using MongoDB.Driver;
+using MongoDB.Driver.Linq;
+
+namespace LexBoxApi.GraphQL.CustomTypes;
+
+public class IsLanguageForgeProjectDataLoader : BatchDataLoader<string, bool>, IIsLanguageForgeProjectDataLoader
+{
+    private readonly SystemDbContext _systemDbContext;
+
+    public IsLanguageForgeProjectDataLoader(
+        SystemDbContext systemDbContext,
+        IBatchScheduler batchScheduler,
+        DataLoaderOptions? options = null)
+        : base(batchScheduler, options)
+    {
+        _systemDbContext = systemDbContext;
+    }
+
+    protected override async Task<IReadOnlyDictionary<string, bool>> LoadBatchAsync(
+        IReadOnlyList<string> projectCodes,
+        CancellationToken cancellationToken)
+    {
+        return await MongoExtensions.ToAsyncEnumerable(_systemDbContext.Projects.AsQueryable()
+            .Select(p => p.ProjectCode)
+            .Where(projectCode => projectCodes.Contains(projectCode)))
+            .ToDictionaryAsync(projectCode => projectCode, _ => true, cancellationToken);
+    }
+}

--- a/backend/LexBoxApi/GraphQL/GraphQlSetupKernel.cs
+++ b/backend/LexBoxApi/GraphQL/GraphQlSetupKernel.cs
@@ -20,6 +20,7 @@ public static class GraphQlSetupKernel
             .InitializeOnStartup()
             .RegisterDbContext<LexBoxDbContext>()
             .RegisterService<IHgService>()
+            .RegisterService<IIsLanguageForgeProjectDataLoader>()
             .RegisterService<LoggedInContext>()
             .RegisterService<EmailService>()
             .RegisterService<LexAuthService>()

--- a/backend/LexBoxApi/LexBoxKernel.cs
+++ b/backend/LexBoxApi/LexBoxKernel.cs
@@ -1,6 +1,7 @@
 using LexBoxApi.Auth;
 using LexBoxApi.Config;
 using LexBoxApi.GraphQL;
+using LexBoxApi.GraphQL.CustomTypes;
 using LexBoxApi.Services;
 using LexCore.Config;
 using LexCore.ServiceInterfaces;
@@ -52,6 +53,7 @@ public static class LexBoxKernel
         services.AddScoped<TusService>();
         services.AddScoped<TurnstileService>();
         services.AddScoped<IHgService, HgService>();
+        services.AddScoped<IIsLanguageForgeProjectDataLoader, IsLanguageForgeProjectDataLoader>();
         services.AddScoped<ILexProxyService, LexProxyService>();
         services.AddSingleton<ISendReceiveService, SendReceiveService>();
         services.AddSingleton<LexboxLinkGenerator>();

--- a/backend/LexCore/Entities/Project.cs
+++ b/backend/LexCore/Entities/Project.cs
@@ -50,6 +50,15 @@ public class Project : EntityBase
     {
         return hgService.HasAbandonedTransactions(Code);
     }
+
+    public Task<bool> GetIsLanguageForgeProject(IIsLanguageForgeProjectDataLoader loader)
+    {
+        if (Type is ProjectType.Unknown or ProjectType.FLEx)
+        {
+            return loader.LoadAsync(Code);
+        }
+        return Task.FromResult(false);
+    }
 }
 
 public enum ProjectMigrationStatus

--- a/backend/LexCore/ServiceInterfaces/IIsLanguageForgeProjectDataLoader.cs
+++ b/backend/LexCore/ServiceInterfaces/IIsLanguageForgeProjectDataLoader.cs
@@ -1,0 +1,6 @@
+﻿namespace LexCore.ServiceInterfaces;
+
+public interface IIsLanguageForgeProjectDataLoader
+{
+    public Task<bool> LoadAsync(string projectCode, CancellationToken cancellationToken = default);
+}

--- a/frontend/schema.graphql
+++ b/frontend/schema.graphql
@@ -214,6 +214,7 @@ type Project {
   users: [ProjectUsers!]!
   changesets: [Changeset!]!
   hasAbandonedTransactions: Boolean!
+  isLanguageForgeProject: Boolean!
   parentId: UUID
   name: String!
   description: String

--- a/frontend/src/routes/(authenticated)/project/[project_code]/+page.svelte
+++ b/frontend/src/routes/(authenticated)/project/[project_code]/+page.svelte
@@ -234,12 +234,14 @@
   <HeaderPage wide title={project.name}>
     <svelte:fragment slot="actions">
       {#if project.type === ProjectType.FlEx && $isDev}
+        {#if project.isLanguageForgeProject}
           <a href="./{project.code}/viewer" class="btn btn-neutral text-[#DCA54C] flex items-center gap-2">
             {$t('project_page.open_with_viewer')}
             <span class="i-mdi-dictionary text-2xl" />
           </a>
-          <OpenInFlexModal bind:this={openInFlexModal} {project}/>
-          <OpenInFlexButton projectId={project.id} on:click={openInFlexModal.open}/>
+        {/if}
+        <OpenInFlexModal bind:this={openInFlexModal} {project}/>
+        <OpenInFlexButton projectId={project.id} on:click={openInFlexModal.open}/>
       {:else}
         <Dropdown>
           <button class="btn btn-primary">

--- a/frontend/src/routes/(authenticated)/project/[project_code]/+page.ts
+++ b/frontend/src/routes/(authenticated)/project/[project_code]/+page.ts
@@ -45,6 +45,7 @@ export async function load(event: PageLoadEvent) {
 						createdDate
 						retentionPolicy
 						isConfidential
+            isLanguageForgeProject
 						users {
 							id
 							role


### PR DESCRIPTION
So, this works, but I have a couple concerns:
1) I don't think it's guarunteed that `Project.Type` is available, so presumably sometimes we'll query more projects than we want to 🤷 
2) I think the mongo `$in` operator could get a bit overloaded if we tried to query lots (e.g. 3000) projects. I know we're not planning to, but...it would be kind of cool if we could show this in the project tables. I wonder if it would be smarter to just load all the projects and do the `.Contains()` in .NET?

E.g. based on [this comment](https://stackoverflow.com/a/39567887/2301416):
> However, from engineering point of view, if N goes to a big number, it is better to let your business logic server to simulate the $in operation, either by batch or one-by-one.
> 
> This is simply because: memory in database servers is way more valuable than the memory in business logic servers.

![image](https://github.com/sillsdev/languageforge-lexbox/assets/12587509/4ea86559-2490-4af5-9837-0458e2191c99)
![image](https://github.com/sillsdev/languageforge-lexbox/assets/12587509/11badaa4-466d-4091-901d-719d2a488f5c)


![image](https://github.com/sillsdev/languageforge-lexbox/assets/12587509/f33c35e8-eebb-4b37-a87f-905b48e5e118)
![image](https://github.com/sillsdev/languageforge-lexbox/assets/12587509/4c7940d2-fe2a-45d3-996e-ee443ce11fcb)

Fixes #687