### PR TITLE
Send email notifications for approved project request and getting added to project

### DIFF
--- a/backend/LexBoxApi/Controllers/AdminController.cs
+++ b/backend/LexBoxApi/Controllers/AdminController.cs
@@ -2,6 +2,7 @@ using System.ComponentModel.DataAnnotations;
 using LexBoxApi.Auth;
 using LexBoxApi.Auth.Attributes;
 using LexBoxApi.Services;
+using LexBoxApi.Services.Email;
 using LexCore;
 using LexData;
 using Microsoft.AspNetCore.Mvc;
@@ -16,12 +17,12 @@ public class AdminController : ControllerBase
     private readonly LexBoxDbContext _lexBoxDbContext;
     private readonly LoggedInContext _loggedInContext;
     private readonly UserService _userService;
-    private readonly EmailService _emailService;
+    private readonly IEmailService _emailService;
 
     public AdminController(LexBoxDbContext lexBoxDbContext,
         LoggedInContext loggedInContext,
         UserService userService,
-        EmailService emailService
+        IEmailService emailService
     )
     {
         _lexBoxDbContext = lexBoxDbContext;

--- a/backend/LexBoxApi/Controllers/LoginController.cs
+++ b/backend/LexBoxApi/Controllers/LoginController.cs
@@ -13,6 +13,7 @@ using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.ModelBinding;
 using System.Security.Claims;
 using Microsoft.AspNetCore.Authentication.Google;
+using LexBoxApi.Services.Email;
 
 namespace LexBoxApi.Controllers;
 
@@ -22,7 +23,7 @@ public class LoginController(
     LexAuthService lexAuthService,
     LexBoxDbContext lexBoxDbContext,
     LoggedInContext loggedInContext,
-    EmailService emailService,
+    IEmailService emailService,
     UserService userService,
     TurnstileService turnstileService)
     : ControllerBase

--- a/backend/LexBoxApi/Controllers/UserController.cs
+++ b/backend/LexBoxApi/Controllers/UserController.cs
@@ -4,6 +4,7 @@ using LexBoxApi.Auth.Attributes;
 using LexBoxApi.Models;
 using LexBoxApi.Otel;
 using LexBoxApi.Services;
+using LexBoxApi.Services.Email;
 using LexCore;
 using LexCore.Auth;
 using LexCore.Entities;
@@ -24,14 +25,14 @@ public class UserController : ControllerBase
     private readonly LexBoxDbContext _lexBoxDbContext;
     private readonly TurnstileService _turnstileService;
     private readonly LoggedInContext _loggedInContext;
-    private readonly EmailService _emailService;
+    private readonly IEmailService _emailService;
     private readonly LexAuthService _lexAuthService;
 
     public UserController(
         LexBoxDbContext lexBoxDbContext,
         TurnstileService turnstileService,
         LoggedInContext loggedInContext,
-        EmailService emailService,
+        IEmailService emailService,
         LexAuthService lexAuthService
     )
     {

--- a/backend/LexBoxApi/GraphQL/GraphQlSetupKernel.cs
+++ b/backend/LexBoxApi/GraphQL/GraphQlSetupKernel.cs
@@ -3,6 +3,7 @@ using HotChocolate.Diagnostics;
 using LexBoxApi.Auth;
 using LexBoxApi.GraphQL.CustomFilters;
 using LexBoxApi.Services;
+using LexBoxApi.Services.Email;
 using LexCore.ServiceInterfaces;
 using LexData;
 
@@ -22,7 +23,7 @@ public static class GraphQlSetupKernel
             .RegisterService<IHgService>()
             .RegisterService<IIsLanguageForgeProjectDataLoader>()
             .RegisterService<LoggedInContext>()
-            .RegisterService<EmailService>()
+            .RegisterService<IEmailService>()
             .RegisterService<LexAuthService>()
             .RegisterService<IPermissionService>()
             .AddDataAnnotationsValidator()

--- a/backend/LexBoxApi/GraphQL/ProjectMutations.cs
+++ b/backend/LexBoxApi/GraphQL/ProjectMutations.cs
@@ -106,6 +106,7 @@ public class ProjectMutations
         user.UpdateUpdatedDate();
         project.UpdateUpdatedDate();
         await dbContext.SaveChangesAsync();
+        await emailService.SendUserAddedEmail(user, project.Name, project.Code);
         return dbContext.Projects.Where(p => p.Id == input.ProjectId);
     }
 

--- a/backend/LexBoxApi/GraphQL/ProjectMutations.cs
+++ b/backend/LexBoxApi/GraphQL/ProjectMutations.cs
@@ -37,6 +37,7 @@ public class ProjectMutations
         LoggedInContext loggedInContext,
         IPermissionService permissionService,
         CreateProjectInput input,
+        LexBoxDbContext dbContext,
         [Service] ProjectService projectService,
         [Service] EmailService emailService)
     {
@@ -54,8 +55,16 @@ public class ProjectMutations
             await emailService.SendCreateProjectRequestEmail(loggedInContext.User, input);
             return new CreateProjectResponse(draftProjectId, CreateProjectResult.Requested);
         }
-
+        var draftProject = await dbContext.DraftProjects.FindAsync(input.Id);
         var projectId = await projectService.CreateProject(input);
+        if (draftProject is not null)
+        {
+            var manager = await dbContext.Users.FindAsync(draftProject.ProjectManagerId);
+            if (manager is not null)
+            {
+                await emailService.SendApproveProjectRequestEmail(manager, input);
+            }
+        }
         return new CreateProjectResponse(projectId, CreateProjectResult.Created);
     }
 

