### PR TITLE
Invalidate project code to ID cache on project deletion

### DIFF
--- a/backend/LexBoxApi/GraphQL/ProjectMutations.cs
+++ b/backend/LexBoxApi/GraphQL/ProjectMutations.cs
@@ -406,6 +406,7 @@ public class ProjectMutations
         await dbContext.SaveChangesAsync();
         await hgService.SoftDeleteRepo(projectCode, timestamp);
         projectService.InvalidateProjectConfidentialityCache(projectId);
+        projectService.InvalidateProjectCodeCache(projectCode);
         await transaction.CommitAsync();
 
         return dbContext.Projects.Where(p => p.Id == projectId);

--- a/backend/LexBoxApi/Services/ProjectService.cs
+++ b/backend/LexBoxApi/Services/ProjectService.cs
@@ -96,6 +96,12 @@ public class ProjectService(LexBoxDbContext dbContext, IHgService hgService, IOp
         return projectId;
     }
 
+    public void InvalidateProjectCodeCache(string projectCode)
+    {
+        try { memoryCache.Remove($"ProjectIdForCode:{projectCode}"); }
+        catch (Exception) { }; // Never allow this to throw
+    }
+
     public async Task<BackupExecutor?> BackupProject(string code)
     {
         var exists = await dbContext.Projects.Where(p => p.Code == code)


### PR DESCRIPTION
Otherwise when you delete a project and create a new one with the same code, it will return errors from GraphQL queries until the project code to project ID cache expires, because it will still be trying to use the GUID of the old project that was deleted.

Fixes #781.