### PR TITLE
Add "Created by" in user details modal

### DIFF
--- a/frontend/src/lib/components/Users/UserModal.svelte
+++ b/frontend/src/lib/components/Users/UserModal.svelte
@@ -3,6 +3,7 @@
   import { Modal } from '$lib/components/modals';
   import DevContent from '$lib/layout/DevContent.svelte';
   import UserLockedAlert from './UserLockedAlert.svelte';
+  import { NULL_LABEL } from '$lib/i18n';
 
   type User = {
     id: string;
@@ -68,7 +69,7 @@
       <div>
         <h3>{$t('admin_dashboard.column_login')}</h3>
         <p class="value">
-          {user.username ?? '-'}
+          {user.username ?? NULL_LABEL}
         </p>
       </div>
       <div>
@@ -89,7 +90,7 @@
       </div>
       <div>
         <h3>{$t('admin_dashboard.user_details_modal.createdBy')}</h3>
-        <p class="value">{user.createdBy?.name  ?? '-'}</p>
+        <p class="value">{user.createdBy?.name  ?? NULL_LABEL}</p>
       </div>
       <DevContent>
         <div>

--- a/frontend/src/lib/components/Users/UserModal.svelte
+++ b/frontend/src/lib/components/Users/UserModal.svelte
@@ -17,7 +17,7 @@
     updatedDate: string | Date
     lastActive: string | Date
     canCreateProjects: boolean
-    createdBy: string
+    createdBy?: Partial<User> | null
   };
   let userDetailsModal: Modal;
   let user: User;
@@ -89,7 +89,7 @@
       </div>
       <div>
         <h3>{$t('admin_dashboard.user_details_modal.createdBy')}</h3>
-        <p class="value">{user.createdBy}</p>
+        <p class="value">{user.createdBy?.name  ?? '-'}</p>
       </div>
       <DevContent>
         <div>

--- a/frontend/src/lib/components/Users/UserModal.svelte
+++ b/frontend/src/lib/components/Users/UserModal.svelte
@@ -17,6 +17,7 @@
     updatedDate: string | Date
     lastActive: string | Date
     canCreateProjects: boolean
+    createdBy: string
   };
   let userDetailsModal: Modal;
   let user: User;
@@ -85,6 +86,10 @@
       <div>
         <h3>{$t('admin_dashboard.user_details_modal.locale')}</h3>
         <p class="value">{user.localizationCode}</p>
+      </div>
+      <div>
+        <h3>{$t('admin_dashboard.user_details_modal.createdBy')}</h3>
+        <p class="value">{user.createdBy}</p>
       </div>
       <DevContent>
         <div>

--- a/frontend/src/lib/i18n/index.ts
+++ b/frontend/src/lib/i18n/index.ts
@@ -115,7 +115,7 @@ export const locale: Readable<string> = {
 const t: I18n = buildI18n(locale);
 export default t;
 
-const NULL_LABEL = '–';
+export const NULL_LABEL = '–';
 
 export const number = withLocale(_number, (numberFunc, value, options) => numberFunc(Number(value), options));
 

--- a/frontend/src/lib/i18n/locales/en.json
+++ b/frontend/src/lib/i18n/locales/en.json
@@ -56,6 +56,7 @@
       "updated": "Updated",
       "last_active": "Last active",
       "can_create_projects": "Can create projects",
+      "createdBy": "Created by",
     },
     "user_filter": {
       "title": "User filters",

--- a/frontend/src/routes/(authenticated)/admin/+page.ts
+++ b/frontend/src/routes/(authenticated)/admin/+page.ts
@@ -114,6 +114,9 @@ export async function load(event: PageLoadEvent) {
                 lastActive
                 canCreateProjects
                 createdById
+                createdBy {
+                  name
+                }
                 projects {
                     id
                     projectId

--- a/frontend/src/routes/(authenticated)/admin/+page.ts
+++ b/frontend/src/routes/(authenticated)/admin/+page.ts
@@ -115,6 +115,7 @@ export async function load(event: PageLoadEvent) {
                 canCreateProjects
                 createdById
                 createdBy {
+                  id
                   name
                 }
                 projects {

--- a/frontend/src/routes/(authenticated)/org/[org_id]/+page.ts
+++ b/frontend/src/routes/(authenticated)/org/[org_id]/+page.ts
@@ -59,6 +59,9 @@ export async function load(event: PageLoadEvent) {
                   canCreateProjects
                   isAdmin
                   emailVerified
+                  createdBy {
+                    name
+                  }
                 }
               }
             }

--- a/frontend/src/routes/(authenticated)/org/[org_id]/+page.ts
+++ b/frontend/src/routes/(authenticated)/org/[org_id]/+page.ts
@@ -60,6 +60,7 @@ export async function load(event: PageLoadEvent) {
                   isAdmin
                   emailVerified
                   createdBy {
+                    id
                     name
                   }
                 }

--- a/frontend/src/routes/(authenticated)/project/[project_code]/+page.ts
+++ b/frontend/src/routes/(authenticated)/project/[project_code]/+page.ts
@@ -64,6 +64,9 @@ export async function load(event: PageLoadEvent) {
                   canCreateProjects
                   isAdmin
                   emailVerified
+                  createdBy {
+                    name
+                  }
                 }
 							}
 						}

--- a/frontend/src/routes/(authenticated)/project/[project_code]/+page.ts
+++ b/frontend/src/routes/(authenticated)/project/[project_code]/+page.ts
@@ -65,6 +65,7 @@ export async function load(event: PageLoadEvent) {
                   isAdmin
                   emailVerified
                   createdBy {
+                    id
                     name
                   }
                 }


### PR DESCRIPTION
Will fix #897 

Add "Created by" in user details. 

If you sign up yourself, the 'Created by' field will be null and will display `NULL_LABEL`.

e.g.
![image](https://github.com/sillsdev/languageforge-lexbox/assets/30375118/71d22410-8c9b-41b7-858b-225fb184d0cd)