--- a/backend/LexBoxApi/GraphQL/ProjectMutations.cs
+++ b/backend/LexBoxApi/GraphQL/ProjectMutations.cs
@@ -14,6 +14,7 @@ using LexData.Entities;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.IdentityModel.Tokens;
 using System.Net.Mail;
+using LexBoxApi.Services.Email;
 
 namespace LexBoxApi.GraphQL;
 
@@ -39,7 +40,7 @@ public class ProjectMutations
         CreateProjectInput input,
         LexBoxDbContext dbContext,
         [Service] ProjectService projectService,
-        [Service] EmailService emailService)
+        [Service] IEmailService emailService)
     {
         if (!loggedInContext.User.IsAdmin)
         {
@@ -82,7 +83,7 @@ public class ProjectMutations
         LoggedInContext loggedInContext,
         AddProjectMemberInput input,
         LexBoxDbContext dbContext,
-        [Service] EmailService emailService)
+        [Service] IEmailService emailService)
     {
         permissionService.AssertCanManageProject(input.ProjectId);
         var project = await dbContext.Projects.FindAsync(input.ProjectId);

--- a/backend/LexBoxApi/GraphQL/ProjectMutations.cs
+++ b/backend/LexBoxApi/GraphQL/ProjectMutations.cs
@@ -38,7 +38,6 @@ public class ProjectMutations
         LoggedInContext loggedInContext,
         IPermissionService permissionService,
         CreateProjectInput input,
-        LexBoxDbContext dbContext,
         [Service] ProjectService projectService,
         [Service] IEmailService emailService)
     {
@@ -56,16 +55,7 @@ public class ProjectMutations
             await emailService.SendCreateProjectRequestEmail(loggedInContext.User, input);
             return new CreateProjectResponse(draftProjectId, CreateProjectResult.Requested);
         }
-        var draftProject = await dbContext.DraftProjects.FindAsync(input.Id);
         var projectId = await projectService.CreateProject(input);
-        if (draftProject is not null)
-        {
-            var manager = await dbContext.Users.FindAsync(draftProject.ProjectManagerId);
-            if (manager is not null)
-            {
-                await emailService.SendApproveProjectRequestEmail(manager, input);
-            }
-        }
         return new CreateProjectResponse(projectId, CreateProjectResult.Created);
     }
 

--- a/backend/LexBoxApi/GraphQL/UserMutations.cs
+++ b/backend/LexBoxApi/GraphQL/UserMutations.cs
@@ -6,6 +6,7 @@ using LexBoxApi.GraphQL.CustomTypes;
 using LexBoxApi.Models.Project;
 using LexBoxApi.Otel;
 using LexBoxApi.Services;
+using LexBoxApi.Services.Email;
 using LexCore;
 using LexCore.Auth;
 using LexCore.Entities;
@@ -45,7 +46,7 @@ public class UserMutations
         IPermissionService permissionService,
         ChangeUserAccountBySelfInput input,
         LexBoxDbContext dbContext,
