### PR TITLE
Allow MongoDB to be unavailable

### DIFF
--- a/backend/LexBoxApi/GraphQL/CustomTypes/IsLanguageForgeProjectDataLoader.cs
+++ b/backend/LexBoxApi/GraphQL/CustomTypes/IsLanguageForgeProjectDataLoader.cs
@@ -22,6 +22,9 @@ public class IsLanguageForgeProjectDataLoader : BatchDataLoader<string, bool>, I
         IReadOnlyList<string> projectCodes,
         CancellationToken cancellationToken)
     {
+        if (!await _systemDbContext.IsAvailable())
+            return new Dictionary<string, bool>();
+
         return await MongoExtensions.ToAsyncEnumerable(_systemDbContext.Projects.AsQueryable()
             .Select(p => p.ProjectCode)
             .Where(projectCode => projectCodes.Contains(projectCode)))

--- a/backend/LexBoxApi/GraphQL/CustomTypes/IsLanguageForgeProjectDataLoader.cs
+++ b/backend/LexBoxApi/GraphQL/CustomTypes/IsLanguageForgeProjectDataLoader.cs
@@ -1,3 +1,4 @@
+using System.Collections.ObjectModel;
 using LexCore.ServiceInterfaces;
 using LfClassicData;
 using MongoDB.Driver;
@@ -23,7 +24,7 @@ public class IsLanguageForgeProjectDataLoader : BatchDataLoader<string, bool>, I
         CancellationToken cancellationToken)
     {
         if (!await _systemDbContext.IsAvailable())
-            return new Dictionary<string, bool>();
+            return ReadOnlyDictionary<string, bool>.Empty;
 
         return await MongoExtensions.ToAsyncEnumerable(_systemDbContext.Projects.AsQueryable()
             .Select(p => p.ProjectCode)

--- a/backend/LfClassicData/SystemDbContext.cs
+++ b/backend/LfClassicData/SystemDbContext.cs
@@ -1,4 +1,5 @@
 using LfClassicData.Entities;
+using MongoDB.Bson;
 using MongoDB.Driver;
 
 namespace LfClassicData;
@@ -7,6 +8,7 @@ public class SystemDbContext
 {
     public const string SystemDbName = "scriptureforge";
     private readonly IMongoDatabase _mongoDatabase;
+    private bool? _isAvailable;
 
     public SystemDbContext(MongoClient mongoClient)
     {
@@ -17,4 +19,16 @@ public class SystemDbContext
 
     internal IMongoCollection<User> Users { get; }
     public IMongoCollection<LfProject> Projects { get; }
+
+    public async Task<bool> IsAvailable()
+    {
+        if (_isAvailable is null or false)
+        {
+            _isAvailable = await Task.Run(() =>
+            {
+                return _mongoDatabase.RunCommandAsync((Command<BsonDocument>)"{ping:1}").Wait(100);
+            });
+        }
+        return _isAvailable.Value;
+    }
 }

--- a/backend/LfClassicData/SystemDbContext.cs
+++ b/backend/LfClassicData/SystemDbContext.cs
@@ -22,13 +22,19 @@ public class SystemDbContext
 
     public async Task<bool> IsAvailable()
     {
-        if (_isAvailable is null or false)
+        if (_isAvailable is null)
         {
-            _isAvailable = await Task.Run(() =>
+            try
             {
                 //lang=json
-                return _mongoDatabase.RunCommandAsync((Command<BsonDocument>)"{ping:1}").Wait(TimeSpan.FromMilliseconds(100));
-            });
+                await _mongoDatabase.RunCommandAsync((Command<BsonDocument>)"{ping:1}")
+                    .WaitAsync(TimeSpan.FromSeconds(3));
+                _isAvailable = true;
+            }
+            catch
+            {
+                _isAvailable = false;
+            }
         }
         return _isAvailable.Value;
     }

--- a/backend/LfClassicData/SystemDbContext.cs
+++ b/backend/LfClassicData/SystemDbContext.cs
@@ -26,7 +26,8 @@ public class SystemDbContext
         {
             _isAvailable = await Task.Run(() =>
             {
-                return _mongoDatabase.RunCommandAsync((Command<BsonDocument>)"{ping:1}").Wait(100);
+                //lang=json
+                return _mongoDatabase.RunCommandAsync((Command<BsonDocument>)"{ping:1}").Wait(TimeSpan.FromMilliseconds(100));
             });
         }
         return _isAvailable.Value;


### PR DESCRIPTION
I don't love how I've implemented this.
But, LF classic is a seperate service so it seems reasonable to make it optional and have less development dependencies.
I'm not sure how to make it better. 

If anyone thinks this is bad, silly or unnecessary that's fine with me.
Or is there a better way to do this?