### PR TITLE
Add pgadmin for local dev on port 4810

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,7 @@ The SvelteKit UI will be available at http://localhost:3000.
 * http://localhost:5158/api/graphql/ui - GraphQL UI
 * http://localhost:8088/hg - hg web UI (add the project code and use the url in FLEx to clone)
 * http://localhost:1080 - maildev UI
+* http://localhost:4810 - pgadmin UI (username admin@test.com, password pass)
 * http://localhost:18888 - [aspire dashboard](https://learn.microsoft.com/en-us/dotnet/aspire/fundamentals/dashboard) (OTEL traces)
 
 ### Seeded data

--- a/deployment/Taskfile.yml
+++ b/deployment/Taskfile.yml
@@ -32,6 +32,7 @@ tasks:
       - local-maildev-forward
       - local-maildev-smtp-forward
       - local-aspire-ui-forward
+      - local-pgadmin-forward
   backend-forward:
     interactive: true
     deps: [infra-forward, local-api-forward]
@@ -67,6 +68,10 @@ tasks:
     internal: true
     cmds:
       - kubectl port-forward service/lexbox 1025:1025 -n languagedepot --context docker-desktop
+  local-pgadmin-forward:
+    internal: true
+    cmds:
+      - kubectl port-forward service/pgadmin 4810:80 -n languagedepot --context docker-desktop
 
   local-api-forward:
     cmds:

--- a/deployment/local-dev/kustomization.yaml
+++ b/deployment/local-dev/kustomization.yaml
@@ -9,6 +9,7 @@ resources:
 - db-secrets.yaml
 - lf-classic-secrets.yaml
 - self-signed-ssl.yaml
+- pgadmin-deployment.yaml
 
 components:
   - ../init-repos

--- a/deployment/local-dev/pgadmin-deployment.yaml
+++ b/deployment/local-dev/pgadmin-deployment.yaml
@@ -1,0 +1,107 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: pgadmin-auth
+  namespace: languagedepot
+stringData:
+  PGADMIN_DEFAULT_EMAIL: 'admin@test.com'
+  PGADMIN_DEFAULT_PASSWORD: 'pass'
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: pgadmin-config
+data:
+  servers.json: |
+    {
+      "Servers": {
+        "1": {
+          "Name": "Lexbox Local",
+          "Group": "Servers",
+          "Port": 5432,
+          "Username": "postgres",
+          "PassFile": "/tmp/pgadmin/lexbox-passfile/POSTGRES_PASSWORD",
+          "Host": "db",
+          "SSLMode": "prefer",
+          "MaintenanceDB": "postgres"
+        }
+      }
+    }
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: pgadmin
+  namespace: languagedepot
+  labels:
+    app: pgadmin
+spec:
+  type: ClusterIP
+  clusterIP: None
+  selector:
+    app: pgadmin
+  ports:
+    - name: http
+      protocol: TCP
+      port: 80
+
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: pgadmin
+  namespace: languagedepot
+  labels:
+    app: pgadmin
+spec:
+  selector:
+    matchLabels:
+      app: pgadmin
+  strategy:
+      type: RollingUpdate
+      rollingUpdate:
+        maxSurge: 2
+        maxUnavailable: 0
+  template:
+    metadata:
+      labels:
+        app: pgadmin
+    spec:
+      # TODO: Health check, since pgadmin takes a few seconds to start up
+      volumes:
+      - name: pgadmin-config
+        configMap:
+          name: pgadmin-config
+      - name: pgadmin-auth
+        secret:
+          secretName: db
+      containers:
+      - name: pgadmin
+        image: dpage/pgadmin4:8.10
+        volumeMounts:
+        - name: pgadmin-config
+          mountPath: /pgadmin4/servers.json
+          subPath: servers.json
+          readOnly: true
+        - name: pgadmin-auth
+          mountPath: /tmp/pgadmin/lexbox-passfile
+          readOnly: true
+        # - name: pgadmin-data
+        #   mountPath: /var/lib/pgadmin
+        env:
+        - name: PGADMIN_LISTEN_ADDRESS
+          value: "0.0.0.0"
+        - name: PGADMIN_DEFAULT_EMAIL
+          valueFrom:
+            secretKeyRef:
+              name: pgadmin-auth
+              key: PGADMIN_DEFAULT_EMAIL
+        - name: PGADMIN_DEFAULT_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: pgadmin-auth
+              key: PGADMIN_DEFAULT_PASSWORD
+        ports:
+          - name: http
+            protocol: TCP
+            containerPort: 80