-        EmailService emailService
+        IEmailService emailService
     )
     {
         if (loggedInContext.User.Id != input.UserId) throw new UnauthorizedAccessException();
@@ -68,7 +69,7 @@ public class UserMutations
         IPermissionService permissionService,
         ChangeUserAccountByAdminInput input,
         LexBoxDbContext dbContext,
-        EmailService emailService
+        IEmailService emailService
     )
     {
         return UpdateUser(loggedInContext, permissionService, input, dbContext, emailService);
@@ -83,7 +84,7 @@ public class UserMutations
         LoggedInContext loggedInContext,
         CreateGuestUserByAdminInput input,
         LexBoxDbContext dbContext,
-        EmailService emailService
+        IEmailService emailService
     )
     {
         using var createGuestUserActivity = LexBoxActivitySource.Get().StartActivity("CreateGuestUser");
@@ -128,7 +129,7 @@ public class UserMutations
         IPermissionService permissionService,
         ChangeUserAccountDataInput input,
         LexBoxDbContext dbContext,
-        EmailService emailService
+        IEmailService emailService
     )
     {
         var user = await dbContext.Users.FindAsync(input.UserId);

--- a/backend/LexBoxApi/Jobs/RetryEmailJob.cs
+++ b/backend/LexBoxApi/Jobs/RetryEmailJob.cs
@@ -1,10 +1,10 @@
-﻿using LexBoxApi.Services;
+﻿using LexBoxApi.Services.Email;
 using MimeKit;
 using Quartz;
 
 namespace LexBoxApi.Jobs;
 
-public class RetryEmailJob(EmailService emailService) : LexJob
+public class RetryEmailJob(IEmailService emailService) : LexJob
 {
     public static async Task Queue(ISchedulerFactory schedulerFactory,
         MimeMessage email,

--- a/backend/LexBoxApi/LexBoxKernel.cs
+++ b/backend/LexBoxApi/LexBoxKernel.cs
@@ -3,6 +3,7 @@ using LexBoxApi.Config;
 using LexBoxApi.GraphQL;
 using LexBoxApi.GraphQL.CustomTypes;
 using LexBoxApi.Services;
+using LexBoxApi.Services.Email;
 using LexCore.Config;
 using LexCore.ServiceInterfaces;
 using LexSyncReverseProxy;
@@ -50,7 +51,7 @@ public static class LexBoxKernel
         services.AddScoped<IPermissionService, PermissionService>();
         services.AddScoped<ProjectService>();
         services.AddScoped<UserService>();
-        services.AddScoped<EmailService>();
+        services.AddScoped<IEmailService, EmailService>();
         services.AddScoped<TusService>();
         services.AddScoped<TurnstileService>();
         services.AddScoped<IHgService, HgService>();

--- a/backend/LexBoxApi/Services/Email/EmailTemplates.cs
+++ b/backend/LexBoxApi/Services/Email/EmailTemplates.cs
@@ -18,7 +18,8 @@ public enum EmailTemplate
     VerifyEmailAddress,
     PasswordChanged,
     CreateAccountRequest,
-    CreateProjectRequest
+    CreateProjectRequest,
+    ApproveProjectRequest,
 }
 
 public record ForgotPasswordEmail(string Name, string ResetUrl, TimeSpan lifetime) : EmailTemplateBase(EmailTemplate.ForgotPassword);
@@ -33,3 +34,4 @@ public record PasswordChangedEmail(string Name) : EmailTemplateBase(EmailTemplat
 
 public record CreateProjectRequestUser(string Name, string Email);
 public record CreateProjectRequestEmail(string Name, CreateProjectRequestUser User, CreateProjectInput Project): EmailTemplateBase(EmailTemplate.CreateProjectRequest);
+public record ApproveProjectRequestEmail(string Name, CreateProjectRequestUser User, CreateProjectInput Project): EmailTemplateBase(EmailTemplate.ApproveProjectRequest);

--- a/backend/LexBoxApi/Services/Email/EmailTemplates.cs
+++ b/backend/LexBoxApi/Services/Email/EmailTemplates.cs
@@ -35,5 +35,5 @@ public record PasswordChangedEmail(string Name) : EmailTemplateBase(EmailTemplat
 
 public record CreateProjectRequestUser(string Name, string Email);
 public record CreateProjectRequestEmail(string Name, CreateProjectRequestUser User, CreateProjectInput Project) : EmailTemplateBase(EmailTemplate.CreateProjectRequest);
-public record ApproveProjectRequestEmail(string Name, CreateProjectRequestUser User, CreateProjectInput Project, string ProjectName, string ProjectCode) : EmailTemplateBase(EmailTemplate.ApproveProjectRequest);
+public record ApproveProjectRequestEmail(string Name, CreateProjectRequestUser User, CreateProjectInput Project) : EmailTemplateBase(EmailTemplate.ApproveProjectRequest);
 public record UserAddedEmail(string Name, string Email) : EmailTemplateBase(EmailTemplate.UserAdded);

--- a/backend/LexBoxApi/Services/Email/EmailTemplates.cs
+++ b/backend/LexBoxApi/Services/Email/EmailTemplates.cs
@@ -36,4 +36,4 @@ public record PasswordChangedEmail(string Name) : EmailTemplateBase(EmailTemplat
 public record CreateProjectRequestUser(string Name, string Email);
 public record CreateProjectRequestEmail(string Name, CreateProjectRequestUser User, CreateProjectInput Project) : EmailTemplateBase(EmailTemplate.CreateProjectRequest);
 public record ApproveProjectRequestEmail(string Name, CreateProjectRequestUser User, CreateProjectInput Project) : EmailTemplateBase(EmailTemplate.ApproveProjectRequest);
-public record UserAddedEmail(string Name, string Email) : EmailTemplateBase(EmailTemplate.UserAdded);
+public record UserAddedEmail(string Name, string Email, string ProjectName, string ProjectCode) : EmailTemplateBase(EmailTemplate.UserAdded);

--- a/backend/LexBoxApi/Services/Email/EmailTemplates.cs
+++ b/backend/LexBoxApi/Services/Email/EmailTemplates.cs
@@ -35,5 +35,5 @@ public record PasswordChangedEmail(string Name) : EmailTemplateBase(EmailTemplat
 
 public record CreateProjectRequestUser(string Name, string Email);
 public record CreateProjectRequestEmail(string Name, CreateProjectRequestUser User, CreateProjectInput Project) : EmailTemplateBase(EmailTemplate.CreateProjectRequest);
-public record ApproveProjectRequestEmail(string Name, CreateProjectRequestUser User, CreateProjectInput Project, string ProjectName, string ProjectUrl) : EmailTemplateBase(EmailTemplate.ApproveProjectRequest);
+public record ApproveProjectRequestEmail(string Name, CreateProjectRequestUser User, CreateProjectInput Project, string ProjectName, string ProjectCode) : EmailTemplateBase(EmailTemplate.ApproveProjectRequest);
 public record UserAddedEmail(string Name, string Email) : EmailTemplateBase(EmailTemplate.UserAdded);

--- a/backend/LexBoxApi/Services/Email/EmailTemplates.cs
+++ b/backend/LexBoxApi/Services/Email/EmailTemplates.cs
@@ -20,6 +20,7 @@ public enum EmailTemplate
     CreateAccountRequest,
     CreateProjectRequest,
     ApproveProjectRequest,
+    UserAdded,
 }
 
 public record ForgotPasswordEmail(string Name, string ResetUrl, TimeSpan lifetime) : EmailTemplateBase(EmailTemplate.ForgotPassword);
@@ -33,5 +34,6 @@ public record ProjectInviteEmail(string Email, string ProjectId, string ManagerN
 public record PasswordChangedEmail(string Name) : EmailTemplateBase(EmailTemplate.PasswordChanged);
 
 public record CreateProjectRequestUser(string Name, string Email);
-public record CreateProjectRequestEmail(string Name, CreateProjectRequestUser User, CreateProjectInput Project): EmailTemplateBase(EmailTemplate.CreateProjectRequest);
-public record ApproveProjectRequestEmail(string Name, CreateProjectRequestUser User, CreateProjectInput Project): EmailTemplateBase(EmailTemplate.ApproveProjectRequest);
+public record CreateProjectRequestEmail(string Name, CreateProjectRequestUser User, CreateProjectInput Project) : EmailTemplateBase(EmailTemplate.CreateProjectRequest);
+public record ApproveProjectRequestEmail(string Name, CreateProjectRequestUser User, CreateProjectInput Project, string ProjectName, string ProjectUrl) : EmailTemplateBase(EmailTemplate.ApproveProjectRequest);
+public record UserAddedEmail(string Name, string Email) : EmailTemplateBase(EmailTemplate.UserAdded);

--- a/backend/LexBoxApi/Services/Email/IEmailService.cs
+++ b/backend/LexBoxApi/Services/Email/IEmailService.cs
@@ -39,5 +39,6 @@ public interface IEmailService
 
     public Task SendCreateProjectRequestEmail(LexAuthUser user, CreateProjectInput projectInput);
     public Task SendApproveProjectRequestEmail(User user, CreateProjectInput projectInput);
+    public Task SendUserAddedEmail(User user, string projectName, string projectCode);
     public Task SendEmailAsync(MimeMessage message);
 }

--- a/backend/LexBoxApi/Services/Email/IEmailService.cs
+++ b/backend/LexBoxApi/Services/Email/IEmailService.cs
@@ -1,0 +1,43 @@
+using LexBoxApi.Models.Project;
+using LexCore.Auth;
+using LexCore.Entities;
+using MimeKit;
+
+namespace LexBoxApi.Services.Email;
+
+public interface IEmailService
+{
+    public Task SendForgotPasswordEmail(string emailAddress);
+
+    public Task SendNewAdminEmail(IAsyncEnumerable<User> admins, string newAdminName, string newAdminEmail);
+
+    /// <summary>
+    /// Sends a verification email to the user for their email address.
+    /// </summary>
+    /// <param name="user">The user to verify the email address for.</param>
+    /// <param name="newEmail">
+    /// If the user is trying to change their address, this is the new email address.
+    /// If null, the verification email will be sent to the current email address of the user.
+    /// </param>
+    public Task SendVerifyAddressEmail(User user, string? newEmail = null);
+
+    /// <summary>
+    /// Sends a project invitation email to a new user, whose account will be created when they accept.
+    /// </summary>
+    /// <param name="name">The name (real name, NOT username) of user to invite.</param>
+    /// <param name="emailAddress">The email address to send the invitation to</param>
+    /// <param name="projectId">The GUID of the project the user is being invited to</param>
+    /// <param name="language">The language in which the invitation email should be sent (default English)</param>
+    public Task SendCreateAccountEmail(string emailAddress,
+        Guid projectId,
+        ProjectRole role,
+        string managerName,
+        string projectName,
+        string? language = null);
+
+    public Task SendPasswordChangedEmail(User user);
+
+    public Task SendCreateProjectRequestEmail(LexAuthUser user, CreateProjectInput projectInput);
+    public Task SendApproveProjectRequestEmail(User user, CreateProjectInput projectInput);
+    public Task SendEmailAsync(MimeMessage message);
+}

--- a/backend/LexBoxApi/Services/EmailService.cs
+++ b/backend/LexBoxApi/Services/EmailService.cs
@@ -25,7 +25,7 @@ public class EmailService(
     LexboxLinkGenerator linkGenerator,
     IHttpContextAccessor httpContextAccessor,
     Quartz.ISchedulerFactory schedulerFactory,
-    LexAuthService lexAuthService)
+    LexAuthService lexAuthService) : IEmailService
 {
     private readonly EmailConfig _emailConfig = emailConfig.Value;
     private readonly LinkGenerator _linkGenerator = linkGenerator;

--- a/backend/LexBoxApi/Services/EmailService.cs
+++ b/backend/LexBoxApi/Services/EmailService.cs
@@ -163,6 +163,12 @@ public class EmailService(
             new ApproveProjectRequestEmail(user.Name, new CreateProjectRequestUser(user.Name, user.Email!), projectInput), "en");
         await SendEmailWithRetriesAsync(email);
     }
+    public async Task SendUserAddedEmail(User user, string projectName, string projectCode)
+    {
+        var email = StartUserEmail(user) ?? throw new ArgumentNullException("emailAddress");
+        await RenderEmail(email, new UserAddedEmail(user.Name, user.Email!, projectName, projectCode), user.LocalizationCode);
+        await SendEmailWithRetriesAsync(email);
+    }
     public async Task SendEmailAsync(MimeMessage message)
     {
         message.From.Add(MailboxAddress.Parse(_emailConfig.From));
@@ -187,7 +193,7 @@ public class EmailService(
             throw;
         }
     }
-     private async Task SendEmailWithRetriesAsync(MimeMessage message, int retryCount = 3, int retryWaitSeconds = 5 * 60)
+    private async Task SendEmailWithRetriesAsync(MimeMessage message, int retryCount = 3, int retryWaitSeconds = 5 * 60)
     {
         try
         {

--- a/backend/LexBoxApi/Services/EmailService.cs
+++ b/backend/LexBoxApi/Services/EmailService.cs
@@ -156,7 +156,14 @@ public class EmailService(
             new CreateProjectRequestEmail("Admin", new CreateProjectRequestUser(user.Name, user.Email), projectInput), "en");
         await SendEmailWithRetriesAsync(email);
     }
-
+    public async Task SendApproveProjectRequestEmail(User user, CreateProjectInput projectInput)
+    {
+        var email = StartUserEmail(user);
+        if (email is null) throw new ArgumentNullException("emailAddress");
+        await RenderEmail(email,
+            new ApproveProjectRequestEmail(user.Name, new CreateProjectRequestUser(user.Name, user.Email!), projectInput), "en");
+        await SendEmailWithRetriesAsync(email);
+    }
     public async Task SendEmailAsync(MimeMessage message)
     {
         message.From.Add(MailboxAddress.Parse(_emailConfig.From));

--- a/backend/LexBoxApi/Services/EmailService.cs
+++ b/backend/LexBoxApi/Services/EmailService.cs
@@ -158,10 +158,9 @@ public class EmailService(
     }
     public async Task SendApproveProjectRequestEmail(User user, CreateProjectInput projectInput)
     {
-        var email = StartUserEmail(user);
-        if (email is null) throw new ArgumentNullException("emailAddress");
+        var email = StartUserEmail(user) ?? throw new ArgumentNullException("emailAddress");
         await RenderEmail(email,
-            new ApproveProjectRequestEmail(user.Name, new CreateProjectRequestUser(user.Name, user.Email!), projectInput), "en");
+            new ApproveProjectRequestEmail(user.Name, new CreateProjectRequestUser(user.Name, user.Email!), projectInput, projectInput.Name, projectInput.Code), "en");
         await SendEmailWithRetriesAsync(email);
     }
     public async Task SendEmailAsync(MimeMessage message)

--- a/backend/LexBoxApi/Services/EmailService.cs
+++ b/backend/LexBoxApi/Services/EmailService.cs
@@ -160,7 +160,7 @@ public class EmailService(
     {
         var email = StartUserEmail(user) ?? throw new ArgumentNullException("emailAddress");
         await RenderEmail(email,
-            new ApproveProjectRequestEmail(user.Name, new CreateProjectRequestUser(user.Name, user.Email!), projectInput), "en");
+            new ApproveProjectRequestEmail(user.Name, new CreateProjectRequestUser(user.Name, user.Email!), projectInput), user.LocalizationCode);
         await SendEmailWithRetriesAsync(email);
     }
     public async Task SendUserAddedEmail(User user, string projectName, string projectCode)

--- a/backend/LexBoxApi/Services/EmailService.cs
+++ b/backend/LexBoxApi/Services/EmailService.cs
@@ -160,7 +160,7 @@ public class EmailService(
     {
         var email = StartUserEmail(user) ?? throw new ArgumentNullException("emailAddress");
         await RenderEmail(email,
-            new ApproveProjectRequestEmail(user.Name, new CreateProjectRequestUser(user.Name, user.Email!), projectInput, projectInput.Name, projectInput.Code), "en");
+            new ApproveProjectRequestEmail(user.Name, new CreateProjectRequestUser(user.Name, user.Email!), projectInput), "en");
         await SendEmailWithRetriesAsync(email);
     }
     public async Task SendEmailAsync(MimeMessage message)

--- a/backend/LexBoxApi/Services/ProjectService.cs
+++ b/backend/LexBoxApi/Services/ProjectService.cs
@@ -42,7 +42,7 @@ public class ProjectService(LexBoxDbContext dbContext, IHgService hgService, IOp
         if (input.ProjectManagerId.HasValue)
         {
             var manager = await dbContext.Users.FindAsync(input.ProjectManagerId.Value);
-            manager?.UpdateCreateProjectsPermission(ProjectRole.Manager); // Comment this out
+            manager?.UpdateCreateProjectsPermission(ProjectRole.Manager);
             if (draftProject != null && manager != null)
             {
                 await emailService.SendApproveProjectRequestEmail(manager, input);

--- a/backend/LexBoxApi/Services/ProjectService.cs
+++ b/backend/LexBoxApi/Services/ProjectService.cs
@@ -11,7 +11,7 @@ using Microsoft.Extensions.Options;
 
 namespace LexBoxApi.Services;
 
-public class ProjectService(LexBoxDbContext dbContext, IHgService hgService, IOptions<HgConfig> hgConfig, IMemoryCache memoryCache, [Service] EmailService emailService)
+public class ProjectService(LexBoxDbContext dbContext, IHgService hgService, IOptions<HgConfig> hgConfig, IMemoryCache memoryCache)
 {
     public async Task<Guid> CreateProject(CreateProjectInput input)
     {
@@ -42,7 +42,6 @@ public class ProjectService(LexBoxDbContext dbContext, IHgService hgService, IOp
         {
             var manager = await dbContext.Users.FindAsync(input.ProjectManagerId.Value);
             manager?.UpdateCreateProjectsPermission(ProjectRole.Manager);
-           if (draftProject is not null && manager is not null) await emailService.SendApproveProjectRequestEmail(manager, input);
         }
         await dbContext.SaveChangesAsync();
         await hgService.InitRepo(input.Code);

--- a/backend/LexBoxApi/Services/ProjectService.cs
+++ b/backend/LexBoxApi/Services/ProjectService.cs
@@ -1,5 +1,6 @@
 using System.Data.Common;
 using LexBoxApi.Models.Project;
+using LexBoxApi.Services.Email;
 using LexCore.Config;
 using LexCore.Entities;
 using LexCore.Exceptions;
@@ -11,7 +12,7 @@ using Microsoft.Extensions.Options;
 
 namespace LexBoxApi.Services;
 
-public class ProjectService(LexBoxDbContext dbContext, IHgService hgService, IOptions<HgConfig> hgConfig, IMemoryCache memoryCache)
+public class ProjectService(LexBoxDbContext dbContext, IHgService hgService, IOptions<HgConfig> hgConfig, IMemoryCache memoryCache, IEmailService emailService)
 {
     public async Task<Guid> CreateProject(CreateProjectInput input)
     {
@@ -41,7 +42,11 @@ public class ProjectService(LexBoxDbContext dbContext, IHgService hgService, IOp
         if (input.ProjectManagerId.HasValue)
         {
             var manager = await dbContext.Users.FindAsync(input.ProjectManagerId.Value);
-            manager?.UpdateCreateProjectsPermission(ProjectRole.Manager);
+            manager?.UpdateCreateProjectsPermission(ProjectRole.Manager); // Comment this out
+            if (draftProject != null && manager != null)
+            {
+                await emailService.SendApproveProjectRequestEmail(manager, input);
+            }
         }
         await dbContext.SaveChangesAsync();
         await hgService.InitRepo(input.Code);

--- a/backend/LexBoxApi/Services/UserService.cs
+++ b/backend/LexBoxApi/Services/UserService.cs
@@ -1,10 +1,11 @@
 ﻿using LexBoxApi.Auth;
+using LexBoxApi.Services.Email;
 using LexData;
 using Microsoft.EntityFrameworkCore;
 
 namespace LexBoxApi.Services;
 
-public class UserService(LexBoxDbContext dbContext, EmailService emailService, LexAuthService lexAuthService)
+public class UserService(LexBoxDbContext dbContext, IEmailService emailService, LexAuthService lexAuthService)
 {
     public async Task ForgotPassword(string email)
     {

--- a/backend/Testing/LexCore/Services/ProjectServiceTest.cs
+++ b/backend/Testing/LexCore/Services/ProjectServiceTest.cs
@@ -1,7 +1,7 @@
 using LexBoxApi.Services;
+using LexBoxApi.Services.Email;
 using LexCore.Entities;
 using LexCore.ServiceInterfaces;
-using LexData;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.DependencyInjection;
@@ -22,6 +22,7 @@ public class ProjectServiceTest
         var serviceProvider = testing.ConfigureServices(s =>
         {
             s.AddScoped<IHgService>(_ => Mock.Of<IHgService>());
+            s.AddScoped<IEmailService>(_ => Mock.Of<IEmailService>());
             s.AddSingleton<IMemoryCache>(_ => Mock.Of<IMemoryCache>());
             s.AddScoped<ProjectService>();
         });

--- a/frontend/src/lib/email/ApproveProjectRequest.svelte
+++ b/frontend/src/lib/email/ApproveProjectRequest.svelte
@@ -1,12 +1,13 @@
 <script lang="ts">
   import Email from '$lib/email/Email.svelte';
+  import type { CreateProjectInput } from '$lib/gql/types';
   import t from '$lib/i18n';
 
   export let name: string;
   export let baseUrl: string;
-  export let projectName: string;
-  export let projectCode: string;
-  let projectUrl = new URL(`/project/${projectCode}`, baseUrl);
+  export let project: CreateProjectInput;
+  let projectUrl = new URL(`/project/${project.code}`, baseUrl);
+  let projectName = project.name;
 </script>
 
 <Email subject={$t('emails.approve_project_request_email.subject', {projectName})} {name}>

--- a/frontend/src/lib/email/ApproveProjectRequest.svelte
+++ b/frontend/src/lib/email/ApproveProjectRequest.svelte
@@ -3,8 +3,10 @@
   import t from '$lib/i18n';
 
   export let name: string;
+  export let baseUrl: string;
   export let projectName: string;
-  export let projectUrl: string;
+  export let projectCode: string;
+  let projectUrl = new URL(`/project/${projectCode}`, baseUrl);
 </script>
 
 <Email subject={$t('emails.approve_project_request_email.subject', {projectName})} {name}>

--- a/frontend/src/lib/email/ApproveProjectRequest.svelte
+++ b/frontend/src/lib/email/ApproveProjectRequest.svelte
@@ -1,0 +1,11 @@
+<script lang="ts">
+  import Email from '$lib/email/Email.svelte';
+  // import t from '$lib/i18n';
+
+  export let name: string;
+</script>
+
+<!-- add $t() -->
+<Email subject={'Your project has been approved.'} {name}>
+  <mj-text>Your project has been approved.</mj-text>
+</Email>

--- a/frontend/src/lib/email/ApproveProjectRequest.svelte
+++ b/frontend/src/lib/email/ApproveProjectRequest.svelte
@@ -1,11 +1,10 @@
 <script lang="ts">
   import Email from '$lib/email/Email.svelte';
-  // import t from '$lib/i18n';
+  import t from '$lib/i18n';
 
   export let name: string;
 </script>
 
-<!-- add $t() -->
-<Email subject={'Your project has been approved.'} {name}>
-  <mj-text>Your project has been approved.</mj-text>
+<Email subject={$t('emails.approve_project_request_email.subject')} {name}>
+  <mj-text>$t('emails.approve_project_request_email.heading')</mj-text>
 </Email>

--- a/frontend/src/lib/email/ApproveProjectRequest.svelte
+++ b/frontend/src/lib/email/ApproveProjectRequest.svelte
@@ -6,7 +6,7 @@
   export let name: string;
   export let baseUrl: string;
   export let project: CreateProjectInput;
-  let projectUrl = new URL(`/project/${project.code}`, baseUrl);
+  let projectUrl = new URL(`/?projectSearch=${encodeURIComponent(project.code)}`, baseUrl);
   let projectName = project.name;
 </script>
 

--- a/frontend/src/lib/email/ApproveProjectRequest.svelte
+++ b/frontend/src/lib/email/ApproveProjectRequest.svelte
@@ -3,8 +3,11 @@
   import t from '$lib/i18n';
 
   export let name: string;
+  export let projectName: string;
+  export let projectUrl: string;
 </script>
 
-<Email subject={$t('emails.approve_project_request_email.subject')} {name}>
-  <mj-text>{$t('emails.approve_project_request_email.heading')}</mj-text>
+<Email subject={$t('emails.approve_project_request_email.subject', {projectName})} {name}>
+  <mj-text>{$t('emails.approve_project_request_email.heading', {projectName})}</mj-text>
+  <mj-button href={projectUrl}>{$t('emails.approve_project_request_email.view_button')}</mj-button>
 </Email>

--- a/frontend/src/lib/email/ApproveProjectRequest.svelte
+++ b/frontend/src/lib/email/ApproveProjectRequest.svelte
@@ -6,5 +6,5 @@
 </script>
 
 <Email subject={$t('emails.approve_project_request_email.subject')} {name}>
-  <mj-text>$t('emails.approve_project_request_email.heading')</mj-text>
+  <mj-text>{$t('emails.approve_project_request_email.heading')}</mj-text>
 </Email>

--- a/frontend/src/lib/email/UserAdded.svelte
+++ b/frontend/src/lib/email/UserAdded.svelte
@@ -1,0 +1,10 @@
+<script lang="ts">
+  import Email from '$lib/email/Email.svelte';
+  import t from '$lib/i18n';
+
+  export let name: string;
+</script>
+
+<Email subject={'User Added'} {name}>
+  <mj-text></mj-text>
+</Email>

--- a/frontend/src/lib/email/UserAdded.svelte
+++ b/frontend/src/lib/email/UserAdded.svelte
@@ -3,8 +3,13 @@
   import t from '$lib/i18n';
 
   export let name: string;
+  export let baseUrl: string;
+  export let projectName: string;
+  export let projectCode: string;
+  let projectUrl = new URL(`/project/${projectCode}`, baseUrl);
 </script>
 
-<Email subject={'User Added'} {name}>
-  <mj-text></mj-text>
+<Email subject={$t('emails.user_added.subject', {projectName})} {name}>
+  <mj-text>{$t('emails.user_added.body', {projectName})}</mj-text>
+  <mj-button href={projectUrl}>{$t('emails.user_added.view_button')}</mj-button>
 </Email>

--- a/frontend/src/lib/email/UserAdded.svelte
+++ b/frontend/src/lib/email/UserAdded.svelte
@@ -6,7 +6,7 @@
   export let baseUrl: string;
   export let projectName: string;
   export let projectCode: string;
-  let projectUrl = new URL(`/project/${projectCode}`, baseUrl);
+  let projectUrl = new URL(`/?projectSearch=${encodeURIComponent(projectCode)}`, baseUrl);
 </script>
 
 <Email subject={$t('emails.user_added.subject', {projectName})} {name}>

--- a/frontend/src/lib/i18n/locales/en.json
+++ b/frontend/src/lib/i18n/locales/en.json
@@ -575,6 +575,10 @@ If you don't see a dialog or already closed it, click the button below:",
     "create_project_request_email": {
       "subject": "Project request: {projectName}",
       "heading": "User {name} ({email}) requested that a project be created for them. Details below:"
+    },
+    "approve_project_request_email": {
+      "subject": "Project approval: {projectName}",
+      "heading": "{projectName} has been approved."
     }
   },
   "footer": {

--- a/frontend/src/lib/i18n/locales/en.json
+++ b/frontend/src/lib/i18n/locales/en.json
@@ -580,6 +580,11 @@ If you don't see a dialog or already closed it, click the button below:",
       "subject": "Project approved: {projectName}",
       "heading": "The project you requested, {projectName}, has been approved and created.",
       "view_button": "View project"
+    },
+    "user_added": {
+      "subject": "You've Joined {projectName}!",
+      "body": "You have been added to the project, {projectName}.",
+      "view_button": "View project"
     }
   },
   "footer": {

--- a/frontend/src/lib/i18n/locales/en.json
+++ b/frontend/src/lib/i18n/locales/en.json
@@ -577,8 +577,9 @@ If you don't see a dialog or already closed it, click the button below:",
       "heading": "User {name} ({email}) requested that a project be created for them. Details below:"
     },
     "approve_project_request_email": {
-      "subject": "Project approval: {projectName}",
-      "heading": "{projectName} has been approved."
+      "subject": "Project approved: {projectName}",
+      "heading": "The project you requested, {projectName}, has been approved and created.",
+      "view_button": "View project"
     }
   },
   "footer": {

--- a/frontend/src/lib/i18n/locales/en.json
+++ b/frontend/src/lib/i18n/locales/en.json
@@ -569,7 +569,7 @@ If you don't see a dialog or already closed it, click the button below:",
     },
     "create_account_request_email": {
       "subject": "Project invitation: {projectName}",
-      "body": "{managerName} has invited you to join the {projectName} language project. Click below to join.",
+      "body": "{managerName} has invited you to join the project: {projectName}. Click below to join.",
       "join_button": "Join project"
     },
     "create_project_request_email": {
@@ -582,8 +582,8 @@ If you don't see a dialog or already closed it, click the button below:",
       "view_button": "View project"
     },
     "user_added": {
-      "subject": "You've Joined {projectName}!",
-      "body": "You have been added to the project, {projectName}.",
+      "subject": "You joined project: {projectName}!",
+      "body": "You have been added to the project: {projectName}.",
       "view_button": "View project"
     }
   },

--- a/frontend/src/routes/email/emails.ts
+++ b/frontend/src/routes/email/emails.ts
@@ -6,6 +6,7 @@ import PasswordChanged from '$lib/email/PasswordChanged.svelte';
 import CreateAccountRequest from '$lib/email/CreateAccountRequest.svelte';
 import CreateProjectRequest from '$lib/email/CreateProjectRequest.svelte';
 import type {CreateProjectInput} from '$lib/gql/generated/graphql';
+import ApproveProjectRequest from '$lib/email/ApproveProjectRequest.svelte';
 
 export const enum EmailTemplate {
     NewAdmin = 'NEW_ADMIN',
@@ -14,6 +15,7 @@ export const enum EmailTemplate {
     PasswordChanged = 'PASSWORD_CHANGED',
     CreateAccountRequest = 'CREATE_ACCOUNT_REQUEST',
     CreateProjectRequest = 'CREATE_PROJECT_REQUEST',
+    ApproveProjectRequest = 'APPROVE_PROJECT_REQUEST',
 }
 
 export const componentMap = {
@@ -23,6 +25,7 @@ export const componentMap = {
     [EmailTemplate.PasswordChanged]: PasswordChanged,
     [EmailTemplate.CreateAccountRequest]: CreateAccountRequest,
     [EmailTemplate.CreateProjectRequest]: CreateProjectRequest,
+    [EmailTemplate.ApproveProjectRequest]: ApproveProjectRequest,
 } satisfies Record<EmailTemplate, ComponentType>;
 
 interface EmailTemplatePropsBase<T extends EmailTemplate> {
@@ -59,10 +62,16 @@ interface CreateProjectProps extends EmailTemplatePropsBase<EmailTemplate.Create
     user: { name: string, email: string };
 }
 
+interface ApproveProjectProps extends EmailTemplatePropsBase<EmailTemplate.ApproveProjectRequest> {
+  project: CreateProjectInput;
+  user: { name: string, email: string };
+}
+
 export type EmailTemplateProps =
     ForgotPasswordProps
     | NewAdminProps
     | VerifyEmailAddressProps
     | CreateAccountProps
     | CreateProjectProps
+    | ApproveProjectProps
     | EmailTemplatePropsBase<EmailTemplate>;

--- a/frontend/src/routes/email/emails.ts
+++ b/frontend/src/routes/email/emails.ts
@@ -7,6 +7,8 @@ import CreateAccountRequest from '$lib/email/CreateAccountRequest.svelte';
 import CreateProjectRequest from '$lib/email/CreateProjectRequest.svelte';
 import type {CreateProjectInput} from '$lib/gql/generated/graphql';
 import ApproveProjectRequest from '$lib/email/ApproveProjectRequest.svelte';
+import UserAdded from '$lib/email/UserAdded.svelte';
+
 
 export const enum EmailTemplate {
     NewAdmin = 'NEW_ADMIN',
@@ -16,6 +18,7 @@ export const enum EmailTemplate {
     CreateAccountRequest = 'CREATE_ACCOUNT_REQUEST',
     CreateProjectRequest = 'CREATE_PROJECT_REQUEST',
     ApproveProjectRequest = 'APPROVE_PROJECT_REQUEST',
+    UserAdded = 'USER_ADDED',
 }
 
 export const componentMap = {
@@ -26,6 +29,7 @@ export const componentMap = {
     [EmailTemplate.CreateAccountRequest]: CreateAccountRequest,
     [EmailTemplate.CreateProjectRequest]: CreateProjectRequest,
     [EmailTemplate.ApproveProjectRequest]: ApproveProjectRequest,
+    [EmailTemplate.UserAdded]: UserAdded,
 } satisfies Record<EmailTemplate, ComponentType>;
 
 interface EmailTemplatePropsBase<T extends EmailTemplate> {
@@ -67,6 +71,11 @@ interface ApproveProjectProps extends EmailTemplatePropsBase<EmailTemplate.Appro
   user: { name: string, email: string };
 }
 
+interface UserAddedProps extends EmailTemplatePropsBase<EmailTemplate.UserAdded> {
+  projectName: string;
+  projectCode: string;
+}
+
 export type EmailTemplateProps =
     ForgotPasswordProps
     | NewAdminProps
@@ -74,4 +83,5 @@ export type EmailTemplateProps =
     | CreateAccountProps
     | CreateProjectProps
     | ApproveProjectProps
+    | UserAddedProps
     | EmailTemplatePropsBase<EmailTemplate>;


### PR DESCRIPTION
Work in progress.
Will fix #867. 

- [x] send email to users when pending project creation request has been approved
- [x] send email to users when they have been added to existing project