### PR TITLE
Use Mongo auth for Lf Classic connections

### DIFF
--- a/backend/LfClassicData/DataServiceKernel.cs
+++ b/backend/LfClassicData/DataServiceKernel.cs
@@ -35,6 +35,14 @@ public static class DataServiceKernel
     {
         var config = provider.GetRequiredService<IOptions<LfClassicConfig>>();
         var mongoSettings = MongoClientSettings.FromConnectionString(config.Value.ConnectionString);
+        if (config.Value.HasCredentials)
+        {
+            mongoSettings.Credential = MongoCredential.CreateCredential(
+                databaseName: config.Value.AuthSource,
+                username: config.Value.Username,
+                password: config.Value.Password
+            );
+        }
         mongoSettings.LoggingSettings = new LoggingSettings(provider.GetRequiredService<ILoggerFactory>());
         mongoSettings.ClusterConfigurator = cb =>
             cb.Subscribe(new DiagnosticsActivityEventSubscriber(new() { CaptureCommandText = true }));

--- a/backend/LfClassicData/LfClassicConfig.cs
+++ b/backend/LfClassicData/LfClassicConfig.cs
@@ -6,4 +6,9 @@ public class LfClassicConfig
 {
     [Required]
     public required string ConnectionString { get; set; }
+
+    public string? AuthSource { get; set; }
+    public string? Username { get; set; }
+    public string? Password { get; set; }
+    public bool HasCredentials => AuthSource is not null && Username is not null && Password is not null;
 }

--- a/deployment/base/lexbox-deployment.yaml
+++ b/deployment/base/lexbox-deployment.yaml
@@ -120,6 +120,21 @@ spec:
             value: Host=db;Port=5432;Username=postgres;Password=$(POSTGRES_PASSWORD);Database=$(POSTGRES_DB)
           - name: LfClassicConfig__ConnectionString
             value: mongodb://db.languageforge:27017
+          - name: LfClassicConfig__AuthSource
+            valueFrom:
+              secretKeyRef:
+                  key: MONGODB_AUTHSOURCE
+                  name: lf-mongo-auth
+          - name: LfClassicConfig__Username
+            valueFrom:
+              secretKeyRef:
+                  key: MONGODB_USER
+                  name: lf-mongo-auth
+          - name: LfClassicConfig__Password
+            valueFrom:
+              secretKeyRef:
+                  key: MONGODB_PASS
+                  name: lf-mongo-auth
           - name: Authentication__Jwt__Secret
             valueFrom:
               secretKeyRef:

--- a/deployment/base/secrets.yaml
+++ b/deployment/base/secrets.yaml
@@ -16,6 +16,18 @@ stringData:
 apiVersion: v1
 kind: Secret
 metadata:
+  name: lf-mongo-auth
+  namespace: languagedepot
+stringData:
+  MONGODB_AUTHSOURCE: ''
+  MONGODB_USER: ''
+  MONGODB_PASS: ''
+
+---
+
+apiVersion: v1
+kind: Secret
+metadata:
   name: otel
   namespace: languagedepot
 stringData:


### PR DESCRIPTION
Fix #812.

The username and password supplied in the k8s secrets (which have already been created in Rancher) are for an account with read-only access to any non-system database in Language Forge. LexBox dev and staging will access LF staging (since there is currently no LF dev environment), while LexBox prod will access LF prod.