### PR TITLE
Show organizations in summary section on project page

### DIFF
--- a/backend/LexBoxApi/GraphQL/OrgMutations.cs
+++ b/backend/LexBoxApi/GraphQL/OrgMutations.cs
@@ -65,12 +65,14 @@ public class OrgMutations
         Guid projectId)
     {
         var org = await dbContext.Orgs.FindAsync(orgId);
-        NotFoundException.ThrowIfNull(org);
+        // old: NotFoundException.ThrowIfNull(org);
+        if (!org) throw new NotFoundException("Organization not found", "org");
         permissionService.AssertCanAddProjectToOrg(org);
         var project = await dbContext.Projects.Where(p => p.Id == projectId)
             .Include(p => p.Organizations)
             .SingleOrDefaultAsync();
-        NotFoundException.ThrowIfNull(project);
+        // old: NotFoundException.ThrowIfNull(project);
+        if (!project) throw new NotFoundException("Project not found", "project");
         permissionService.AssertCanManageProject(projectId);
 
         if (project.Organizations.Exists(o => o.Id == orgId))

--- a/backend/LexBoxApi/GraphQL/OrgMutations.cs
+++ b/backend/LexBoxApi/GraphQL/OrgMutations.cs
@@ -65,14 +65,12 @@ public class OrgMutations
         Guid projectId)
     {
         var org = await dbContext.Orgs.FindAsync(orgId);
-        // old: NotFoundException.ThrowIfNull(org);
-        if (org is null) throw new NotFoundException("Organization not found", "org");
+        NotFoundException.ThrowIfNull(org);
         permissionService.AssertCanAddProjectToOrg(org);
         var project = await dbContext.Projects.Where(p => p.Id == projectId)
             .Include(p => p.Organizations)
             .SingleOrDefaultAsync();
-        // old: NotFoundException.ThrowIfNull(project);
-        if (project is null) throw new NotFoundException("Project not found", "project");
+        NotFoundException.ThrowIfNull(project);
         permissionService.AssertCanManageProject(projectId);
 
         if (project.Organizations.Exists(o => o.Id == orgId))

--- a/backend/LexBoxApi/GraphQL/OrgMutations.cs
+++ b/backend/LexBoxApi/GraphQL/OrgMutations.cs
@@ -66,13 +66,13 @@ public class OrgMutations
     {
         var org = await dbContext.Orgs.FindAsync(orgId);
         // old: NotFoundException.ThrowIfNull(org);
-        if (!org) throw new NotFoundException("Organization not found", "org");
+        if (org is null) throw new NotFoundException("Organization not found", "org");
         permissionService.AssertCanAddProjectToOrg(org);
         var project = await dbContext.Projects.Where(p => p.Id == projectId)
             .Include(p => p.Organizations)
             .SingleOrDefaultAsync();
         // old: NotFoundException.ThrowIfNull(project);
-        if (!project) throw new NotFoundException("Project not found", "project");
+        if (project is null) throw new NotFoundException("Project not found", "project");
         permissionService.AssertCanManageProject(projectId);
 
         if (project.Organizations.Exists(o => o.Id == orgId))

--- a/frontend/src/lib/gql/gql-client.ts
+++ b/frontend/src/lib/gql/gql-client.ts
@@ -27,6 +27,7 @@ import {
   type SoftDeleteProjectMutationVariables,
   type BulkAddProjectMembersMutationVariables,
   type DeleteDraftProjectMutationVariables,
+  type MutationAddProjectToOrgArgs,
 } from './types';
 import type {Readable, Unsubscriber} from 'svelte/store';
 import {derived} from 'svelte/store';
@@ -70,6 +71,9 @@ function createGqlClient(_gqlEndpoint?: string): Client {
               }
             },
             leaveProject: (result, args: LeaveProjectMutationVariables, cache, _info) => {
+              cache.invalidate({__typename: 'Project', id: args.input.projectId});
+            },
+            addProjectToOrg: (result, args: MutationAddProjectToOrgArgs, cache, _info) => {
               cache.invalidate({__typename: 'Project', id: args.input.projectId});
             }
           }

