### PR TITLE
Unable to demote admin to user status

### DIFF
--- a/backend/LexBoxApi/GraphQL/UserMutations.cs
+++ b/backend/LexBoxApi/GraphQL/UserMutations.cs
@@ -141,7 +141,6 @@ public class UserMutations
         }
 
         bool wasPromotedToAdmin = false;
-        bool wasDemotedToUser = false;
         if (input is ChangeUserAccountByAdminInput adminInput)
         {
             permissionService.AssertIsAdmin();
@@ -158,7 +157,6 @@ public class UserMutations
                 if (user.IsAdmin && adminInput.Role == UserRole.user)
                 {
                     user.IsAdmin = false;
-                    wasDemotedToUser = true;
                 }
             }
         }
@@ -186,13 +184,6 @@ public class UserMutations
             ArgumentException.ThrowIfNullOrEmpty(user.Email);
             await emailService.SendNewAdminEmail(admins, user.Name, user.Email);
         }
-
-        //TODO: Should we send an email when admin gets demoted to user status?
-        // if (wasDemotedToUser)
-        // {
-        //     await emailService.SendDemotedToUserEmail(user);
-        // }
-
         return user;
     }
 

--- a/backend/LexBoxApi/GraphQL/UserMutations.cs
+++ b/backend/LexBoxApi/GraphQL/UserMutations.cs
@@ -141,6 +141,7 @@ public class UserMutations
         }
 
         bool wasPromotedToAdmin = false;
+        bool wasDemotedToUser = false;
         if (input is ChangeUserAccountByAdminInput adminInput)
         {
             permissionService.AssertIsAdmin();
@@ -153,6 +154,11 @@ public class UserMutations
                         throw new ValidationException("User must have a verified email address to be promoted to admin");
                     }
                     wasPromotedToAdmin = user.IsAdmin = true;
+                }
+                if (user.IsAdmin && adminInput.Role == UserRole.user)
+                {
+                    user.IsAdmin = false;
+                    wasDemotedToUser = true;
                 }
             }
         }
@@ -180,6 +186,12 @@ public class UserMutations
             ArgumentException.ThrowIfNullOrEmpty(user.Email);
             await emailService.SendNewAdminEmail(admins, user.Name, user.Email);
         }
+
+        //TODO: Should we send an email when admin gets demoted to user status?
+        // if (wasDemotedToUser)
+        // {
+        //     await emailService.SendDemotedToUserEmail(user);
+        // }
 
         return user;
     }


### PR DESCRIPTION
Fixes #923 

In `UserMutations.cs`, we’re not handling the scenario where an admin is demoted to user status. 
Added a logic that handles that specific case where admin gets demoted to user status.

However, I do not know if this behavior was intentional.

