### PR TITLE
Orgs own projects

### DIFF
--- a/backend/LexBoxApi/GraphQL/CustomTypes/OrgGqlConfiguration.cs
+++ b/backend/LexBoxApi/GraphQL/CustomTypes/OrgGqlConfiguration.cs
@@ -1,4 +1,4 @@
-using LexCore.Entities;
+﻿using LexCore.Entities;
 
 namespace LexBoxApi.GraphQL.CustomTypes;
 
@@ -7,9 +7,6 @@ public class OrgGqlConfiguration : ObjectType<Organization>
 {
     protected override void Configure(IObjectTypeDescriptor<Organization> descriptor)
     {
-        descriptor.Field(o => o.CreatedDate).IsProjected();
-        // TODO: Will we want something similar to the following Project code for orgs?
-        // descriptor.Field(o => o.Id).Use<RefreshJwtProjectMembershipMiddleware>();
-        // descriptor.Field(o => o.Members).Use<RefreshJwtProjectMembershipMiddleware>();
+        descriptor.Field(p => p.CreatedDate).IsProjected();
     }
 }

--- a/backend/LexBoxApi/GraphQL/CustomTypes/OrgGqlConfiguration.cs
+++ b/backend/LexBoxApi/GraphQL/CustomTypes/OrgGqlConfiguration.cs
@@ -1,4 +1,4 @@
-﻿using LexCore.Entities;
+using LexCore.Entities;
 
 namespace LexBoxApi.GraphQL.CustomTypes;
 

--- a/backend/LexBoxApi/GraphQL/CustomTypes/OrgGqlConfiguration.cs
+++ b/backend/LexBoxApi/GraphQL/CustomTypes/OrgGqlConfiguration.cs
@@ -7,6 +7,6 @@ public class OrgGqlConfiguration : ObjectType<Organization>
 {
     protected override void Configure(IObjectTypeDescriptor<Organization> descriptor)
     {
-        descriptor.Field(p => p.CreatedDate).IsProjected();
+        descriptor.Field(o => o.CreatedDate).IsProjected();
     }
 }

--- a/backend/LexBoxApi/GraphQL/CustomTypes/OrgProjectsGqlConfiguration.cs
+++ b/backend/LexBoxApi/GraphQL/CustomTypes/OrgProjectsGqlConfiguration.cs
@@ -7,7 +7,7 @@ public class OrgProjectsGqlConfiguration : ObjectType<OrgProjects>
 {
     protected override void Configure(IObjectTypeDescriptor<OrgProjects> descriptor)
     {
-        descriptor.Field(f => f.Org).Type<NonNullType<OrgGqlConfiguration>>();
-        descriptor.Field(f => f.Project).Type<NonNullType<ProjectGqlConfiguration>>();
+        descriptor.Field(op => op.Org).Type<NonNullType<OrgGqlConfiguration>>();
+        descriptor.Field(op => op.Project).Type<NonNullType<ProjectGqlConfiguration>>();
     }
 }

--- a/backend/LexBoxApi/GraphQL/CustomTypes/OrgProjectsGqlConfiguration.cs
+++ b/backend/LexBoxApi/GraphQL/CustomTypes/OrgProjectsGqlConfiguration.cs
@@ -1,4 +1,4 @@
-﻿using LexCore.Entities;
+using LexCore.Entities;
 
 namespace LexBoxApi.GraphQL.CustomTypes;
 

--- a/backend/LexBoxApi/GraphQL/CustomTypes/OrgProjectsGqlConfiguration.cs
+++ b/backend/LexBoxApi/GraphQL/CustomTypes/OrgProjectsGqlConfiguration.cs
@@ -1,0 +1,13 @@
+﻿using LexCore.Entities;
+
+namespace LexBoxApi.GraphQL.CustomTypes;
+
+[ObjectType]
+public class OrgProjectsGqlConfiguration : ObjectType<OrgProjects>
+{
+    protected override void Configure(IObjectTypeDescriptor<OrgProjects> descriptor)
+    {
+        descriptor.Field(f => f.Org).Type<NonNullType<OrgGqlConfiguration>>();
+        descriptor.Field(f => f.Project).Type<NonNullType<ProjectGqlConfiguration>>();
+    }
+}

