### PR TITLE
Only use MS ICU package on Windows, and fix some hardcoded Windows-only paths

### DIFF
--- a/backend/FwLite/FwDataMiniLcmBridge/FwDataMiniLcmBridge.csproj
+++ b/backend/FwLite/FwDataMiniLcmBridge/FwDataMiniLcmBridge.csproj
@@ -11,7 +11,7 @@
         <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="8.0.0" />
         <PackageReference Include="Microsoft.Extensions.Logging" Version="8.0.0" />
         <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.1" />
-        <PackageReference Include="Microsoft.ICU.ICU4C.Runtime" Version="72.1.0.3" />
+        <PackageReference Include="Microsoft.ICU.ICU4C.Runtime" Version="72.1.0.3" Condition="$([MSBuild]::IsOsPlatform('Windows'))" />
         <PackageReference Include="SIL.LCModel" Version="11.0.0-beta0100 " />
         <PackageReference Include="structuremap.patched" Version="4.7.3" />
         <PackageReference Include="System.Linq.Async" Version="6.0.1" />

--- a/backend/FwLite/FwDataMiniLcmBridge/LcmUtils/ProjectLoader.cs
+++ b/backend/FwLite/FwDataMiniLcmBridge/LcmUtils/ProjectLoader.cs
@@ -17,10 +17,11 @@ public interface IProjectLoader
 
 public class ProjectLoader : IProjectLoader
 {
+    public static string UnixDataFolder => Environment.GetEnvironmentVariable("XDG_DATA_HOME") ?? Path.Join(Environment.GetEnvironmentVariable("HOME") ?? "", ".local", "share");
     public static string DataFolder =
         RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ?
             @"C:\ProgramData\SIL\FieldWorks" :
-            Path.Join(Environment.GetEnvironmentVariable("XDG_DATA_HOME") ?? Path.Join(Environment.GetEnvironmentVariable("HOME"), ".local", "share"), "fieldworks");
+            Path.Join(UnixDataFolder, "fieldworks");
     public static string ProjectFolder = Path.Join(DataFolder, "Projects");
     private static string TemplatesFolder { get; } = Path.Join(DataFolder, "Templates");
     private static bool _init;

--- a/backend/FwLite/FwDataMiniLcmBridge/LcmUtils/ProjectLoader.cs
+++ b/backend/FwLite/FwDataMiniLcmBridge/LcmUtils/ProjectLoader.cs
@@ -17,8 +17,12 @@ public interface IProjectLoader
 
 public class ProjectLoader : IProjectLoader
 {
-    public const string ProjectFolder = @"C:\ProgramData\SIL\FieldWorks\Projects";
-    private static string TemplatesFolder { get; } = @"C:\ProgramData\SIL\FieldWorks\Templates";
+    public static string DataFolder =
+        RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ?
+            @"C:\ProgramData\SIL\FieldWorks" :
+            Path.Join(Environment.GetEnvironmentVariable("XDG_DATA_HOME") ?? Path.Join(Environment.GetEnvironmentVariable("HOME"), ".local", "share"), "fieldworks");
+    public static string ProjectFolder = Path.Join(DataFolder, "Projects");
+    private static string TemplatesFolder { get; } = Path.Join(DataFolder, "Templates");
     private static bool _init;
 
     public static void Init()

--- a/backend/FwLite/FwDataMiniLcmBridge/LcmUtils/ProjectLoader.cs
+++ b/backend/FwLite/FwDataMiniLcmBridge/LcmUtils/ProjectLoader.cs
@@ -18,11 +18,11 @@ public interface IProjectLoader
 public class ProjectLoader : IProjectLoader
 {
     public static string UnixDataFolder => Environment.GetEnvironmentVariable("XDG_DATA_HOME") ?? Path.Join(Environment.GetEnvironmentVariable("HOME") ?? "", ".local", "share");
-    public static string DataFolder =
+    public static readonly string DataFolder =
         RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ?
             @"C:\ProgramData\SIL\FieldWorks" :
             Path.Join(UnixDataFolder, "fieldworks");
-    public static string ProjectFolder = Path.Join(DataFolder, "Projects");
+    public static readonly string ProjectFolder = Path.Join(DataFolder, "Projects");
     private static string TemplatesFolder { get; } = Path.Join(DataFolder, "Templates");
     private static bool _init;
 

--- a/backend/FwLite/FwDataMiniLcmBridge/LcmUtils/ProjectLoader.cs
+++ b/backend/FwLite/FwDataMiniLcmBridge/LcmUtils/ProjectLoader.cs
@@ -1,4 +1,5 @@
 ﻿using System.Diagnostics;
+using System.Runtime.InteropServices;
 using SIL.LCModel;
 using SIL.WritingSystems;
 
@@ -28,7 +29,10 @@ public class ProjectLoader : IProjectLoader
         }
 
         Icu.Wrapper.Init();
-        Debug.Assert(Icu.Wrapper.IcuVersion == "72.1.0.3");
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        {
+            Debug.Assert(Icu.Wrapper.IcuVersion == "72.1.0.3");
+        }
         Sldr.Initialize();
         _init = true;
     }


### PR DESCRIPTION
Fixes #974,
Fixes #1005.

On Linux and OS X, we use system ICU libraries instead of the MS package, allowing icu.net to find them dynamically.

This PR also fixes the hardcoded Windows-only path to FieldWorks projects. Result:

![image](https://github.com/user-attachments/assets/c8bc5cc2-f712-4b0c-93de-11c7c2fff876)
