### PR TITLE
Error thrown when trying to promote guest user to admin

### DIFF
--- a/frontend/src/lib/i18n/locales/en.json
+++ b/frontend/src/lib/i18n/locales/en.json
@@ -32,6 +32,10 @@
       "email_label": "Email",
       "name_label": "Display name",
       "password_label": "Change User Password",
+      "role_label": {
+        "label": "Role",
+        "email_required_for_admin": "The user must provide a valid email address to gain administrator access."
+      },
       "update_user": "Update User",
       "lock": "Lock User",
       "unlock": "Unlock User",

--- a/frontend/src/lib/i18n/locales/en.json
+++ b/frontend/src/lib/i18n/locales/en.json
@@ -34,7 +34,7 @@
       "password_label": "Change User Password",
       "role_label": {
         "label": "Role",
-        "email_required_for_admin": "The user must provide a valid email address to gain administrator access."
+        "verified_email_required_for_admin": "The user must provide a verified email address to gain administrator access."
       },
       "update_user": "Update User",
       "lock": "Lock User",

--- a/frontend/src/routes/(authenticated)/admin/+page.ts
+++ b/frontend/src/routes/(authenticated)/admin/+page.ts
@@ -148,6 +148,7 @@ export async function _changeUserAccountByAdmin(input: ChangeUserAccountByAdminI
               name
               email
               isAdmin
+              emailVerified
             }
             errors {
                 __typename

--- a/frontend/src/routes/(authenticated)/admin/EditUserAccount.svelte
+++ b/frontend/src/routes/(authenticated)/admin/EditUserAccount.svelte
@@ -19,13 +19,14 @@
   const schema = z
     .object({
     email: z.string().email($t('form.invalid_email')).nullish(),
+    emailVerified: z.boolean(),
     name: z.string(),
     password: passwordFormRules($t).or(emptyString()).default(''),
     score: z.number(),
     role: z.enum([UserRole.User, UserRole.Admin]),
     })
   const refinedSchema = schema
-    .refine((data) => data.role !== UserRole.Admin || (data.email && _user.emailVerified), {
+    .refine((data) => data.role !== UserRole.Admin || (data.email && data.emailVerified), {
     message: $t('admin_dashboard.form_modal.role_label.verified_email_required_for_admin'),
     path: ['role'],
     });
@@ -48,7 +49,7 @@
     _user = user;
     userIsLocked = user.locked;
     const role = user.isAdmin ? UserRole.Admin : UserRole.User;
-    return await formModal.open({ name: user.name, email: user.email ?? null, role }, async () => {
+    return await formModal.open({ name: user.name, email: user.email ?? null, role, emailVerified: user.emailVerified }, async () => {
       const { error, data } = await _changeUserAccountByAdmin({
         userId: user.id,
         email: $form.email,

--- a/frontend/src/routes/(authenticated)/admin/EditUserAccount.svelte
+++ b/frontend/src/routes/(authenticated)/admin/EditUserAccount.svelte
@@ -25,8 +25,8 @@
     role: z.enum([UserRole.User, UserRole.Admin]),
     })
   const refinedSchema = schema
-    .refine((data) => data.email || data.role !== UserRole.Admin, {
-    message: $t('admin_dashboard.form_modal.role_label.email_required_for_admin'),
+    .refine((data) => data.role !== UserRole.Admin || (data.email && _user.emailVerified), {
+    message: $t('admin_dashboard.form_modal.role_label.verified_email_required_for_admin'),
     path: ['role'],
     });
 

--- a/frontend/src/routes/(authenticated)/admin/EditUserAccount.svelte
+++ b/frontend/src/routes/(authenticated)/admin/EditUserAccount.svelte
@@ -24,13 +24,15 @@
     score: z.number(),
     role: z.enum([UserRole.User, UserRole.Admin]),
     })
+  const refinedSchema = schema
     .refine((data) => data.email || data.role !== UserRole.Admin, {
     message: 'You must have a valid email.',
     path: ['role'],
     });
 
   type Schema = typeof schema;
-  let formModal: FormModal<Schema>;
+  type RefinedSchema = typeof refinedSchema;
+  let formModal: FormModal<RefinedSchema>;
   $: form = formModal?.form();
 
   export function close(): void {
@@ -91,7 +93,7 @@
   }
 </script>
 
-<FormModal bind:this={formModal} {schema} let:errors>
+<FormModal bind:this={formModal} schema={refinedSchema} let:errors>
   <span slot="title">
     {$t('admin_dashboard.form_modal.title')}
   </span>

--- a/frontend/src/routes/(authenticated)/admin/EditUserAccount.svelte
+++ b/frontend/src/routes/(authenticated)/admin/EditUserAccount.svelte
@@ -16,13 +16,19 @@
   export let currUser: LexAuthUser;
   export let deleteUser: (user: User) => void;
 
-  const schema = z.object({
+  const schema = z
+    .object({
     email: z.string().email($t('form.invalid_email')).nullish(),
     name: z.string(),
     password: passwordFormRules($t).or(emptyString()).default(''),
     score: z.number(),
     role: z.enum([UserRole.User, UserRole.Admin]),
-  });
+    })
+    .refine((data) => data.email || data.role !== UserRole.Admin, {
+    message: 'You must have a valid email.',
+    path: ['role'],
+    });
+
   type Schema = typeof schema;
   let formModal: FormModal<Schema>;
   $: form = formModal?.form();
@@ -98,6 +104,7 @@
     error={errors.email}
     autofocus
   />
+  <!-- if !email && role.UserRole.ADMIN -->
   <Input
     id="name"
     type="text"

--- a/frontend/src/routes/(authenticated)/admin/EditUserAccount.svelte
+++ b/frontend/src/routes/(authenticated)/admin/EditUserAccount.svelte
@@ -26,7 +26,7 @@
     })
   const refinedSchema = schema
     .refine((data) => data.email || data.role !== UserRole.Admin, {
-    message: 'You must have a valid email.',
+    message: $t('admin_dashboard.form_modal.role_label.email_required_for_admin'),
     path: ['role'],
     });
 
@@ -106,7 +106,6 @@
     error={errors.email}
     autofocus
   />
-  <!-- if !email && role.UserRole.ADMIN -->
   <Input
     id="name"
     type="text"


### PR DESCRIPTION
When trying to promote guest user without an email to site admin, it throws an error.
To prevent this error, we can define a custom validation check on the schema.