### PR TITLE
Fix incorrect deleteDraftProject logic

### DIFF
--- a/frontend/src/routes/(authenticated)/admin/AdminProjects.svelte
+++ b/frontend/src/routes/(authenticated)/admin/AdminProjects.svelte
@@ -60,7 +60,7 @@
 
   let deleteProjectModal: ConfirmDeleteModal;
   async function deleteProjectOrDraft(project: ProjectItemWithDraftStatus): Promise<void> {
-    const deleteFn = project.isDraft ? _deleteProject : _deleteDraftProject;
+    const deleteFn = project.isDraft ? _deleteDraftProject : _deleteProject;
     const result = await deleteProjectModal.open(project.name, async () => {
       const { error } = await deleteFn(project.id);
       return error?.message;


### PR DESCRIPTION
Fixes #825.

This bug prevents the admin dashboard from being able to delete *any* projects, draft or real, because we got the conditional logic wrong, submitting `deleteDraftProjects` for real projects and `deleteProject` for draft projects.