### PR TITLE
Invalidate GQL cache for org when a new project added to it

### DIFF
--- a/backend/LexBoxApi/GraphQL/OrgMutations.cs
+++ b/backend/LexBoxApi/GraphQL/OrgMutations.cs
@@ -67,7 +67,7 @@ public class OrgMutations
         Guid orgId,
         Guid projectId)
     {
-        var org = await dbContext.Orgs.FindAsync(orgId);
+        var org = await dbContext.Orgs.Include(o => o.Members).SingleOrDefaultAsync(o => o.Id == orgId);
         NotFoundException.ThrowIfNull(org);
         permissionService.AssertCanAddProjectToOrg(org);
         var project = await dbContext.Projects.Where(p => p.Id == projectId)
@@ -101,7 +101,7 @@ public class OrgMutations
         Guid orgId,
         Guid projectId)
     {
-        var org = await dbContext.Orgs.FindAsync(orgId);
+        var org = await dbContext.Orgs.Include(o => o.Members).SingleOrDefaultAsync(o => o.Id == orgId);
         NotFoundException.ThrowIfNull(org);
         permissionService.AssertCanAddProjectToOrg(org);
         var project = await dbContext.Projects.Where(p => p.Id == projectId)

--- a/frontend/src/lib/gql/gql-client.ts
+++ b/frontend/src/lib/gql/gql-client.ts
@@ -60,7 +60,7 @@ function createGqlClient(_gqlEndpoint?: string): Client {
           Mutation: {
             createProject: (result, args: CreateProjectMutationVariables, cache, _info) => {
               if (args.input.orgId) {
-                cache.invalidate({__typename: 'OrgById', id: args.input.orgId});
+                cache.invalidate({__typename: 'OrgById', id: args.input.orgId}, 'projects');
               }
             },
             softDeleteProject: (result, args: SoftDeleteProjectMutationVariables, cache, _info) => {
@@ -94,7 +94,7 @@ function createGqlClient(_gqlEndpoint?: string): Client {
             },
             addProjectToOrg: (result, args: MutationAddProjectToOrgArgs, cache, _info) => {
               cache.invalidate({__typename: 'Project', id: args.input.projectId});
-              cache.invalidate({__typename: 'OrgById', id: args.input.orgId});
+              cache.invalidate({__typename: 'OrgById', id: args.input.orgId}, 'projects');
             },
             removeProjectFromOrg: (result, args: MutationRemoveProjectFromOrgArgs, cache, _info) => {
               cache.invalidate({__typename: 'Project', id: args.input.projectId});

--- a/frontend/src/lib/gql/gql-client.ts
+++ b/frontend/src/lib/gql/gql-client.ts
@@ -32,6 +32,7 @@ import {
   type BulkAddOrgMembersMutationVariables,
   type ChangeOrgMemberRoleMutationVariables,
   type AddOrgMemberMutationVariables,
+  type CreateProjectMutationVariables,
 } from './types';
 import type {Readable, Unsubscriber} from 'svelte/store';
 import {derived} from 'svelte/store';
@@ -57,6 +58,11 @@ function createGqlClient(_gqlEndpoint?: string): Client {
         },
         updates: {
           Mutation: {
+            createProject: (result, args: CreateProjectMutationVariables, cache, _info) => {
+              if (args.input.orgId) {
+                cache.invalidate({__typename: 'OrgById', id: args.input.orgId});
+              }
+            },
             softDeleteProject: (result, args: SoftDeleteProjectMutationVariables, cache, _info) => {
               cache.invalidate({__typename: 'Project', id: args.input.projectId});
             },
@@ -88,6 +94,7 @@ function createGqlClient(_gqlEndpoint?: string): Client {
             },
             addProjectToOrg: (result, args: MutationAddProjectToOrgArgs, cache, _info) => {
               cache.invalidate({__typename: 'Project', id: args.input.projectId});
+              cache.invalidate({__typename: 'OrgById', id: args.input.orgId});
             },
             removeProjectFromOrg: (result, args: MutationRemoveProjectFromOrgArgs, cache, _info) => {
               cache.invalidate({__typename: 'Project', id: args.input.projectId});

--- a/frontend/src/lib/gql/gql-client.ts
+++ b/frontend/src/lib/gql/gql-client.ts
@@ -98,6 +98,7 @@ function createGqlClient(_gqlEndpoint?: string): Client {
             },
             removeProjectFromOrg: (result, args: MutationRemoveProjectFromOrgArgs, cache, _info) => {
               cache.invalidate({__typename: 'Project', id: args.input.projectId});
+              cache.invalidate({__typename: 'OrgById', id: args.input.orgId}, 'projects');
             }
           }
         }


### PR DESCRIPTION
Fixes #933.

This PR attempts to only invalidate the `projects` field of orgById to minimize the amount of information the next GQL query needs to pull, however in practice it looks like we'd have to run more granular queries to take advantage of that. URQL apparently does *not* reduce the info requested in a query just because the GraphQL cache is up-to-date for most of it (since that could fail if you're using persisted queries), so our `orgById` query pulls the entire org data even when it would only have needed to pull the `projects` field. So we could, in theory, do away with commit 3db96a68. In practice, it might as well stay since it does no harm and may, in the future, do some good.