### PR TITLE
provide oauth certs using cert-manager

### DIFF
--- a/backend/LexBoxApi/Auth/AuthKernel.cs
+++ b/backend/LexBoxApi/Auth/AuthKernel.cs
@@ -242,6 +242,8 @@ public static class AuthKernel
                 options.SetUserinfoEndpointUris("api/oauth/userinfo");
                 options.Configure(serverOptions => serverOptions.Handlers.Add(ScopeRequestFixer.Descriptor));
 
+                options.SetAccessTokenLifetime(TimeSpan.FromHours(1));
+                options.SetRefreshTokenLifetime(TimeSpan.FromDays(14));
                 options.AllowAuthorizationCodeFlow()
                     .AllowRefreshTokenFlow();
 

--- a/deployment/base/kustomization.yaml
+++ b/deployment/base/kustomization.yaml
@@ -13,3 +13,4 @@ resources:
 - ui-deployment.yaml
 - proxy-deployment.yaml
 - app-config.yaml
+- oauth-certs.yaml

--- a/deployment/base/lexbox-deployment.yaml
+++ b/deployment/base/lexbox-deployment.yaml
@@ -75,6 +75,12 @@ spec:
         volumeMounts:
         - name: repos
           mountPath: /hg-repos
+        - name: oauth-signing-cert
+          mountPath: /oauth-certs/signing
+          readOnly: true
+        - name: oauth-encryption-cert
+          mountPath: /oauth-certs/encryption
+          readOnly: true
 
         env:
           - name: DOTNET_URLS
@@ -231,6 +237,14 @@ spec:
           items:
             - key: collector-config.yaml
               path: config.yaml
+      - name: oauth-signing-cert
+        secret:
+          secretName: oauth-signing-cert
+          optional: true
+      - name: oauth-encryption-cert
+        secret:
+          secretName: oauth-encryption-cert
+          optional: true
 
       initContainers:
       - name: db-migrations

--- a/deployment/base/oauth-certs.yaml
+++ b/deployment/base/oauth-certs.yaml
@@ -1,0 +1,46 @@
+﻿apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: selfsigned-issuer
+spec:
+  selfSigned: { }
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: oauth-encryption-cert
+spec:
+  commonName: lexbox Encryption cert
+  duration: 2160h # 90 days
+  renewBefore: 360h # 15 days
+  issuerRef:
+    group: cert-manager.io
+    kind: Issuer
+    name: selfsigned-issuer
+  privateKey:
+      rotationPolicy: Always
+      algorithm: RSA
+  revisionHistoryLimit: 5
+  secretName: oauth-encryption-cert
+  usages:
+    - key encipherment
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: oauth-signing-cert
+spec:
+  commonName: lexbox Signing cert
+  duration: 2160h # 90 days
+  renewBefore: 360h # 15 days
+  issuerRef:
+    group: cert-manager.io
+    kind: Issuer
+    name: selfsigned-issuer
+  privateKey:
+    rotationPolicy: Always
+    algorithm: RSA
+  revisionHistoryLimit: 5
+  secretName: oauth-signing-cert
+  usages:
+    - digital signature

--- a/deployment/develop/lexbox-deployment.patch.yaml
+++ b/deployment/develop/lexbox-deployment.patch.yaml
@@ -16,6 +16,8 @@ spec:
             - name: ASPNETCORE_ENVIRONMENT
               value: "Staging" #we don't want to act like dev as that's for local development
               valueFrom:
+            - name: Authentication__OpenId__Enable
+              value: "true"
             - name: Email__SmtpHost
               value: email-smtp.us-east-1.amazonaws.com
             - name: Email__SmtpPort

--- a/deployment/local-dev/delete-oauth-certs.yaml
+++ b/deployment/local-dev/delete-oauth-certs.yaml
@@ -1,0 +1,8 @@
+﻿$patch: delete
+# This patch deletes the Issuer and Certificate resources that are used for OAuth because local dev does not support them
+# the values here are actually ignored, the $patch: delete is the only important part
+# we can't remove the following otherwise there would be a parsing error
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: selfsigned-issuer

--- a/deployment/local-dev/kustomization.yaml
+++ b/deployment/local-dev/kustomization.yaml
@@ -29,6 +29,13 @@ patches:
       version: v1
       kind: PersistentVolumeClaim
     path: change-storage-class.patch.yaml
+  - target:
+      kind: Issuer
+    path: delete-oauth-certs.yaml
+  - target:
+      kind: Certificate
+    path: delete-oauth-certs.yaml
+
   - path: lexbox-deployment.patch.yaml
   - path: ui-deployment.patch.yaml
   - path: hg-repos-pvc.patch.yaml

--- a/deployment/local-dev/lexbox-deployment.patch.yaml
+++ b/deployment/local-dev/lexbox-deployment.patch.yaml
@@ -23,6 +23,8 @@ spec:
             valueFrom: # don't use secret as defined in base
           - $patch: delete
             name: Authentication__Jwt__Secret
+          - name: Authentication__OpenId__Enable
+            value: "true"
           - name: LfClassicConfig__ConnectionString
             value: mongodb://host.docker.internal:27017
           - name: ForwardedHeadersOptions__KnownNetworks__0

--- a/deployment/local-dev/lexbox-deployment.patch.yaml
+++ b/deployment/local-dev/lexbox-deployment.patch.yaml
@@ -23,8 +23,6 @@ spec:
             valueFrom: # don't use secret as defined in base
           - $patch: delete
             name: Authentication__Jwt__Secret
-          - name: Authentication__OpenId__Enable
-            value: "true"
           - name: LfClassicConfig__ConnectionString
             value: mongodb://host.docker.internal:27017
           - name: ForwardedHeadersOptions__KnownNetworks__0


### PR DESCRIPTION
rancher provides cert-manager.io to generate certificates, this configures dotnet to use certs generated in k8s, it also enables oauth in develop to test it out on a real server

closes #832