### PR TITLE
Use hg 6 by default

### DIFF
--- a/backend/Testing/Testing.csproj
+++ b/backend/Testing/Testing.csproj
@@ -7,9 +7,9 @@
 
         <IsPackable>false</IsPackable>
         <Mercurial4ChorusDestDir>$(MSBuildProjectDirectory)</Mercurial4ChorusDestDir>
-        <!-- To switch Mercurial versions, do dotnet build /p:MercurialVersion=6 followed by dotnet test -->
-        <!-- Note that if you run dotnet test /p:MercurialVersion=6 it will not work as expected; you must run dotnet build first in order to switch Mercurial versions -->
-        <MercurialVersion Condition=" '$(MercurialVersion)' == '' ">3</MercurialVersion>
+        <!-- To switch Mercurial versions, do dotnet build /p:MercurialVersion=3 followed by dotnet test -->
+        <!-- Note that if you run dotnet test /p:MercurialVersion=3 it will not work as expected; you must run dotnet build first in order to switch Mercurial versions -->
+        <MercurialVersion Condition=" '$(MercurialVersion)' == '' ">6</MercurialVersion>
     </PropertyGroup>
 
     <Choose>


### PR DESCRIPTION
I think it makes sense to use hg 6 by default, so that we pick up the fixes we've been adding to Chorus