### PR TITLE
Bump Chorus NuGet package so we won't log passwords

### DIFF
--- a/backend/Testing/Testing.csproj
+++ b/backend/Testing/Testing.csproj
@@ -15,8 +15,8 @@
     <Choose>
         <When Condition=" '$(MercurialVersion)' == '6' ">
             <ItemGroup>
-                <PackageReference Include="SIL.Chorus.LibChorus" Version="6.0.0-beta0045" />
-                <PackageReference Include="SIL.Chorus.Mercurial" Version="6.5.1.29" />
+                <PackageReference Include="SIL.Chorus.LibChorus" Version="6.0.0-beta0046" />
+                <PackageReference Include="SIL.Chorus.Mercurial" Version="6.*" />
             </ItemGroup>
         </When>
         <Otherwise>


### PR DESCRIPTION
The Chorus bugfix that omits logging passwords in Send/Receive URLs was included in the beta0046 build.

We also switch the SIL.Chorus.Mercurial package version so that we can't accidentally conflict with the version specified in LibChorus.

Fixes #801.