### PR TITLE
Fix JWT's in cookies array attribute not redacted

### DIFF
--- a/backend/SyncReverseProxy/HgRequestTransformer.cs
+++ b/backend/SyncReverseProxy/HgRequestTransformer.cs
@@ -1,4 +1,5 @@
 ﻿using System.Text.RegularExpressions;
+using Microsoft.Net.Http.Headers;
 using Yarp.ReverseProxy.Forwarder;
 
 namespace LexSyncReverseProxy;
@@ -14,6 +15,11 @@ public partial class HgRequestTransformer : HttpTransformer
         CancellationToken cancellationToken)
     {
         await base.TransformRequestAsync(httpContext, proxyRequest, destinationPrefix, cancellationToken);
+
+        // Remove the cookie header from the request
+        proxyRequest.Headers.Remove(HeaderNames.Cookie);
+        proxyRequest.Headers.Remove(HeaderNames.Authorization);
+
         var path = httpContext.Request.Path.ToString();
         if (path.StartsWith("/hg")) path = path["/hg".Length..];
         var builder = new UriBuilder(RequestUtilities.MakeDestinationAddress(destinationPrefix,

--- a/deployment/base/lexbox-deployment.yaml
+++ b/deployment/base/lexbox-deployment.yaml
@@ -192,7 +192,7 @@ spec:
             value: /tmp/tus-reset-upload
 
       - name: otel-collector
-        image: otel/opentelemetry-collector-contrib:0.87.0
+        image: otel/opentelemetry-collector-contrib:0.101.0
         args:
           - "--config"
           - "/etc/otelcol-contrib/config.yaml"

--- a/otel/collector-config.yaml
+++ b/otel/collector-config.yaml
@@ -26,6 +26,11 @@ processors:
   memory_limiter:
     check_interval: 1s
     limit_mib: 400
+  transform/squash_cookie_array:
+    trace_statements:
+      - context: span
+        statements:
+          - set(attributes["http.request.header.cookie"], String(attributes["http.request.header.cookie"])) where IsList(attributes["http.request.header.cookie"])
   redaction: # https://pkg.go.dev/github.com/open-telemetry/opentelemetry-collector-contrib/processor/redactionprocessor#section-readme
     allow_all_keys: true
     blocked_values:
@@ -55,7 +60,7 @@ service:
   pipelines:
     traces:
       receivers: [otlp]
-      processors: [memory_limiter, redaction, batch]
+      processors: [memory_limiter, transform/squash_cookie_array, redaction, batch]
       exporters: [otlp]
     metrics:
       receivers: [otlp]


### PR DESCRIPTION
I found this occurence of an unredacted JWT in our otel data:
![image](https://github.com/sillsdev/languageforge-lexbox/assets/12587509/22fc315a-8aa8-45db-92ca-1a7bc9a3be10)

I traced it to the fact that the value is an array rather than a string. So, in order to have it get redacted I had to toString() it.
![image](https://github.com/sillsdev/languageforge-lexbox/assets/12587509/e82fd918-4031-43f8-a982-20a94f9c6fed)

This is of course somewhat dissatisfying, because we wouldn't notice if JWTs were in an array in a different attribute.
I'm not sure what to do about that.

There doesn't currently seem to be a way to stringify all arrays by default.
I'm not sure if we'd want that anyway.
It wouldn't be too hard to create a custom transform similar to [this one](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/pkg/ottl/ottlfuncs/func_replace_all_matches.go) that would do that for us.

This does seem to be the one and only attribute name that's currently standardly used for cookies in OTEL.
![image](https://github.com/sillsdev/languageforge-lexbox/assets/12587509/f1b40d36-e046-4e4d-98d8-0979269381bf)
