### PR TITLE
Longer lexbox-deployment time for local-dev

### DIFF
--- a/deployment/local-dev/lexbox-deployment.patch.yaml
+++ b/deployment/local-dev/lexbox-deployment.patch.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     app: lexbox
 spec:
+  progressDeadlineSeconds: 300
   template:
     spec:
       containers:


### PR DESCRIPTION
The lexbox deployment is always the last one to finish, and if anything has gone slightly wrong with other deployments (such as low RAM causing other deployments to happen one at a time instead of all at once), it's easy for it to go past the 80-second timeout we set, and for `task up` to fail. So on local-dev, we want a 5-minute timeout for the lexbox deployment, which should be plenty long enough for everything to settle.

Fixes #883.