### PR TITLE
Tooltip for locked user icon is clipped

### DIFF
--- a/frontend/src/routes/(authenticated)/admin/+page.svelte
+++ b/frontend/src/routes/(authenticated)/admin/+page.svelte
@@ -158,7 +158,7 @@
       </div>
 
       <div class="divider" />
-      <div class="overflow-x-auto @container scroll-shadow">
+      <div class="overflow-x-visible @container scroll-shadow">
         <UserTable
           {shownUsers}
           on:openUserModal={(event) => userModal.open(event.detail)}


### PR DESCRIPTION
Fix #868

The tooltip for the locked user icon was being clipped because the `overflow-x` class was set to `auto`, causing it to be clipped and enabling scroll. However, tooltips do not require scrolling. By setting `overflow-x` to `visible`, any overflowing elements will be displayed properly.