--- a/backend/LexBoxApi/GraphQL/OrgMutations.cs
+++ b/backend/LexBoxApi/GraphQL/OrgMutations.cs
@@ -66,7 +66,7 @@ public class OrgMutations
     {
         var org = await dbContext.Orgs.FindAsync(orgId);
         NotFoundException.ThrowIfNull(org);
-        permissionService.AssertCanEditOrg(org);
+        permissionService.AssertCanAddProjectToOrg(org);
         var project = await dbContext.Projects.Where(p => p.Id == projectId)
             .Include(p => p.Organizations)
             .SingleOrDefaultAsync();
@@ -98,7 +98,7 @@ public class OrgMutations
     {
         var org = await dbContext.Orgs.FindAsync(orgId);
         NotFoundException.ThrowIfNull(org);
-        permissionService.AssertCanEditOrg(org);
+        permissionService.AssertCanAddProjectToOrg(org);
         var project = await dbContext.Projects.Where(p => p.Id == projectId)
             .Include(p => p.Organizations)
             .SingleOrDefaultAsync();

--- a/backend/LexBoxApi/GraphQL/OrgMutations.cs
+++ b/backend/LexBoxApi/GraphQL/OrgMutations.cs
@@ -58,7 +58,7 @@ public class OrgMutations
     [UseMutationConvention]
     [UseFirstOrDefault]
     [UseProjection]
-    public async Task<IQueryable<Organization>> AcquireProject(
+    public async Task<IQueryable<Organization>> AddProjectToOrg(
         LexBoxDbContext dbContext,
         IPermissionService permissionService,
         Guid orgId,
@@ -90,7 +90,7 @@ public class OrgMutations
     [UseMutationConvention]
     [UseFirstOrDefault]
     [UseProjection]
-    public async Task<IQueryable<Organization>> ReleaseProject(
+    public async Task<IQueryable<Organization>> RemoveProjectFromOrg(
         LexBoxDbContext dbContext,
         IPermissionService permissionService,
         Guid orgId,

--- a/backend/LexBoxApi/GraphQL/OrgMutations.cs
+++ b/backend/LexBoxApi/GraphQL/OrgMutations.cs
@@ -32,7 +32,8 @@ public class OrgMutations
             Members =
             [
                 new OrgMember() { Role = OrgRole.Admin, UserId = userId }
-            ]
+            ],
+            Projects = []
         });
         await dbContext.SaveChangesAsync();
         return dbContext.Orgs.Where(o => o.Id == orgId);

--- a/backend/LexBoxApi/GraphQL/OrgMutations.cs
+++ b/backend/LexBoxApi/GraphQL/OrgMutations.cs
@@ -69,6 +69,7 @@ public class OrgMutations
         permissionService.AssertCanEditOrg(org);
         var project = await dbContext.Projects.FindAsync(projectId);
         NotFoundException.ThrowIfNull(project);
+        permissionService.AssertCanManageProject(projectId);
 
         if (await dbContext.OrgProjects.AnyAsync(op => op.OrgId == orgId && op.ProjectId == projectId))
         {

--- a/backend/LexBoxApi/GraphQL/OrgMutations.cs
+++ b/backend/LexBoxApi/GraphQL/OrgMutations.cs
@@ -99,6 +99,7 @@ public class OrgMutations
             .Include(p => p.Organizations)
             .SingleOrDefaultAsync();
         NotFoundException.ThrowIfNull(project);
+        permissionService.AssertCanManageProject(projectId);
         var foundOrg = project.Organizations.FirstOrDefault(o => o.Id == orgId);
         if (foundOrg is not null)
         {

--- a/backend/LexBoxApi/GraphQL/OrgMutations.cs
+++ b/backend/LexBoxApi/GraphQL/OrgMutations.cs
@@ -55,7 +55,6 @@ public class OrgMutations
 
     [Error<DbError>]
     [Error<NotFoundException>]
-    [Error<AlreadyExistsException>]
     [UseMutationConvention]
     [UseFirstOrDefault]
     [UseProjection]
@@ -73,7 +72,8 @@ public class OrgMutations
 
         if (await dbContext.OrgProjects.AnyAsync(op => op.OrgId == orgId && op.ProjectId == projectId))
         {
-            throw new AlreadyExistsException("Organization already owns this project");
+            // No error since we're already in desired state; just return early
+            return dbContext.Orgs.Where(o => o.Id == orgId);
         }
         await dbContext.OrgProjects.AddAsync(new OrgProjects { OrgId = orgId, ProjectId = projectId });
         await dbContext.SaveChangesAsync();

--- a/backend/LexBoxApi/Models/Project/CreateProjectInput.cs
+++ b/backend/LexBoxApi/Models/Project/CreateProjectInput.cs
@@ -12,5 +12,6 @@ public record CreateProjectInput(
     ProjectType Type,
     RetentionPolicy RetentionPolicy,
     bool IsConfidential,
+    Guid? OwningOrgId,
     Guid? ProjectManagerId
 );

--- a/backend/LexBoxApi/Services/PermissionService.cs
+++ b/backend/LexBoxApi/Services/PermissionService.cs
@@ -108,4 +108,12 @@ public class PermissionService(
         if (org.Members.Any(m => m.UserId == User.Id && m.Role == OrgRole.Admin)) return;
         throw new UnauthorizedAccessException();
     }
+
+    public void AssertCanAddProjectToOrg(Organization org)
+    {
+        if (User is null) throw new UnauthorizedAccessException();
+        if (User.Role == UserRole.admin) return;
+        if (org.Members.Any(m => m.UserId == User.Id)) return;
+        throw new UnauthorizedAccessException();
+    }
 }

--- a/backend/LexBoxApi/Services/ProjectService.cs
+++ b/backend/LexBoxApi/Services/ProjectService.cs
@@ -34,6 +34,7 @@ public class ProjectService(LexBoxDbContext dbContext, IHgService hgService, IOp
                 LastCommit = null,
                 RetentionPolicy = input.RetentionPolicy,
                 IsConfidential = isConfidentialIsUntrustworthy ? null : input.IsConfidential,
+                Organizations = [],
                 Users = input.ProjectManagerId.HasValue ? [new() { UserId = input.ProjectManagerId.Value, Role = ProjectRole.Manager }] : [],
             });
         // Also delete draft project, if any

--- a/backend/LexBoxApi/Services/ProjectService.cs
+++ b/backend/LexBoxApi/Services/ProjectService.cs
@@ -45,6 +45,12 @@ public class ProjectService(LexBoxDbContext dbContext, IHgService hgService, IOp
             manager?.UpdateCreateProjectsPermission(ProjectRole.Manager);
 
         }
+        if (input.OwningOrgId.HasValue)
+        {
+            dbContext.OrgProjects.Add(
+                new OrgProjects { ProjectId = projectId, OrgId = input.OwningOrgId.Value }
+            );
+        }
         await dbContext.SaveChangesAsync();
         await hgService.InitRepo(input.Code);
         await transaction.CommitAsync();

--- a/backend/LexCore/Entities/OrgProjects.cs
+++ b/backend/LexCore/Entities/OrgProjects.cs
@@ -1,0 +1,9 @@
+namespace LexCore.Entities;
+
+public class OrgProjects : EntityBase
+{
+    public Guid OrgId { get; set; }
+    public Guid ProjectId { get; set; }
+    public Organization? Org { get; set; }
+    public Project? Project { get; set; }
+}

--- a/backend/LexCore/Entities/Organization.cs
+++ b/backend/LexCore/Entities/Organization.cs
@@ -8,11 +8,17 @@ public class Organization : EntityBase
 {
     public required string Name { get; set; }
     public required List<OrgMember> Members { get; set; }
+    public required List<Project> Projects { get; set; }
 
     [NotMapped]
     [Projectable(UseMemberBody = nameof(SqlMemberCount))]
     public int MemberCount { get; set; }
     private static Expression<Func<Organization, int>> SqlMemberCount => org => org.Members.Count;
+
+    [NotMapped]
+    [Projectable(UseMemberBody = nameof(SqlProjectCount))]
+    public int ProjectCount { get; set; }
+    private static Expression<Func<Organization, int>> SqlProjectCount => org => org.Projects.Count;
 }
 
 public class OrgMember : EntityBase

--- a/backend/LexCore/Entities/Project.cs
+++ b/backend/LexCore/Entities/Project.cs
@@ -18,6 +18,7 @@ public class Project : EntityBase
     public required bool? IsConfidential { get; set; }
     public FlexProjectMetadata? FlexProjectMetadata { get; set; }
     public required List<ProjectUsers> Users { get; set; }
+    public required List<Organization> Organizations { get; set; }
     public required DateTimeOffset? LastCommit { get; set; }
     public DateTimeOffset? DeletedDate { get; set; }
     public ResetStatus ResetStatus { get; set; } = ResetStatus.None;

--- a/backend/LexCore/ServiceInterfaces/IPermissionService.cs
+++ b/backend/LexCore/ServiceInterfaces/IPermissionService.cs
@@ -20,4 +20,5 @@ public interface IPermissionService
     void AssertCanLockOrUnlockUser(Guid userId);
     void AssertCanCreateOrg();
     void AssertCanEditOrg(Organization org);
+    void AssertCanAddProjectToOrg(Organization org);
 }

--- a/backend/LexData/Entities/OrgProjectsEntityConfiguration.cs
+++ b/backend/LexData/Entities/OrgProjectsEntityConfiguration.cs
@@ -1,0 +1,15 @@
+using LexCore.Entities;
+using LexData.Configuration;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace LexData.Entities;
+
+public class OrgProjectsEntityConfiguration : EntityBaseConfiguration<OrgProjects>
+{
+    public override void Configure(EntityTypeBuilder<OrgProjects> builder)
+    {
+        base.Configure(builder);
+        builder.HasIndex(pu => new { pu.OrgId, pu.ProjectId }).IsUnique();
+        builder.HasQueryFilter(pu => pu.Project!.DeletedDate == null);
+    }
+}

--- a/backend/LexData/Entities/OrgProjectsEntityConfiguration.cs
+++ b/backend/LexData/Entities/OrgProjectsEntityConfiguration.cs
@@ -9,7 +9,7 @@ public class OrgProjectsEntityConfiguration : EntityBaseConfiguration<OrgProject
     public override void Configure(EntityTypeBuilder<OrgProjects> builder)
     {
         base.Configure(builder);
-        builder.HasIndex(pu => new { pu.OrgId, pu.ProjectId }).IsUnique();
-        builder.HasQueryFilter(pu => pu.Project!.DeletedDate == null);
+        builder.HasIndex(op => new { op.OrgId, op.ProjectId }).IsUnique();
+        builder.HasQueryFilter(op => op.Project!.DeletedDate == null);
     }
 }

--- a/backend/LexData/Entities/OrganizationEntityConfiguration.cs
+++ b/backend/LexData/Entities/OrganizationEntityConfiguration.cs
@@ -16,5 +16,11 @@ public class OrganizationEntityConfiguration: EntityBaseConfiguration<Organizati
             .WithOne(m => m.Organization)
             .HasForeignKey(m => m.OrgId)
             .OnDelete(DeleteBehavior.Cascade);
+        builder.HasMany(o => o.Projects)
+            .WithMany(p => p.Organizations)
+            .UsingEntity<OrgProjects>(
+                op => op.HasOne(op => op.Project).WithMany().HasForeignKey(op => op.ProjectId),
+                op => op.HasOne(op => op.Org).WithMany().HasForeignKey(op => op.OrgId)
+            );
     }
 }

