### PR TITLE
allow filtering user type in admin page

### DIFF
--- a/frontend/src/lib/components/Users/UserFilter.svelte
+++ b/frontend/src/lib/components/Users/UserFilter.svelte
@@ -1,7 +1,7 @@
 <script  context="module" lang="ts">
   import type { User } from '../../../routes/(authenticated)/admin/+page';
 
-  export type UserType = 'admin' | 'nonAdmin' | 'guest' | '';
+  export type UserType = 'admin' | 'nonAdmin' | 'guest' | undefined;
 
   export type UserFilters = {
     userSearch: string;
@@ -30,6 +30,7 @@
   import ActiveFilter from '$lib/components/FilterBar/ActiveFilter.svelte';
   import { Icon } from '$lib/icons';
   import t from '$lib/i18n';
+  import UserTypeSelect from '$lib/forms/UserTypeSelect.svelte';
 
 
   type Filters = Partial<UserFilters> & Pick<UserFilters, 'userSearch'>;
@@ -83,6 +84,7 @@
     <h2 class="card-title">{$t('admin_dashboard.user_filter.title')}</h2>
     {#if filterEnabled('userType')}
       <div class="form-control">
+        <UserTypeSelect bind:value={$filters.userType} undefinedOptionLabel={$t('common.any')}/>
       </div>
     {/if}
     {#if filterEnabled('usersICreated')}

--- a/frontend/src/lib/components/Users/UserFilter.svelte
+++ b/frontend/src/lib/components/Users/UserFilter.svelte
@@ -68,7 +68,6 @@
             <Icon icon="i-mdi-shield-lock-open-outline" />
             {$t('admin_dashboard.user_filter.user_type.nonAdmin')}
           {:else if filter.value === 'guest'}
-            <Icon icon="i-mdi-shield-lock-outline" color="text-warning" />
             {$t('admin_dashboard.user_filter.user_type.guest')}
           {/if}
         </ActiveFilter>

--- a/frontend/src/lib/components/Users/UserFilter.svelte
+++ b/frontend/src/lib/components/Users/UserFilter.svelte
@@ -62,12 +62,13 @@
       {#if filter.key === 'userType' && filter.value}
         <ActiveFilter {filter}>
           {#if filter.value === 'admin'}
-            <Icon icon="i-mdi-shield-lock-outline" color="text-warning" />
+            <Icon icon="i-mdi-security" color="text-accent" />
             {$t('admin_dashboard.user_filter.user_type.admin')}
           {:else if filter.value === 'nonAdmin'}
-            <Icon icon="i-mdi-shield-lock-open-outline" />
+            <Icon icon="i-mdi-account" />
             {$t('admin_dashboard.user_filter.user_type.nonAdmin')}
           {:else if filter.value === 'guest'}
+            <Icon icon="i-mdi-account-outline" />
             {$t('admin_dashboard.user_filter.user_type.guest')}
           {/if}
         </ActiveFilter>

--- a/frontend/src/lib/components/Users/UserFilter.svelte
+++ b/frontend/src/lib/components/Users/UserFilter.svelte
@@ -1,9 +1,12 @@
 <script  context="module" lang="ts">
-  import type { User } from './+page';
+  import type { User } from '../../../routes/(authenticated)/admin/+page';
+
+  export type UserType = 'admin' | 'nonAdmin' | 'guest' | '';
 
   export type UserFilters = {
     userSearch: string;
     usersICreated: boolean;
+    userType: UserType;
   }
 
   export function filterUsers(
@@ -13,7 +16,10 @@
   ): User[] {
     return users.filter(
       (u) =>
-        (!userFilter.usersICreated || u.createdById === adminId)
+        (!userFilter.usersICreated || u.createdById === adminId) &&
+        (!userFilter.userType ||
+          (userFilter.userType === (u.isAdmin ? 'admin' : 'nonAdmin')) ||
+          (userFilter.userType === 'guest' && u.createdById))
     );
   }
 </script>
@@ -31,7 +37,7 @@
   export let filterDefaults: Filters;
   export let hasActiveFilter: boolean = false;
   export let autofocus: true | undefined = undefined;
-  export let filterKeys: ReadonlyArray<(keyof Filters)> = ['userSearch', 'usersICreated'];
+  export let filterKeys: ReadonlyArray<(keyof Filters)> = ['userSearch', 'usersICreated', 'userType'];
   export let loading = false;
 
   function filterEnabled(filter: keyof Filters): boolean {
@@ -52,7 +58,20 @@
 >
   <svelte:fragment slot="activeFilters" let:activeFilters>
     {#each activeFilters as filter}
-      {#if filter.key === 'usersICreated' && filter.value}
+      {#if filter.key === 'userType' && filter.value}
+        <ActiveFilter {filter}>
+          {#if filter.value === 'admin'}
+            <Icon icon="i-mdi-shield-lock-outline" color="text-warning" />
+            {'Admin'}
+          {:else if filter.value === 'nonAdmin'}
+            <Icon icon="i-mdi-shield-lock-open-outline" />
+            {'Non-admin'}
+          {:else if filter.value === 'guest'}
+            <Icon icon="i-mdi-shield-lock-outline" color="text-warning" />
+            {'Guest'}
+          {/if}
+        </ActiveFilter>
+      {:else if filter.key === 'usersICreated' && filter.value}
         <ActiveFilter {filter}>
           <Icon icon="i-mdi-account-plus-outline" color="text-warning" />
           {$t('admin_dashboard.user_filter.guest_users_i_added')}
@@ -62,6 +81,10 @@
   </svelte:fragment>
   <svelte:fragment slot="filters">
     <h2 class="card-title">{$t('admin_dashboard.user_filter.title')}</h2>
+    {#if filterEnabled('userType')}
+      <div class="form-control">
+      </div>
+    {/if}
     {#if filterEnabled('usersICreated')}
       <div class="form-control">
         <label class="cursor-pointer label gap-4">

--- a/frontend/src/lib/components/Users/UserFilter.svelte
+++ b/frontend/src/lib/components/Users/UserFilter.svelte
@@ -63,13 +63,13 @@
         <ActiveFilter {filter}>
           {#if filter.value === 'admin'}
             <Icon icon="i-mdi-shield-lock-outline" color="text-warning" />
-            {'Admin'}
+            {$t('admin_dashboard.user_filter.user_type.admin')}
           {:else if filter.value === 'nonAdmin'}
             <Icon icon="i-mdi-shield-lock-open-outline" />
-            {'Non-admin'}
+            {$t('admin_dashboard.user_filter.user_type.nonAdmin')}
           {:else if filter.value === 'guest'}
             <Icon icon="i-mdi-shield-lock-outline" color="text-warning" />
-            {'Guest'}
+            {$t('admin_dashboard.user_filter.user_type.guest')}
           {/if}
         </ActiveFilter>
       {:else if filter.key === 'usersICreated' && filter.value}

--- a/frontend/src/lib/components/Users/UserTable.svelte
+++ b/frontend/src/lib/components/Users/UserTable.svelte
@@ -4,7 +4,7 @@
   import { AdminIcon, Icon } from '$lib/icons';
   import { createEventDispatcher } from 'svelte';
   import Dropdown from '$lib/components/Dropdown.svelte';
-  import type { User } from './+page';
+  import type { User } from '../../../routes/(authenticated)/admin/+page';
 
   export let shownUsers: User[];
 

--- a/frontend/src/lib/components/Users/index.ts
+++ b/frontend/src/lib/components/Users/index.ts
@@ -1,0 +1,1 @@
+export * from './UserFilter.svelte'

--- a/frontend/src/lib/forms/UserTypeSelect.svelte
+++ b/frontend/src/lib/forms/UserTypeSelect.svelte
@@ -1,0 +1,25 @@
+<script lang="ts">
+  import t, { type I18nKey } from '$lib/i18n';
+  import Select from './Select.svelte';
+  import type { UserType } from '$lib/components/Users';
+
+  export let value: UserType;
+  export let undefinedOptionLabel: string | undefined = undefined;
+
+  const options: Record<Exclude<UserType, undefined>, I18nKey> = {
+    admin: 'admin_dashboard.user_filter.user_type.admin',
+    nonAdmin: 'admin_dashboard.user_filter.user_type.nonAdmin',
+    guest: 'admin_dashboard.user_filter.user_type.guest'
+  };
+</script>
+
+<div class="relative">
+  <Select id="type" label={$t('admin_dashboard.user_filter.user_type.label')} bind:value on:change>
+    {#if undefinedOptionLabel}
+      <option value={undefined}>{undefinedOptionLabel}</option>
+    {/if}
+    {#each Object.entries(options) as [value, label]}
+      <option value={value}>{$t(label)}</option>
+    {/each}
+  </Select>
+</div>

--- a/frontend/src/lib/i18n/locales/en.json
+++ b/frontend/src/lib/i18n/locales/en.json
@@ -64,6 +64,12 @@
     },
     "user_filter": {
       "title": "User filters",
+      "user_type": {
+        "label": "User Type",
+        "admin": "Admin",
+        "nonAdmin": "Non-admin",
+        "guest": "Guest user"
+      },
       "guest_users_i_added": "Guest users I added",
     }
   },

--- a/frontend/src/routes/(authenticated)/admin/+page.svelte
+++ b/frontend/src/routes/(authenticated)/admin/+page.svelte
@@ -21,8 +21,8 @@
   import CreateUserModal from '$lib/components/Users/CreateUserModal.svelte';
   import type { Confidentiality } from '$lib/components/Projects';
   import { browser } from '$app/environment';
-  import UserTable from './UserTable.svelte';
-  import UserFilter, { filterUsers, type UserFilters } from './UserFilter.svelte';
+  import UserTable from '$lib/components/Users/UserTable.svelte';
+  import UserFilter, { filterUsers, type UserFilters, type UserType } from '$lib/components/Users/UserFilter.svelte';
 
   export let data: PageData;
   $: projects = data.projects;
@@ -43,10 +43,11 @@
     memberSearch: queryParam.string(undefined),
     projectSearch: queryParam.string<string>(''),
     usersICreated: queryParam.boolean<boolean>(false),
+    userType: queryParam.string<UserType>(''),
     tab: queryParam.string<AdminTabId>('projects'),
   });
 
-  const userFilterKeys = ['userSearch', 'usersICreated'] as const satisfies Readonly<(keyof UserFilters)[]>;
+  const userFilterKeys = ['userSearch', 'usersICreated', 'userType'] as const satisfies Readonly<(keyof UserFilters)[]>;
 
   const { queryParamValues, defaultQueryParamValues } = queryParams;
   $: tab = $queryParamValues.tab;

--- a/frontend/src/routes/(authenticated)/admin/+page.svelte
+++ b/frontend/src/routes/(authenticated)/admin/+page.svelte
@@ -43,7 +43,7 @@
     memberSearch: queryParam.string(undefined),
     projectSearch: queryParam.string<string>(''),
     usersICreated: queryParam.boolean<boolean>(false),
-    userType: queryParam.string<UserType>(''),
+    userType: queryParam.string<UserType>(undefined),
     tab: queryParam.string<AdminTabId>('projects'),
   });
 

--- a/frontend/src/routes/(authenticated)/admin/+page.ts
+++ b/frontend/src/routes/(authenticated)/admin/+page.ts
@@ -22,12 +22,14 @@ import type { ProjectFilters } from '$lib/components/Projects';
 import { DEFAULT_PAGE_SIZE } from '$lib/components/Paging';
 import type { AdminTabId } from './AdminTabs.svelte';
 import { derived, readable } from 'svelte/store';
+import type { UserType } from '$lib/components/Users/UserFilter.svelte';
 
 // eslint-disable-next-line @typescript-eslint/no-redundant-type-constituents -- false positive?
 export type AdminSearchParams = ProjectFilters & {
   userSearch: string
   tab: AdminTabId
   usersICreated: boolean
+  userType: UserType
 };
 
 export type Project = NonNullable<LoadAdminDashboardProjectsQuery['projects']>[number];


### PR DESCRIPTION
fixes #593.

this PR implements user type filter in admin page. user type can be admin, non-admin, or guest user.