### PR TITLE
Bump Chorus version

### DIFF
--- a/backend/Testing/Testing.csproj
+++ b/backend/Testing/Testing.csproj
@@ -15,7 +15,7 @@
     <Choose>
         <When Condition=" '$(MercurialVersion)' == '6' ">
             <ItemGroup>
-                <PackageReference Include="SIL.Chorus.LibChorus" Version="6.0.0-beta0046" />
+                <PackageReference Include="SIL.Chorus.LibChorus" Version="6.0.0-beta0048" />
                 <PackageReference Include="SIL.Chorus.Mercurial" Version="6.*" />
             </ItemGroup>
         </When>


### PR DESCRIPTION
I'm somewhat confused.
This new version of Chorus ensures that `hg.exe` and not `hg` is run on Windows.
But now when I build, I don't even have an `hg`. I'm not sure how I get into the different states.

So, I can't really test this. I just know that I had to manually rename hg.exe to hg several times to be able to run integration tests 😆 