### PR TITLE
Mark some integration tests as flaky

### DIFF
--- a/.github/workflows/integration-test.yaml
+++ b/.github/workflows/integration-test.yaml
@@ -121,6 +121,22 @@ jobs:
           DOTNET_GCHeapHardLimit: '0x2CB417800'
 
         run: dotnet test LexBoxOnly.slnf --output ./bin --logger trx --results-directory ./test-results --filter Category=Integration
+
+      - name: Flaky Integration tests (.NET)
+        continue-on-error: true
+        env:
+          TEST_SERVER_HOSTNAME: ${{ vars.TEST_SERVER_HOSTNAME }}
+          #      this is not a typo, we need to use the lf domain because it has a cert that hg will validate
+          TEST_STANDARD_HG_HOSTNAME: ${{ vars.TEST_STANDARD_HG_HOSTNAME }}
+          TEST_RESUMABLE_HG_HOSTNAME: ${{ vars.TEST_RESUMABLE_HG_HOSTNAME }}
+          TEST_PROJECT_CODE: 'sena-3'
+          TEST_DEFAULT_PASSWORD: ${{ secrets.TEST_USER_PASSWORD }}
+          # 1.5gb max heap size, must be in hex https://learn.microsoft.com/en-us/dotnet/core/runtime-config/garbage-collector#heap-limit
+          # the self hosted runner only has 2gb so this should prevent it from running out of memory
+          DOTNET_GCHeapHardLimit: '0x2CB417800'
+
+        run: dotnet test LexBoxOnly.slnf --output ./bin --logger trx --results-directory ./test-results --filter Category=FlakyIntegration
+
       - name: Publish unit test results
         uses: EnricoMi/publish-unit-test-result-action/composite@8885e273a4343cd7b48eaa72428dea0c3067ea98 # v2.14.0
         if: ${{ always() && !env.act }}

--- a/.github/workflows/lexbox-api.yaml
+++ b/.github/workflows/lexbox-api.yaml
@@ -53,7 +53,7 @@ jobs:
       - name: Dotnet build
         run: dotnet build LexBoxOnly.slnf
       - name: Unit tests
-        run: dotnet test LexBoxOnly.slnf --logger:"xunit;LogFileName={assembly}.results.xml" --results-directory ./test-results --filter "Category!=Integration" --blame-hang-timeout 10m
+        run: dotnet test LexBoxOnly.slnf --logger:"xunit;LogFileName={assembly}.results.xml" --results-directory ./test-results --filter "Category!=Integration&Category!=FlakyIntegration" --blame-hang-timeout 10m
       - name: Publish unit test results
         uses: EnricoMi/publish-unit-test-result-action@8885e273a4343cd7b48eaa72428dea0c3067ea98 # v2.14.0
         if: always()

--- a/backend/Testing/SyncReverseProxy/SendReceiveServiceTests.cs
+++ b/backend/Testing/SyncReverseProxy/SendReceiveServiceTests.cs
@@ -14,7 +14,7 @@ using static Testing.Services.Utils;
 
 namespace Testing.SyncReverseProxy;
 
-[Trait("Category", "Integration")]
+[Trait("Category", "FlakyIntegration")]
 public class SendReceiveServiceTests : IClassFixture<IntegrationFixture>
 {
     private readonly ITestOutputHelper _output;

--- a/backend/Testing/Taskfile.yml
+++ b/backend/Testing/Taskfile.yml
@@ -9,13 +9,19 @@ tasks:
     vars:
       FILTER: '{{default "." .CLI_ARGS}}'
     cmds:
-      - dotnet test --filter="Category!=Integration&{{.FILTER}}"
+      - dotnet test --filter="Category!=Integration&Category!=FlakyIntegration&{{.FILTER}}"
 
   integration:
     vars:
       FILTER: '{{default "." .CLI_ARGS}}'
     cmds:
       - dotnet test --filter="Category=Integration&FullyQualifiedName!~Testing.Browser&{{.FILTER}}" --results-directory ./test-results --logger trx
+
+  flaky-integration:
+    vars:
+      FILTER: '{{default "." .CLI_ARGS}}'
+    cmds:
+      - dotnet test --filter="Category=FlakyIntegration&FullyQualifiedName!~Testing.Browser&{{.FILTER}}" --results-directory ./test-results --logger trx
 
   integration-env:
     dotenv: [ local.env ]
@@ -27,6 +33,17 @@ tasks:
     cmds:
 #     - 'read -p "password: " TEST_DEFAULT_PASSWORD'
       - task integration -- {{.CLI_ARGS}}
+
+  flaky-integration-env:
+    dotenv: [ local.env ]
+    env:
+#      TEST_DEFAULT_PASSWORD: ***
+      TEST_SERVER_HOSTNAME: 'staging.languagedepot.org'
+      TEST_STANDARD_HG_HOSTNAME: 'hg-staging.languageforge.org'
+      TEST_RESUMABLE_HG_HOSTNAME: 'resumable-staging.languagedepot.org'
+    cmds:
+#     - 'read -p "password: " TEST_DEFAULT_PASSWORD'
+      - task flaky-integration -- {{.CLI_ARGS}}
 
   # Playwright
   playwright:


### PR DESCRIPTION
Run flaky integration tests in a separate step in GitHub Actions, and mark that step with `continue-on-error: true` so the whole test list will be considered to have passed if the flaky tests flake out.

Fixes #1009.