### PR TITLE
Download large test repo once, then store in image

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 .DS_Store
 bin/
 obj/
+/data/
 /packages/
 riderModule.iml
 /_ReSharper.Caches/

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -5,6 +5,7 @@ version: '3'
 vars:
   TESTING_DIR: './backend/Testing'
   HG_REPO_DIR: './hgweb/repos'
+  DATA_DIR: './data'
 includes:
   k8s:
     taskfile: ./deployment/Taskfile.yml
@@ -35,24 +36,25 @@ tasks:
       - echo "GOOGLE_OAUTH_CLIENT_ID=__REPLACE__.apps.googleusercontent.com" >> deployment/local-dev/local.env
       - echo "GOOGLE_OAUTH_CLIENT_SECRET=__REPLACE__" >> deployment/local-dev/local.env
       - kubectl --context=docker-desktop apply -f deployment/setup/namespace.yaml
+      - docker build -t local-dev-init data/
   setup-win:
     platforms: [ windows ]
     cmds:
       - cmd: powershell "if (test-path {{.HG_REPO_DIR}}/sena-3) { rm -r {{.HG_REPO_DIR}}/sena-3 }"
         ignore_error: true
         silent: true
-      - powershell -Command "Invoke-WebRequest 'https://drive.google.com/uc?export=download&id=1I-hwc0RHoQqW774gbS5qR-GHa1E7BlsS' -OutFile sena-3.zip"
-      - powershell -Command "Expand-Archive sena-3.zip -DestinationPath {{.HG_REPO_DIR}}"
-      - powershell rm sena-3.zip
+      - powershell -Command "Invoke-WebRequest 'https://drive.google.com/uc?export=download&id=1I-hwc0RHoQqW774gbS5qR-GHa1E7BlsS' -OutFile {{.DATA_DIR}}/sena-3.zip -Resume"
+      - powershell -Command "Expand-Archive {{.DATA_DIR}}/sena-3.zip -DestinationPath {{.HG_REPO_DIR}}"
+      - powershell -Command "Invoke-WebRequest 'https://drive.usercontent.google.com/download?export=download&id=1Jk-eSDho8ATBMS-Kmfatwi-MWQth26ro&confirm=t' -OutFile {{.DATA_DIR}}/elawa.zip -Resume"
   setup-unix:
     platforms: [ linux, darwin ]
     cmds:
       - cmd: rm -rf {{.HG_REPO_DIR}}/sena-3
         ignore_error: true
         silent: true
-      - wget -O sena-3.zip 'https://drive.google.com/uc?export=download&id=1I-hwc0RHoQqW774gbS5qR-GHa1E7BlsS'
-      - unzip -q sena-3.zip -d {{.HG_REPO_DIR}}/
-      - rm sena-3.zip
+      - wget -c -O {{.DATA_DIR}}/sena-3.zip 'https://drive.google.com/uc?export=download&id=1I-hwc0RHoQqW774gbS5qR-GHa1E7BlsS'
+      - unzip -q {{.DATA_DIR}}/sena-3.zip -d {{.HG_REPO_DIR}}/
+      - wget -c -O {{.DATA_DIR}}/elawa.zip 'https://drive.usercontent.google.com/download?export=download&id=1Jk-eSDho8ATBMS-Kmfatwi-MWQth26ro&confirm=t'
 
   # k8s
   up:

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -40,20 +40,12 @@ tasks:
   setup-win:
     platforms: [ windows ]
     cmds:
-      - cmd: powershell "if (test-path {{.HG_REPO_DIR}}/sena-3) { rm -r {{.HG_REPO_DIR}}/sena-3 }"
-        ignore_error: true
-        silent: true
       - powershell -Command "Invoke-WebRequest 'https://drive.google.com/uc?export=download&id=1I-hwc0RHoQqW774gbS5qR-GHa1E7BlsS' -OutFile {{.DATA_DIR}}/sena-3.zip -Resume"
-      - powershell -Command "Expand-Archive {{.DATA_DIR}}/sena-3.zip -DestinationPath {{.HG_REPO_DIR}}"
       - powershell -Command "Invoke-WebRequest 'https://drive.usercontent.google.com/download?export=download&id=1Jk-eSDho8ATBMS-Kmfatwi-MWQth26ro&confirm=t' -OutFile {{.DATA_DIR}}/elawa.zip -Resume"
   setup-unix:
     platforms: [ linux, darwin ]
     cmds:
-      - cmd: rm -rf {{.HG_REPO_DIR}}/sena-3
-        ignore_error: true
-        silent: true
       - wget -c -O {{.DATA_DIR}}/sena-3.zip 'https://drive.google.com/uc?export=download&id=1I-hwc0RHoQqW774gbS5qR-GHa1E7BlsS'
-      - unzip -q {{.DATA_DIR}}/sena-3.zip -d {{.HG_REPO_DIR}}/
       - wget -c -O {{.DATA_DIR}}/elawa.zip 'https://drive.usercontent.google.com/download?export=download&id=1Jk-eSDho8ATBMS-Kmfatwi-MWQth26ro&confirm=t'
 
   # k8s

--- a/data/Dockerfile
+++ b/data/Dockerfile
@@ -1,0 +1,4 @@
+FROM busybox:1.36.1
+
+WORKDIR /init-repos
+COPY . /init-repos/