--- a/backend/LexData/Entities/ProjectEntityConfiguration.cs
+++ b/backend/LexData/Entities/ProjectEntityConfiguration.cs
@@ -25,7 +25,7 @@ public class ProjectEntityConfiguration : EntityBaseConfiguration<Project>
             .HasForeignKey(projectUser => projectUser.ProjectId)
             .OnDelete(DeleteBehavior.Cascade);
         builder.HasMany(p => p.Organizations)
-            .WithMany(p => p.Projects)
+            .WithMany(o => o.Projects)
             .UsingEntity<OrgProjects>(
                 op => op.HasOne(op => op.Org).WithMany().HasForeignKey(op => op.OrgId),
                 op => op.HasOne(op => op.Project).WithMany().HasForeignKey(op => op.ProjectId)

--- a/backend/LexData/Entities/ProjectEntityConfiguration.cs
+++ b/backend/LexData/Entities/ProjectEntityConfiguration.cs
@@ -24,6 +24,12 @@ public class ProjectEntityConfiguration : EntityBaseConfiguration<Project>
             .WithOne(projectUser => projectUser.Project)
             .HasForeignKey(projectUser => projectUser.ProjectId)
             .OnDelete(DeleteBehavior.Cascade);
+        builder.HasMany(p => p.Organizations)
+            .WithMany(p => p.Projects)
+            .UsingEntity<OrgProjects>(
+                op => op.HasOne(op => op.Org).WithMany().HasForeignKey(op => op.OrgId),
+                op => op.HasOne(op => op.Project).WithMany().HasForeignKey(op => op.ProjectId)
+            );
         builder.HasQueryFilter(p => p.DeletedDate == null);
     }
 }