--- a/frontend/src/lib/i18n/locales/en.json
+++ b/frontend/src/lib/i18n/locales/en.json
@@ -375,6 +375,7 @@ the [Linguistics Institute at Payap University](https://li.payap.ac.th/) in Chia
     "description": "Description",
     "created_at": "Created",
     "last_commit": "Last Commit",
+    "organizations": "Organizations",
     "members": {
       "title": "Members",
       "filter_members_placeholder": "Filter members...",

--- a/frontend/src/lib/i18n/locales/en.json
+++ b/frontend/src/lib/i18n/locales/en.json
@@ -382,7 +382,10 @@ the [Linguistics Institute at Payap University](https://li.payap.ac.th/) in Chia
     "description": "Description",
     "created_at": "Created",
     "last_commit": "Last Commit",
-    "organizations": "Organizations",
+    "organization": {
+      "title": "Organizations",
+      "placeholder": "No organization"
+    },
     "members": {
       "title": "Members",
       "filter_members_placeholder": "Filter members...",

--- a/frontend/src/lib/i18n/locales/en.json
+++ b/frontend/src/lib/i18n/locales/en.json
@@ -309,7 +309,9 @@ the [Linguistics Institute at Payap University](https://li.payap.ac.th/) in Chia
     "add_org": {
       "add_button": "Add Organization",
       "modal_title": "Choose organization",
-      "submit_button": "Add Organization"
+      "submit_button": "Add Organization",
+      "org_not_found": "Organization not found. Please refresh the page.",
+      "project_not_found": "Project not found. Please refresh the page."
     },
     "bulk_add_members": {
       "add_button": "Bulk Add/Create Members",

--- a/frontend/src/lib/i18n/locales/en.json
+++ b/frontend/src/lib/i18n/locales/en.json
@@ -306,6 +306,11 @@ the [Linguistics Institute at Payap University](https://li.payap.ac.th/) in Chia
       "user_needs_to_relogin": "Added members will need to log out and back in again before they see the new project.",
       "invalid_email_address": "Invalid email address: {email}",
     },
+    "add_org": {
+      "add_button": "Add Organization",
+      "modal_title": "Choose organization",
+      "submit_button": "Add Organization"
+    },
     "bulk_add_members": {
       "add_button": "Bulk Add/Create Members",
       "explanation": "Adds all the entered logins and emails to this project. New accounts will be created automatically for users that don't have one yet.",

--- a/frontend/src/routes/(authenticated)/project/[project_code]/+page.svelte
+++ b/frontend/src/routes/(authenticated)/project/[project_code]/+page.svelte
@@ -50,7 +50,6 @@
   $: user = data.user;
   let projectStore = data.project;
   $: project = $projectStore;
-  $: orgList = data.myOrgs;
   $: changesetStore = data.changesets;
   let isEmpty: boolean = false;
   $: isEmpty = project?.lastCommit == null;
@@ -350,7 +349,7 @@
       >
         <svelte:fragment slot="extraButtons">
           {#if canManage}
-            <AddOrganization {orgList} projectId={project.id} />
+            <AddOrganization projectId={project.id} userIsAdmin={user.isAdmin} />
           {/if}
         </svelte:fragment>
       </OrgList>

--- a/frontend/src/routes/(authenticated)/project/[project_code]/+page.svelte
+++ b/frontend/src/routes/(authenticated)/project/[project_code]/+page.svelte
@@ -50,6 +50,7 @@
   $: user = data.user;
   let projectStore = data.project;
   $: project = $projectStore;
+  $: orgList = data.myOrgs;
   $: changesetStore = data.changesets;
   let isEmpty: boolean = false;
   $: isEmpty = project?.lastCommit == null;
@@ -348,7 +349,9 @@
         organizations={project.organizations}
       >
         <svelte:fragment slot="extraButtons">
-          <AddOrganization orgList={data.myOrgs} projectId={project.id} />
+          {#if canManage}
+            <AddOrganization {orgList} projectId={project.id} />
+          {/if}
         </svelte:fragment>
       </OrgList>
 

--- a/frontend/src/routes/(authenticated)/project/[project_code]/+page.svelte
+++ b/frontend/src/routes/(authenticated)/project/[project_code]/+page.svelte
@@ -44,6 +44,7 @@
   import MembersList from './MembersList.svelte';
   import DetailsPage from '$lib/layout/DetailsPage.svelte';
   import OrgList from './OrgList.svelte';
+  import AddOrganization from './AddOrganization.svelte';
 
   export let data: PageData;
   $: user = data.user;
@@ -346,6 +347,9 @@
       <OrgList
         organizations={project.organizations}
       >
+        <svelte:fragment slot="extraButtons">
+          <AddOrganization orgList={data.myOrgs} projectId={project.id} />
+        </svelte:fragment>
       </OrgList>
 
       <MembersList

--- a/frontend/src/routes/(authenticated)/project/[project_code]/+page.svelte
+++ b/frontend/src/routes/(authenticated)/project/[project_code]/+page.svelte
@@ -43,6 +43,7 @@
   import { DetailItem, EditableDetailItem } from '$lib/layout';
   import MembersList from './MembersList.svelte';
   import DetailsPage from '$lib/layout/DetailsPage.svelte';
+  import OrgList from './OrgList.svelte';
 
   export let data: PageData;
   $: user = data.user;
@@ -342,6 +343,11 @@
     </svelte:fragment>
 
     <div class="space-y-4">
+      <OrgList
+        organizations={project.organizations}
+      >
+      </OrgList>
+
       <MembersList
         projectId={project.id}
         {members}

--- a/frontend/src/routes/(authenticated)/project/[project_code]/+page.ts
+++ b/frontend/src/routes/(authenticated)/project/[project_code]/+page.ts
@@ -115,7 +115,7 @@ export async function load(event: PageLoadEvent) {
 
   let orgs;
   if (userIsAdmin) {
-  const orgsPromise = await client.query(graphql(`
+  const orgsResult = await client.query(graphql(`
         query loadOrgs {
             orgs {
                 id
@@ -123,9 +123,9 @@ export async function load(event: PageLoadEvent) {
             }
         }
      `), {}, { fetch: event.fetch });
-    orgs = orgsPromise.data?.orgs;
+    orgs = orgsResult.data?.orgs;
   } else {
-  const myOrgsPromise = await client.query(graphql(`
+  const myOrgsResult = await client.query(graphql(`
         query loadMyOrgs {
             myOrgs {
                 id
@@ -133,7 +133,7 @@ export async function load(event: PageLoadEvent) {
             }
         }
       `), {}, { fetch: event.fetch });
-    orgs = myOrgsPromise.data?.myOrgs;
+    orgs = myOrgsResult.data?.myOrgs;
   }
 
   return {

--- a/frontend/src/routes/(authenticated)/project/[project_code]/+page.ts
+++ b/frontend/src/routes/(authenticated)/project/[project_code]/+page.ts
@@ -74,6 +74,10 @@ export async function load(event: PageLoadEvent) {
 						flexProjectMetadata {
 							lexEntryCount
 						}
+            organizations {
+              id
+              name
+            }
 					}
 				}
 			`),

--- a/frontend/src/routes/(authenticated)/project/[project_code]/+page.ts
+++ b/frontend/src/routes/(authenticated)/project/[project_code]/+page.ts
@@ -112,6 +112,7 @@ export async function load(event: PageLoadEvent) {
   }
 
   event.depends(`project:${projectCode}`);
+
   let orgs;
   if (userIsAdmin) {
   const orgsPromise = await client.query(graphql(`

--- a/frontend/src/routes/(authenticated)/project/[project_code]/AddOrganization.svelte
+++ b/frontend/src/routes/(authenticated)/project/[project_code]/AddOrganization.svelte
@@ -7,7 +7,8 @@
   import { FormModal } from '$lib/components/modals';
   import { BadgeButton } from '$lib/components/Badges';
 
-  export let orgList: Partial<Organization>[] = [];
+  type Org = Pick<Organization, 'id' | 'name'>;
+  export let orgList: Org[] = [];
   export let projectId: string;
 
   const schema = z.object({
@@ -20,13 +21,17 @@
 
   async function openModal(): Promise<void> {
     await formModal.open(async () => {
-      await _addProjectToOrg({
+      const { error } = await _addProjectToOrg({
         projectId,
         orgId: $form.orgId,
       })
+      if (error?.byType('NotFoundError')) {
+        if (error.message === 'Organization not found') return $t('project_page.add_org.org_not_found');
+      }
+      if (error?.byType('NotFoundError')) {
+        if (error.message === 'Project not found') return $t('project_page.add_org.project_not_found');
+      }
     });
-
-    // Error Handling
   }
 
 </script>

--- a/frontend/src/routes/(authenticated)/project/[project_code]/AddOrganization.svelte
+++ b/frontend/src/routes/(authenticated)/project/[project_code]/AddOrganization.svelte
@@ -27,8 +27,6 @@
       })
       if (error?.byType('NotFoundError')) {
         if (error.message === 'Organization not found') return $t('project_page.add_org.org_not_found');
-      }
-      if (error?.byType('NotFoundError')) {
         if (error.message === 'Project not found') return $t('project_page.add_org.project_not_found');
       }
     });

--- a/frontend/src/routes/(authenticated)/project/[project_code]/AddOrganization.svelte
+++ b/frontend/src/routes/(authenticated)/project/[project_code]/AddOrganization.svelte
@@ -1,11 +1,13 @@
 <script lang="ts">
-  import { BadgeButton } from '$lib/components/Badges';
-  import { FormModal } from '$lib/components/modals';
   import { z } from 'zod';
-  import { _addProjectToOrg } from './+page';
+  import t from '$lib/i18n';
   import { Select } from '$lib/forms';
+  import { _addProjectToOrg } from './+page';
+  import type { Organization } from '$lib/gql/types';
+  import { FormModal } from '$lib/components/modals';
+  import { BadgeButton } from '$lib/components/Badges';
 
-  export let orgList;
+  export let orgList: Partial<Organization>[] = [];
   export let projectId: string;
 
   const schema = z.object({
@@ -30,14 +32,14 @@
 </script>
 
 <BadgeButton variant="badge-success" icon="i-mdi-account-plus-outline" on:click={openModal}>
-  {'Add Organization'}
+  {$t('project_page.add_org.add_button')}
 </BadgeButton>
 
 <FormModal bind:this={formModal} {schema} let:errors>
-  <span slot="title">{'Choose Organization'}</span>
+  <span slot="title">{$t('project_page.add_org.modal_title')}</span>
   <Select
     id="org"
-    label={'organization'}
+    label={$t('project_page.organizations')}
     bind:value={$form.orgId}
     error={errors.orgId}
     on:change
@@ -46,4 +48,5 @@
       <option value={org.id}>{org.name}</option>
     {/each}
   </Select>
+  <span slot="submitText">{$t('project_page.add_org.submit_button')}</span>
 </FormModal>

--- a/frontend/src/routes/(authenticated)/project/[project_code]/AddOrganization.svelte
+++ b/frontend/src/routes/(authenticated)/project/[project_code]/AddOrganization.svelte
@@ -42,7 +42,7 @@
   <span slot="title">{$t('project_page.add_org.modal_title')}</span>
   <Select
     id="org"
-    label={$t('project_page.organizations')}
+    label={$t('project_page.organization.title')}
     bind:value={$form.orgId}
     error={errors.orgId}
   >

--- a/frontend/src/routes/(authenticated)/project/[project_code]/AddOrganization.svelte
+++ b/frontend/src/routes/(authenticated)/project/[project_code]/AddOrganization.svelte
@@ -2,14 +2,15 @@
   import { z } from 'zod';
   import t from '$lib/i18n';
   import { Select } from '$lib/forms';
-  import { _addProjectToOrg } from './+page';
+  import { _addProjectToOrg, _getOrgs } from './+page';
   import type { Organization } from '$lib/gql/types';
   import { FormModal } from '$lib/components/modals';
   import { BadgeButton } from '$lib/components/Badges';
 
   type Org = Pick<Organization, 'id' | 'name'>;
-  export let orgList: Org[] = [];
   export let projectId: string;
+  export let userIsAdmin: boolean;
+  let orgList: Org[] = [];
 
   const schema = z.object({
     orgId: z.string().trim()
@@ -20,6 +21,8 @@
   $: form = formModal?.form();
 
   async function openModal(): Promise<void> {
+    orgList = await _getOrgs(userIsAdmin);
+
     await formModal.open(async () => {
       const { error } = await _addProjectToOrg({
         projectId,

--- a/frontend/src/routes/(authenticated)/project/[project_code]/AddOrganization.svelte
+++ b/frontend/src/routes/(authenticated)/project/[project_code]/AddOrganization.svelte
@@ -1,0 +1,49 @@
+<script lang="ts">
+  import { BadgeButton } from '$lib/components/Badges';
+  import { FormModal } from '$lib/components/modals';
+  import { z } from 'zod';
+  import { _addProjectToOrg } from './+page';
+  import { Select } from '$lib/forms';
+
+  export let orgList;
+  export let projectId: string;
+
+  const schema = z.object({
+    orgId: z.string().trim()
+  });
+
+  type Schema = typeof schema;
+  let formModal: FormModal<Schema>;
+  $: form = formModal?.form();
+
+  async function openModal(): Promise<void> {
+    await formModal.open(async () => {
+      await _addProjectToOrg({
+        projectId,
+        orgId: $form.orgId,
+      })
+    });
+
+    // Error Handling
+  }
+
+</script>
+
+<BadgeButton variant="badge-success" icon="i-mdi-account-plus-outline" on:click={openModal}>
+  {'Add Organization'}
+</BadgeButton>
+
+<FormModal bind:this={formModal} {schema} let:errors>
+  <span slot="title">{'Choose Organization'}</span>
+  <Select
+    id="org"
+    label={'organization'}
+    bind:value={$form.orgId}
+    error={errors.orgId}
+    on:change
+  >
+    {#each orgList as org}
+      <option value={org.id}>{org.name}</option>
+    {/each}
+  </Select>
+</FormModal>

--- a/frontend/src/routes/(authenticated)/project/[project_code]/AddOrganization.svelte
+++ b/frontend/src/routes/(authenticated)/project/[project_code]/AddOrganization.svelte
@@ -42,7 +42,6 @@
     label={$t('project_page.organizations')}
     bind:value={$form.orgId}
     error={errors.orgId}
-    on:change
   >
     {#each orgList as org}
       <option value={org.id}>{org.name}</option>

--- a/frontend/src/routes/(authenticated)/project/[project_code]/OrgList.svelte
+++ b/frontend/src/routes/(authenticated)/project/[project_code]/OrgList.svelte
@@ -26,7 +26,7 @@
     {/if}
     {#each organizations as org (org.id)}
       <Badge>
-        {org}
+        {org.name}
       </Badge>
     {/each}
   </BadgeList>

--- a/frontend/src/routes/(authenticated)/project/[project_code]/OrgList.svelte
+++ b/frontend/src/routes/(authenticated)/project/[project_code]/OrgList.svelte
@@ -12,7 +12,7 @@
 
 <div>
   <p class="text-2xl mb-4 flex items-baseline gap-4 max-sm:flex-col">
-    {$t('project_page.organizations')}
+    {$t('project_page.organization.title')}
   </p>
 
   <BadgeList grid={organizations.length > TRUNCATED_MEMBER_COUNT}>

--- a/frontend/src/routes/(authenticated)/project/[project_code]/OrgList.svelte
+++ b/frontend/src/routes/(authenticated)/project/[project_code]/OrgList.svelte
@@ -1,10 +1,3 @@
-<script context="module" lang="ts">
-  // export type Org = {
-  //   id: string
-  //   name: string
-  // };
-</script>
-
 <script lang="ts">
   import t from '$lib/i18n';
   import { Badge, BadgeList } from '$lib/components/Badges';
@@ -18,7 +11,7 @@
 
 <div>
   <p class="text-2xl mb-4 flex items-baseline gap-4 max-sm:flex-col">
-    {'Organizations'}
+    {$t('project_page.organizations')}
   </p>
 
   <BadgeList grid={organizations.length > TRUNCATED_MEMBER_COUNT}>

--- a/frontend/src/routes/(authenticated)/project/[project_code]/OrgList.svelte
+++ b/frontend/src/routes/(authenticated)/project/[project_code]/OrgList.svelte
@@ -4,7 +4,6 @@
   import type { Organization } from '$lib/gql/types';
 
   type Org = Pick<Organization, 'id' | 'name'>;
-
   export let organizations: Org[] = [];
 
   const TRUNCATED_MEMBER_COUNT = 5;

--- a/frontend/src/routes/(authenticated)/project/[project_code]/OrgList.svelte
+++ b/frontend/src/routes/(authenticated)/project/[project_code]/OrgList.svelte
@@ -1,0 +1,33 @@
+<script context="module" lang="ts">
+  export type Org = {
+    id: string
+    name: string
+  };
+</script>
+
+<script lang="ts">
+  import t from '$lib/i18n';
+  import { Badge, BadgeList } from '$lib/components/Badges';
+
+  export let organizations: Org[] = [];
+
+  const TRUNCATED_MEMBER_COUNT = 5;
+</script>
+
+
+<div>
+  <p class="text-2xl mb-4 flex items-baseline gap-4 max-sm:flex-col">
+    {'Organizations'}
+  </p>
+
+  <BadgeList grid={organizations.length > TRUNCATED_MEMBER_COUNT}>
+    {#if !organizations.length}
+      <span class="text-secondary mx-2 my-1">{$t('common.none')}</span>
+    {/if}
+    {#each organizations as org (org.id)}
+      <Badge>
+        {org}
+      </Badge>
+    {/each}
+  </BadgeList>
+</div>

--- a/frontend/src/routes/(authenticated)/project/[project_code]/OrgList.svelte
+++ b/frontend/src/routes/(authenticated)/project/[project_code]/OrgList.svelte
@@ -1,15 +1,16 @@
 <script context="module" lang="ts">
-  export type Org = {
-    id: string
-    name: string
-  };
+  // export type Org = {
+  //   id: string
+  //   name: string
+  // };
 </script>
 
 <script lang="ts">
   import t from '$lib/i18n';
   import { Badge, BadgeList } from '$lib/components/Badges';
+  import type { Organization } from '$lib/gql/types';
 
-  export let organizations: Org[] = [];
+  export let organizations: Partial<Organization>[] = [];
 
   const TRUNCATED_MEMBER_COUNT = 5;
 </script>

--- a/frontend/src/routes/(authenticated)/project/[project_code]/OrgList.svelte
+++ b/frontend/src/routes/(authenticated)/project/[project_code]/OrgList.svelte
@@ -17,6 +17,9 @@
   <BadgeList grid={organizations.length > TRUNCATED_MEMBER_COUNT}>
     {#if !organizations.length}
       <span class="text-secondary mx-2 my-1">{$t('common.none')}</span>
+      <div class="flex grow flex-wrap place-self-end gap-3 place-content-end" style="grid-column: -2 / -1">
+        <slot name="extraButtons" />
+      </div>
     {/if}
     {#each organizations as org (org.id)}
       <Badge>

--- a/frontend/src/routes/(authenticated)/project/[project_code]/OrgList.svelte
+++ b/frontend/src/routes/(authenticated)/project/[project_code]/OrgList.svelte
@@ -3,7 +3,9 @@
   import { Badge, BadgeList } from '$lib/components/Badges';
   import type { Organization } from '$lib/gql/types';
 
-  export let organizations: Partial<Organization>[] = [];
+  type Org = Pick<Organization, 'id' | 'name'>;
+
+  export let organizations: Org[] = [];
 
   const TRUNCATED_MEMBER_COUNT = 5;
 </script>


### PR DESCRIPTION
Fixes #906 

This PR implements features that show organizations in summary on project page if any. If the project does not belong to any organizations, there would be a button to add an organization, but you have to be a project manager AND a member of the organization that you are trying to add the project to.