### PR TITLE
Use GraphQL mutations for FLEx metadata updates

### DIFF
--- a/backend/LexBoxApi/GraphQL/ProjectMutations.cs
+++ b/backend/LexBoxApi/GraphQL/ProjectMutations.cs
@@ -352,35 +352,6 @@ public class ProjectMutations
     [Error<DbError>]
     [Error<UnauthorizedAccessException>]
     [UseMutationConvention]
-    [UseProjection]
-    [AdminRequired]
-    public async Task<IQueryable<Project>> UpdateProjectLanguageListWhereMissing(
-        [Service] IHgService hgService,
-        LexBoxDbContext dbContext,
-        int limit = 10)
-    {
-        var projects = dbContext.Projects
-            .Include(p => p.FlexProjectMetadata)
-            .Where(p => p.Type == ProjectType.FLEx && p.LastCommit != null && p.FlexProjectMetadata!.WritingSystems == null)
-            .Take(limit)
-            .AsAsyncEnumerable();
-        var projectIds = new List<Guid>(limit);
-        await foreach (var project in projects)
-        {
-            projectIds.Add(project.Id);
-            project.FlexProjectMetadata ??= new FlexProjectMetadata();
-            project.FlexProjectMetadata.WritingSystems = await hgService.GetProjectWritingSystems(project.Code);
-        }
-
-        await dbContext.SaveChangesAsync();
-
-        return dbContext.Projects.Where(p => projectIds.Contains(p.Id));
-    }
-
-    [Error<NotFoundException>]
-    [Error<DbError>]
-    [Error<UnauthorizedAccessException>]
-    [UseMutationConvention]
     [UseFirstOrDefault]
     [UseProjection]
     public async Task<IQueryable<Project>> UpdateLangProjectId(string code,
@@ -395,35 +366,6 @@ public class ProjectMutations
         NotFoundException.ThrowIfNull(project);
         await hgService.GetProjectIdOfFlexProject(code);
         return dbContext.Projects.Where(p => p.Id == projectId);
-    }
-
-    [Error<NotFoundException>]
-    [Error<DbError>]
-    [Error<UnauthorizedAccessException>]
-    [UseMutationConvention]
-    [UseProjection]
-    [AdminRequired]
-    public async Task<IQueryable<Project>> UpdateLangProjectIdWhereMissing(
-        [Service] IHgService hgService,
-        LexBoxDbContext dbContext,
-        int limit = 10)
-    {
-        var projects = dbContext.Projects
-            .Include(p => p.FlexProjectMetadata)
-            .Where(p => p.Type == ProjectType.FLEx && p.LastCommit != null && p.FlexProjectMetadata!.LangProjectId == null)
-            .Take(limit)
-            .AsAsyncEnumerable();
-        var projectIds = new List<Guid>(limit);
-        await foreach (var project in projects)
-        {
-            projectIds.Add(project.Id);
-            project.FlexProjectMetadata ??= new FlexProjectMetadata();
-            project.FlexProjectMetadata.LangProjectId = await hgService.GetProjectIdOfFlexProject(project.Code);
-        }
-
-        await dbContext.SaveChangesAsync();
-
-        return dbContext.Projects.Where(p => projectIds.Contains(p.Id));
     }
 
     [Error<NotFoundException>]