--- a/deployment/local-dev/pgadmin-deployment.yaml
+++ b/deployment/local-dev/pgadmin-deployment.yaml
@@ -16,11 +16,11 @@ data:
     {
       "Servers": {
         "1": {
-          "Name": "Lexbox Local",
+          "Name": "lexbox",
           "Group": "Servers",
           "Port": 5432,
           "Username": "postgres",
-          "PassFile": "pgpass",
+          "PassFile": "/lexbox",
           "Host": "db",
           "SSLMode": "prefer",
           "MaintenanceDB": "postgres"
@@ -67,42 +67,37 @@ spec:
       labels:
         app: pgadmin
     spec:
-      # TODO: Health check, since pgadmin takes a few seconds to start up
       volumes:
       - name: pgadmin-config
         configMap:
           name: pgadmin-config
-      - name: pgadmin-auth
-        secret:
-          secretName: db
       containers:
       - name: pgadmin
         image: dpage/pgadmin4:8.10
         # pgadmin needs a specific format for its pgpass files
+        # Can't just mount k8s secret, so have to run some pre-entrypoint code instead
         command: ["/bin/sh"]
         args:
           - "-c"
           - |
-            echo "*:*:${POSTGRES_DB}:${POSTGRES_USERNAME}:${POSTGRES_PASSWORD}" > /tmp/pgpass
-            # cp -pv /tmp/pgpass /pgadmin4/
-            mkdir -p /var/lib/pgadmin/storage/admin_test.com
-            chmod 700 /var/lib/pgadmin/storage/admin_test.com
-            chown -R pgadmin:root /var/lib/pgadmin
-            cp -pv /tmp/pgpass /var/lib/pgadmin/storage/admin_test.com/pgpass
-            chmod 600 /var/lib/pgadmin/storage/admin_test.com/pgpass
-            rm /tmp/pgpass
+            mkdir -p  /tmp/pgadmin/admin_test.com
+            echo "${POSTGRES_HOSTNAME}:${POSTGRES_PORT}:*:${POSTGRES_USERNAME}:${POSTGRES_PASSWORD}" > /tmp/pgadmin/admin_test.com/lexbox
+            chown -R pgadmin /tmp/pgadmin/admin_test.com
+            chmod 700 /tmp/pgadmin/admin_test.com
+            chmod 600 /tmp/pgadmin/admin_test.com/lexbox
+            ls -l /tmp/pgadmin/admin_test.com/lexbox"
             /entrypoint.sh "$@"
         volumeMounts:
         - name: pgadmin-config
           mountPath: /pgadmin4/servers.json
           subPath: servers.json
           readOnly: true
-        - name: pgadmin-auth
-          mountPath: /tmp/pgadmin/lexbox-passfile
-          readOnly: true
+        # TODO: After testing, create a persistent volume claim and mount it here
         # - name: pgadmin-data
         #   mountPath: /var/lib/pgadmin
         env:
+        - name: PGADMIN_CONFIG_STORAGE_DIR
+          value: "'/tmp/pgadmin'"
         - name: PGADMIN_LISTEN_ADDRESS
           value: "0.0.0.0"
         # Don't want pgadmin to run a Postfix instance, we don't need password-reset emails
@@ -122,11 +117,6 @@ spec:
           value: db
         - name: POSTGRES_PORT
           value: "5432"
-        - name: POSTGRES_DB
-          valueFrom:
-            secretKeyRef:
-              name: db
-              key: POSTGRES_DB
         - name: POSTGRES_USERNAME
           value: "postgres"
         - name: POSTGRES_PASSWORD
@@ -138,3 +128,9 @@ spec:
           - name: http
             protocol: TCP
             containerPort: 80
+        startupProbe:
+          httpGet:
+            path: /
+            port: 80
+          failureThreshold: 30
+          periodSeconds: 10

--- a/deployment/local-dev/pgadmin-deployment.yaml
+++ b/deployment/local-dev/pgadmin-deployment.yaml
@@ -85,7 +85,7 @@ spec:
             chown -R pgadmin /tmp/pgadmin/admin_test.com
             chmod 700 /tmp/pgadmin/admin_test.com
             chmod 600 /tmp/pgadmin/admin_test.com/lexbox
-            ls -l /tmp/pgadmin/admin_test.com/lexbox"
+            ls -l /tmp/pgadmin/admin_test.com/lexbox
             /entrypoint.sh "$@"
         volumeMounts:
         - name: pgadmin-config

--- a/deployment/local-dev/pgadmin-deployment.yaml
+++ b/deployment/local-dev/pgadmin-deployment.yaml
@@ -1,13 +1,4 @@
 apiVersion: v1
-kind: Secret
-metadata:
-  name: pgadmin-auth
-  namespace: languagedepot
-stringData:
-  PGADMIN_DEFAULT_EMAIL: 'admin@test.com'
-  PGADMIN_DEFAULT_PASSWORD: 'pass'
----
-apiVersion: v1
 kind: ConfigMap
 metadata:
   name: pgadmin-config
@@ -58,10 +49,7 @@ spec:
     matchLabels:
       app: pgadmin
   strategy:
-      type: RollingUpdate
-      rollingUpdate:
-        maxSurge: 2
-        maxUnavailable: 0
+      type: Recreate
   template:
     metadata:
       labels:
@@ -97,6 +85,7 @@ spec:
         #   mountPath: /var/lib/pgadmin
         env:
         - name: PGADMIN_CONFIG_STORAGE_DIR
+          # pgadmin wants quotes around this string, so we need to quote the quotes so YAML will pass the inner quotes through
           value: "'/tmp/pgadmin'"
         - name: PGADMIN_LISTEN_ADDRESS
           value: "0.0.0.0"
@@ -104,15 +93,9 @@ spec:
         - name: PGADMIN_DISABLE_POSTFIX
           value: "true"
         - name: PGADMIN_DEFAULT_EMAIL
-          valueFrom:
-            secretKeyRef:
-              name: pgadmin-auth
-              key: PGADMIN_DEFAULT_EMAIL
+          value: admin@test.com
         - name: PGADMIN_DEFAULT_PASSWORD
-          valueFrom:
-            secretKeyRef:
-              name: pgadmin-auth
-              key: PGADMIN_DEFAULT_PASSWORD
+          value: pass
         - name: POSTGRES_HOSTNAME
           value: db
         - name: POSTGRES_PORT
@@ -128,9 +111,3 @@ spec:
           - name: http
             protocol: TCP
             containerPort: 80
-        startupProbe:
-          httpGet:
-            path: /
-            port: 80
-          failureThreshold: 30
-          periodSeconds: 10

--- a/deployment/local-dev/pgadmin-deployment.yaml
+++ b/deployment/local-dev/pgadmin-deployment.yaml
@@ -20,7 +20,7 @@ data:
           "Group": "Servers",
           "Port": 5432,
           "Username": "postgres",
-          "PassFile": "/tmp/pgadmin/lexbox-passfile/POSTGRES_PASSWORD",
+          "PassFile": "pgpass",
           "Host": "db",
           "SSLMode": "prefer",
           "MaintenanceDB": "postgres"
@@ -78,6 +78,20 @@ spec:
       containers:
       - name: pgadmin
         image: dpage/pgadmin4:8.10
+        # pgadmin needs a specific format for its pgpass files
+        command: ["/bin/sh"]
+        args:
+          - "-c"
+          - |
+            echo "*:*:${POSTGRES_DB}:${POSTGRES_USERNAME}:${POSTGRES_PASSWORD}" > /tmp/pgpass
+            # cp -pv /tmp/pgpass /pgadmin4/
+            mkdir -p /var/lib/pgadmin/storage/admin_test.com
+            chmod 700 /var/lib/pgadmin/storage/admin_test.com
+            chown -R pgadmin:root /var/lib/pgadmin
+            cp -pv /tmp/pgpass /var/lib/pgadmin/storage/admin_test.com/pgpass
+            chmod 600 /var/lib/pgadmin/storage/admin_test.com/pgpass
+            rm /tmp/pgpass
+            /entrypoint.sh "$@"
         volumeMounts:
         - name: pgadmin-config
           mountPath: /pgadmin4/servers.json
@@ -91,6 +105,9 @@ spec:
         env:
         - name: PGADMIN_LISTEN_ADDRESS
           value: "0.0.0.0"
+        # Don't want pgadmin to run a Postfix instance, we don't need password-reset emails
+        - name: PGADMIN_DISABLE_POSTFIX
+          value: "true"
         - name: PGADMIN_DEFAULT_EMAIL
           valueFrom:
             secretKeyRef:
@@ -101,6 +118,22 @@ spec:
             secretKeyRef:
               name: pgadmin-auth
               key: PGADMIN_DEFAULT_PASSWORD
+        - name: POSTGRES_HOSTNAME
+          value: db
+        - name: POSTGRES_PORT
+          value: "5432"
+        - name: POSTGRES_DB
+          valueFrom:
+            secretKeyRef:
+              name: db
+              key: POSTGRES_DB
+        - name: POSTGRES_USERNAME
+          value: "postgres"
+        - name: POSTGRES_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: db
+              key: POSTGRES_PASSWORD
         ports:
           - name: http
             protocol: TCP

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -65,6 +65,12 @@ portForward:
     resourceName: hg
     namespace: languagedepot
     port: 8088 # web
+  # pgadmin
+  - resourceType: Service
+    resourceName: pgadmin
+    namespace: languagedepot
+    port: 80
+    localPort: 4810
 
 manifests:
   kustomize:
@@ -115,6 +121,12 @@ profiles:
         resourceName: lexbox
         namespace: languagedepot
         port: 1025
+      # pgadmin
+      - resourceType: Service
+        resourceName: pgadmin
+        namespace: languagedepot
+        port: 80
+        localPort: 4810
 
   - name: no-frontend
     portForward:
@@ -143,3 +155,9 @@ profiles:
       resourceName: lexbox
       namespace: languagedepot
       port: 1080
+    # pgadmin
+    - resourceType: Service
+      resourceName: pgadmin
+      namespace: languagedepot
+      port: 80
+      localPort: 4810


### PR DESCRIPTION
Fixes #1020.

To test:

- Run `task up`
- Connect to `localhost:4810`
- Log in as `admin@test.com` with same default password as in LexBox.
- Open up the servers list on the left, click on lexbox.
- Dig down into the `projects` table, right-click, choose "View/Edit Data -> All Rows"
- Should see something similar to the following (though without my test projects)

![image](https://github.com/user-attachments/assets/b5625e23-b6cd-417f-82a3-955166479f07)