--- a/deployment/init-repos/hg-deployment-patch.yaml
+++ b/deployment/init-repos/hg-deployment-patch.yaml
@@ -12,18 +12,20 @@ spec:
             runAsUser: 33
             runAsGroup: 33 # www-data
             runAsNonRoot: true
-          image: busybox:1.36.1
+          image: local-dev-init
+          imagePullPolicy: IfNotPresent
           command:
             - 'sh'
             - '-c'
             - |
+              mkdir -p /init-repos || true
               if [ ! -d /repos/s/sena-3 ] && [ ! -d /repos/sena-3 ]; then
-                wget -O /tmp/sena-3.zip 'https://drive.google.com/uc?export=download&id=1I-hwc0RHoQqW774gbS5qR-GHa1E7BlsS'
-                unzip -q /tmp/sena-3.zip -d /repos/s/
+                [ -f /init-repos/sena-3.zip ] || wget -c -O /init-repos/sena-3.zip 'https://drive.google.com/uc?export=download&id=1I-hwc0RHoQqW774gbS5qR-GHa1E7BlsS'
+                unzip -q /init-repos/sena-3.zip -d /repos/s/
               fi
               if [ ! -d /repos/e/elawa-dev-flex ] && [ ! -d /repos/elawa-dev-flex ]; then
-                wget -O /tmp/elawa.zip 'https://drive.usercontent.google.com/download?export=download&id=1Jk-eSDho8ATBMS-Kmfatwi-MWQth26ro&confirm=t'
-                unzip -q /tmp/elawa.zip -d /repos/e/
+                [ -f /init-repos/elawa.zip ] || wget -c -O /init-repos/elawa.zip 'https://drive.usercontent.google.com/download?export=download&id=1Jk-eSDho8ATBMS-Kmfatwi-MWQth26ro&confirm=t'
+                unzip -q /init-repos/elawa.zip -d /repos/e/
               fi
           volumeMounts:
             - name: repos

--- a/deployment/init-repos/hg-deployment-patch.yaml
+++ b/deployment/init-repos/hg-deployment-patch.yaml
@@ -18,14 +18,21 @@ spec:
             - 'sh'
             - '-c'
             - |
-              mkdir -p /init-repos || true
               if [ ! -d /repos/s/sena-3 ] && [ ! -d /repos/sena-3 ]; then
-                [ -f /init-repos/sena-3.zip ] || wget -c -O /init-repos/sena-3.zip 'https://drive.google.com/uc?export=download&id=1I-hwc0RHoQqW774gbS5qR-GHa1E7BlsS'
-                unzip -q /init-repos/sena-3.zip -d /repos/s/
+                if [ -f /init-repos/sena-3.zip ]; then
+                  unzip -q /init-repos/sena-3.zip -d /repos/s/
+                else
+                  wget -O /tmp/sena-3.zip 'https://drive.google.com/uc?export=download&id=1I-hwc0RHoQqW774gbS5qR-GHa1E7BlsS'
+                  unzip -q /tmp/sena-3.zip -d /repos/s/
+                fi
               fi
               if [ ! -d /repos/e/elawa-dev-flex ] && [ ! -d /repos/elawa-dev-flex ]; then
-                [ -f /init-repos/elawa.zip ] || wget -c -O /init-repos/elawa.zip 'https://drive.usercontent.google.com/download?export=download&id=1Jk-eSDho8ATBMS-Kmfatwi-MWQth26ro&confirm=t'
-                unzip -q /init-repos/elawa.zip -d /repos/e/
+                if [ -f /init-repos/elawa.zip ]; then
+                  unzip -q /init-repos/elawa.zip -d /repos/e/
+                else
+                  wget -O /tmp/elawa.zip 'https://drive.usercontent.google.com/download?export=download&id=1Jk-eSDho8ATBMS-Kmfatwi-MWQth26ro&confirm=t'
+                  unzip -q /tmp/elawa.zip -d /repos/e/
+                fi
               fi
           volumeMounts:
             - name: repos

--- a/deployment/init-repos/hg-deployment-patch.yaml
+++ b/deployment/init-repos/hg-deployment-patch.yaml
@@ -12,7 +12,7 @@ spec:
             runAsUser: 33
             runAsGroup: 33 # www-data
             runAsNonRoot: true
-          image: local-dev-init
+          image: busybox:1.36.1
           imagePullPolicy: IfNotPresent
           command:
             - 'sh'

--- a/deployment/local-dev/kustomization.yaml
+++ b/deployment/local-dev/kustomization.yaml
@@ -38,3 +38,7 @@ patches:
       kind: Ingress
       name: proxy
       namespace: languagedepot
+
+images:
+  - name: busybox:1.36.1
+    newName: local-dev-init

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -32,6 +32,10 @@ build:
         dockerfile: Dockerfile
         buildArgs:
           APP_VERSION: dockerDev
+    - image: local-dev-init
+      context: data
+      docker:
+        dockerfile: Dockerfile
   local:
     useBuildkit: true
     concurrency: 2


### PR DESCRIPTION
This allows us to skip the lengthy step of downloading elawa.zip from Google Drive every time `skaffold delete` gets run, or the hg-repos volume gets deleted.

Fixes #758.