### PR TITLE
Hide management buttons for non-admin org members

### DIFF
--- a/frontend/src/routes/(authenticated)/org/[org_id]/OrgMemberTable.svelte
+++ b/frontend/src/routes/(authenticated)/org/[org_id]/OrgMemberTable.svelte
@@ -42,12 +42,18 @@
         <tr>
           <td>
             <div class="flex items-center gap-2 max-w-40 @xl:max-w-52">
-              <Button variant="btn-ghost" size="btn-sm" class="max-w-full" on:click={() => dispatch('openUserModal', user)}>
+              {#if showEmailColumn}
+                <Button variant="btn-ghost" size="btn-sm" class="max-w-full" on:click={() => dispatch('openUserModal', user)}>
+                  <span class="max-width-full overflow-x-clip text-ellipsis" title={user.name}>
+                    {user.name}
+                  </span>
+                  <Icon icon="i-mdi-card-account-details-outline" />
+                </Button>
+              {:else}
                 <span class="max-width-full overflow-x-clip text-ellipsis" title={user.name}>
                   {user.name}
                 </span>
-                <Icon icon="i-mdi-card-account-details-outline" />
-              </Button>
+              {/if}
             </div>
           </td>
           {#if showEmailColumn}

--- a/frontend/src/routes/(authenticated)/org/[org_id]/OrgMemberTable.svelte
+++ b/frontend/src/routes/(authenticated)/org/[org_id]/OrgMemberTable.svelte
@@ -62,6 +62,7 @@
           <td class="@2xl:table-cell">
             <FormatUserOrgRole role={member.role} />
           </td>
+          {#if showEmailColumn}
           <td class="p-0">
             <Dropdown>
               <button class="btn btn-ghost btn-square">
@@ -83,6 +84,7 @@
               </ul>
             </Dropdown>
           </td>
+          {/if}
         </tr>
       {/each}
     </tbody>


### PR DESCRIPTION
Fixes #942.

This PR adds a logic that disables management buttons/actions for non-admin organization members on org page.