### PR TITLE
prevent sending emails to admins from staging

### DIFF
--- a/backend/LexBoxApi/appsettings.json
+++ b/backend/LexBoxApi/appsettings.json
@@ -12,7 +12,7 @@
       "Microsoft.AspNetCore": "Information",
       "Microsoft.AspNetCore.HttpOverrides.ForwardedHeadersMiddleware": "Debug",
       "Microsoft.EntityFrameworkCore": "Information",
-      "MongoDB.Command": "Debug",
+      "MongoDB.Command": "Debug"
     }
   },
   "ForwardedHeadersOptions": {
@@ -66,6 +66,6 @@
     "Endpoint": "http://localhost:4317"
   },
   "Email": {
-    "CreateProjectEmailDestination": "admin@languagedepot.org"
+    "CreateProjectEmailDestination": "lexbox_support@groups.sil.org"
   }
 }

--- a/deployment/develop/lexbox-deployment.patch.yaml
+++ b/deployment/develop/lexbox-deployment.patch.yaml
@@ -21,7 +21,6 @@ spec:
             - name: Email__SmtpPort
               value: '587'
             - name: Email__From
-              # TODO: need to parameterize this
               value: "Language Depot (Develop) <no-reply@develop.languagedepot.org>"
             - name: Email__BaseUrl
               value: "https://develop.lexbox.org"

--- a/deployment/production/lexbox-deployment.patch.yaml
+++ b/deployment/production/lexbox-deployment.patch.yaml
@@ -21,7 +21,8 @@ spec:
             - name: Email__SmtpPort
               value: '587'
             - name: Email__From
-              # TODO: need to parameterize this
               value: "Language Depot <no-reply@languagedepot.org>"
+            - name: Email__CreateProjectEmailDestination
+              value: "admin@languagedepot.org"
             - name: Email__BaseUrl
               value: "https://languagedepot.org"

--- a/deployment/staging/lexbox-deployment.patch.yaml
+++ b/deployment/staging/lexbox-deployment.patch.yaml
@@ -24,7 +24,6 @@ spec:
             - name: Email__SmtpPort
               value: '587'
             - name: Email__From
-              # TODO: need to parameterize this
               value: "Language Depot (Staging) <no-reply@staging.languagedepot.org>"
             - name: Email__BaseUrl
               value: "https://staging.languagedepot.org"


### PR DESCRIPTION
right now if a project request is made on staging the admin group is emailed. We should only do that on production