### PR TITLE
Fix viewer bug with Mongo deserialization of parts of speech

### DIFF
--- a/backend/LfClassicData/Entities/Entry.cs
+++ b/backend/LfClassicData/Entities/Entry.cs
@@ -36,6 +36,7 @@ public class Example
 
 }
 
+[BsonIgnoreExtraElements]
 public class OptionListRecord
 {
     public required string Code { get; set; }


### PR DESCRIPTION
The Mongo data includes an `_id` field which needs to be ignored, otherwise Mongo will throw an exception saying that it doesn't know what to do with that field.

Fixes #996.