### PR TITLE
Invite guest users by email, don't add right away

### DIFF
--- a/backend/LexBoxApi/Services/EmailService.cs
+++ b/backend/LexBoxApi/Services/EmailService.cs
@@ -100,10 +100,10 @@ public class EmailService(
     /// <param name="projectId">The GUID of the project the user is being invited to</param>
     /// <param name="language">The language in which the invitation email should be sent (default English)</param>
     public async Task SendCreateAccountEmail(string emailAddress,
-        Guid projectId,
+        Guid? projectId,
         ProjectRole role,
         string managerName,
-        string projectName,
+        string? projectName,
         string? language = null)
     {
         language ??= User.DefaultLocalizationCode;
@@ -116,7 +116,7 @@ public class EmailService(
                 EmailVerificationRequired = null,
                 Role = UserRole.user,
                 UpdatedDate = DateTimeOffset.Now.ToUnixTimeSeconds(),
-                Projects = [new AuthUserProject(role, projectId)],
+                Projects = projectId.HasValue ? [new AuthUserProject(role, projectId.Value)] : [],
                 CanCreateProjects = null,
                 Locale = language,
                 Locked = null,
@@ -134,7 +134,7 @@ public class EmailService(
             new { jwt, returnTo });
 
         ArgumentException.ThrowIfNullOrEmpty(registerLink);
-        await RenderEmail(email, new ProjectInviteEmail(emailAddress, projectId.ToString(), managerName, projectName, registerLink, lifetime), language);
+        await RenderEmail(email, new ProjectInviteEmail(emailAddress, projectId.ToString() ?? "", managerName, projectName ?? "", registerLink, lifetime), language);
         await SendEmailAsync(email);
 
     }

--- a/frontend/schema.graphql
+++ b/frontend/schema.graphql
@@ -30,6 +30,7 @@ type BulkAddProjectMembersResult {
   addedMembers: [UserProjectRole!]!
   createdMembers: [UserProjectRole!]!
   existingMembers: [UserProjectRole!]!
+  invitedMembers: [UserProjectRole!]!
 }
 
 type ChangeProjectDescriptionPayload {

--- a/frontend/schema.graphql
+++ b/frontend/schema.graphql
@@ -370,7 +370,7 @@ union ChangeUserAccountByAdminError = NotFoundError | DbError | UniqueValueError
 
 union ChangeUserAccountBySelfError = NotFoundError | DbError | UniqueValueError
 
-union CreateGuestUserByAdminError = NotFoundError | DbError | UniqueValueError | RequiredError
+union CreateGuestUserByAdminError = NotFoundError | DbError | UniqueValueError | ProjectMemberInvitedByEmail | RequiredError
 
 union CreateOrganizationError = DbError
 

--- a/frontend/src/lib/components/Users/CreateUser.svelte
+++ b/frontend/src/lib/components/Users/CreateUser.svelte
@@ -51,6 +51,9 @@
       if (error.invalidInput) {
         $errors.email = [validateAsEmail($form.email) ? $t('form.invalid_email') : $t('register.invalid_username')];
       }
+      if (error.invited) {
+        dispatch('invited');
+      }
       return;
     }
     if (user) {

--- a/frontend/src/lib/components/Users/CreateUserModal.svelte
+++ b/frontend/src/lib/components/Users/CreateUserModal.svelte
@@ -36,6 +36,8 @@
   <h1 class="text-center text-xl">{$t('admin_dashboard.create_user_modal.create_user')}</h1>
   <CreateUser {handleSubmit} allowUsernames skipTurnstile
     on:submitted={() => createUserModal.submitModal()}
+    on:invited={() => createUserModal.submitModal()}
     submitButtonText={$t('admin_dashboard.create_user_modal.create_user')}
   />
+  <!-- TODO: Display toast notification when user invited? Or leave up to caller to decide how to handle, and just pass event on? -->
 </Modal>

--- a/frontend/src/lib/email/CreateAccountRequest.svelte
+++ b/frontend/src/lib/email/CreateAccountRequest.svelte
@@ -9,10 +9,12 @@
   export let lifetime: string;
 
   $: [expirationText, expirationParam] = toI18nKey(lifetime);
+  let template: 'emails.create_account_request_email' | 'emails.create_account_without_project_request_email';
+  $: template = projectName ? 'emails.create_account_request_email' : 'emails.create_account_without_project_request_email';
 </script>
 
-<Email subject={$t('emails.create_account_request_email.subject', {projectName})} name="">
-  <mj-text>{$t('emails.create_account_request_email.body', {managerName, projectName})}</mj-text>
-  <mj-button href={verifyUrl}>{$t('emails.create_account_request_email.join_button')}</mj-button>
+<Email subject={$t(`${template}.subject`, {projectName})} name="">
+  <mj-text>{$t(`${template}.body`, {managerName, projectName})}</mj-text>
+  <mj-button href={verifyUrl}>{$t(`${template}.join_button`)}</mj-button>
   <mj-text>{$t(expirationText, expirationParam)}</mj-text>
 </Email>

--- a/frontend/src/lib/i18n/locales/en.json
+++ b/frontend/src/lib/i18n/locales/en.json
@@ -475,6 +475,11 @@ If you don't see a dialog or already closed it, click the button below:",
       "body": "{managerName} has invited you to join the {projectName} language project. Click below to join.",
       "join_button": "Join project"
     },
+    "create_account_without_project_request_email": {
+      "subject": "Invitation to join Language Depot",
+      "body": "{managerName} has invited you to join the Language Depot website. Click below to create your account.",
+      "join_button": "Create account"
+    },
     "create_project_request_email": {
       "subject": "Project request: {projectName}",
       "heading": "User {name} ({email}) requested that a project be created for them. Details below:"

--- a/frontend/src/lib/user.ts
+++ b/frontend/src/lib/user.ts
@@ -85,7 +85,7 @@ export async function login(userId: string, password: string): Promise<LoginResu
     : { success: false, error: await response.text() as LoginError };
 }
 
-export type RegisterResponse = { error?: { turnstile?: boolean, accountExists?: boolean, invalidInput?: boolean }, user?: LexAuthUser };
+export type RegisterResponse = { error?: { turnstile?: boolean, accountExists?: boolean, invalidInput?: boolean, invited?: boolean }, user?: LexAuthUser };
 export async function createUser(endpoint: string, password: string, passwordStrength: number, name: string, email: string, locale: string, turnstileToken: string): Promise<RegisterResponse> {
   const response = await fetch(endpoint, {
     method: 'post',
@@ -137,6 +137,9 @@ export async function createGuestUserByAdmin(password: string, passwordStrength:
   }
   if (gqlResponse.error?.byType('RequiredError')) {
     return { error: { invalidInput: true }};
+  }
+  if (gqlResponse.error?.byType('ProjectMemberInvitedByEmail')) {
+    return { error: { invited: true }};
   }
   if (!gqlResponse.data?.createGuestUserByAdmin.lexAuthUser ) {
     return { error: { invalidInput: true }};

--- a/frontend/src/routes/(authenticated)/project/[project_code]/+page.ts
+++ b/frontend/src/routes/(authenticated)/project/[project_code]/+page.ts
@@ -173,6 +173,10 @@ export async function _bulkAddProjectMembers(input: BulkAddProjectMembersInput):
                 username
                 role
               }
+              invitedMembers {
+                username
+                role
+              }
             }
             errors {
               __typename

--- a/frontend/src/routes/(authenticated)/project/[project_code]/BulkAddProjectMembers.svelte
+++ b/frontend/src/routes/(authenticated)/project/[project_code]/BulkAddProjectMembers.svelte
@@ -34,6 +34,7 @@
   let addedMembers: BulkAddProjectMembersResult['addedMembers'] = [];
   let createdMembers: BulkAddProjectMembersResult['createdMembers'] = [];
   let existingMembers: BulkAddProjectMembersResult['existingMembers'] = [];
+  let invitedMembers: BulkAddProjectMembersResult['invitedMembers'] = [];
   $: addedCount = addedMembers.length + createdMembers.length;
 
   function validateBulkAddInput(usernames: string[]): FormSubmitReturn<typeof schema> {
@@ -79,6 +80,7 @@
       addedMembers = data?.bulkAddProjectMembers.bulkAddProjectMembersResult?.addedMembers ?? [];
       createdMembers = data?.bulkAddProjectMembers.bulkAddProjectMembersResult?.createdMembers ?? [];
       existingMembers = data?.bulkAddProjectMembers.bulkAddProjectMembersResult?.existingMembers ?? [];
+      invitedMembers = data?.bulkAddProjectMembers.bulkAddProjectMembersResult?.invitedMembers ?? [];
       return error?.message;
     }, { keepOpenOnSubmit: true });
 
@@ -148,6 +150,21 @@
           <div class="mt-2">
             <BadgeList>
               {#each createdMembers as user}
+                <MemberBadge member={{ name: user.username, role: user.role }} />
+              {/each}
+            </BadgeList>
+          </div>
+        {/if}
+      </div>
+      <div class="mb-4 ml-8">
+        <p class="flex gap-1 items-center">
+          <Icon icon="i-mdi-creation-outline" color="text-success" />
+          {$t('project_page.bulk_add_members.accounts_invited', {invitedCount: invitedMembers.length})}
+        </p>
+        {#if invitedMembers.length > 0}
+          <div class="mt-2">
+            <BadgeList>
+              {#each invitedMembers as user}
                 <MemberBadge member={{ name: user.username, role: user.role }} />
               {/each}
             </BadgeList>


### PR DESCRIPTION
Fixes #815.

Now the bulk-add button and the Create User modal will send invitations, rather than creating user accounts immediately, if an email address is given. (Username-only accounts are still created immediately, because we don't have an email address to send an invite to.)