### PR TITLE
Tiny permission/user check change

### DIFF
--- a/deployment/base/hg-deployment.yaml
+++ b/deployment/base/hg-deployment.yaml
@@ -176,6 +176,7 @@ spec:
         securityContext:
           runAsUser: 33
           runAsGroup: 33 # www-data
+          runAsNonRoot: true
         image: busybox:1.36.1
         command:
           - 'sh'

--- a/deployment/init-repos/hg-deployment-patch.yaml
+++ b/deployment/init-repos/hg-deployment-patch.yaml
@@ -11,6 +11,7 @@ spec:
           securityContext:
             runAsUser: 33
             runAsGroup: 33 # www-data
+            runAsNonRoot: true
           image: busybox:1.36.1
           command:
             - 'sh'


### PR DESCRIPTION
This is a draft, because I hardly know what I'm doing here.
I'm tempted to just revert the user/group commits for the next release, because I can't figure out what's going on.

@rmunn do these changes make sense? They don't seem to be necessary, because Send/Receive doesn't result in files owned by root. Or should we be using `fsGroup: 33` on the lexbox-api container as well?