### PR TITLE
Don't allow non members to view project member list

### DIFF
--- a/backend/LexBoxApi/Auth/Attributes/LexAuthPolicies.cs
+++ b/backend/LexBoxApi/Auth/Attributes/LexAuthPolicies.cs
@@ -1,0 +1,6 @@
+﻿namespace LexBoxApi.Auth.Attributes;
+
+public static class LexAuthPolicies
+{
+    public const string CanAccessProjectUsers = "CanAccessProjectUsers";
+}

--- a/backend/LexBoxApi/Auth/AuthKernel.cs
+++ b/backend/LexBoxApi/Auth/AuthKernel.cs
@@ -35,6 +35,7 @@ public static class AuthKernel
 
         services.AddScoped<LexAuthService>();
         services.AddSingleton<IAuthorizationHandler, AudienceRequirementHandler>();
+        services.AddScoped<IAuthorizationHandler, AccessProjectUsersRequirementHandler>();
         services.AddSingleton<IAuthorizationHandler, ValidateUserUpdatedHandler>();
         services.AddAuthorization(options =>
         {
@@ -53,6 +54,8 @@ public static class AuthKernel
             options.AddPolicy(AdminRequiredAttribute.PolicyName,
                 builder => builder.RequireDefaultLexboxAuth()
                     .RequireAssertion(context => context.User.IsInRole(UserRole.admin.ToString())));
+            options.AddPolicy(LexAuthPolicies.CanAccessProjectUsers,
+                builder => builder.RequireDefaultLexboxAuth().AddRequirements(new AccessProjectUsersRequirement()));
             options.AddPolicy(VerifiedEmailRequiredAttribute.PolicyName,
                 builder => builder.RequireDefaultLexboxAuth()
                     .RequireAssertion(context => !context.User.HasClaim(LexAuthConstants.EmailUnverifiedClaimType, "true")));

--- a/backend/LexBoxApi/Auth/Requirements/AccessProjectUsersRequirementHandler.cs
+++ b/backend/LexBoxApi/Auth/Requirements/AccessProjectUsersRequirementHandler.cs
@@ -15,7 +15,6 @@ public class AccessProjectUsersRequirementHandler(
     protected override async Task HandleRequirementAsync(AuthorizationHandlerContext context,
         AccessProjectUsersRequirement requirement)
     {
-        //todo get guid.
         Guid projectId = Guid.Empty;
         if (context.Resource is IMiddlewareContext middlewareContext)
         {

--- a/backend/LexBoxApi/Auth/Requirements/AccessProjectUsersRequirementHandler.cs
+++ b/backend/LexBoxApi/Auth/Requirements/AccessProjectUsersRequirementHandler.cs
@@ -1,0 +1,37 @@
+﻿using HotChocolate.Resolvers;
+using LexCore.Entities;
+using LexCore.ServiceInterfaces;
+using Microsoft.AspNetCore.Authorization;
+
+namespace LexBoxApi.Auth.Requirements;
+
+public class AccessProjectUsersRequirement : IAuthorizationRequirement;
+
+public class AccessProjectUsersRequirementHandler(
+    IPermissionService permissions,
+    ILogger<AccessProjectUsersRequirementHandler> logger
+) : AuthorizationHandler<AccessProjectUsersRequirement>
+{
+    protected override async Task HandleRequirementAsync(AuthorizationHandlerContext context,
+        AccessProjectUsersRequirement requirement)
+    {
+        //todo get guid.
+        Guid projectId = Guid.Empty;
+        if (context.Resource is IMiddlewareContext middlewareContext)
+        {
+            projectId = middlewareContext.Parent<Project>().Id;
+        }
+        if (projectId != Guid.Empty && await permissions.CanSyncProjectAsync(projectId))
+        {
+            context.Succeed(requirement);
+        } else
+        {
+            if (projectId == Guid.Empty)
+            {
+                logger.LogInformation("unable to determine project id, context resource is {Type}", context.Resource?.GetType().Name ?? "null");
+            }
+            context.Fail(new AuthorizationFailureReason(this, "User does not have permission to access project users"));
+        }
+    }
+}
+

--- a/backend/LexBoxApi/GraphQL/CustomTypes/ProjectGqlConfiguration.cs
+++ b/backend/LexBoxApi/GraphQL/CustomTypes/ProjectGqlConfiguration.cs
@@ -1,4 +1,5 @@
-﻿using LexCore.Entities;
+﻿using LexBoxApi.Auth.Attributes;
+using LexCore.Entities;
 
 namespace LexBoxApi.GraphQL.CustomTypes;
 
@@ -10,7 +11,7 @@ public class ProjectGqlConfiguration : ObjectType<Project>
         descriptor.Field(p => p.Code).IsProjected();
         descriptor.Field(p => p.CreatedDate).IsProjected();
         descriptor.Field(p => p.Id).Use<RefreshJwtProjectMembershipMiddleware>();
-        descriptor.Field(p => p.Users).Use<RefreshJwtProjectMembershipMiddleware>();
+        descriptor.Field(p => p.Users).Use<RefreshJwtProjectMembershipMiddleware>().Authorize(LexAuthPolicies.CanAccessProjectUsers);
         // descriptor.Field("userCount").Resolve(ctx => ctx.Parent<Project>().UserCount);
     }
 }

--- a/frontend/schema.graphql
+++ b/frontend/schema.graphql
@@ -318,7 +318,7 @@ type Project {
   code: String!
   createdDate: DateTime!
   id: UUID!
-  users: [ProjectUsers!]!
+  users: [ProjectUsers!]! @authorize(policy: "CanAccessProjectUsers")
   changesets: [Changeset!]!
   hasAbandonedTransactions: Boolean!
   isLanguageForgeProject: Boolean!

--- a/frontend/src/lib/components/ProjectList.svelte
+++ b/frontend/src/lib/components/ProjectList.svelte
@@ -33,7 +33,7 @@
         </div>
       </div>
     {:else}
-      <a class="card aspect-square bg-base-200 shadow-base-300 overflow-hidden" href={`/project/${project.code}`}>
+      <a class="card aspect-square bg-base-200 shadow-base-300 overflow-hidden" href={`/project/${project.code}?id=${project.id}`}>
         <div class="bg" style="background-image: url('{getProjectTypeIcon(project.type)}')" />
         <div class="card-body z-[1] max-sm:p-6">
           <h2 class="card-title overflow-hidden text-ellipsis" title={project.name}>

--- a/frontend/src/lib/components/Projects/ProjectTable.svelte
+++ b/frontend/src/lib/components/Projects/ProjectTable.svelte
@@ -69,7 +69,7 @@
                     <TrashIcon pale />
                   </span>
                 {:else}
-                  <a class="link" href={`/project/${project.code}`}>
+                  <a class="link" href={`/project/${project.code}?id=${project.id}`}>
                     {project.name}
                   </a>
                 {/if}

--- a/frontend/src/lib/user.test.ts
+++ b/frontend/src/lib/user.test.ts
@@ -1,0 +1,72 @@
+﻿import {describe, expect, it} from 'vitest';
+import {jwtToUser} from '$lib/user';
+import type {AuthUserOrg} from '$lib/gql/generated/graphql';
+describe('jwtToUser', () => {
+  it('should convert a jwt token to a LexAuthUser', () => {
+    const jwtUser = {
+      'sub': '6dc9965b-4021-4606-92df-133fcce75fcb',
+      'date': 1717123406,
+      'email': 'editor@test.com',
+      'user': 'editor',
+      'name': 'Test Editor',
+      'role': 'user' as const,
+      'orgs': [
+        {
+          // eslint-disable-next-line @typescript-eslint/naming-convention
+          'Role': 'User',
+          // eslint-disable-next-line @typescript-eslint/naming-convention
+          'OrgId': '292c80e6-a815-4cd1-9ea2-34bd01274de6'
+        } as unknown as AuthUserOrg
+      ],
+      'proj': 'e:0ebc5976058d4447aaa7297f8569f968|e91ccdb50b46401a97b1ee6fe6179f73,m:7a43d4788e484a64bd9a52f0d7b1d883|58ff3987c3ec40728717574537d61a67',
+      'mkproj': true,
+      'loc': 'en',
+      'jti': '391c2d93',
+      'props.persistent': '',
+      'nbf': 1721377515,
+      'exp': 1722673515,
+      'iat': 1721377515,
+      'iss': 'LexboxApi',
+      'aud': 'LexboxApi'
+    };
+    const user = jwtToUser(jwtUser);
+    expect(user).toEqual({
+      'id': '6dc9965b-4021-4606-92df-133fcce75fcb',
+      'name': 'Test Editor',
+      'email': 'editor@test.com',
+      'username': 'editor',
+      'role': 'USER',
+      'isAdmin': false,
+      'projects': [
+        {
+          'projectId': '0ebc5976-058d-4447-aaa7-297f8569f968',
+          'role': 'EDITOR'
+        },
+        {
+          'projectId': 'e91ccdb5-0b46-401a-97b1-ee6fe6179f73',
+          'role': 'EDITOR'
+        },
+        {
+          'projectId': '7a43d478-8e48-4a64-bd9a-52f0d7b1d883',
+          'role': 'MANAGER'
+        },
+        {
+          'projectId': '58ff3987-c3ec-4072-8717-574537d61a67',
+          'role': 'MANAGER'
+        }
+      ],
+      'orgs': [
+        {
+          'orgId': '292c80e6-a815-4cd1-9ea2-34bd01274de6',
+          'role': 'USER'
+        }
+      ],
+      'locked': false,
+      'emailVerified': true,
+      'canCreateProjects': true,
+      'createdByAdmin': false,
+      'locale': 'en',
+      'emailOrUsername': 'editor@test.com'
+    });
+  });
+});

--- a/frontend/src/lib/user.ts
+++ b/frontend/src/lib/user.ts
@@ -32,10 +32,10 @@ type JwtTokenUser = {
   role: 'admin' | 'user'
   proj?: string,
   orgs?: AuthUserOrg[],
-  lock: boolean | undefined,
-  unver: boolean | undefined,
-  mkproj: boolean | undefined,
-  creat: boolean | undefined,
+  lock?: boolean | undefined,
+  unver?: boolean | undefined,
+  mkproj?: boolean | undefined,
+  creat?: boolean | undefined,
   loc: string,
 }
 
@@ -175,7 +175,7 @@ export function getUser(cookies: Cookies): LexAuthUser | null {
   }
 }
 
-function jwtToUser(user: JwtTokenUser): LexAuthUser {
+export function jwtToUser(user: JwtTokenUser): LexAuthUser {
   const { sub: id, name, email, user: username, proj: projectsString, role: jwtRole } = user;
   const role = Object.values(UserRole).find(r => r.toLowerCase() === jwtRole) ?? UserRole.User;
 
@@ -216,9 +216,16 @@ function projectsStringToProjects(projectsString: string | undefined): AuthUserP
         role = ProjectRole.Editor;
         break;
     }
-    projects.push(...pString.split('|').map(id => ({projectId: id, role})));
+    //substring to remove the first character which is the role code plus the colon
+    projects.push(...pString.substring(2).split('|').map(id => ({projectId: stringToUuid(id), role})));
   }
   return projects;
+}
+
+function stringToUuid(str: string): string {
+  str = str.replace('-', '');
+  if (str.length !== 32) throw new Error('Invalid UUID: ' + str);
+  return str.substring(0, 8) + '-' + str.substring(8, 12) + '-' + str.substring(12, 16) + '-' + str.substring(16, 20) + '-' + str.substring(20);
 }
 
 export function logout(cookies?: Cookies): void {

--- a/frontend/src/routes/(authenticated)/project/[project_code]/+page.svelte
+++ b/frontend/src/routes/(authenticated)/project/[project_code]/+page.svelte
@@ -116,7 +116,7 @@
 
   $: userId = user.id;
   $: orgsManagedByUser = user.orgs.filter(o => o.role === OrgRole.Admin).map(o => o.orgId);
-  $: canManage = user.isAdmin || project?.users.find((u) => u.user.id == userId)?.role == ProjectRole.Manager || !!project?.organizations.find((o) => orgsManagedByUser.includes(o.id));
+  $: canManage = user.isAdmin || project?.users?.find((u) => u.user.id == userId)?.role == ProjectRole.Manager || !!project?.organizations?.find((o) => orgsManagedByUser.includes(o.id));
 
   const projectNameValidation = z.string().trim().min(1, $t('project_page.project_name_empty_error'));
 

--- a/frontend/src/routes/(authenticated)/project/[project_code]/+page.svelte
+++ b/frontend/src/routes/(authenticated)/project/[project_code]/+page.svelte
@@ -55,7 +55,7 @@
   $: isEmpty = project?.lastCommit == null;
   // TODO: Once we've stabilized the lastCommit issue with project reset, get rid of the next line
   $: if (! $changesetStore.fetching) isEmpty = $changesetStore.changesets.length === 0;
-  $: members = project.users.sort((a, b) => {
+  $: members = project.users?.sort((a, b) => {
     if (a.role !== b.role) {
       return a.role === ProjectRole.Manager ? -1 : 1;
     }
@@ -354,31 +354,32 @@
           {/if}
         </svelte:fragment>
       </OrgList>
-
-      <MembersList
-        projectId={project.id}
-        {members}
-        canManageMember={(member) => canManage && (member.user?.id !== userId || user.isAdmin)}
-        canManageList={canManage}
-        on:openUserModal={(event) => userModal.open(event.detail.user)}
-        on:deleteProjectUser={(event) => deleteProjectUser(event.detail)}
-        >
-          <svelte:fragment slot="extraButtons">
-            <AddProjectMember projectId={project.id} />
-            <BulkAddProjectMembers projectId={project.id} />
-          </svelte:fragment>
-          <UserModal bind:this={userModal}/>
-
-          <DeleteModal
-            bind:this={removeUserModal}
-            entityName={$t('project_page.remove_project_user_title')}
-            isRemoveDialog
+      {#if members}
+        <MembersList
+          projectId={project.id}
+          {members}
+          canManageMember={(member) => canManage && (member.user?.id !== userId || user.isAdmin)}
+          canManageList={canManage}
+          on:openUserModal={(event) => userModal.open(event.detail.user)}
+          on:deleteProjectUser={(event) => deleteProjectUser(event.detail)}
           >
-            {$t('project_page.confirm_remove', {
-              userName: userToDelete?.user.name ?? '',
-            })}
-          </DeleteModal>
-      </MembersList>
+            <svelte:fragment slot="extraButtons">
+              <AddProjectMember projectId={project.id} />
+              <BulkAddProjectMembers projectId={project.id} />
+            </svelte:fragment>
+            <UserModal bind:this={userModal}/>
+
+            <DeleteModal
+              bind:this={removeUserModal}
+              entityName={$t('project_page.remove_project_user_title')}
+              isRemoveDialog
+            >
+              {$t('project_page.confirm_remove', {
+                userName: userToDelete?.user.name ?? '',
+              })}
+            </DeleteModal>
+        </MembersList>
+      {/if}
 
       <div class="divider" />
       <div class="space-y-2">

--- a/frontend/src/routes/(authenticated)/project/[project_code]/+page.ts
+++ b/frontend/src/routes/(authenticated)/project/[project_code]/+page.ts
@@ -27,7 +27,7 @@ import { error } from '@sveltejs/kit';
 import { tryMakeNonNullable } from '$lib/util/store';
 
 export type Project = NonNullable<ProjectPageQuery['projectByCode']>;
-export type ProjectUser = Project['users'][number];
+export type ProjectUser = NonNullable<Project['users']>[number];
 export type User = ProjectUser['user'];
 export type Org = Pick<Organization, 'id' | 'name'>;
 

--- a/frontend/src/routes/(authenticated)/project/[project_code]/+page.ts
+++ b/frontend/src/routes/(authenticated)/project/[project_code]/+page.ts
@@ -33,12 +33,12 @@ export type Org = Pick<Organization, 'id' | 'name'>;
 
 export async function load(event: PageLoadEvent) {
   const client = getClient();
-  const userIsAdmin = (await event.parent()).user.isAdmin;
+  const user = (await event.parent()).user;
   const projectCode = event.params.project_code;
   const projectResult = await client
     .awaitedQueryStore(event.fetch,
       graphql(`
-				query projectPage($projectCode: String!, $userIsAdmin: Boolean!) {
+				query projectPage($projectCode: String!, $userIsAdmin: Boolean!, $userIsMember: Boolean!) {
 					projectByCode(code: $projectCode) {
 						id
 						name
@@ -88,7 +88,7 @@ export async function load(event: PageLoadEvent) {
 					}
 				}
 			`),
-      { projectCode, userIsAdmin }
+      { projectCode, userIsAdmin: user.isAdmin, userIsMember: user. }//todo can't determine if user is member here right now
     );
   const changesetResultStore = client
     .queryStore(event.fetch,


### PR DESCRIPTION
closes #958 

this works by restricting the query on the backend. Then the front end will only query the members if the user is a member. 