### PR TITLE
enable submit button label change via invite checkbox toggles

### DIFF
--- a/frontend/src/lib/i18n/locales/en.json
+++ b/frontend/src/lib/i18n/locales/en.json
@@ -324,7 +324,7 @@ the [Linguistics Institute at Payap University](https://li.payap.ac.th/) in Chia
       "submit_button": "Add Member",
       "invite_checkbox": "Invite",
       "empty_user_field": "Please enter an email address or login",
-      "submit_button_email": "Add or invite Member",
+      "submit_button_invite": "Add or invite Member",
       "project_not_found": "Project not found. Please refresh the page.",
       "username_not_found": "No user was found with this login",
       "user_must_be_verified": "User needs a verified email address",

--- a/frontend/src/lib/i18n/locales/en.json
+++ b/frontend/src/lib/i18n/locales/en.json
@@ -324,7 +324,7 @@ the [Linguistics Institute at Payap University](https://li.payap.ac.th/) in Chia
       "submit_button": "Add Member",
       "invite_checkbox": "Invite",
       "empty_user_field": "Please enter an email address or login",
-      "submit_button_invite": "Add or invite Member",
+      "submit_button_invite": "Add/Invite Member",
       "project_not_found": "Project not found. Please refresh the page.",
       "username_not_found": "No user was found with this login",
       "user_must_be_verified": "User needs a verified email address",

--- a/frontend/src/routes/(authenticated)/project/[project_code]/AddProjectMember.svelte
+++ b/frontend/src/routes/(authenticated)/project/[project_code]/AddProjectMember.svelte
@@ -107,7 +107,7 @@
   </svelte:fragment>
   <span slot="submitText">
     {#if $form.canInvite}
-      {$t('project_page.add_user.submit_button_email')}
+      {$t('project_page.add_user.submit_button_invite')}
     {:else}
       {$t('project_page.add_user.submit_button')}
     {/if}

--- a/frontend/src/routes/(authenticated)/project/[project_code]/AddProjectMember.svelte
+++ b/frontend/src/routes/(authenticated)/project/[project_code]/AddProjectMember.svelte
@@ -106,6 +106,10 @@
     />
   </svelte:fragment>
   <span slot="submitText">
-    {$t('project_page.add_user.submit_button')}
+    {#if $form.canInvite}
+      {$t('project_page.add_user.submit_button_email')}
+    {:else}
+      {$t('project_page.add_user.submit_button')}
+    {/if}
   </span>
 </FormModal>


### PR DESCRIPTION
fixes #963.

when the invite checkbox is checked, the label of the submit button changes from "Add member" to "Add/Invite member".