### PR TITLE
Don't expose port 3000 in k8s

### DIFF
--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -48,11 +48,6 @@ portForward:
     resourceName: lexbox
     namespace: languagedepot
     port: 18888
-  # Svelte-Kit frontend
-  - resourceType: Service
-    resourceName: ui
-    namespace: languagedepot
-    port: 3000
   - resourceType: Service
     resourceName: db
     namespace: languagedepot


### PR DESCRIPTION
The UI in k8s doesn't work properly when accessed over port 3000, so it's just confusing that it's open and sort of works.
The UI should always be accessed over port 80 i.e. directly at localhost