### PR TITLE
improve startup time of task up

### DIFF
--- a/deployment/local-dev/lexbox-deployment.patch.yaml
+++ b/deployment/local-dev/lexbox-deployment.patch.yaml
@@ -13,6 +13,9 @@ spec:
       containers:
       - name: lexbox-api
         imagePullPolicy: IfNotPresent
+        startupProbe:
+          # don't use the startup probe for local dev as it blocks skaffold from showing results until watch has started the app, which takes a while
+          $patch: delete
         resources:
             requests:
                 memory: 2Gi


### PR DESCRIPTION
I realized today that skaffold waiting for lexbox-api to return health actually works against us as it delays making the app avalible and it also means that if the app crashes on startup then task up fails, but since we're using dotnet watch we could recover. Once I did this task up was more responsive and everything is avalible a little quicker. Once I did that I found a race condition where DbStartup would only try to connect to the db once, we now verify if we can connect first and try again for 30 seconds if we can't.