### PR TITLE
Org list page

### DIFF
--- a/backend/LexBoxApi/GraphQL/CustomTypes/OrgGqlConfiguration.cs
+++ b/backend/LexBoxApi/GraphQL/CustomTypes/OrgGqlConfiguration.cs
@@ -11,6 +11,5 @@ public class OrgGqlConfiguration : ObjectType<Organization>
         // TODO: Will we want something similar to the following Project code for orgs?
         // descriptor.Field(o => o.Id).Use<RefreshJwtProjectMembershipMiddleware>();
         // descriptor.Field(o => o.Members).Use<RefreshJwtProjectMembershipMiddleware>();
-        descriptor.Field("memberCount").Resolve(ctx => ctx.Parent<Organization>().MemberCount);
     }
 }

--- a/backend/LexBoxApi/GraphQL/CustomTypes/OrgGqlConfiguration.cs
+++ b/backend/LexBoxApi/GraphQL/CustomTypes/OrgGqlConfiguration.cs
@@ -1,0 +1,16 @@
+using LexCore.Entities;
+
+namespace LexBoxApi.GraphQL.CustomTypes;
+
+[ObjectType]
+public class OrgGqlConfiguration : ObjectType<Organization>
+{
+    protected override void Configure(IObjectTypeDescriptor<Organization> descriptor)
+    {
+        descriptor.Field(o => o.CreatedDate).IsProjected();
+        // TODO: Will we want something similar to the following Project code for orgs?
+        // descriptor.Field(o => o.Id).Use<RefreshJwtProjectMembershipMiddleware>();
+        // descriptor.Field(o => o.Members).Use<RefreshJwtProjectMembershipMiddleware>();
+        descriptor.Field("memberCount").Resolve(ctx => ctx.Parent<Organization>().MemberCount);
+    }
+}

--- a/backend/LexCore/Entities/Organization.cs
+++ b/backend/LexCore/Entities/Organization.cs
@@ -10,14 +10,14 @@ public class Organization : EntityBase
     public required List<OrgMember> Members { get; set; }
 
     // This doesn't seem to work:
-    // [NotMapped]
-    // [Projectable(UseMemberBody = nameof(SqlMemberCount))]
-    // public int MemberCount { get; set; }
-    // private static Expression<Func<Organization, int>> SqlMemberCount => org => org.Members.Count;
+    [NotMapped]
+    [Projectable(UseMemberBody = nameof(SqlMemberCount))]
+    public int MemberCount { get; set; }
+    private static Expression<Func<Organization, int>> SqlMemberCount => org => org.Members.Count;
 
     // We'll use this simpler method until we can debug the SqlMemberCount method
-    [Projectable]
-    public int MemberCount => Members.Count;
+    // [Projectable]
+    // public int MemberCount => Members.Count;
     // Note that this will fail with a NullReferenceException if the GQL query doesn't include `members { at least one property }`
 }
 

--- a/backend/LexCore/Entities/Organization.cs
+++ b/backend/LexCore/Entities/Organization.cs
@@ -18,6 +18,7 @@ public class Organization : EntityBase
     // We'll use this simpler method until we can debug the SqlMemberCount method
     [Projectable]
     public int MemberCount => Members.Count;
+    // Note that this will fail with a NullReferenceException if the GQL query doesn't include `members { at least one property }`
 }
 
 public class OrgMember : EntityBase

--- a/backend/LexCore/Entities/Organization.cs
+++ b/backend/LexCore/Entities/Organization.cs
@@ -10,10 +10,10 @@ public class Organization : EntityBase
     public required List<OrgMember> Members { get; set; }
 
     // This doesn't seem to work:
-    [NotMapped]
-    [Projectable(UseMemberBody = nameof(SqlMemberCount))]
-    public int MemberCountAlternate { get; set; } // TODO: Rename to MemberCount once I get this working
-    private static Expression<Func<Organization, int>> SqlMemberCount => org => org.Members.Count;
+    // [NotMapped]
+    // [Projectable(UseMemberBody = nameof(SqlMemberCount))]
+    // public int MemberCount { get; set; }
+    // private static Expression<Func<Organization, int>> SqlMemberCount => org => org.Members.Count;
 
     // We'll use this simpler method until we can debug the SqlMemberCount method
     [Projectable]

--- a/backend/LexCore/Entities/Organization.cs
+++ b/backend/LexCore/Entities/Organization.cs
@@ -1,9 +1,23 @@
-﻿namespace LexCore.Entities;
+using System.ComponentModel.DataAnnotations.Schema;
+using System.Linq.Expressions;
+using EntityFrameworkCore.Projectables;
+
+namespace LexCore.Entities;
 
 public class Organization : EntityBase
 {
     public required string Name { get; set; }
     public required List<OrgMember> Members { get; set; }
+
+    // This doesn't seem to work:
+    [NotMapped]
+    [Projectable(UseMemberBody = nameof(SqlMemberCount))]
+    public int MemberCountAlternate { get; set; } // TODO: Rename to MemberCount once I get this working
+    private static Expression<Func<Organization, int>> SqlMemberCount => org => org.Members.Count;
+
+    // We'll use this simpler method until we can debug the SqlMemberCount method
+    [Projectable]
+    public int MemberCount => Members.Count;
 }
 
 public class OrgMember : EntityBase

--- a/backend/LexCore/Entities/Organization.cs
+++ b/backend/LexCore/Entities/Organization.cs
@@ -9,16 +9,10 @@ public class Organization : EntityBase
     public required string Name { get; set; }
     public required List<OrgMember> Members { get; set; }
 
