### PR TITLE
users who register via google login still have to verify their email

### DIFF
--- a/backend/LexBoxApi/Controllers/UserController.cs
+++ b/backend/LexBoxApi/Controllers/UserController.cs
@@ -140,6 +140,7 @@ public class UserController : ControllerBase
             Locked = false,
             CanCreateProjects = false
         };
+        userEntity.EmailVerified = jwtUser?.Email == userEntity.Email;
         // This audience check is redundant now because of [RequireAudience(LexboxAudience.RegisterAccount, true)], but let's leave it in for safety
         if (jwtUser?.Audience == LexboxAudience.RegisterAccount && jwtUser.Projects.Length > 0)
         {


### PR DESCRIPTION
Fixes #943. 

Implemented logic to verify that the Google email provided in a JWT matches the email entered in the input form.