--- a/backend/LexData/LexBoxDbContext.cs
+++ b/backend/LexData/LexBoxDbContext.cs
@@ -29,6 +29,7 @@ public class LexBoxDbContext(DbContextOptions<LexBoxDbContext> options, IEnumera
     public DbSet<ProjectUsers> ProjectUsers => Set<ProjectUsers>();
     public DbSet<DraftProject> DraftProjects => Set<DraftProject>();
     public DbSet<Organization> Orgs => Set<Organization>();
+    public DbSet<OrgProjects> OrgProjects => Set<OrgProjects>();
 
     public async Task<bool> HeathCheck(CancellationToken cancellationToken)
     {

--- a/backend/LexData/Migrations/20240606084230_AddOrgProjectsTable.Designer.cs
+++ b/backend/LexData/Migrations/20240606084230_AddOrgProjectsTable.Designer.cs
@@ -634,6 +634,8 @@ namespace LexData.Migrations
 
                     b.HasKey("Id");
 
+                    b.HasIndex("OrgId");
+
                     b.HasIndex("ProjectId");
 
                     b.HasIndex("OrgId", "ProjectId")

--- a/backend/LexData/Migrations/20240606084230_AddOrgProjectsTable.Designer.cs
+++ b/backend/LexData/Migrations/20240606084230_AddOrgProjectsTable.Designer.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using LexData;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -12,9 +13,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace LexData.Migrations
 {
     [DbContext(typeof(LexBoxDbContext))]
-    partial class LexBoxDbContextModelSnapshot : ModelSnapshot
+    [Migration("20240606084230_AddOrgProjectsTable")]
+    partial class AddOrgProjectsTable
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder
@@ -477,6 +480,7 @@ namespace LexData.Migrations
                         .HasColumnType("uuid");
 
                     b.Property<string>("Hash")
+                        .IsRequired()
                         .HasColumnType("text");
 
                     b.Property<string>("Metadata")
@@ -484,6 +488,7 @@ namespace LexData.Migrations
                         .HasColumnType("text");
 
                     b.Property<string>("ParentHash")
+                        .IsRequired()
                         .HasColumnType("text");
 
                     b.Property<Guid>("ProjectId")

--- a/backend/LexData/Migrations/20240606084230_AddOrgProjectsTable.cs
+++ b/backend/LexData/Migrations/20240606084230_AddOrgProjectsTable.cs
@@ -1,0 +1,60 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace LexData.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddOrgProjectsTable : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "OrgProjects",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false),
+                    OrgId = table.Column<Guid>(type: "uuid", nullable: false),
+                    ProjectId = table.Column<Guid>(type: "uuid", nullable: false),
+                    CreatedDate = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: false, defaultValueSql: "now()"),
+                    UpdatedDate = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: false, defaultValueSql: "now()")
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_OrgProjects", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_OrgProjects_Orgs_OrgId",
+                        column: x => x.OrgId,
+                        principalTable: "Orgs",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                    table.ForeignKey(
+                        name: "FK_OrgProjects_Projects_ProjectId",
+                        column: x => x.ProjectId,
+                        principalTable: "Projects",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_OrgProjects_OrgId_ProjectId",
+                table: "OrgProjects",
+                columns: new[] { "OrgId", "ProjectId" },
+                unique: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_OrgProjects_ProjectId",
+                table: "OrgProjects",
+                column: "ProjectId");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "OrgProjects");
+        }
+    }
+}

--- a/backend/LexData/Migrations/20240606084230_AddOrgProjectsTable.cs
+++ b/backend/LexData/Migrations/20240606084230_AddOrgProjectsTable.cs
@@ -45,6 +45,11 @@ namespace LexData.Migrations
                 unique: true);
 
             migrationBuilder.CreateIndex(
+                name: "IX_OrgProjects_OrgId",
+                table: "OrgProjects",
+                column: "OrgId");
+
+            migrationBuilder.CreateIndex(
                 name: "IX_OrgProjects_ProjectId",
                 table: "OrgProjects",
                 column: "ProjectId");

--- a/backend/LexData/Migrations/LexBoxDbContextModelSnapshot.cs
+++ b/backend/LexData/Migrations/LexBoxDbContextModelSnapshot.cs
@@ -629,6 +629,8 @@ namespace LexData.Migrations
 
                     b.HasKey("Id");
 
+                    b.HasIndex("OrgId");
+
                     b.HasIndex("ProjectId");
 
                     b.HasIndex("OrgId", "ProjectId")

--- a/backend/LexData/SeedingData.cs
+++ b/backend/LexData/SeedingData.cs
@@ -177,6 +177,28 @@ public class SeedingData(
             ]
         });
 