-    // This doesn't seem to work:
     [NotMapped]
     [Projectable(UseMemberBody = nameof(SqlMemberCount))]
     public int MemberCount { get; set; }
     private static Expression<Func<Organization, int>> SqlMemberCount => org => org.Members.Count;
-
-    // We'll use this simpler method until we can debug the SqlMemberCount method
-    // [Projectable]
-    // public int MemberCount => Members.Count;
-    // Note that this will fail with a NullReferenceException if the GQL query doesn't include `members { at least one property }`
 }
 
 public class OrgMember : EntityBase

--- a/frontend/schema.graphql
+++ b/frontend/schema.graphql
@@ -212,10 +212,11 @@ type OrgMember {
 }
 
 type Organization {
+  createdDate: DateTime!
+  memberCount: Int!
   name: String!
   members: [OrgMember!]!
   id: UUID!
-  createdDate: DateTime!
   updatedDate: DateTime!
 }
 
@@ -591,6 +592,7 @@ input OrganizationFilterInput {
   or: [OrganizationFilterInput!]
   name: StringOperationFilterInput
   members: ListFilterInputTypeOfOrgMemberFilterInput
+  memberCount: IntOperationFilterInput
   id: UuidOperationFilterInput
   createdDate: DateTimeOperationFilterInput
   updatedDate: DateTimeOperationFilterInput
@@ -598,6 +600,7 @@ input OrganizationFilterInput {
 
 input OrganizationSortInput {
   name: SortEnumType
+  memberCount: SortEnumType
   id: SortEnumType
   createdDate: SortEnumType
   updatedDate: SortEnumType

--- a/frontend/src/lib/i18n/locales/en.json
+++ b/frontend/src/lib/i18n/locales/en.json
@@ -94,6 +94,7 @@
   },
   "appmenu": {
     "log_out": "Log out",
+    "orgs": "Organizations",
     "help": "Help"
   },
   "close": "Close",

--- a/frontend/src/lib/i18n/locales/en.json
+++ b/frontend/src/lib/i18n/locales/en.json
@@ -172,6 +172,8 @@ the [Linguistics Institute at Payap University](https://li.payap.ac.th/) in Chia
       "migrated": "Migrated",
       "type": "Type",
       "users": "Users",
+      "members": "Members",
+      "__comment": "Move 'members' to 'org.table' once org page PR is merged",
     },
     "filter": {
       "title": "Project filters",

--- a/frontend/src/lib/i18n/locales/en.json
+++ b/frontend/src/lib/i18n/locales/en.json
@@ -142,6 +142,14 @@
 It is provided as a service to language communities by [SIL Language Technology](https://software.sil.org/) and \
 the [Linguistics Institute at Payap University](https://li.payap.ac.th/) in Chiang Mai, Thailand."
   },
+  "org": {
+    "table": {
+      "title": "Organizations",
+      "name": "Name",
+      "created_at": "Created",
+      "members": "Members"
+    },
+  },
   "project": {
     "create": {
       "title": "Create Project",

--- a/frontend/src/lib/icons/HomeIcon.svelte
+++ b/frontend/src/lib/icons/HomeIcon.svelte
@@ -1,2 +1,5 @@
-<!-- https://icon-sets.iconify.design/mdi/logout/ -->
-<span class="i-mdi-home text-2xl" />
+<script lang="ts">
+  export let size: 'text-2xl' | 'text-xl' = 'text-2xl';
+</script>
+
+<span class="i-mdi-home-outline {size}" />

--- a/frontend/src/lib/layout/AppBar.svelte
+++ b/frontend/src/lib/layout/AppBar.svelte
@@ -31,7 +31,7 @@
     <div>
       {#if user}
         <!-- using a label means it works before hydration is complete -->
-        <label for="drawer-toggle" class="btn btn-primary px-2">
+        <label for="drawer-toggle" class="btn btn-primary glass px-2">
           {user.name}
           <AuthenticatedUserIcon size="text-4xl" />
         </label>

--- a/frontend/src/lib/layout/AppMenu.svelte
+++ b/frontend/src/lib/layout/AppMenu.svelte
@@ -46,13 +46,6 @@
     </a>
   </li>
 
-  <li>
-    <a href="/user" data-sveltekit-preload-data="tap">
-      {$t('account_settings.title')}
-      <AuthenticatedUserIcon />
-    </a>
-  </li>
-
   <DevContent>
   <li>
     <a href="/org/list" data-sveltekit-preload-data="tap">
@@ -61,6 +54,13 @@
     </a>
   </li>
   </DevContent>
+
+  <li>
+    <a href="/user" data-sveltekit-preload-data="tap">
+      {$t('account_settings.title')}
+      <AuthenticatedUserIcon />
+    </a>
+  </li>
 
   <li>
     <a href={helpLinks.helpList} target="_blank" rel="external">
@@ -81,5 +81,9 @@
 <style>
   a {
     justify-content: flex-end;
+  }
+
+  .menu {
+    scrollbar-gutter: stable;
   }
 </style>

--- a/frontend/src/lib/layout/AppMenu.svelte
+++ b/frontend/src/lib/layout/AppMenu.svelte
@@ -7,6 +7,7 @@
   import type {LexAuthUser} from '$lib/user';
   import Icon from '$lib/icons/Icon.svelte';
   import { helpLinks } from '$lib/components/help';
+  import DevContent from './DevContent.svelte';
 
   export let serverVersion: string;
   export let apiVersion: string | null;
@@ -51,6 +52,15 @@
       <AuthenticatedUserIcon />
     </a>
   </li>
+
+  <DevContent>
+  <li>
+    <a href="/org/list" data-sveltekit-preload-data="tap">
+      {$t('appmenu.orgs')}
+      <Icon icon="i-mdi-account-group-outline" size="text-2xl" />
+    </a>
+  </li>
+  </DevContent>
 
   <li>
     <a href={helpLinks.helpList} target="_blank" rel="external">

--- a/frontend/src/lib/layout/Breadcrumbs/HomeBreadcrumb.svelte
+++ b/frontend/src/lib/layout/Breadcrumbs/HomeBreadcrumb.svelte
@@ -1,11 +1,7 @@
 <script>
-  import t from '$lib/i18n';
   import PageBreadcrumb from './PageBreadcrumb.svelte';
 </script>
 
 <PageBreadcrumb href="/">
-  <span class="inline-flex gap-1 items-center">
-    {$t('user_dashboard.home_title')}
-    <span class="i-mdi-home-outline text-sm mb-[-1px]" />
-  </span>
+  <span class="i-mdi-home-outline text-lg mb-[-4px]"></span>
 </PageBreadcrumb>

--- a/frontend/src/lib/layout/Layout.svelte
+++ b/frontend/src/lib/layout/Layout.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import EmailVerificationStatus, { initEmailResult, initRequestedEmail } from '$lib/email/EmailVerificationStatus.svelte';
   import t from '$lib/i18n';
-  import { AdminIcon, Icon } from '$lib/icons';
+  import { AdminIcon, HomeIcon, Icon } from '$lib/icons';
   import { AdminContent, AppBar, AppMenu, Breadcrumbs, Content } from '$lib/layout';
   import { onMount } from 'svelte';
   import { ensureClientMatchesUser } from '$lib/gql';
@@ -46,30 +46,33 @@
           <Breadcrumbs />
           <div class="flex gap-4 items-center">
             <DevContent>
-              <a href="/sandbox" class="btn btn-sm btn-secondary">
-                <span class="max-sm:hidden">
-                  Sandbox
-                </span>
+              <a href="/sandbox" class="btn btn-sm btn-neutral glass">
                 <Icon size="text-2xl" icon="i-mdi-box-variant" />
               </a>
             </DevContent>
             <a href={helpLinks.helpList} target="_blank" rel="external"
-              class="btn btn-sm btn-info btn-outline max-sm:hidden">
+              class="btn btn-sm btn-info btn-outline hidden lg:flex">
               {$t('appmenu.help')}
               <Icon icon="i-mdi-open-in-new" size="text-lg" />
             </a>
             <DevContent>
-            <a href="/org/list" class="btn btn-sm btn-warning max-sm:hidden">
+            <a href="/org/list" class="btn btn-sm btn-secondary hidden lg:flex">
               {$t('appmenu.orgs')}
-              <Icon icon="i-mdi-account-group-outline" size="text-lg" />
+              <Icon icon="i-mdi-account-group-outline" size="text-xl" />
             </a>
             </DevContent>
+            <a href="/" class="btn btn-sm btn-primary">
+              <span class="max-sm:hidden">
+                {$t('user_dashboard.title')}
+              </span>
+              <HomeIcon size="text-xl" />
+            </a>
             <AdminContent>
               <a href="/admin" class="btn btn-sm btn-accent">
                 <span class="max-sm:hidden">
                   {$t('admin_dashboard.title')}
                 </span>
-                <AdminIcon />
+                <AdminIcon size="text-xl" />
               </a>
             </AdminContent>
           </div>

--- a/frontend/src/lib/layout/Layout.svelte
+++ b/frontend/src/lib/layout/Layout.svelte
@@ -58,6 +58,12 @@
               {$t('appmenu.help')}
               <Icon icon="i-mdi-open-in-new" size="text-lg" />
             </a>
+            <DevContent>
+            <a href="/org/list" class="btn btn-sm btn-warning max-sm:hidden">
+              {$t('appmenu.orgs')}
+              <Icon icon="i-mdi-account-group-outline" size="text-lg" />
+            </a>
+            </DevContent>
             <AdminContent>
               <a href="/admin" class="btn btn-sm btn-accent">
                 <span class="max-sm:hidden">

--- a/frontend/src/routes/(authenticated)/+page.svelte
+++ b/frontend/src/routes/(authenticated)/+page.svelte
@@ -50,7 +50,7 @@
   $: shownProjects = limitResults ? limit(filteredProjects) : filteredProjects;
 </script>
 
-<HeaderPage wide title={$t('user_dashboard.title')} setBreadcrumb={false}>
+<HeaderPage wide title={$t('user_dashboard.title')}>
   <svelte:fragment slot="header-content">
     <div class="flex gap-4 w-full">
       <div class="grow">

--- a/frontend/src/routes/(authenticated)/org/list/+page.svelte
+++ b/frontend/src/routes/(authenticated)/org/list/+page.svelte
@@ -1,11 +1,13 @@
 <script lang="ts">
+  import type { OrgListPageQuery } from '$lib/gql/types';
   import t, { date, number } from '$lib/i18n';
   import { Page } from '$lib/layout';
-  import type { Readable } from 'svelte/store';
   import type { PageData } from './$types';
 
   export let data: PageData;
   $: orgs = data.orgs;
+
+  type OrgList = OrgListPageQuery['orgs']
 
   type Column = 'name' | 'users' | 'created_at';
   let sortColumn = 'created_at' as Column;
@@ -25,8 +27,8 @@
     }
   }
 
-  function sortOrgs<T>(orgs: Readable<T>, sortColumn: Column, sortDir: Dir): T[] {
-    const data = [... $orgs];
+  function sortOrgs(orgs: OrgList, sortColumn: Column, sortDir: Dir): OrgList {
+    const data = [... orgs];
     let mult = sortDir === 'ascending' ? 1 : -1;
     data.sort((a, b) => {
       if (sortColumn === 'users') {
@@ -35,7 +37,7 @@
         const comp = a.name < b.name ? -1 : a.name > b.name ? 1 : 0;
         return comp * mult;
       } else if (sortColumn === 'created_at') {
-        const comp = a.created_at < b.created_at ? -1 : a.created_at > b.created_at ? 1 : 0;
+        const comp = a.createdDate < b.createdDate ? -1 : a.createdDate > b.createdDate ? 1 : 0;
         return comp * mult;
       }
       return 0;
@@ -43,7 +45,7 @@
     return data;
   }
 
-  $: displayOrgs = sortOrgs($orgs, sortColumn, sortDir);
+  $: displayOrgs = $orgs ? sortOrgs($orgs, sortColumn, sortDir) : [];
 </script>
 
 <!--

--- a/frontend/src/routes/(authenticated)/org/list/+page.svelte
+++ b/frontend/src/routes/(authenticated)/org/list/+page.svelte
@@ -5,6 +5,24 @@
 
   export let data: PageData;
   $: orgs = data.orgs;
+
+  type Column = 'name' | 'users' | 'created_at';
+  let sortColumn = 'created_at' as Column;
+  type Dir = 'ascending' | 'descending';
+  let sortDir = 'ascending' as Dir;
+
+  function swapSortDir(): void {
+    sortDir = sortDir == 'ascending' ? 'descending' : 'ascending';
+  }
+
+  function handleSortClick(clickedColumn: Column): void {
+    if (sortColumn === clickedColumn) {
+      swapSortDir();
+    } else {
+      sortColumn = clickedColumn;
+      sortDir = 'ascending';
+    }
+  }
 </script>
 
 <!--
@@ -20,11 +38,23 @@ TODO:
     <table class="table table-lg">
       <thead>
         <tr class="bg-base-200">
-          <th>{$t('project.table.name')}</th>
-          <th class="hidden @md:table-cell">{$t('project.table.users')}</th>
-          <th class="hidden @xl:table-cell">
+          <th on:click={() => handleSortClick('name')}>
+            {$t('project.table.name')}
+            {#if sortColumn == 'name'}
+            <span class="{`i-mdi-sort-${sortDir}`} text-xl align-[-5px] ml-2" />
+            {/if}
+          </th>
+          <th on:click={() => handleSortClick('users')} class="hidden @md:table-cell">
+            {$t('project.table.users')}
+            {#if sortColumn == 'users'}
+            <span class="{`i-mdi-sort-${sortDir}`} text-xl align-[-5px] ml-2" />
+            {/if}
+          </th>
+          <th on:click={() => handleSortClick('created_at')} class="hidden @xl:table-cell">
               {$t('project.table.created_at')}
-              <span class="i-mdi-sort-descending text-xl align-[-5px] ml-2" />
+              {#if sortColumn == 'created_at'}
+              <span class="{`i-mdi-sort-${sortDir}`} text-xl align-[-5px] ml-2" />
+              {/if}
           </th>
         </tr>
       </thead>

--- a/frontend/src/routes/(authenticated)/org/list/+page.svelte
+++ b/frontend/src/routes/(authenticated)/org/list/+page.svelte
@@ -15,7 +15,7 @@ TODO:
 -->
 
 <Page wide>
-  <h1 class="text-3xl text-left grow max-w-full my-2">Organisations</h1>
+  <h1 class="text-3xl text-left grow max-w-full mb-4">Organisations</h1>
   <div class="overflow-x-auto @container scroll-shadow">
     <table class="table table-lg">
       <thead>

--- a/frontend/src/routes/(authenticated)/org/list/+page.svelte
+++ b/frontend/src/routes/(authenticated)/org/list/+page.svelte
@@ -1,12 +1,20 @@
 <script lang="ts">
+  import { FilterBar } from '$lib/components/FilterBar';
   import type { OrgListPageQuery } from '$lib/gql/types';
   import t, { date, number } from '$lib/i18n';
   import { Icon } from '$lib/icons';
   import { Page } from '$lib/layout';
+  import { getSearchParams, queryParam } from '$lib/util/query-params';
   import type { PageData } from './$types';
+  import type { OrgListSearchParams } from './+page';
 
   export let data: PageData;
   $: orgs = data.orgs;
+
+  const queryParams = getSearchParams<OrgListSearchParams>({
+    search: queryParam.string<string>(''),
+  });
+  const { queryParamValues, defaultQueryParamValues } = queryParams;
 
   type OrgList = OrgListPageQuery['orgs']
 
@@ -28,6 +36,10 @@
     }
   }
 
+  function filterOrgs(orgs: OrgList, search: string): OrgList {
+    return orgs.filter((org) => org.name.toLowerCase().includes(search.toLowerCase()));
+  }
+
   function sortOrgs(orgs: OrgList, sortColumn: Column, sortDir: Dir): OrgList {
     const data = [... orgs];
     let mult = sortDir === 'ascending' ? 1 : -1;
@@ -46,7 +58,8 @@
     return data;
   }
 
-  $: displayOrgs = $orgs ? sortOrgs($orgs, sortColumn, sortDir) : [];
+  $: filteredOrgs = $orgs ? filterOrgs($orgs, $queryParamValues.search) : [];
+  $: displayOrgs = sortOrgs(filteredOrgs, sortColumn, sortDir);
 </script>
 
 <!--
@@ -61,6 +74,17 @@ TODO:
     Organisations
     <Icon icon="i-mdi-account-group-outline" size="text-5xl" />
   </h1>
+
+  <div class="mt-4">
+    <FilterBar
+      searchKey="search"
+      filterKeys={['search']}
+      filters={queryParamValues}
+      filterDefaults={defaultQueryParamValues}
+    />
+  </div>
+
+  <div class="divider" />
   <div class="overflow-x-auto @container scroll-shadow">
     <table class="table table-lg">
       <thead>

--- a/frontend/src/routes/(authenticated)/org/list/+page.svelte
+++ b/frontend/src/routes/(authenticated)/org/list/+page.svelte
@@ -1,0 +1,19 @@
+<script lang="ts">
+  import type { PageData } from './$types';
+
+  export let data: PageData;
+  $: orgs = data.orgs;
+</script>
+
+<h1>Organisations</h1>
+<ul>
+  {#each $orgs as org}
+  <li>
+    <a
+      href="./{org.id}"
+    >
+      {org.name}
+    </a>
+  </li>
+  {/each}
+</ul>

--- a/frontend/src/routes/(authenticated)/org/list/+page.svelte
+++ b/frontend/src/routes/(authenticated)/org/list/+page.svelte
@@ -19,7 +19,7 @@
   type OrgList = OrgListPageQuery['orgs']
 
   type Column = 'name' | 'users' | 'created_at';
-  let sortColumn: Column = 'created_at';
+  let sortColumn: Column = 'name';
   type Dir = 'ascending' | 'descending';
   let sortDir: Dir = 'ascending';
 

--- a/frontend/src/routes/(authenticated)/org/list/+page.svelte
+++ b/frontend/src/routes/(authenticated)/org/list/+page.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import t, { date, number } from '$lib/i18n';
   import { Page } from '$lib/layout';
+  import type { Readable } from 'svelte/store';
   import type { PageData } from './$types';
 
   export let data: PageData;
@@ -23,6 +24,26 @@
       sortDir = 'ascending';
     }
   }
+
+  function sortOrgs<T>(orgs: Readable<T>, sortColumn: Column, sortDir: Dir): T[] {
+    const data = [... $orgs];
+    let mult = sortDir === 'ascending' ? 1 : -1;
+    data.sort((a, b) => {
+      if (sortColumn === 'users') {
+        return (a.members.length - b.members.length) * mult;
+      } else if (sortColumn === 'name') {
+        const comp = a.name < b.name ? -1 : a.name > b.name ? 1 : 0;
+        return comp * mult;
+      } else if (sortColumn === 'created_at') {
+        const comp = a.created_at < b.created_at ? -1 : a.created_at > b.created_at ? 1 : 0;
+        return comp * mult;
+      }
+      return 0;
+    });
+    return data;
+  }
+
+  $: displayOrgs = sortOrgs($orgs, sortColumn, sortDir);
 </script>
 
 <!--
@@ -59,7 +80,7 @@ TODO:
         </tr>
       </thead>
       <tbody>
-        {#each $orgs as org}
+        {#each displayOrgs as org}
           <tr>
             <td>
               <span class="flex gap-2 items-center">

--- a/frontend/src/routes/(authenticated)/org/list/+page.svelte
+++ b/frontend/src/routes/(authenticated)/org/list/+page.svelte
@@ -45,7 +45,7 @@
     let mult = sortDir === 'ascending' ? 1 : -1;
     data.sort((a, b) => {
       if (sortColumn === 'members') {
-        return (a.members.length - b.members.length) * mult;
+        return (a.memberCount - b.memberCount) * mult;
       } else if (sortColumn === 'name') {
         const comp = a.name < b.name ? -1 : a.name > b.name ? 1 : 0;
         return comp * mult;
@@ -114,7 +114,7 @@ TODO:
               </span>
             </td>
             <td class="hidden @md:table-cell">
-              {$number(org.members.length)}
+              {$number(org.memberCount)}
             </td>
             <td class="hidden @xl:table-cell">
               {$date(org.createdDate)}

--- a/frontend/src/routes/(authenticated)/org/list/+page.svelte
+++ b/frontend/src/routes/(authenticated)/org/list/+page.svelte
@@ -61,19 +61,19 @@ TODO:
     <table class="table table-lg">
       <thead>
         <tr class="bg-base-200">
-          <th on:click={() => handleSortClick('name')}>
+          <th on:click={() => handleSortClick('name')} class="cursor-pointer">
             {$t('project.table.name')}
             {#if sortColumn == 'name'}
             <span class="{`i-mdi-sort-${sortDir}`} text-xl align-[-5px] ml-2" />
             {/if}
           </th>
-          <th on:click={() => handleSortClick('users')} class="hidden @md:table-cell">
+          <th on:click={() => handleSortClick('users')} class="cursor-pointer hidden @md:table-cell">
             {$t('project.table.users')}
             {#if sortColumn == 'users'}
             <span class="{`i-mdi-sort-${sortDir}`} text-xl align-[-5px] ml-2" />
             {/if}
           </th>
-          <th on:click={() => handleSortClick('created_at')} class="hidden @xl:table-cell">
+          <th on:click={() => handleSortClick('created_at')} class="cursor-pointer hidden @xl:table-cell">
               {$t('project.table.created_at')}
               {#if sortColumn == 'created_at'}
               <span class="{`i-mdi-sort-${sortDir}`} text-xl align-[-5px] ml-2" />

--- a/frontend/src/routes/(authenticated)/org/list/+page.svelte
+++ b/frontend/src/routes/(authenticated)/org/list/+page.svelte
@@ -17,3 +17,11 @@
   </li>
   {/each}
 </ul>
+
+<!--
+TODO:
+
+* Sort options: name, created date, # users
+* Table view
+* Paging
+-->

--- a/frontend/src/routes/(authenticated)/org/list/+page.svelte
+++ b/frontend/src/routes/(authenticated)/org/list/+page.svelte
@@ -19,9 +19,9 @@
   type OrgList = OrgListPageQuery['orgs']
 
   type Column = 'name' | 'users' | 'created_at';
-  let sortColumn = 'created_at' as Column;
+  let sortColumn: Column = 'created_at';
   type Dir = 'ascending' | 'descending';
-  let sortDir = 'ascending' as Dir;
+  let sortDir: Dir = 'ascending';
 
   function swapSortDir(): void {
     sortDir = sortDir === 'ascending' ? 'descending' : 'ascending';

--- a/frontend/src/routes/(authenticated)/org/list/+page.svelte
+++ b/frontend/src/routes/(authenticated)/org/list/+page.svelte
@@ -89,23 +89,17 @@ TODO:
     <table class="table table-lg">
       <thead>
         <tr class="bg-base-200">
-          <th on:click={() => handleSortClick('name')} class="cursor-pointer">
+          <th on:click={() => handleSortClick('name')} class="cursor-pointer hover:bg-base-300">
             {$t('project.table.name')}
-            {#if sortColumn === 'name'}
-            <span class="{`i-mdi-sort-${sortDir}`} text-xl align-[-5px] ml-2" />
-            {/if}
+            <span class:invisible={sortColumn !== 'name'}  class="{`i-mdi-sort-${sortDir}`} text-xl align-[-5px] ml-2" />
           </th>
-          <th on:click={() => handleSortClick('users')} class="cursor-pointer hidden @md:table-cell">
+          <th on:click={() => handleSortClick('users')} class="cursor-pointer hover:bg-base-300 hidden @md:table-cell">
             {$t('project.table.users')}
-            {#if sortColumn === 'users'}
-            <span class="{`i-mdi-sort-${sortDir}`} text-xl align-[-5px] ml-2" />
-            {/if}
+            <span class:invisible={sortColumn !== 'users'} class="{`i-mdi-sort-${sortDir}`} text-xl align-[-5px] ml-2" />
           </th>
-          <th on:click={() => handleSortClick('created_at')} class="cursor-pointer hidden @xl:table-cell">
-              {$t('project.table.created_at')}
-              {#if sortColumn === 'created_at'}
-              <span class="{`i-mdi-sort-${sortDir}`} text-xl align-[-5px] ml-2" />
-              {/if}
+          <th on:click={() => handleSortClick('created_at')} class="cursor-pointer hover:bg-base-300 hidden @xl:table-cell">
+            {$t('project.table.created_at')}
+            <span class:invisible={sortColumn !== 'created_at'}  class="{`i-mdi-sort-${sortDir}`} text-xl align-[-5px] ml-2" />
           </th>
         </tr>
       </thead>

--- a/frontend/src/routes/(authenticated)/org/list/+page.svelte
+++ b/frontend/src/routes/(authenticated)/org/list/+page.svelte
@@ -69,9 +69,9 @@ TODO:
 * Paging
 -->
 
-<Page wide>
+<Page wide title={$t('org.table.title')}>
   <h1 class="text-3xl text-left grow max-w-full mb-4 flex gap-4 items-center">
-    Organisations
+    {$t('org.table.title')}
     <Icon icon="i-mdi-account-group-outline" size="text-5xl" />
   </h1>
 
@@ -90,15 +90,15 @@ TODO:
       <thead>
         <tr class="bg-base-200">
           <th on:click={() => handleSortClick('name')} class="cursor-pointer hover:bg-base-300">
-            {$t('project.table.name')}
+            {$t('org.table.name')}
             <span class:invisible={sortColumn !== 'name'}  class="{`i-mdi-sort-${sortDir}`} text-xl align-[-5px] ml-2" />
           </th>
           <th on:click={() => handleSortClick('members')} class="cursor-pointer hover:bg-base-300 hidden @md:table-cell">
-            {$t('project.table.members')}
+            {$t('org.table.members')}
             <span class:invisible={sortColumn !== 'members'} class="{`i-mdi-sort-${sortDir}`} text-xl align-[-5px] ml-2" />
           </th>
           <th on:click={() => handleSortClick('created_at')} class="cursor-pointer hover:bg-base-300 hidden @xl:table-cell">
-            {$t('project.table.created_at')}
+            {$t('org.table.created_at')}
             <span class:invisible={sortColumn !== 'created_at'}  class="{`i-mdi-sort-${sortDir}`} text-xl align-[-5px] ml-2" />
           </th>
         </tr>
@@ -107,11 +107,9 @@ TODO:
         {#each displayOrgs as org}
           <tr>
             <td>
-              <span class="flex gap-2 items-center">
-                  <a class="link" href={`/org/${org.id}`}>
-                    {org.name}
-                  </a>
-              </span>
+                <a class="link" href={`/org/${org.id}`}>
+                  {org.name}
+                </a>
             </td>
             <td class="hidden @md:table-cell">
               {$number(org.memberCount)}

--- a/frontend/src/routes/(authenticated)/org/list/+page.svelte
+++ b/frontend/src/routes/(authenticated)/org/list/+page.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import type { OrgListPageQuery } from '$lib/gql/types';
   import t, { date, number } from '$lib/i18n';
+  import { Icon } from '$lib/icons';
   import { Page } from '$lib/layout';
   import type { PageData } from './$types';
 
@@ -56,7 +57,10 @@ TODO:
 -->
 
 <Page wide>
-  <h1 class="text-3xl text-left grow max-w-full mb-4">Organisations</h1>
+  <h1 class="text-3xl text-left grow max-w-full mb-4 flex gap-4 items-center">
+    Organisations
+    <Icon icon="i-mdi-account-group-outline" size="text-5xl" />
+  </h1>
   <div class="overflow-x-auto @container scroll-shadow">
     <table class="table table-lg">
       <thead>

--- a/frontend/src/routes/(authenticated)/org/list/+page.svelte
+++ b/frontend/src/routes/(authenticated)/org/list/+page.svelte
@@ -24,7 +24,7 @@
   let sortDir = 'ascending' as Dir;
 
   function swapSortDir(): void {
-    sortDir = sortDir == 'ascending' ? 'descending' : 'ascending';
+    sortDir = sortDir === 'ascending' ? 'descending' : 'ascending';
   }
 
   function handleSortClick(clickedColumn: Column): void {
@@ -91,19 +91,19 @@ TODO:
         <tr class="bg-base-200">
           <th on:click={() => handleSortClick('name')} class="cursor-pointer">
             {$t('project.table.name')}
-            {#if sortColumn == 'name'}
+            {#if sortColumn === 'name'}
             <span class="{`i-mdi-sort-${sortDir}`} text-xl align-[-5px] ml-2" />
             {/if}
           </th>
           <th on:click={() => handleSortClick('users')} class="cursor-pointer hidden @md:table-cell">
             {$t('project.table.users')}
-            {#if sortColumn == 'users'}
+            {#if sortColumn === 'users'}
             <span class="{`i-mdi-sort-${sortDir}`} text-xl align-[-5px] ml-2" />
             {/if}
           </th>
           <th on:click={() => handleSortClick('created_at')} class="cursor-pointer hidden @xl:table-cell">
               {$t('project.table.created_at')}
-              {#if sortColumn == 'created_at'}
+              {#if sortColumn === 'created_at'}
               <span class="{`i-mdi-sort-${sortDir}`} text-xl align-[-5px] ml-2" />
               {/if}
           </th>

--- a/frontend/src/routes/(authenticated)/org/list/+page.svelte
+++ b/frontend/src/routes/(authenticated)/org/list/+page.svelte
@@ -1,27 +1,52 @@
 <script lang="ts">
+  import t, { date, number } from '$lib/i18n';
+  import { Page } from '$lib/layout';
   import type { PageData } from './$types';
 
   export let data: PageData;
   $: orgs = data.orgs;
 </script>
 
-<h1>Organisations</h1>
-<ul>
-  {#each $orgs as org}
-  <li>
-    <a
-      href="./{org.id}"
-    >
-      {org.name}
-    </a>
-  </li>
-  {/each}
-</ul>
-
 <!--
 TODO:
 
 * Sort options: name, created date, # users
-* Table view
 * Paging
 -->
+
+<Page wide>
+  <h1 class="text-3xl text-left grow max-w-full my-2">Organisations</h1>
+  <div class="overflow-x-auto @container scroll-shadow">
+    <table class="table table-lg">
+      <thead>
+        <tr class="bg-base-200">
+          <th>{$t('project.table.name')}</th>
+          <th class="hidden @md:table-cell">{$t('project.table.users')}</th>
+          <th class="hidden @xl:table-cell">
+              {$t('project.table.created_at')}
+              <span class="i-mdi-sort-descending text-xl align-[-5px] ml-2" />
+          </th>
+        </tr>
+      </thead>
+      <tbody>
+        {#each $orgs as org}
+          <tr>
+            <td>
+              <span class="flex gap-2 items-center">
+                  <a class="link" href={`/org/${org.id}`}>
+                    {org.name}
+                  </a>
+              </span>
+            </td>
+            <td class="hidden @md:table-cell">
+              {$number(org.members.length)}
+            </td>
+            <td class="hidden @xl:table-cell">
+              {$date(org.createdDate)}
+            </td>
+          </tr>
+        {/each}
+      </tbody>
+    </table>
+  </div>
+</Page>

--- a/frontend/src/routes/(authenticated)/org/list/+page.svelte
+++ b/frontend/src/routes/(authenticated)/org/list/+page.svelte
@@ -18,7 +18,7 @@
 
   type OrgList = OrgListPageQuery['orgs']
 
-  type Column = 'name' | 'users' | 'created_at';
+  type Column = 'name' | 'members' | 'created_at';
   let sortColumn: Column = 'name';
   type Dir = 'ascending' | 'descending';
   let sortDir: Dir = 'ascending';
@@ -44,7 +44,7 @@
     const data = [... orgs];
     let mult = sortDir === 'ascending' ? 1 : -1;
     data.sort((a, b) => {
-      if (sortColumn === 'users') {
+      if (sortColumn === 'members') {
         return (a.members.length - b.members.length) * mult;
       } else if (sortColumn === 'name') {
         const comp = a.name < b.name ? -1 : a.name > b.name ? 1 : 0;
@@ -93,9 +93,9 @@ TODO:
             {$t('project.table.name')}
             <span class:invisible={sortColumn !== 'name'}  class="{`i-mdi-sort-${sortDir}`} text-xl align-[-5px] ml-2" />
           </th>
-          <th on:click={() => handleSortClick('users')} class="cursor-pointer hover:bg-base-300 hidden @md:table-cell">
-            {$t('project.table.users')}
-            <span class:invisible={sortColumn !== 'users'} class="{`i-mdi-sort-${sortDir}`} text-xl align-[-5px] ml-2" />
+          <th on:click={() => handleSortClick('members')} class="cursor-pointer hover:bg-base-300 hidden @md:table-cell">
+            {$t('project.table.members')}
+            <span class:invisible={sortColumn !== 'members'} class="{`i-mdi-sort-${sortDir}`} text-xl align-[-5px] ml-2" />
           </th>
           <th on:click={() => handleSortClick('created_at')} class="cursor-pointer hover:bg-base-300 hidden @xl:table-cell">
             {$t('project.table.created_at')}

--- a/frontend/src/routes/(authenticated)/org/list/+page.ts
+++ b/frontend/src/routes/(authenticated)/org/list/+page.ts
@@ -18,9 +18,6 @@ export async function load(event: PageLoadEvent) {
             name
             createdDate
             memberCount
-            members {
-              userId
-            }
           }
         }
       `)

--- a/frontend/src/routes/(authenticated)/org/list/+page.ts
+++ b/frontend/src/routes/(authenticated)/org/list/+page.ts
@@ -37,5 +37,4 @@ export async function load(event: PageLoadEvent) {
     );
   const nonNullableOrgs = tryMakeNonNullable(orgQueryResult.orgs);
   return {orgs: nonNullableOrgs};
-  // return {orgs: orgQueryResult};
 }

--- a/frontend/src/routes/(authenticated)/org/list/+page.ts
+++ b/frontend/src/routes/(authenticated)/org/list/+page.ts
@@ -20,7 +20,8 @@ export async function load(event: PageLoadEvent) {
             memberCount
           }
         }
-      `)
+      `),
+    {}
     );
   const nonNullableOrgs = tryMakeNonNullable(orgQueryResult.orgs);
   return {orgs: nonNullableOrgs};

--- a/frontend/src/routes/(authenticated)/org/list/+page.ts
+++ b/frontend/src/routes/(authenticated)/org/list/+page.ts
@@ -18,6 +18,7 @@ export async function load(event: PageLoadEvent) {
             id
             name
             createdDate
+            memberCount
             members {
               id
               role

--- a/frontend/src/routes/(authenticated)/org/list/+page.ts
+++ b/frontend/src/routes/(authenticated)/org/list/+page.ts
@@ -1,6 +1,11 @@
 import { getClient, graphql } from '$lib/gql';
-import { tryMakeNonNullable } from '$lib/util/store';
+
 import type {PageLoadEvent} from './$types';
+import { tryMakeNonNullable } from '$lib/util/store';
+
+export type OrgListSearchParams = {
+  search: string,
+};
 
 export async function load(event: PageLoadEvent) {
   const client = getClient();

--- a/frontend/src/routes/(authenticated)/org/list/+page.ts
+++ b/frontend/src/routes/(authenticated)/org/list/+page.ts
@@ -1,0 +1,36 @@
+import { getClient, graphql } from '$lib/gql';
+import { tryMakeNonNullable } from '$lib/util/store';
+import type {PageLoadEvent} from './$types';
+
+export async function load(event: PageLoadEvent) {
+  const client = getClient();
+  const userIsAdmin = (await event.parent()).user.isAdmin;
+  const orgQueryResult = await client
+    .awaitedQueryStore(event.fetch,
+      graphql(`
+        query orgListPage($userIsAdmin: Boolean!) {
+          orgs {
+            id
+            name
+            createdDate
+            members {
+              id
+              role
+              user {
+                id
+                name
+                ... on User @include(if: $userIsAdmin) {
+                  username
+                  email
+                }
+              }
+            }
+          }
+        }
+      `),
+      { userIsAdmin }
+    );
+  const nonNullableOrgs = tryMakeNonNullable(orgQueryResult.orgs);
+  return {orgs: nonNullableOrgs};
+  // return {orgs: orgQueryResult};
+}

--- a/frontend/src/routes/(authenticated)/org/list/+page.ts
+++ b/frontend/src/routes/(authenticated)/org/list/+page.ts
@@ -18,6 +18,9 @@ export async function load(event: PageLoadEvent) {
             name
             createdDate
             memberCount
+            members {
+              userId
+            }
           }
         }
       `)

--- a/frontend/src/routes/(authenticated)/org/list/+page.ts
+++ b/frontend/src/routes/(authenticated)/org/list/+page.ts
@@ -9,32 +9,18 @@ export type OrgListSearchParams = {
 
 export async function load(event: PageLoadEvent) {
   const client = getClient();
-  const userIsAdmin = (await event.parent()).user.isAdmin;
   const orgQueryResult = await client
     .awaitedQueryStore(event.fetch,
       graphql(`
-        query orgListPage($userIsAdmin: Boolean!) {
+        query orgListPage {
           orgs {
             id
             name
             createdDate
             memberCount
-            members {
-              id
-              role
-              user {
-                id
-                name
-                ... on User @include(if: $userIsAdmin) {
-                  username
-                  email
-                }
-              }
-            }
           }
         }
-      `),
-      { userIsAdmin }
+      `)
     );
   const nonNullableOrgs = tryMakeNonNullable(orgQueryResult.orgs);
   return {orgs: nonNullableOrgs};

--- a/frontend/tailwind.config.cjs
+++ b/frontend/tailwind.config.cjs
@@ -16,6 +16,7 @@ module.exports = {
         'winter': {
           ...require("daisyui/src/theming/themes")["winter"],
           "warning": "#FFBE00", // warning color from corporate, because it has much better contrast
+          "primary": "#0058BF", // easier on the eyes
         },
       },
       {


### PR DESCRIPTION
Fixes https://github.com/sillsdev/languageforge-lexbox/issues/776, except that I chose not to implement filtering yet.

Very barebones UI, but does just enough for what we need at this stage.

Orgs are formatted as a table, looking somewhat like this:

![image](https://github.com/sillsdev/languageforge-lexbox/assets/90762/f5a3fd7d-5ba8-40c6-a18f-ce5c21b5c11d)

Clicking on a table header will sort by that value, in ascending order. Clicking again will flip to descending order. All very standard table-sorting UI.

To make the links work for testing purposes, do `git merge --no-commit feat/org-page` and then links should work. Then do `git merge --abort` to back out the changes, otherwise your git worktree will get into a very confusing state when you try to switch to another branch.
