### PR TITLE
don't seed crdt projects when importing or downloading them

### DIFF
--- a/backend/FwLite/FwLiteProjectSync.Tests/Fixtures/SyncFixture.cs
+++ b/backend/FwLite/FwLiteProjectSync.Tests/Fixtures/SyncFixture.cs
@@ -55,7 +55,7 @@ public class SyncFixture : IAsyncLifetime
         if (Path.Exists(crdtProjectsFolder)) Directory.Delete(crdtProjectsFolder, true);
         Directory.CreateDirectory(crdtProjectsFolder);
         var crdtProject = await _services.ServiceProvider.GetRequiredService<ProjectsService>()
-            .CreateProject(_projectName, projectGuid);
+            .CreateProject(new(_projectName, projectGuid));
         _services.ServiceProvider.GetRequiredService<ProjectContext>().Project = crdtProject;
         CrdtApi = _services.ServiceProvider.GetRequiredService<ILexboxApi>();
     }

--- a/backend/FwLite/FwLiteProjectSync/Program.cs
+++ b/backend/FwLite/FwLiteProjectSync/Program.cs
@@ -52,7 +52,7 @@ syncCommand.SetHandler(async (crdtFile, fwDataFile, createCrdtDir, dryRun) =>
         var crdtProject = projectsService.GetProject(crdtProjectName);
         if (crdtProject is null)
         {
-            crdtProject = await projectsService.CreateProject(crdtProjectName, fwdataApi.ProjectId);
+            crdtProject = await projectsService.CreateProject(new(crdtProjectName, fwdataApi.ProjectId, SeedNewProjectData: false));
         }
         projectsService.SetProjectScope(crdtProject);
         await services.GetRequiredService<CurrentProjectService>().PopulateProjectDataCache();

--- a/backend/FwLite/LocalWebApp/Routes/ProjectRoutes.cs
+++ b/backend/FwLite/LocalWebApp/Routes/ProjectRoutes.cs
@@ -55,7 +55,7 @@ public static partial class ProjectRoutes
                     return Results.BadRequest("Project already exists");
                 if (!ProjectName().IsMatch(name))
                     return Results.BadRequest("Only letters, numbers, '-' and '_' are allowed");
-                await projectService.CreateProject(name, afterCreate: AfterCreate);
+                await projectService.CreateProject(new(name, AfterCreate: AfterCreate));
                 return TypedResults.Ok();
             });
         group.MapPost($"/upload/crdt/{{{CrdtMiniLcmApiHub.ProjectRouteKey}}}",
@@ -86,11 +86,11 @@ public static partial class ProjectRoutes
                 var foundProjectGuid = await lexboxProjectService.GetLexboxProjectId(newProjectName);
                 if (foundProjectGuid is null)
                     return Results.BadRequest($"Project code {newProjectName} not found on lexbox");
-                await projectService.CreateProject(newProjectName, foundProjectGuid.Value, options.Value.DefaultAuthority,
+                await projectService.CreateProject(new(newProjectName, foundProjectGuid.Value, options.Value.DefaultAuthority,
                     async (provider, project) =>
                     {
                         await provider.GetRequiredService<SyncService>().ExecuteSync();
-                    });
+                    }, SeedNewProjectData: false));
                 return TypedResults.Ok();
             });
         return group;


### PR DESCRIPTION
There was a bug where downloading a new project would fail because the project saw the seeded date from `ProjectsService.SeedSystemData` as new and therefore would try to push it to the server. The server would reject the change because it already had it.