### PR TITLE
Bulk-add users to existing org

### DIFF
--- a/backend/LexBoxApi/GraphQL/OrgMutations.cs
+++ b/backend/LexBoxApi/GraphQL/OrgMutations.cs
@@ -202,12 +202,14 @@ public class OrgMutations
 
     [Error<NotFoundException>]
     [Error<DbError>]
-    [AdminRequired]
+    [Error<UnauthorizedAccessException>]
     [UseMutationConvention]
     public async Task<BulkAddOrgMembersResult> BulkAddOrgMembers(
         BulkAddOrgMembersInput input,
+        IPermissionService permissionService,
         LexBoxDbContext dbContext)
     {
+        permissionService.AssertCanEditOrg(input.OrgId);
         var orgExists = await dbContext.Orgs.AnyAsync(p => p.Id == input.OrgId);
         if (!orgExists) throw NotFoundException.ForType<Organization>();
         List<OrgMemberRole> AddedMembers = [];

--- a/backend/LexBoxApi/GraphQL/OrgMutations.cs
+++ b/backend/LexBoxApi/GraphQL/OrgMutations.cs
@@ -210,7 +210,7 @@ public class OrgMutations
         LexBoxDbContext dbContext)
     {
         permissionService.AssertCanEditOrg(input.OrgId);
-        var orgExists = await dbContext.Orgs.AnyAsync(p => p.Id == input.OrgId);
+        var orgExists = await dbContext.Orgs.AnyAsync(o => o.Id == input.OrgId);
         if (!orgExists) throw NotFoundException.ForType<Organization>();
         List<OrgMemberRole> AddedMembers = [];
         List<OrgMemberRole> ExistingMembers = [];

--- a/backend/LexBoxApi/GraphQL/OrgMutations.cs
+++ b/backend/LexBoxApi/GraphQL/OrgMutations.cs
@@ -196,6 +196,52 @@ public class OrgMutations
         await dbContext.SaveChangesAsync();
     }
 
+    public record BulkAddOrgMembersInput(Guid OrgId, string[] Usernames, OrgRole Role);
+    public record OrgMemberRole(string Username, OrgRole Role);
+    public record BulkAddOrgMembersResult(List<OrgMemberRole> AddedMembers, List<OrgMemberRole> NotFoundMembers, List<OrgMemberRole> ExistingMembers);
+
+    [Error<NotFoundException>]
+    [Error<DbError>]
+    [AdminRequired]
+    [UseMutationConvention]
+    public async Task<BulkAddOrgMembersResult> BulkAddOrgMembers(
+        BulkAddOrgMembersInput input,
+        LexBoxDbContext dbContext)
+    {
+        var orgExists = await dbContext.Orgs.AnyAsync(p => p.Id == input.OrgId);
+        if (!orgExists) throw NotFoundException.ForType<Organization>();
+        List<OrgMemberRole> AddedMembers = [];
+        List<OrgMemberRole> ExistingMembers = [];
+        List<OrgMemberRole> NotFoundMembers = [];
+        var existingUsers = await dbContext.Users.Include(u => u.Organizations).Where(u => input.Usernames.Contains(u.Username) || input.Usernames.Contains(u.Email)).ToArrayAsync();
+        var byUsername = existingUsers.Where(u => u.Username is not null).ToDictionary(u => u.Username!);
+        var byEmail = existingUsers.Where(u => u.Email is not null).ToDictionary(u => u.Email!);
+        foreach (var usernameOrEmail in input.Usernames)
+        {
+            var user = byUsername.GetValueOrDefault(usernameOrEmail) ?? byEmail.GetValueOrDefault(usernameOrEmail);
+            if (user is null)
+            {
+                NotFoundMembers.Add(new OrgMemberRole(usernameOrEmail, input.Role));
+            }
+            else
+            {
+                var userOrg = user.Organizations.FirstOrDefault(p => p.OrgId == input.OrgId);
+                if (userOrg is not null)
+                {
+                    ExistingMembers.Add(new OrgMemberRole(user.Username ?? user.Email!, userOrg.Role));
+                }
+                else
+                {
+                    AddedMembers.Add(new OrgMemberRole(user.Username ?? user.Email!, input.Role));
+                    // Not yet a member, so add a membership. We don't want to touch existing memberships, which might have other roles
+                    user.Organizations.Add(new OrgMember { Role = input.Role, OrgId = input.OrgId, UserId = user.Id });
+                }
+            }
+        }
+        await dbContext.SaveChangesAsync();
+        return new BulkAddOrgMembersResult(AddedMembers, NotFoundMembers, ExistingMembers);
+    }
+
     [Error<NotFoundException>]
     [Error<DbError>]
     [Error<RequiredException>]