+        lexBoxDbContext.Attach(new Organization
+        {
+            Id = new Guid("a748bd8b-6348-4980-8dee-6de8b63e4a39"),
+            Name = "Second Test Org",
+            Projects = [],
+            Members =
+            [
+                new OrgMember
+                {
+                    Id = new Guid("03d54e43-ba53-410f-adc2-5ae0bc3cfb21"), Role = OrgRole.Admin, UserId = MangerId,
+                },
+                new OrgMember
+                {
+                    Id = new Guid("d00c7149-c3b2-448a-93ed-9ba2746d38f0"), Role = OrgRole.User, UserId = EditorId,
+                },
+                new OrgMember
+                {
+                    Id = new Guid("3035a412-8503-465b-8525-b60aaadd9488"), Role = OrgRole.User, UserId = TestAdminId,
+                },
+            ]
+        });
+
         foreach (var entry in lexBoxDbContext.ChangeTracker.Entries())
         {
             var exists = await entry.GetDatabaseValuesAsync(cancellationToken) is not null;

--- a/backend/LexData/SeedingData.cs
+++ b/backend/LexData/SeedingData.cs
@@ -105,6 +105,7 @@ public class SeedingData(
                 LexEntryCount = -1
             },
             IsConfidential = null,
+            Organizations = [],
             Users = new()
             {
                 new()
@@ -154,6 +155,7 @@ public class SeedingData(
             LastCommit = DateTimeOffset.UtcNow,
             RetentionPolicy = RetentionPolicy.Dev,
             IsConfidential = false,
+            Organizations = [],
             Users = [],
         });
 
@@ -161,6 +163,7 @@ public class SeedingData(
         {
             Id = new Guid("292c80e6-a815-4cd1-9ea2-34bd01274de6"),
             Name = "Test Org",
+            Projects = [],
             Members =
             [
                 new OrgMember

--- a/backend/LexData/SeedingData.cs
+++ b/backend/LexData/SeedingData.cs
@@ -22,6 +22,9 @@ public class SeedingData(
     public static readonly Guid QaAdminId = new("99b00c58-0dc7-4fe4-b6f2-c27b828811e0");
     private static readonly Guid MangerId = new Guid("703701a8-005c-4747-91f2-ac7650455118");
     private static readonly Guid EditorId = new Guid("6dc9965b-4021-4606-92df-133fcce75fcb");
+    private static readonly Guid TestOrgId = new Guid("292c80e6-a815-4cd1-9ea2-34bd01274de6");
+    private static readonly Guid SecondTestOrgId = new Guid("a748bd8b-6348-4980-8dee-6de8b63e4a39");
+    private static readonly Guid Sena3ProjId = new Guid("0ebc5976-058d-4447-aaa7-297f8569f968");
 
     public async Task SeedIfNoUsers(CancellationToken cancellationToken = default)
     {
@@ -93,7 +96,7 @@ public class SeedingData(
 
         lexBoxDbContext.Attach(new Project
         {
-            Id = new Guid("0ebc5976-058d-4447-aaa7-297f8569f968"),
+            Id = Sena3ProjId,
             Name = "Sena 3",
             Code = "sena-3",
             Type = ProjectType.FLEx,
@@ -161,7 +164,7 @@ public class SeedingData(
 
         lexBoxDbContext.Attach(new Organization
         {
-            Id = new Guid("292c80e6-a815-4cd1-9ea2-34bd01274de6"),
+            Id = TestOrgId,
             Name = "Test Org",
             Projects = [],
             Members =
@@ -179,7 +182,7 @@ public class SeedingData(
 
         lexBoxDbContext.Attach(new Organization
         {
-            Id = new Guid("a748bd8b-6348-4980-8dee-6de8b63e4a39"),
+            Id = SecondTestOrgId,
             Name = "Second Test Org",
             Projects = [],
             Members =
@@ -197,6 +200,13 @@ public class SeedingData(
                     Id = new Guid("3035a412-8503-465b-8525-b60aaadd9488"), Role = OrgRole.User, UserId = TestAdminId,
                 },
             ]
+        });
+
+        lexBoxDbContext.Attach(new OrgProjects
+        {
+            Id = new Guid("f659eb4c-0289-475d-b44a-095ffddb31c8"),
+            OrgId = TestOrgId,
+            ProjectId = Sena3ProjId,
         });
 
         foreach (var entry in lexBoxDbContext.ChangeTracker.Entries())

--- a/backend/Testing/LexCore/Services/ProjectServiceTest.cs
+++ b/backend/Testing/LexCore/Services/ProjectServiceTest.cs
@@ -32,7 +32,7 @@ public class ProjectServiceTest
     public async Task CanCreateProject()
     {
         var projectId = await _projectService.CreateProject(
-            new(null, "TestProject", "Test", "test", ProjectType.FLEx, RetentionPolicy.Test, false, null));
+            new(null, "TestProject", "Test", "test", ProjectType.FLEx, RetentionPolicy.Test, false, null, null));
         projectId.ShouldNotBe(default);
     }
 
@@ -41,10 +41,10 @@ public class ProjectServiceTest
     {
         //first project should be created
         await _projectService.CreateProject(
-            new(null, "TestProject", "Test", "test-dup-code", ProjectType.FLEx, RetentionPolicy.Test, false, null));
+            new(null, "TestProject", "Test", "test-dup-code", ProjectType.FLEx, RetentionPolicy.Test, false, null, null));
 
         var exception = await _projectService.CreateProject(
-            new(null, "Test2", "Test desc", "test-dup-code", ProjectType.Unknown, RetentionPolicy.Dev, false, null)
+            new(null, "Test2", "Test desc", "test-dup-code", ProjectType.Unknown, RetentionPolicy.Dev, false, null, null)
         ).ShouldThrowAsync<DbUpdateException>();
 
         exception.InnerException.ShouldBeOfType<PostgresException>()

--- a/frontend/schema.graphql
+++ b/frontend/schema.graphql
@@ -7,6 +7,11 @@ interface Error {
   message: String!
 }
 
+type AcquireProjectPayload {
+  organization: Organization
+  errors: [AcquireProjectError!]
+}
+
 type AddProjectMemberPayload {
   project: Project
   errors: [AddProjectMemberError!]
@@ -192,6 +197,8 @@ type MeDto {
 type Mutation {
   createOrganization(input: CreateOrganizationInput!): CreateOrganizationPayload!
   deleteOrg(input: DeleteOrgInput!): DeleteOrgPayload! @authorize(policy: "AdminRequiredPolicy")
+  acquireProject(input: AcquireProjectInput!): AcquireProjectPayload!
+  releaseProject(input: ReleaseProjectInput!): ReleaseProjectPayload!
   setOrgMemberRole(input: SetOrgMemberRoleInput!): SetOrgMemberRolePayload!
   changeOrgMemberRole(input: ChangeOrgMemberRoleInput!): ChangeOrgMemberRolePayload!
   changeOrgName(input: ChangeOrgNameInput!): ChangeOrgNamePayload!
@@ -320,6 +327,11 @@ type Query {
   isAdmin: IsAdminResponse! @authorize(policy: "AdminRequiredPolicy")
 }
 
+type ReleaseProjectPayload {
+  organization: Organization
+  errors: [ReleaseProjectError!]
+}
+
 type RemoveProjectMemberPayload {
   project: Project
 }
@@ -388,6 +400,8 @@ type UsersCollectionSegment {
   totalCount: Int!
 }
 
+union AcquireProjectError = DbError | NotFoundError | AlreadyExistsError
+
 union AddProjectMemberError = NotFoundError | DbError | ProjectMembersMustBeVerified | ProjectMembersMustBeVerifiedForRole | ProjectMemberInvitedByEmail | InvalidEmailError | AlreadyExistsError
 
 union BulkAddProjectMembersError = NotFoundError | InvalidEmailError | DbError
@@ -420,6 +434,8 @@ union DeleteUserByAdminOrSelfError = NotFoundError | DbError
 
 union LeaveProjectError = NotFoundError | LastMemberCantLeaveError
 
+union ReleaseProjectError = DbError | NotFoundError
+
 union SetOrgMemberRoleError = DbError | NotFoundError
 
 union SetProjectConfidentialityError = NotFoundError | DbError
@@ -427,6 +443,11 @@ union SetProjectConfidentialityError = NotFoundError | DbError
 union SetUserLockedError = NotFoundError
 
 union SoftDeleteProjectError = NotFoundError | DbError
+
+input AcquireProjectInput {
+  orgId: UUID!
+  projectId: UUID!
+}
 
 input AddProjectMemberInput {
   projectId: UUID!
@@ -508,6 +529,7 @@ input CreateProjectInput {
   type: ProjectType!
   retentionPolicy: RetentionPolicy!
   isConfidential: Boolean!
+  owningOrgId: UUID
   projectManagerId: UUID
 }
 
@@ -752,6 +774,11 @@ input ProjectUsersFilterInput {
   id: UuidOperationFilterInput
   createdDate: DateTimeOperationFilterInput
   updatedDate: DateTimeOperationFilterInput
+}
+
+input ReleaseProjectInput {
+  orgId: UUID!
+  projectId: UUID!
 }
 
 input RemoveProjectMemberInput {

--- a/frontend/schema.graphql
+++ b/frontend/schema.graphql
@@ -400,7 +400,7 @@ type UsersCollectionSegment {
   totalCount: Int!
 }
 
-union AcquireProjectError = DbError | NotFoundError | AlreadyExistsError
+union AcquireProjectError = DbError | NotFoundError
 
 union AddProjectMemberError = NotFoundError | DbError | ProjectMembersMustBeVerified | ProjectMembersMustBeVerifiedForRole | ProjectMemberInvitedByEmail | InvalidEmailError | AlreadyExistsError
 

--- a/frontend/schema.graphql
+++ b/frontend/schema.graphql
@@ -7,14 +7,14 @@ interface Error {
   message: String!
 }
 
-type AcquireProjectPayload {
-  organization: Organization
-  errors: [AcquireProjectError!]
-}
-
 type AddProjectMemberPayload {
   project: Project
   errors: [AddProjectMemberError!]
+}
+
+type AddProjectToOrgPayload {
+  organization: Organization
+  errors: [AddProjectToOrgError!]
 }
 
 type AlreadyExistsError implements Error {
@@ -197,8 +197,8 @@ type MeDto {
 type Mutation {
   createOrganization(input: CreateOrganizationInput!): CreateOrganizationPayload!
   deleteOrg(input: DeleteOrgInput!): DeleteOrgPayload! @authorize(policy: "AdminRequiredPolicy")
-  acquireProject(input: AcquireProjectInput!): AcquireProjectPayload!
-  releaseProject(input: ReleaseProjectInput!): ReleaseProjectPayload!
+  addProjectToOrg(input: AddProjectToOrgInput!): AddProjectToOrgPayload!
+  removeProjectFromOrg(input: RemoveProjectFromOrgInput!): RemoveProjectFromOrgPayload!
   setOrgMemberRole(input: SetOrgMemberRoleInput!): SetOrgMemberRolePayload!
   changeOrgMemberRole(input: ChangeOrgMemberRoleInput!): ChangeOrgMemberRolePayload!
   changeOrgName(input: ChangeOrgNameInput!): ChangeOrgNamePayload!
@@ -248,10 +248,10 @@ type OrgProjects {
 
 type Organization {
   createdDate: DateTime!
-  memberCount: Int!
   name: String!
   members: [OrgMember!]!
   projects: [Project!]!
+  memberCount: Int!
   projectCount: Int!
   id: UUID!
   updatedDate: DateTime!
@@ -311,8 +311,8 @@ type ProjectUsers {
 
 type Query {
   myProjects(orderBy: [ProjectSortInput!]): [Project!]!
-  myDraftProjects(orderBy: [DraftProjectSortInput!]): [DraftProject!]!
   projects(withDeleted: Boolean! = false where: ProjectFilterInput orderBy: [ProjectSortInput!]): [Project!]! @authorize(policy: "AdminRequiredPolicy")
+  myDraftProjects(orderBy: [DraftProjectSortInput!]): [DraftProject!]!
   draftProjects(where: DraftProjectFilterInput orderBy: [DraftProjectSortInput!]): [DraftProject!]! @authorize(policy: "AdminRequiredPolicy")
   projectById(projectId: UUID!): Project
   projectByCode(code: String!): Project
@@ -327,9 +327,9 @@ type Query {
   isAdmin: IsAdminResponse! @authorize(policy: "AdminRequiredPolicy")
 }
 
-type ReleaseProjectPayload {
+type RemoveProjectFromOrgPayload {
   organization: Organization
-  errors: [ReleaseProjectError!]
+  errors: [RemoveProjectFromOrgError!]
 }
 
 type RemoveProjectMemberPayload {
@@ -400,9 +400,9 @@ type UsersCollectionSegment {
   totalCount: Int!
 }
 
-union AcquireProjectError = DbError | NotFoundError
-
 union AddProjectMemberError = NotFoundError | DbError | ProjectMembersMustBeVerified | ProjectMembersMustBeVerifiedForRole | ProjectMemberInvitedByEmail | InvalidEmailError | AlreadyExistsError
+
+union AddProjectToOrgError = DbError | NotFoundError
 
 union BulkAddProjectMembersError = NotFoundError | InvalidEmailError | DbError
 
@@ -434,7 +434,7 @@ union DeleteUserByAdminOrSelfError = NotFoundError | DbError
 
 union LeaveProjectError = NotFoundError | LastMemberCantLeaveError
 
-union ReleaseProjectError = DbError | NotFoundError
+union RemoveProjectFromOrgError = DbError | NotFoundError
 
 union SetOrgMemberRoleError = DbError | NotFoundError
 
@@ -444,15 +444,15 @@ union SetUserLockedError = NotFoundError
 
 union SoftDeleteProjectError = NotFoundError | DbError
 
-input AcquireProjectInput {
-  orgId: UUID!
-  projectId: UUID!
-}
-
 input AddProjectMemberInput {
   projectId: UUID!
   usernameOrEmail: String!
   role: ProjectRole!
+}
+
+input AddProjectToOrgInput {
+  orgId: UUID!
+  projectId: UUID!
 }
 
 input BooleanOperationFilterInput {
@@ -681,8 +681,8 @@ input OrganizationFilterInput {
   or: [OrganizationFilterInput!]
   name: StringOperationFilterInput
   members: ListFilterInputTypeOfOrgMemberFilterInput
-  memberCount: IntOperationFilterInput
   projects: ListFilterInputTypeOfProjectFilterInput
+  memberCount: IntOperationFilterInput
   projectCount: IntOperationFilterInput
   id: UuidOperationFilterInput
   createdDate: DateTimeOperationFilterInput
@@ -776,7 +776,7 @@ input ProjectUsersFilterInput {
   updatedDate: DateTimeOperationFilterInput
 }
 
-input ReleaseProjectInput {
+input RemoveProjectFromOrgInput {
   orgId: UUID!
   projectId: UUID!
 }

--- a/frontend/schema.graphql
+++ b/frontend/schema.graphql
@@ -229,11 +229,23 @@ type OrgMember {
   updatedDate: DateTime!
 }
 
+type OrgProjects {
+  org: Organization!
+  project: Project!
+  orgId: UUID!
+  projectId: UUID!
+  id: UUID!
+  createdDate: DateTime!
+  updatedDate: DateTime!
+}
+
 type Organization {
   createdDate: DateTime!
   memberCount: Int!
   name: String!
   members: [OrgMember!]!
+  projects: [Project!]!
+  projectCount: Int!
   id: UUID!
   updatedDate: DateTime!
 }
@@ -253,6 +265,7 @@ type Project {
   type: ProjectType!
   isConfidential: Boolean
   flexProjectMetadata: FlexProjectMetadata
+  organizations: [Organization!]!
   lastCommit: DateTime
   deletedDate: DateTime
   resetStatus: ResetStatus!
@@ -593,6 +606,20 @@ input ListFilterInputTypeOfOrgMemberFilterInput {
   any: Boolean
 }
 
+input ListFilterInputTypeOfOrganizationFilterInput {
+  all: OrganizationFilterInput
+  none: OrganizationFilterInput
+  some: OrganizationFilterInput
+  any: Boolean
+}
+
+input ListFilterInputTypeOfProjectFilterInput {
+  all: ProjectFilterInput
+  none: ProjectFilterInput
+  some: ProjectFilterInput
+  any: Boolean
+}
+
 input ListFilterInputTypeOfProjectUsersFilterInput {
   all: ProjectUsersFilterInput
   none: ProjectUsersFilterInput
@@ -633,6 +660,8 @@ input OrganizationFilterInput {
   name: StringOperationFilterInput
   members: ListFilterInputTypeOfOrgMemberFilterInput
   memberCount: IntOperationFilterInput
+  projects: ListFilterInputTypeOfProjectFilterInput
+  projectCount: IntOperationFilterInput
   id: UuidOperationFilterInput
   createdDate: DateTimeOperationFilterInput
   updatedDate: DateTimeOperationFilterInput
@@ -641,6 +670,7 @@ input OrganizationFilterInput {
 input OrganizationSortInput {
   name: SortEnumType
   memberCount: SortEnumType
+  projectCount: SortEnumType
   id: SortEnumType
   createdDate: SortEnumType
   updatedDate: SortEnumType
@@ -658,6 +688,7 @@ input ProjectFilterInput {
   isConfidential: BooleanOperationFilterInput
   flexProjectMetadata: FlexProjectMetadataFilterInput
   users: ListFilterInputTypeOfProjectUsersFilterInput
+  organizations: ListFilterInputTypeOfOrganizationFilterInput
   lastCommit: DateTimeOperationFilterInput
   deletedDate: DateTimeOperationFilterInput
   resetStatus: ResetStatusOperationFilterInput

--- a/frontend/src/lib/gql/mutations.ts
+++ b/frontend/src/lib/gql/mutations.ts
@@ -1,65 +1,7 @@
-import type { $OpResult, DeleteUserByAdminOrSelfInput, DeleteUserByAdminOrSelfMutation, SoftDeleteProjectMutation, DeleteDraftProjectMutation, AcquireProjectMutation, ReleaseProjectMutation } from './types';
+import type { $OpResult, DeleteUserByAdminOrSelfInput, DeleteUserByAdminOrSelfMutation, SoftDeleteProjectMutation, DeleteDraftProjectMutation } from './types';
 
 import { getClient } from './gql-client';
 import { graphql } from './generated';
-
-export async function _acquireProject(orgId: string, projectId: string): $OpResult<AcquireProjectMutation> {
-  //language=GraphQL
-  const result = await getClient()
-    .mutation(
-      graphql(`
-        mutation AcquireProject($input: AcquireProjectInput!) {
-          acquireProject(input: $input) {
-            organization {
-              id
-              projects {
-                id
-                name
-                code
-              }
-            }
-            errors {
-              ... on Error {
-                __typename
-                message
-              }
-            }
-          }
-        }
-      `),
-      { input: { orgId, projectId } },
-    );
-  return result;
-}
-
-export async function _releaseProject(orgId: string, projectId: string): $OpResult<ReleaseProjectMutation> {
-  //language=GraphQL
-  const result = await getClient()
-    .mutation(
-      graphql(`
-        mutation ReleaseProject($input: ReleaseProjectInput!) {
-          releaseProject(input: $input) {
-            organization {
-              id
-              projects {
-                id
-                name
-                code
-              }
-            }
-            errors {
-              ... on Error {
-                __typename
-                message
-              }
-            }
-          }
-        }
-      `),
-      { input: { orgId, projectId } },
-    );
-  return result;
-}
 
 export async function _deleteUserByAdminOrSelf(input: DeleteUserByAdminOrSelfInput): $OpResult<DeleteUserByAdminOrSelfMutation> {
   //language=GraphQL

--- a/frontend/src/lib/gql/mutations.ts
+++ b/frontend/src/lib/gql/mutations.ts
@@ -1,7 +1,65 @@
-import type { $OpResult, DeleteUserByAdminOrSelfInput, DeleteUserByAdminOrSelfMutation, SoftDeleteProjectMutation, DeleteDraftProjectMutation } from './types';
+import type { $OpResult, DeleteUserByAdminOrSelfInput, DeleteUserByAdminOrSelfMutation, SoftDeleteProjectMutation, DeleteDraftProjectMutation, AcquireProjectMutation, ReleaseProjectMutation } from './types';
 
 import { getClient } from './gql-client';
 import { graphql } from './generated';
+
+export async function _acquireProject(orgId: string, projectId: string): $OpResult<AcquireProjectMutation> {
+  //language=GraphQL
+  const result = await getClient()
+    .mutation(
+      graphql(`
+        mutation AcquireProject($input: AcquireProjectInput!) {
+          acquireProject(input: $input) {
+            organization {
+              id
+              projects {
+                id
+                name
+                code
+              }
+            }
+            errors {
+              ... on Error {
+                __typename
+                message
+              }
+            }
+          }
+        }
+      `),
+      { input: { orgId, projectId } },
+    );
+  return result;
+}
+
+export async function _releaseProject(orgId: string, projectId: string): $OpResult<ReleaseProjectMutation> {
+  //language=GraphQL
+  const result = await getClient()
+    .mutation(
+      graphql(`
+        mutation ReleaseProject($input: ReleaseProjectInput!) {
+          releaseProject(input: $input) {
+            organization {
+              id
+              projects {
+                id
+                name
+                code
+              }
+            }
+            errors {
+              ... on Error {
+                __typename
+                message
+              }
+            }
+          }
+        }
+      `),
+      { input: { orgId, projectId } },
+    );
+  return result;
+}
 
 export async function _deleteUserByAdminOrSelf(input: DeleteUserByAdminOrSelfInput): $OpResult<DeleteUserByAdminOrSelfMutation> {
   //language=GraphQL

--- a/frontend/src/routes/(authenticated)/org/[org_id]/+page.svelte
+++ b/frontend/src/routes/(authenticated)/org/[org_id]/+page.svelte
@@ -19,6 +19,7 @@
   import ChangeOrgMemberRoleModal from './ChangeOrgMemberRoleModal.svelte';
   import UserModal from '$lib/components/Users/UserModal.svelte';
   import OrgMemberTable from './OrgMemberTable.svelte';
+  import ProjectTable from '$lib/components/Projects/ProjectTable.svelte';
 
   export let data: PageData;
   $: user = data.user;
@@ -112,12 +113,14 @@
     </span>
   </div>
   <div class="mt-6">
-    <!-- TODO: Add project count once orgs can own projects -->
-    <OrgTabs bind:activeTab={$queryParamValues.tab} memberCount={org.members.length} projectCount={0} />
+    <OrgTabs bind:activeTab={$queryParamValues.tab} memberCount={org.members.length} projectCount={org.projects.length} />
   </div>
   <div class="py-6 px-2">
     {#if $queryParamValues.tab === 'projects'}
-    Projects list will go here once orgs have projects associated with them
+    <ProjectTable
+      columns={['name', 'code', 'users', 'type']}
+      projects={org.projects}
+    />
     {:else if $queryParamValues.tab === 'members'}
     <OrgMemberTable
       shownUsers={org.members}

--- a/frontend/src/routes/(authenticated)/org/[org_id]/+page.ts
+++ b/frontend/src/routes/(authenticated)/org/[org_id]/+page.ts
@@ -35,6 +35,13 @@ export async function load(event: PageLoadEvent) {
             createdDate
             updatedDate
             name
+            projects {
+              id
+              code
+              name
+              type
+              userCount
+            }
             members {
               id
               role

--- a/frontend/src/routes/(unauthenticated)/sandbox/+page.svelte
+++ b/frontend/src/routes/(unauthenticated)/sandbox/+page.svelte
@@ -11,6 +11,7 @@
   import ConfirmModal from '$lib/components/modals/ConfirmModal.svelte';
   import {delay} from '$lib/util/time';
   import DeleteModal from '$lib/components/modals/DeleteModal.svelte';
+  import { _acquireProject, _releaseProject } from '$lib/gql/mutations';
 
   function uploadFinished(): void {
     alert('upload done!');
@@ -47,6 +48,17 @@ function preFillForm(): void {
 let modal: ConfirmModal;
 let deleteModal: DeleteModal;
 
+const testOrgId = '292c80e6-a815-4cd1-9ea2-34bd01274de6';
+const sena3Id = '0ebc5976-058d-4447-aaa7-297f8569f968';
+
+async function acquire() {
+  console.log(await _acquireProject(testOrgId, sena3Id));
+}
+
+async function release() {
+  console.log(await _releaseProject(testOrgId, sena3Id));
+}
+
 </script>
 <PageBreadcrumb>Hello from sandbox</PageBreadcrumb>
 <PageBreadcrumb>second value</PageBreadcrumb>
@@ -69,6 +81,12 @@ let deleteModal: DeleteModal;
     <a rel="external" target="_blank" class="btn" href="/api/testing/test500NoException">Goto API 500 new tab</a>
     <button class="btn" on:click={fetch500}>Fetch 500</button>
     <button class="btn" on:click={gqlThrows500}>GQL 500</button>
+  </div>
+  <div class="card w-96 bg-base-200 shadow-lg">
+    <div class="card-body">
+      <button class="btn btn-success" on:click={acquire}>acquire</button>
+      <button class="btn btn-accent" on:click={release}>release</button>
+    </div>
   </div>
   <div class="card w-96 bg-base-200 shadow-lg">
     <div class="card-body">

--- a/frontend/src/routes/(unauthenticated)/sandbox/+page.svelte
+++ b/frontend/src/routes/(unauthenticated)/sandbox/+page.svelte
@@ -11,7 +11,6 @@
   import ConfirmModal from '$lib/components/modals/ConfirmModal.svelte';
   import {delay} from '$lib/util/time';
   import DeleteModal from '$lib/components/modals/DeleteModal.svelte';
-  import { _acquireProject, _releaseProject } from '$lib/gql/mutations';
 
   function uploadFinished(): void {
     alert('upload done!');
@@ -48,17 +47,6 @@ function preFillForm(): void {
 let modal: ConfirmModal;
 let deleteModal: DeleteModal;
 
-const testOrgId = '292c80e6-a815-4cd1-9ea2-34bd01274de6';
-const sena3Id = '0ebc5976-058d-4447-aaa7-297f8569f968';
-
-async function acquire() {
-  console.log(await _acquireProject(testOrgId, sena3Id));
-}
-
-async function release() {
-  console.log(await _releaseProject(testOrgId, sena3Id));
-}
-
 </script>
 <PageBreadcrumb>Hello from sandbox</PageBreadcrumb>
 <PageBreadcrumb>second value</PageBreadcrumb>
@@ -81,12 +69,6 @@ async function release() {
     <a rel="external" target="_blank" class="btn" href="/api/testing/test500NoException">Goto API 500 new tab</a>
     <button class="btn" on:click={fetch500}>Fetch 500</button>
     <button class="btn" on:click={gqlThrows500}>GQL 500</button>
-  </div>
-  <div class="card w-96 bg-base-200 shadow-lg">
-    <div class="card-body">
-      <button class="btn btn-success" on:click={acquire}>acquire</button>
-      <button class="btn btn-accent" on:click={release}>release</button>
-    </div>
   </div>
   <div class="card w-96 bg-base-200 shadow-lg">
     <div class="card-body">


### PR DESCRIPTION
Part of #788, but should not close it yet as this PR is backend-only (well, almost, see below).

This PR contains backend changes for having orgs own projects. As suggested in #788, the DB relation is a many-to-many relationship so that a project can be owned by multiple orgs.

Frontend changes are limited to having the org page now show a list of owned projects. Buttons to add projcts to an org, or remove them, will go in a separate PR as planned.

Screenshot of projects now showing on org page:

![image](https://github.com/sillsdev/languageforge-lexbox/assets/90762/81e0ca42-6c92-46b1-8f31-030070993c9a)
