### PR TITLE
Ensure locked users cannot log in with Google OAuth

### DIFF
--- a/backend/LexBoxApi/Controllers/LoginController.cs
+++ b/backend/LexBoxApi/Controllers/LoginController.cs
@@ -113,6 +113,10 @@ public class LoginController(
             await lexBoxDbContext.SaveChangesAsync();
         }
 
+        if (authUser.Locked == true) {
+            return "/login";
+        }
+
         await HttpContext.SignInAsync(authUser.GetPrincipal("google"),
             new AuthenticationProperties { IsPersistent = true });
         return returnTo;

--- a/backend/LexBoxApi/Controllers/LoginController.cs
+++ b/backend/LexBoxApi/Controllers/LoginController.cs
@@ -114,7 +114,14 @@ public class LoginController(
         }
 
         if (authUser.Locked == true) {
-            return "/login";
+            var queryParams = new Dictionary<string, string?>()
+            {
+                { "message", "account_locked" },
+                { "returnTo", returnTo },
+            };
+            var queryString = QueryString.Create(queryParams);
+            returnTo = "/login" + queryString.ToString();
+            return returnTo;
         }
 
         await HttpContext.SignInAsync(authUser.GetPrincipal("google"),

--- a/backend/LexCore/Auth/LexAuthUser.cs
+++ b/backend/LexCore/Auth/LexAuthUser.cs
@@ -99,7 +99,7 @@ public record LexAuthUser
         CanCreateProjects = user.CanCreateProjects ? true : null;
         CreatedByAdmin = user.CreatedById == null ? null : true;
         Locale = user.LocalizationCode;
-        Locked = user.Locked ? null : true;
+        Locked = user.Locked ? true : null;
     }
 
     [JsonPropertyName(LexAuthConstants.IdClaimType)]

--- a/frontend/src/routes/(unauthenticated)/login/+page.svelte
+++ b/frontend/src/routes/(unauthenticated)/login/+page.svelte
@@ -54,6 +54,8 @@
     const code = urlSearchParams.get('message');
     if (code === 'link_expired') {
       $message = $t('login.link_expired');
+    } else if (code === 'account_locked') {
+      $message = $t('login.your_account_is_locked');
     }
     logout();
   });


### PR DESCRIPTION
Will fix #869

Ensure locked users cannot log in with Google OAuth

Currently, locked users can still authenticate via Google OAuth, which bypasses account restrictions. This PR implements measures to prevent locked users from logging in using Google OAuth.