--- a/backend/LexBoxApi/Services/PermissionService.cs
+++ b/backend/LexBoxApi/Services/PermissionService.cs
@@ -164,6 +164,11 @@ public class PermissionService(
         return false;
     }
 
+    public void AssertCanEditOrg(Guid orgId)
+    {
+        if (!CanEditOrg(orgId)) throw new UnauthorizedAccessException();
+    }
+
     public void AssertCanEditOrg(Organization org)
     {
         if (!CanEditOrg(org.Id)) throw new UnauthorizedAccessException();

--- a/backend/LexCore/ServiceInterfaces/IPermissionService.cs
+++ b/backend/LexCore/ServiceInterfaces/IPermissionService.cs
@@ -34,5 +34,6 @@ public interface IPermissionService
     bool IsOrgMember(Guid orgId);
     bool CanEditOrg(Guid orgId);
     void AssertCanEditOrg(Organization org);
+    void AssertCanEditOrg(Guid orgId);
     void AssertCanAddProjectToOrg(Organization org);
 }

--- a/frontend/schema.graphql
+++ b/frontend/schema.graphql
@@ -31,6 +31,17 @@ type AuthUserProject {
   projectId: UUID!
 }
 
+type BulkAddOrgMembersPayload {
+  bulkAddOrgMembersResult: BulkAddOrgMembersResult
+  errors: [BulkAddOrgMembersError!]
+}
+
+type BulkAddOrgMembersResult {
+  addedMembers: [OrgMemberRole!]!
+  notFoundMembers: [OrgMemberRole!]!
+  existingMembers: [OrgMemberRole!]!
+}
+
 type BulkAddProjectMembersPayload {
   bulkAddProjectMembersResult: BulkAddProjectMembersResult
   errors: [BulkAddProjectMembersError!]
@@ -208,6 +219,7 @@ type Mutation {
   removeProjectFromOrg(input: RemoveProjectFromOrgInput!): RemoveProjectFromOrgPayload!
   setOrgMemberRole(input: SetOrgMemberRoleInput!): SetOrgMemberRolePayload!
   changeOrgMemberRole(input: ChangeOrgMemberRoleInput!): ChangeOrgMemberRolePayload!
+  bulkAddOrgMembers(input: BulkAddOrgMembersInput!): BulkAddOrgMembersPayload! @authorize(policy: "AdminRequiredPolicy")
   changeOrgName(input: ChangeOrgNameInput!): ChangeOrgNamePayload!
   createProject(input: CreateProjectInput!): CreateProjectPayload! @authorize(policy: "VerifiedEmailRequiredPolicy")
   addProjectMember(input: AddProjectMemberInput!): AddProjectMemberPayload!
@@ -291,6 +303,11 @@ type OrgMemberDto {
 type OrgMemberDtoCreatedBy {
   id: UUID!
   name: String!
+}
+
+type OrgMemberRole {
+  username: String!
+  role: OrgRole!
 }
 
 type OrgProjects {
@@ -462,6 +479,8 @@ union AddProjectMemberError = NotFoundError | DbError | ProjectMembersMustBeVeri
 
 union AddProjectToOrgError = DbError | NotFoundError
 
+union BulkAddOrgMembersError = NotFoundError | DbError
+
 union BulkAddProjectMembersError = NotFoundError | InvalidEmailError | DbError
 
 union ChangeOrgMemberRoleError = DbError | NotFoundError
@@ -516,6 +535,12 @@ input AddProjectToOrgInput {
 input BooleanOperationFilterInput {
   eq: Boolean
   neq: Boolean
+}
+
+input BulkAddOrgMembersInput {
+  orgId: UUID!
+  usernames: [String!]!
+  role: OrgRole!
 }
 
 input BulkAddProjectMembersInput {

--- a/frontend/schema.graphql
+++ b/frontend/schema.graphql
@@ -219,7 +219,7 @@ type Mutation {
   removeProjectFromOrg(input: RemoveProjectFromOrgInput!): RemoveProjectFromOrgPayload!
   setOrgMemberRole(input: SetOrgMemberRoleInput!): SetOrgMemberRolePayload!
   changeOrgMemberRole(input: ChangeOrgMemberRoleInput!): ChangeOrgMemberRolePayload!
-  bulkAddOrgMembers(input: BulkAddOrgMembersInput!): BulkAddOrgMembersPayload! @authorize(policy: "AdminRequiredPolicy")
+  bulkAddOrgMembers(input: BulkAddOrgMembersInput!): BulkAddOrgMembersPayload!
   changeOrgName(input: ChangeOrgNameInput!): ChangeOrgNamePayload!
   createProject(input: CreateProjectInput!): CreateProjectPayload! @authorize(policy: "VerifiedEmailRequiredPolicy")
   addProjectMember(input: AddProjectMemberInput!): AddProjectMemberPayload!
@@ -435,6 +435,10 @@ type SoftDeleteProjectPayload {
   errors: [SoftDeleteProjectError!]
 }
 
+type UnauthorizedAccessError implements Error {
+  message: String!
+}
+
 type UniqueValueError implements Error {
   message: String!
 }
@@ -479,7 +483,7 @@ union AddProjectMemberError = NotFoundError | DbError | ProjectMembersMustBeVeri
 
 union AddProjectToOrgError = DbError | NotFoundError
 
-union BulkAddOrgMembersError = NotFoundError | DbError
+union BulkAddOrgMembersError = NotFoundError | DbError | UnauthorizedAccessError
 
 union BulkAddProjectMembersError = NotFoundError | InvalidEmailError | DbError
 

--- a/frontend/src/lib/components/Badges/OrgMemberBadge.svelte
+++ b/frontend/src/lib/components/Badges/OrgMemberBadge.svelte
@@ -1,0 +1,25 @@
+<script lang="ts">
+  import { OrgRole } from '$lib/gql/types';
+  import FormatUserOrgRole from '../Orgs/FormatUserOrgRole.svelte';
+  import ActionBadge from './ActionBadge.svelte';
+  import Badge from './Badge.svelte';
+  export let member: { name: string; role: OrgRole };
+  export let canManage = false;
+
+  export let type: 'existing' | 'new' = 'existing';
+  $: actionIcon = (type === 'existing' ? 'i-mdi-dots-vertical' as const : 'i-mdi-close' as const);
+  $: variant = member.role === OrgRole.Admin ? 'btn-primary' as const : 'btn-secondary' as const;
+</script>
+
+<ActionBadge {actionIcon} {variant} disabled={!canManage} on:action>
+  <span class="pr-3 whitespace-nowrap overflow-ellipsis overflow-x-clip" title={member.name}>
+    {member.name}
+  </span>
+
+  <!-- justify the name left and the role right -->
+  <span class="flex-grow" />
+
+  <Badge>
+    <FormatUserOrgRole role={member.role} />
+  </Badge>
+</ActionBadge>

--- a/frontend/src/lib/gql/gql-client.ts
+++ b/frontend/src/lib/gql/gql-client.ts
@@ -28,6 +28,7 @@ import {
   type BulkAddProjectMembersMutationVariables,
   type DeleteDraftProjectMutationVariables,
   type MutationAddProjectToOrgArgs,
+  type BulkAddOrgMembersMutationVariables,
 } from './types';
 import type {Readable, Unsubscriber} from 'svelte/store';
 import {derived} from 'svelte/store';
@@ -69,6 +70,9 @@ function createGqlClient(_gqlEndpoint?: string): Client {
               if (args.input.projectId) {
                 cache.invalidate({__typename: 'Project', id: args.input.projectId});
               }
+            },
+            bulkAddOrgMembers: (result, args: BulkAddOrgMembersMutationVariables, cache, _info) => {
+              cache.invalidate({__typename: 'Org', id: args.input.orgId});
             },
             leaveProject: (result, args: LeaveProjectMutationVariables, cache, _info) => {
               cache.invalidate({__typename: 'Project', id: args.input.projectId});

--- a/frontend/src/lib/gql/gql-client.ts
+++ b/frontend/src/lib/gql/gql-client.ts
@@ -72,7 +72,7 @@ function createGqlClient(_gqlEndpoint?: string): Client {
               }
             },
             bulkAddOrgMembers: (result, args: BulkAddOrgMembersMutationVariables, cache, _info) => {
-              cache.invalidate({__typename: 'Org', id: args.input.orgId});
+              cache.invalidate({__typename: 'Organization', id: args.input.orgId});
             },
             leaveProject: (result, args: LeaveProjectMutationVariables, cache, _info) => {
               cache.invalidate({__typename: 'Project', id: args.input.projectId});

--- a/frontend/src/lib/gql/gql-client.ts
+++ b/frontend/src/lib/gql/gql-client.ts
@@ -29,6 +29,8 @@ import {
   type DeleteDraftProjectMutationVariables,
   type MutationAddProjectToOrgArgs,
   type BulkAddOrgMembersMutationVariables,
+  type ChangeOrgMemberRoleMutationVariables,
+  type AddOrgMemberMutationVariables,
 } from './types';
 import type {Readable, Unsubscriber} from 'svelte/store';
 import {derived} from 'svelte/store';
@@ -72,7 +74,13 @@ function createGqlClient(_gqlEndpoint?: string): Client {
               }
             },
             bulkAddOrgMembers: (result, args: BulkAddOrgMembersMutationVariables, cache, _info) => {
-              cache.invalidate({__typename: 'Organization', id: args.input.orgId});
+              cache.invalidate({__typename: 'OrgById', id: args.input.orgId});
+            },
+            changeOrgMemberRole: (result, args: ChangeOrgMemberRoleMutationVariables, cache, _info) => {
+              cache.invalidate({__typename: 'OrgById', id: args.input.orgId});
+            },
+            setOrgMemberRole: (result, args: AddOrgMemberMutationVariables, cache, _info) => {
+              cache.invalidate({__typename: 'OrgById', id: args.input.orgId});
             },
             leaveProject: (result, args: LeaveProjectMutationVariables, cache, _info) => {
               cache.invalidate({__typename: 'Project', id: args.input.projectId});

--- a/frontend/src/lib/i18n/locales/en.json
+++ b/frontend/src/lib/i18n/locales/en.json
@@ -273,7 +273,7 @@ the [Linguistics Institute at Payap University](https://li.payap.ac.th/) in Chia
       "usernames_description": "This should be the **email or Send/Receive login** for existing accounts",
       "invalid_username": "Invalid login/username: {username}. Only letters, numbers, and underscore (_) characters are allowed.",
       "empty_user_field": "Please enter email addresses and/or logins",
-      "members_added": "{addedCount} new {addedCount, plural, one {member was} other {members were}} added to organization.",
+      "members_added": "{addedCount} new {addedCount, plural, one {member was} other {members were}} added to the organization.",
       "already_members": "{count, plural, one {# user was} other {# users were}} already in the organization.",
       "accounts_not_found": "{notFoundCount} {notFoundCount, plural, one {user was} other {users were}} not found.",
       "invalid_email_address": "Invalid email address: {email}.",

--- a/frontend/src/lib/i18n/locales/en.json
+++ b/frontend/src/lib/i18n/locales/en.json
@@ -263,6 +263,21 @@ the [Linguistics Institute at Payap University](https://li.payap.ac.th/) in Chia
       "user_needs_to_relogin": "Added members will need to log out and back in again before they see the new organization.",
       "invalid_email_address": "Invalid email address: {email}",
     },
+    "bulk_add_members": {
+      "add_button": "Bulk Add Members",
+      "explanation": "Adds all the entered logins and emails to this organization. Unlike the bulk-add feature for projects, new accounts will NOT be automatically created.",
+      "modal_title": "Bulk Add Members",
+      "submit_button": "Add Members",
+      "finish_button": "Close",
+      "usernames": "Logins or emails (one per line)",
+      "usernames_description": "This should be the **email or Send/Receive login** for existing accounts",
+      "invalid_username": "Invalid login/username: {username}. Only letters, numbers, and underscore (_) characters are allowed.",
+      "empty_user_field": "Please enter email addresses and/or logins",
+      "members_added": "{addedCount} new {addedCount, plural, one {member was} other {members were}} added to organization.",
+      "already_members": "{count, plural, one {# user was} other {# users were}} already in the organization.",
+      "accounts_not_found": "{notFoundCount} {notFoundCount, plural, one {user was} other {users were}} not found.",
+      "invalid_email_address": "Invalid email address: {email}.",
+    },
     "change_role_modal": {
       "title": "Choose role for {name}",
       "button_label": "Change Role"

--- a/frontend/src/routes/(authenticated)/org/[org_id]/+page.svelte
+++ b/frontend/src/routes/(authenticated)/org/[org_id]/+page.svelte
@@ -21,6 +21,7 @@
   import OrgMemberTable from './OrgMemberTable.svelte';
   import ProjectTable from '$lib/components/Projects/ProjectTable.svelte';
   import type { UUID } from 'crypto';
+  import BulkAddOrgMembers from './BulkAddOrgMembers.svelte';
 
   export let data: PageData;
   $: user = data.user;
@@ -102,6 +103,7 @@
         <span class="i-mdi-account-plus-outline text-2xl" />
       </Button>
       <AddOrgMemberModal bind:this={addOrgMemberModal} orgId={org.id} />
+      <BulkAddOrgMembers orgId={org.id} />
     {/if}
   </svelte:fragment>
   <div slot="title" class="max-w-full flex items-baseline flex-wrap">

--- a/frontend/src/routes/(authenticated)/org/[org_id]/+page.ts
+++ b/frontend/src/routes/(authenticated)/org/[org_id]/+page.ts
@@ -110,14 +110,6 @@ export async function _deleteOrgUser(orgId: string, userId: string): $OpResult<D
           changeOrgMemberRole(input: $input) {
             organization {
               id
-              members {
-                id
-                role
-                user {
-                  id
-                  name
-                }
-              }
             }
           }
         }
@@ -136,14 +128,6 @@ export async function _addOrgMember(orgId: UUID, emailOrUsername: string, role: 
           setOrgMemberRole(input: $input) {
             organization {
               id
-              members {
-                id
-                role
-                user {
-                  id
-                  name
-                }
-              }
             }
             errors {
               __typename
@@ -234,14 +218,6 @@ export async function _changeOrgMemberRole(orgId: string, userId: string, role: 
           changeOrgMemberRole(input: $input) {
             organization {
               id
-              members {
-                id
-                role
-                user {
-                  id
-                  name
-                }
-              }
             }
             errors {
               __typename

--- a/frontend/src/routes/(authenticated)/org/[org_id]/+page.ts
+++ b/frontend/src/routes/(authenticated)/org/[org_id]/+page.ts
@@ -1,6 +1,7 @@
 import type {
   $OpResult,
   AddOrgMemberMutation,
+  BulkAddOrgMembersMutation,
   ChangeOrgMemberRoleMutation,
   ChangeOrgNameInput,
   ChangeOrgNameMutation,
@@ -154,6 +155,38 @@ export async function _addOrgMember(orgId: UUID, emailOrUsername: string, role: 
         }
       `),
       { input: { orgId, emailOrUsername, role} },
+    );
+  return result;
+}
+
+export async function _bulkAddOrgMembers(orgId: UUID, usernames: string[], role: OrgRole): $OpResult<BulkAddOrgMembersMutation> {
+  //language=GraphQL
+  const result = await getClient()
+    .mutation(
+      graphql(`
+        mutation BulkAddOrgMembers($input: BulkAddOrgMembersInput!) {
+          bulkAddOrgMembers(input: $input) {
+            bulkAddOrgMembersResult {
+              addedMembers {
+                username
+                role
+              }
+              existingMembers {
+                username
+                role
+              }
+              notFoundMembers {
+                username
+                role
+              }
+            }
+            errors {
+              __typename
+            }
+          }
+        }
+      `),
+      { input: { orgId, usernames, role } }
     );
   return result;
 }

--- a/frontend/src/routes/(authenticated)/org/[org_id]/BulkAddOrgMembers.svelte
+++ b/frontend/src/routes/(authenticated)/org/[org_id]/BulkAddOrgMembers.svelte
@@ -78,7 +78,6 @@
   }
 </script>
 
-<AdminContent>
   <Button variant="btn-success" on:click={openModal}>
     {$t('org_page.bulk_add_members.add_button')}
     <span class="i-mdi-account-multiple-plus-outline text-2xl" />
@@ -150,7 +149,6 @@
     <span slot="submitText">{$t('org_page.bulk_add_members.submit_button')}</span>
     <span slot="closeText">{$t('org_page.bulk_add_members.finish_button')}</span>
   </FormModal>
-</AdminContent>
 
 <style lang="postcss">
   .usernames :global(.description) {

--- a/frontend/src/routes/(authenticated)/org/[org_id]/BulkAddOrgMembers.svelte
+++ b/frontend/src/routes/(authenticated)/org/[org_id]/BulkAddOrgMembers.svelte
@@ -1,0 +1,166 @@
+<script lang="ts">
+  import Button from '$lib/forms/Button.svelte';
+  import { DialogResponse, FormModal, type FormSubmitReturn } from '$lib/components/modals';
+  import { TextArea, isEmail } from '$lib/forms';
+  import { OrgRole, type BulkAddOrgMembersResult } from '$lib/gql/types';
+  import t from '$lib/i18n';
+  import { z } from 'zod';
+  import { _bulkAddOrgMembers } from './+page';
+  import { AdminContent } from '$lib/layout';
+  import Icon from '$lib/icons/Icon.svelte';
+  import BadgeList from '$lib/components/Badges/BadgeList.svelte';
+  import { distinct } from '$lib/util/array';
+  import { SupHelp, helpLinks } from '$lib/components/help';
+  import { usernameRe } from '$lib/user';
+  import OrgMemberBadge from '$lib/components/Badges/OrgMemberBadge.svelte';
+  import type { UUID } from 'crypto';
+
+  enum BulkAddSteps {
+    Add,
+    Results,
+  }
+
+  let currentStep = BulkAddSteps.Add;
+
+  export let orgId: string;
+  const schema = z.object({
+    usernamesText: z.string().trim().min(1, $t('org_page.bulk_add_members.empty_user_field')),
+  });
+
+  let formModal: FormModal<typeof schema>;
+  $: form = formModal?.form();
+
+  let addedMembers: BulkAddOrgMembersResult['addedMembers'] = [];
+  let notFoundMembers: BulkAddOrgMembersResult['notFoundMembers'] = [];
+  let existingMembers: BulkAddOrgMembersResult['existingMembers'] = [];
+
+  function validateBulkAddInput(usernames: string[]): FormSubmitReturn<typeof schema> {
+    if (usernames.length === 0) return { usernamesText: [$t('org_page.bulk_add_members.empty_user_field')] };
+
+    for (const username of usernames) {
+      if (username.includes('@')) {
+        if (!isEmail(username)) return { usernamesText: [$t('org_page.bulk_add_members.invalid_email_address', { email: username })] };
+      } else if (!usernameRe.test(username)) {
+        return { usernamesText: [$t('org_page.bulk_add_members.invalid_username', { username })] };
+      }
+    }
+  }
+
+  async function openModal(): Promise<void> {
+    currentStep = BulkAddSteps.Add;
+    console.log('Opening modal');
+    const { response } = await formModal.open(undefined, async (state) => {
+      console.log('Submit button clicked');
+      const usernames = state.usernamesText.currentValue
+        .split('\n')
+        // Remove whitespace
+        .map(s => s.trim())
+        // Remove empty lines before validating, otherwise final newline would count as invalid because empty string
+        .filter(s => s)
+        .filter(distinct);
+
+      console.log('Usernames:', usernames);
+
+      const bulkErrors = validateBulkAddInput(usernames);
+      if (bulkErrors) return bulkErrors;
+
+      const { error, data } = await _bulkAddOrgMembers(
+        orgId as UUID,
+        usernames,
+        OrgRole.User,
+      );
+
+      console.log('Error:', error);
+      console.log('Data:', data);
+
+      addedMembers = data?.bulkAddOrgMembers.bulkAddOrgMembersResult?.addedMembers ?? [];
+      notFoundMembers = data?.bulkAddOrgMembers.bulkAddOrgMembersResult?.notFoundMembers ?? [];
+      existingMembers = data?.bulkAddOrgMembers.bulkAddOrgMembersResult?.existingMembers ?? [];
+      return error?.message;
+    }, { keepOpenOnSubmit: true });
+
+    if (response === DialogResponse.Submit) {
+      currentStep = BulkAddSteps.Results;
+    }
+  }
+</script>
+
+<AdminContent>
+  <Button variant="btn-success" on:click={openModal}>
+    {$t('org_page.bulk_add_members.add_button')}
+    <span class="i-mdi-account-multiple-plus-outline text-2xl" />
+  </Button>
+
+  <FormModal bind:this={formModal} {schema} let:errors>
+    <span slot="title">
+      {$t('org_page.bulk_add_members.modal_title')}
+      <SupHelp helpLink={helpLinks.bulkAddCreate} />
+    </span>
+    {#if currentStep == BulkAddSteps.Add}
+      <p class="mb-2">{$t('org_page.bulk_add_members.explanation')}</p>
+      <div class="contents usernames">
+        <TextArea
+          id="usernamesText"
+          label={$t('org_page.bulk_add_members.usernames')}
+          description={$t('org_page.bulk_add_members.usernames_description')}
+          bind:value={$form.usernamesText}
+          error={errors.usernamesText}
+        />
+      </div>
+    {:else if currentStep == BulkAddSteps.Results}
+      <p class="flex gap-1 items-center mb-4">
+        <Icon icon="i-mdi-plus" color="text-success" />
+        {$t('org_page.bulk_add_members.members_added', {addedCount: addedMembers.length})}
+      </p>
+      <div class="mb-4 ml-8">
+        {#if addedMembers.length > 0}
+          <div class="mt-2">
+            <BadgeList>
+              {#each addedMembers as user}
+              <OrgMemberBadge member={{ name: user.username, role: user.role }} />
+              {/each}
+            </BadgeList>
+          </div>
+        {/if}
+      </div>
+      <div class="mb-4">
+        <p class="flex gap-1 items-center">
+          <Icon icon="i-mdi-account-off" color="text-info" />
+          {$t('org_page.bulk_add_members.accounts_not_found', {notFoundCount: notFoundMembers.length})}
+        </p>
+        {#if notFoundMembers.length > 0}
+          <div class="mt-2">
+            <BadgeList>
+              {#each notFoundMembers as user}
+                <OrgMemberBadge member={{ name: user.username, role: user.role }} />
+              {/each}
+            </BadgeList>
+          </div>
+        {/if}
+      </div>
+      {#if existingMembers.length > 0}
+        <p class="flex gap-1 items-center">
+          <Icon icon="i-mdi-account-outline" color="text-info" />
+          {$t('org_page.bulk_add_members.already_members', {count: existingMembers.length})}
+        </p>
+        <div class="mt-2">
+          <BadgeList>
+            {#each existingMembers as user}
+              <OrgMemberBadge member={{ name: user.username, role: user.role }} />
+            {/each}
+          </BadgeList>
+        </div>
+      {/if}
+    {:else}
+      <p>Internal error: unknown step {currentStep}</p>
+    {/if}
+    <span slot="submitText">{$t('org_page.bulk_add_members.submit_button')}</span>
+    <span slot="closeText">{$t('org_page.bulk_add_members.finish_button')}</span>
+  </FormModal>
+</AdminContent>
+
+<style lang="postcss">
+  .usernames :global(.description) {
+    @apply text-success;
+  }
+</style>

--- a/frontend/src/routes/(authenticated)/org/[org_id]/BulkAddOrgMembers.svelte
+++ b/frontend/src/routes/(authenticated)/org/[org_id]/BulkAddOrgMembers.svelte
@@ -108,11 +108,11 @@
         />
       </div>
     {:else if currentStep == BulkAddSteps.Results}
-      <p class="flex gap-1 items-center mb-4">
-        <Icon icon="i-mdi-plus" color="text-success" />
-        {$t('org_page.bulk_add_members.members_added', {addedCount: addedMembers.length})}
-      </p>
-      <div class="mb-4 ml-8">
+      <div class="mb-4">
+        <p class="flex gap-1 items-center">
+          <Icon icon="i-mdi-plus" color="text-success" />
+          {$t('org_page.bulk_add_members.members_added', {addedCount: addedMembers.length})}
+        </p>
         {#if addedMembers.length > 0}
           <div class="mt-2">
             <BadgeList>

--- a/frontend/src/routes/(authenticated)/org/[org_id]/BulkAddOrgMembers.svelte
+++ b/frontend/src/routes/(authenticated)/org/[org_id]/BulkAddOrgMembers.svelte
@@ -79,12 +79,12 @@
   }
 </script>
 
-  <Button variant="btn-success" on:click={openModal}>
-    {$t('org_page.bulk_add_members.add_button')}
-    <span class="i-mdi-account-multiple-plus-outline text-2xl" />
-  </Button>
+<Button variant="btn-success" on:click={openModal}>
+  {$t('org_page.bulk_add_members.add_button')}
+  <span class="i-mdi-account-multiple-plus-outline text-2xl" />
+</Button>
 
-  <FormModal bind:this={formModal} {schema} let:errors>
+<FormModal bind:this={formModal} {schema} let:errors>
     <span slot="title">
       {$t('org_page.bulk_add_members.modal_title')}
       <SupHelp helpLink={helpLinks.bulkAddCreate} />

--- a/frontend/src/routes/(authenticated)/org/[org_id]/BulkAddOrgMembers.svelte
+++ b/frontend/src/routes/(authenticated)/org/[org_id]/BulkAddOrgMembers.svelte
@@ -6,7 +6,6 @@
   import t from '$lib/i18n';
   import { z } from 'zod';
   import { _bulkAddOrgMembers } from './+page';
-  import { AdminContent } from '$lib/layout';
   import Icon from '$lib/icons/Icon.svelte';
   import BadgeList from '$lib/components/Badges/BadgeList.svelte';
   import { distinct } from '$lib/util/array';
@@ -14,6 +13,7 @@
   import { usernameRe } from '$lib/user';
   import OrgMemberBadge from '$lib/components/Badges/OrgMemberBadge.svelte';
   import type { UUID } from 'crypto';
+  import { invalidate } from '$app/navigation';
 
   enum BulkAddSteps {
     Add,
@@ -73,6 +73,7 @@
     }, { keepOpenOnSubmit: true });
 
     if (response === DialogResponse.Submit) {
+      await invalidate(`org:${orgId}`);
       currentStep = BulkAddSteps.Results;
     }
   }

--- a/frontend/src/routes/(authenticated)/org/[org_id]/BulkAddOrgMembers.svelte
+++ b/frontend/src/routes/(authenticated)/org/[org_id]/BulkAddOrgMembers.svelte
@@ -48,9 +48,7 @@
 
   async function openModal(): Promise<void> {
     currentStep = BulkAddSteps.Add;
-    console.log('Opening modal');
     const { response } = await formModal.open(undefined, async (state) => {
-      console.log('Submit button clicked');
       const usernames = state.usernamesText.currentValue
         .split('\n')
         // Remove whitespace
@@ -58,8 +56,6 @@
         // Remove empty lines before validating, otherwise final newline would count as invalid because empty string
         .filter(s => s)
         .filter(distinct);
-
-      console.log('Usernames:', usernames);
 
       const bulkErrors = validateBulkAddInput(usernames);
       if (bulkErrors) return bulkErrors;
@@ -69,9 +65,6 @@
         usernames,
         OrgRole.User,
       );
-
-      console.log('Error:', error);
-      console.log('Data:', data);
 
       addedMembers = data?.bulkAddOrgMembers.bulkAddOrgMembersResult?.addedMembers ?? [];
       notFoundMembers = data?.bulkAddOrgMembers.bulkAddOrgMembersResult?.notFoundMembers ?? [];


### PR DESCRIPTION
Fixes #778.

This adds a "Bulk Add Members" button to the organization page:

![org-bulk-add-members-1](https://github.com/user-attachments/assets/720e3f47-4ce6-4c0a-bf10-9b81ae74ec83)

Currently the button is only visible to **site admins**. If we decide to allow **org admins** to use the Bulk-Add feature as well, it will be quite simple to make it visible to them; adding the correct auth requirements to the GraphQL mutation will be slightly harder but doable.

When you click the button, UI very reminiscent of the bulk-add feature from the project page will show up:

![org-bulk-add-members-2](https://github.com/user-attachments/assets/67ea5a23-8fa6-43f0-9934-88b1eaf29e23)

Unlike the project bulk-add feature, the bulk-add feature for orgs does NOT invite users if a username or email address is not found. Instead, it returns a "not found" list to the user and allows them to decide what to do about the not-found accounts:

![org-bulk-add-members-3](https://github.com/user-attachments/assets/03eb9436-af78-4563-810f-4c3f57a83b84)