--- a/frontend/schema.graphql
+++ b/frontend/schema.graphql
@@ -239,9 +239,7 @@ type Mutation {
   setRetentionPolicy(input: SetRetentionPolicyInput!): SetRetentionPolicyPayload!
   updateProjectLexEntryCount(input: UpdateProjectLexEntryCountInput!): UpdateProjectLexEntryCountPayload!
   updateProjectLanguageList(input: UpdateProjectLanguageListInput!): UpdateProjectLanguageListPayload!
-  updateProjectLanguageListWhereMissing(input: UpdateProjectLanguageListWhereMissingInput!): UpdateProjectLanguageListWhereMissingPayload! @authorize(policy: "AdminRequiredPolicy")
   updateLangProjectId(input: UpdateLangProjectIdInput!): UpdateLangProjectIdPayload!
-  updateLangProjectIdWhereMissing(input: UpdateLangProjectIdWhereMissingInput!): UpdateLangProjectIdWhereMissingPayload! @authorize(policy: "AdminRequiredPolicy")
   leaveProject(input: LeaveProjectInput!): LeaveProjectPayload!
   removeProjectMember(input: RemoveProjectMemberInput!): RemoveProjectMemberPayload!
   deleteDraftProject(input: DeleteDraftProjectInput!): DeleteDraftProjectPayload! @authorize(policy: "AdminRequiredPolicy")
@@ -476,19 +474,9 @@ type UpdateLangProjectIdPayload {
   errors: [UpdateLangProjectIdError!]
 }
 
-type UpdateLangProjectIdWhereMissingPayload {
-  project: [Project!]
-  errors: [UpdateLangProjectIdWhereMissingError!]
-}
-
 type UpdateProjectLanguageListPayload {
   project: Project
   errors: [UpdateProjectLanguageListError!]
-}
-
-type UpdateProjectLanguageListWhereMissingPayload {
-  project: [Project!]
-  errors: [UpdateProjectLanguageListWhereMissingError!]
 }
 
 type UpdateProjectLexEntryCountPayload {
@@ -582,11 +570,7 @@ union SoftDeleteProjectError = NotFoundError | DbError
 
 union UpdateLangProjectIdError = NotFoundError | DbError | UnauthorizedAccessError
 
-union UpdateLangProjectIdWhereMissingError = NotFoundError | DbError | UnauthorizedAccessError
-
 union UpdateProjectLanguageListError = NotFoundError | DbError | UnauthorizedAccessError
-
-union UpdateProjectLanguageListWhereMissingError = NotFoundError | DbError | UnauthorizedAccessError
 
 union UpdateProjectLexEntryCountError = NotFoundError | DbError | UnauthorizedAccessError
 
@@ -1027,16 +1011,8 @@ input UpdateLangProjectIdInput {
   code: String!
 }
 
-input UpdateLangProjectIdWhereMissingInput {
-  limit: Int! = 10
-}
-
 input UpdateProjectLanguageListInput {
   code: String!
-}
-
-input UpdateProjectLanguageListWhereMissingInput {
-  limit: Int! = 10
 }
 
 input UpdateProjectLexEntryCountInput {

--- a/frontend/schema.graphql
+++ b/frontend/schema.graphql
@@ -237,6 +237,11 @@ type Mutation {
   changeProjectDescription(input: ChangeProjectDescriptionInput!): ChangeProjectDescriptionPayload!
   setProjectConfidentiality(input: SetProjectConfidentialityInput!): SetProjectConfidentialityPayload!
   setRetentionPolicy(input: SetRetentionPolicyInput!): SetRetentionPolicyPayload!
+  updateProjectLexEntryCount(input: UpdateProjectLexEntryCountInput!): UpdateProjectLexEntryCountPayload!
+  updateProjectLanguageList(input: UpdateProjectLanguageListInput!): UpdateProjectLanguageListPayload!
+  updateProjectLanguageListWhereMissing(input: UpdateProjectLanguageListWhereMissingInput!): UpdateProjectLanguageListWhereMissingPayload! @authorize(policy: "AdminRequiredPolicy")
+  updateLangProjectId(input: UpdateLangProjectIdInput!): UpdateLangProjectIdPayload!
+  updateLangProjectIdWhereMissing(input: UpdateLangProjectIdWhereMissingInput!): UpdateLangProjectIdWhereMissingPayload! @authorize(policy: "AdminRequiredPolicy")
   leaveProject(input: LeaveProjectInput!): LeaveProjectPayload!
   removeProjectMember(input: RemoveProjectMemberInput!): RemoveProjectMemberPayload!
   deleteDraftProject(input: DeleteDraftProjectInput!): DeleteDraftProjectPayload! @authorize(policy: "AdminRequiredPolicy")
@@ -466,6 +471,31 @@ type UniqueValueError implements Error {
   message: String!
 }
 
+type UpdateLangProjectIdPayload {
+  project: Project
+  errors: [UpdateLangProjectIdError!]
+}
+
+type UpdateLangProjectIdWhereMissingPayload {
+  project: [Project!]
+  errors: [UpdateLangProjectIdWhereMissingError!]
+}
+
+type UpdateProjectLanguageListPayload {
+  project: Project
+  errors: [UpdateProjectLanguageListError!]
+}
+
+type UpdateProjectLanguageListWhereMissingPayload {
+  project: [Project!]
+  errors: [UpdateProjectLanguageListWhereMissingError!]
+}
+
+type UpdateProjectLexEntryCountPayload {
+  project: Project
+  errors: [UpdateProjectLexEntryCountError!]
+}
+
 type User {
   email: String @authorize(policy: "AdminRequiredPolicy")
   emailVerified: Boolean! @authorize(policy: "AdminRequiredPolicy")
@@ -549,6 +579,16 @@ union SetRetentionPolicyError = NotFoundError | DbError
 union SetUserLockedError = NotFoundError
 
 union SoftDeleteProjectError = NotFoundError | DbError
+
+union UpdateLangProjectIdError = NotFoundError | DbError | UnauthorizedAccessError
+
+union UpdateLangProjectIdWhereMissingError = NotFoundError | DbError | UnauthorizedAccessError
+
+union UpdateProjectLanguageListError = NotFoundError | DbError | UnauthorizedAccessError
+
+union UpdateProjectLanguageListWhereMissingError = NotFoundError | DbError | UnauthorizedAccessError
+
+union UpdateProjectLexEntryCountError = NotFoundError | DbError | UnauthorizedAccessError
 
 input AddProjectMemberInput {
   projectId: UUID!
@@ -981,6 +1021,26 @@ input StringOperationFilterInput {
   nendsWith: String
   icontains: String
   ieq: String
+}
+
+input UpdateLangProjectIdInput {
+  code: String!
+}
+
+input UpdateLangProjectIdWhereMissingInput {
+  limit: Int! = 10
+}
+
+input UpdateProjectLanguageListInput {
+  code: String!
+}
+
+input UpdateProjectLanguageListWhereMissingInput {
+  limit: Int! = 10
+}
+
+input UpdateProjectLexEntryCountInput {
+  code: String!
 }
 
 input UserFilterInput {

--- a/frontend/src/routes/(authenticated)/project/[project_code]/+page.svelte
+++ b/frontend/src/routes/(authenticated)/project/[project_code]/+page.svelte
@@ -28,7 +28,7 @@
   import Dropdown from '$lib/components/Dropdown.svelte';
   import ConfirmDeleteModal from '$lib/components/modals/ConfirmDeleteModal.svelte';
   import {_deleteProject} from '$lib/gql/mutations';
-  import { goto, invalidate } from '$app/navigation';
+  import { goto } from '$app/navigation';
   import MoreSettings from '$lib/components/MoreSettings.svelte';
   import { AdminContent, PageBreadcrumb } from '$lib/layout';
   import Markdown from 'svelte-exmarkdown';

--- a/frontend/src/routes/(authenticated)/project/[project_code]/+page.svelte
+++ b/frontend/src/routes/(authenticated)/project/[project_code]/+page.svelte
@@ -14,6 +14,8 @@
     _deleteProjectUser,
     _leaveProject,
     _removeProjectFromOrg,
+    _updateProjectLanguageList,
+    _updateProjectLexEntryCount,
     type ProjectUser,
   } from './+page';
   import AddProjectMember from './AddProjectMember.svelte';
@@ -65,7 +67,6 @@
     return a.user.name.localeCompare(b.user.name);
   });
 
-  let lexEntryCount: number | string | null | undefined = undefined;
   $: lexEntryCount = project.flexProjectMetadata?.lexEntryCount;
   $: vernacularLangTags = project.flexProjectMetadata?.writingSystems?.vernacularWss;
   $: analysisLangTags = project.flexProjectMetadata?.writingSystems?.analysisWss;
@@ -77,17 +78,15 @@
   let loadingEntryCount = false;
   async function updateEntryCount(): Promise<void> {
     loadingEntryCount = true;
-    const response = await fetch(`/api/project/updateLexEntryCount/${project.code}`, {method: 'POST'});
-    lexEntryCount = await response.text();
+    await _updateProjectLexEntryCount(project.code);
     loadingEntryCount = false;
   }
 
   let loadingLanguageList = false;
   async function updateLanguageList(): Promise<void> {
     loadingLanguageList = true;
-    await fetch(`/api/project/updateLanguageList/${project.code}`, {method: 'POST'});
+    await _updateProjectLanguageList(project.code);
     loadingLanguageList = false;
-    await invalidate(`project:${project.code}`);
   }
 
   let resetProjectModal: ResetProjectModal;

--- a/frontend/src/routes/(authenticated)/project/[project_code]/+page.ts
+++ b/frontend/src/routes/(authenticated)/project/[project_code]/+page.ts
@@ -21,6 +21,9 @@ import type {
   SetProjectConfidentialityMutation,
   SetRetentionPolicyInput,
   SetRetentionPolicyMutation,
+  UpdateLangProjectIdMutation,
+  UpdateProjectLanguageListMutation,
+  UpdateProjectLexEntryCountMutation,
 } from '$lib/gql/types';
 import { getClient, graphql } from '$lib/gql';
 
@@ -270,6 +273,98 @@ export async function _bulkAddProjectMembers(input: BulkAddProjectMembersInput):
         }
       `),
       { input: input }
+    );
+  return result;
+}
+
+export async function _updateProjectLexEntryCount(code: string): $OpResult<UpdateProjectLexEntryCountMutation> {
+  //language=GraphQL
+  const result = await getClient()
+    .mutation(
+      graphql(`
+        mutation UpdateProjectLexEntryCount($input: UpdateProjectLexEntryCountInput!) {
+          updateProjectLexEntryCount(input: $input) {
+            project {
+              id
+              flexProjectMetadata {
+                lexEntryCount
+              }
+            }
+            errors {
+              __typename
+              ... on Error {
+                message
+              }
+            }
+          }
+        }
+      `),
+      { input: { code } },
+    );
+  return result;
+}
+
+export async function _updateLangProjectId(code: string): $OpResult<UpdateLangProjectIdMutation> {
+  //language=GraphQL
+  const result = await getClient()
+    .mutation(
+      graphql(`
+        mutation UpdateLangProjectId($input: UpdateLangProjectIdInput!) {
+          updateLangProjectId(input: $input) {
+            project {
+              id
+              flexProjectMetadata {
+                langProjectId
+              }
+            }
+            errors {
+              __typename
+              ... on Error {
+                message
+              }
+            }
+          }
+        }
+      `),
+      { input: { code } },
+    );
+  return result;
+}
+
+export async function _updateProjectLanguageList(code: string): $OpResult<UpdateProjectLanguageListMutation> {
+  //language=GraphQL
+  const result = await getClient()
+    .mutation(
+      graphql(`
+        mutation UpdateProjectLanguageList($input: UpdateProjectLanguageListInput!) {
+          updateProjectLanguageList(input: $input) {
+            project {
+              id
+              flexProjectMetadata {
+                writingSystems {
+                  analysisWss {
+                    tag
+                    isActive
+                    isDefault
+                  }
+                  vernacularWss {
+                    tag
+                    isActive
+                    isDefault
+                  }
+                }
+              }
+            }
+            errors {
+              __typename
+              ... on Error {
+                message
+              }
+            }
+          }
+        }
+      `),
+      { input: { code } },
     );
   return result;
 }


### PR DESCRIPTION
Fixes #970.

This changes `updateLexEntryCount` and `updateLanguageList` from being HTTP POST queries to being GraphQL mutations, which means the GraphQL cache is automatically updated when they run. Previously, you could "lose" the updated entry count for a project by navigating away from it and back to the project without a browser reload, because the result of calling `updateLexEntryCount` was being stored on the page but not actually sent to the GraphQL query cache, and the second time the project loaded the GraphQL cache would serve up stale data.

Now that those two updates are using GraphQL mutations, and returning the updated values from the mutation, the GraphQL query cache is doing its job and caching the updated values, so navigating away from a project and back to it works as it should.
