### PR TITLE
FW Lite push entry changes to frontend

### DIFF
--- a/backend/FwLite/LcmCrdt/CurrentProjectService.cs
+++ b/backend/FwLite/LcmCrdt/CurrentProjectService.cs
@@ -17,10 +17,9 @@ public class CurrentProjectService(LcmCrdtDbContext dbContext, ProjectContext pr
         var key = CacheKey(Project);
         if (!memoryCache.TryGetValue(key, out object? result))
         {
-            using var entry = memoryCache.CreateEntry(key);
-            entry.SlidingExpiration = TimeSpan.FromMinutes(10);
             result = await dbContext.ProjectData.AsNoTracking().FirstAsync();
-            entry.Value = result;
+            memoryCache.Set(key, result);
+            memoryCache.Set(CacheKey(((ProjectData)result).Id), result);
         }
         if (result is null) throw new InvalidOperationException("Project data not found");
 
@@ -30,6 +29,16 @@ public class CurrentProjectService(LcmCrdtDbContext dbContext, ProjectContext pr
     private static string CacheKey(CrdtProject project)
     {
         return project.Name + "|ProjectData";
+    }
+
+    private static string CacheKey(Guid projectId)
+    {
+        return $"ProjectData|{projectId}";
+    }
+
+    public static ProjectData? LookupProjectById(IMemoryCache memoryCache, Guid projectId)
+    {
+        return memoryCache.Get<ProjectData>(CacheKey(projectId));
     }
 
     public async ValueTask<ProjectData> PopulateProjectDataCache()

--- a/backend/FwLite/LcmCrdt/ProjectsService.cs
+++ b/backend/FwLite/LcmCrdt/ProjectsService.cs
@@ -83,6 +83,7 @@ public class ProjectsService(IServiceProvider provider, ProjectContext projectCo
 
     public AsyncServiceScope CreateProjectScope(CrdtProject crdtProject)
     {
+        //todo make this helper method call `CurrentProjectService.PopulateProjectDataCache`
         var serviceScope = provider.CreateAsyncScope();
         SetProjectScope(crdtProject);
         return serviceScope;

--- a/backend/FwLite/LocalWebApp/Auth/AuthHelpers.cs
+++ b/backend/FwLite/LocalWebApp/Auth/AuthHelpers.cs
@@ -149,6 +149,12 @@ public class AuthHelpers
         return auth?.Account.Username;
     }
 
+    public async ValueTask<string?> GetCurrentToken()
+    {
+        var auth = await GetAuth();
+        return auth?.AccessToken;
+    }
+
     /// <summary>
     /// will return null if no auth token is available
     /// </summary>

--- a/backend/FwLite/LocalWebApp/BackgroundSyncService.cs
+++ b/backend/FwLite/LocalWebApp/BackgroundSyncService.cs
@@ -14,12 +14,17 @@ public class BackgroundSyncService(
 {
     private readonly Channel<CrdtProject> _syncResultsChannel = Channel.CreateUnbounded<CrdtProject>();
 
-    public void TriggerSync(Guid projectId)
+    public void TriggerSync(Guid projectId, Guid? ignoredClientId = null)
     {
         var projectData = CurrentProjectService.LookupProjectById(memoryCache, projectId);
         if (projectData is null)
         {
             logger.LogWarning("Received project update for unknown project {ProjectId}", projectId);
+            return;
+        }
+        if (ignoredClientId == projectData.ClientId)
+        {
+            logger.LogInformation("Received project update for {ProjectId} triggered by my own change, ignoring", projectId);
             return;
         }
 

--- a/backend/FwLite/LocalWebApp/BackgroundSyncService.cs
+++ b/backend/FwLite/LocalWebApp/BackgroundSyncService.cs
@@ -1,25 +1,45 @@
 ﻿using System.Threading.Channels;
 using SIL.Harmony;
 using LcmCrdt;
-using LocalWebApp.Auth;
-using Microsoft.Extensions.Options;
-using MiniLcm;
+using Microsoft.Extensions.Caching.Memory;
 
 namespace LocalWebApp;
 
 public class BackgroundSyncService(
-    IServiceProvider serviceProvider,
     ProjectsService projectsService,
     IHostApplicationLifetime applicationLifetime,
-    IOptions<AuthConfig>options,
-    ProjectContext projectContext) : BackgroundService
+    ProjectContext projectContext,
+    ILogger<BackgroundSyncService> logger,
+    IMemoryCache memoryCache) : BackgroundService
 {
     private readonly Channel<CrdtProject> _syncResultsChannel = Channel.CreateUnbounded<CrdtProject>();
 
+    public void TriggerSync(Guid projectId)
+    {
+        var projectData = CurrentProjectService.LookupProjectById(memoryCache, projectId);
+        if (projectData is null)
+        {
+            logger.LogWarning("Received project update for unknown project {ProjectId}", projectId);
+            return;
+        }
+
+        var crdtProject = projectsService.GetProject(projectData.Name);
+        if (crdtProject is null)
+        {
+            logger.LogWarning("Received project update for unknown project {ProjectName}", projectData.Name);
+            return;
+        }
+
+        TriggerSync(crdtProject);
+    }
     public void TriggerSync()
     {
-        _syncResultsChannel.Writer.TryWrite(projectContext.Project ??
-                                            throw new InvalidOperationException("No project selected"));
+        TriggerSync(projectContext.Project ?? throw new InvalidOperationException("No project selected"));
+    }
+
+    public void TriggerSync(CrdtProject crdtProject)
+    {
+        _syncResultsChannel.Writer.TryWrite(crdtProject);
     }
 
     private Task StartedAsync()
@@ -50,6 +70,7 @@ public class BackgroundSyncService(
     private async Task<SyncResults> SyncProject(CrdtProject crdtProject)
     {
         await using var serviceScope = projectsService.CreateProjectScope(crdtProject);
+        await serviceScope.ServiceProvider.GetRequiredService<CurrentProjectService>().PopulateProjectDataCache();
         var syncService = serviceScope.ServiceProvider.GetRequiredService<SyncService>();
         return await syncService.ExecuteSync();
     }

--- a/backend/FwLite/LocalWebApp/CrdtHttpSyncService.cs
+++ b/backend/FwLite/LocalWebApp/CrdtHttpSyncService.cs
@@ -53,7 +53,7 @@ public class CrdtHttpSyncService(AuthHelpersFactory authHelpersFactory, ILogger<
         var client = await authHelpersFactory.GetHelper(project).CreateClient();
         if (client is null)
         {
-            logger.LogWarning("Unable to create http client to sync project, user is not authenticated to {OriginDomain}", project.OriginDomain);
+            logger.LogWarning("Unable to create http client to sync project {ProjectName}, user is not authenticated to {OriginDomain}", project.Name, project.OriginDomain);
             return NullSyncable.Instance;
         }
 

--- a/backend/FwLite/LocalWebApp/CrdtHttpSyncService.cs
+++ b/backend/FwLite/LocalWebApp/CrdtHttpSyncService.cs
@@ -57,11 +57,11 @@ public class CrdtHttpSyncService(AuthHelpersFactory authHelpersFactory, ILogger<
             return NullSyncable.Instance;
         }
 
-        return new CrdtProjectSync(RestService.For<ISyncHttp>(client, refitSettings), project.Id, project.OriginDomain, this);
+        return new CrdtProjectSync(RestService.For<ISyncHttp>(client, refitSettings), project.Id, project.ClientId  , project.OriginDomain, this);
     }
 }
 
-public class CrdtProjectSync(ISyncHttp restSyncClient, Guid projectId, string originDomain, CrdtHttpSyncService httpSyncService) : ISyncable
+public class CrdtProjectSync(ISyncHttp restSyncClient, Guid projectId, Guid clientId, string originDomain, CrdtHttpSyncService httpSyncService) : ISyncable
 {
     public ValueTask<bool> ShouldSync()
     {
@@ -70,7 +70,7 @@ public class CrdtProjectSync(ISyncHttp restSyncClient, Guid projectId, string or
 
     async Task ISyncable.AddRangeFromSync(IEnumerable<Commit> commits)
     {
-        await restSyncClient.AddRange(projectId, commits);
+        await restSyncClient.AddRange(projectId, commits, clientId);
     }
 
     async Task<ChangesResult<Commit>> ISyncable.GetChanges(SyncState otherHeads)
@@ -104,7 +104,7 @@ public interface ISyncHttp
     Task<HttpResponseMessage> HealthCheck();
 
     [Post("/api/crdt/{id}/add")]
-    internal Task AddRange(Guid id, IEnumerable<Commit> commits);
+    internal Task AddRange(Guid id, IEnumerable<Commit> commits, Guid? clientId);
 
     [Get("/api/crdt/{id}/get")]
     internal Task<SyncState> GetSyncState(Guid id);

--- a/backend/FwLite/LocalWebApp/Hubs/CrdtMiniLcmApiHub.cs
+++ b/backend/FwLite/LocalWebApp/Hubs/CrdtMiniLcmApiHub.cs
@@ -42,20 +42,6 @@ public class CrdtMiniLcmApiHub(
         return writingSystem;
     }
 
-    public override async Task<Entry> CreateEntry(Entry entry)
-    {
-        var newEntry = await base.CreateEntry(entry);
-        await NotifyEntryUpdated(newEntry);
-        return newEntry;
-    }
-
-    public override async Task<Entry> UpdateEntry(Guid id, JsonPatchDocument<Entry> update)
-    {
-        var entry = await base.UpdateEntry(id, update);
-        await NotifyEntryUpdated(entry);
-        return entry;
-    }
-
     public override async Task<Sense> CreateSense(Guid entryId, Sense sense)
     {
         var createdSense = await base.CreateSense(entryId, sense);

--- a/backend/FwLite/LocalWebApp/LocalAppKernel.cs
+++ b/backend/FwLite/LocalWebApp/LocalAppKernel.cs
@@ -22,6 +22,7 @@ public static class LocalAppKernel
         services.AddSingleton<UrlContext>();
         services.AddScoped<SyncService>();
         services.AddScoped<LexboxProjectService>();
+        services.AddSingleton<ChangeEventBus>();
         services.AddSingleton<ImportFwdataService>();
         services.AddSingleton<BackgroundSyncService>();
         services.AddSingleton<IHostedService>(s => s.GetRequiredService<BackgroundSyncService>());

--- a/backend/FwLite/LocalWebApp/LocalWebApp.csproj
+++ b/backend/FwLite/LocalWebApp/LocalWebApp.csproj
@@ -24,6 +24,7 @@
         <PackageReference Include="Refit" Version="7.0.0" />
         <PackageReference Include="Refit.HttpClientFactory" Version="7.0.0" />
         <PackageReference Include="Swashbuckle.AspNetCore" Version="6.4.0"/>
+        <PackageReference Include="System.Reactive" Version="6.0.1" />
     </ItemGroup>
 
     <ItemGroup>

--- a/backend/FwLite/LocalWebApp/LocalWebApp.csproj
+++ b/backend/FwLite/LocalWebApp/LocalWebApp.csproj
@@ -19,8 +19,9 @@
         <PackageReference Include="Humanizer.Core" Version="2.14.1" />
         <PackageReference Include="icu.net" Version="2.10.1-beta.5" GeneratePathProperty="true" />
         <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="8.0.4"/>
+        <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="8.0.8" />
         <PackageReference Include="Microsoft.Extensions.FileProviders.Embedded" Version="8.0.4" />
-        <PackageReference Include="Microsoft.Identity.Client.Extensions.Msal" Version="4.61.0" />
+        <PackageReference Include="Microsoft.Identity.Client.Extensions.Msal" Version="4.63.0" />
         <PackageReference Include="Refit" Version="7.0.0" />
         <PackageReference Include="Refit.HttpClientFactory" Version="7.0.0" />
         <PackageReference Include="Swashbuckle.AspNetCore" Version="6.4.0"/>

--- a/backend/FwLite/LocalWebApp/Routes/TestRoutes.cs
+++ b/backend/FwLite/LocalWebApp/Routes/TestRoutes.cs
@@ -1,7 +1,5 @@
-﻿using SIL.Harmony.Core;
-using SIL.Harmony.Db;
-using LocalWebApp.Hubs;
-using Microsoft.EntityFrameworkCore;
+﻿using LocalWebApp.Hubs;
+using LocalWebApp.Services;
 using Microsoft.OpenApi.Models;
 using MiniLcm;
 using Entry = LcmCrdt.Objects.Entry;
@@ -27,6 +25,12 @@ public static class TestRoutes
             {
                 return api.GetEntries();
             });
+        group.MapPost("/set-entry-note", async (ILexboxApi api, ChangeEventBus eventBus, Guid entryId, string ws, string note) =>
+        {
+            var entry = await api.UpdateEntry(entryId, api.CreateUpdateBuilder<MiniLcm.Entry>().Set(e => e.Note[ws], note).Build());
+            if (entry is Entry crdtEntry)
+                eventBus.NotifyEntryUpdated(crdtEntry);
+        });
         return group;
     }
 }

--- a/backend/FwLite/LocalWebApp/Services/ChangeEventBus.cs
+++ b/backend/FwLite/LocalWebApp/Services/ChangeEventBus.cs
@@ -7,16 +7,17 @@ using Microsoft.AspNetCore.SignalR;
 
 namespace LocalWebApp.Services;
 
-public class ChangeEventBus(ProjectContext projectContext, IHubContext<CrdtMiniLcmApiHub, ILexboxHubClient> hubContext)
+public class ChangeEventBus(ProjectContext projectContext, IHubContext<CrdtMiniLcmApiHub, ILexboxHubClient> hubContext, ILogger<ChangeEventBus> logger)
     : IDisposable
 {
     private IDisposable? _subscription;
 
-    public void SetupSignalRSubscription()
+    public void SetupGlobalSignalRSubscription()
     {
         if (_subscription is not null) return;
         _subscription = _entryUpdated.Subscribe(notification =>
         {
+            logger.LogInformation("Sending notification for {EntryId} to {ProjectName}", notification.Entry.Id, notification.ProjectName);
             _ = hubContext.Clients.Group(CrdtMiniLcmApiHub.ProjectGroup(notification.ProjectName)).OnEntryUpdated(notification.Entry);
         });
     }

--- a/backend/FwLite/LocalWebApp/Services/ChangeEventBus.cs
+++ b/backend/FwLite/LocalWebApp/Services/ChangeEventBus.cs
@@ -1,0 +1,49 @@
+﻿using System.Reactive.Linq;
+using System.Reactive.Subjects;
+using LcmCrdt;
+using LcmCrdt.Objects;
+using LocalWebApp.Hubs;
+using Microsoft.AspNetCore.SignalR;
+
+namespace LocalWebApp.Services;
+
+public class ChangeEventBus(ProjectContext projectContext, IHubContext<CrdtMiniLcmApiHub, ILexboxHubClient> hubContext)
+    : IDisposable
+{
+    private IDisposable? _subscription;
+
+    public void SetupSignalRSubscription()
+    {
+        if (_subscription is not null) return;
+        _subscription = _entryUpdated.Subscribe(notification =>
+        {
+            _ = hubContext.Clients.Group(CrdtMiniLcmApiHub.ProjectGroup(notification.ProjectName)).OnEntryUpdated(notification.Entry);
+        });
+    }
+
+    private record struct ChangeNotification(Entry Entry, string ProjectName);
+
+    private readonly Subject<ChangeNotification> _entryUpdated = new();
+
+    public IObservable<Entry> OnEntryUpdated
+    {
+        get
+        {
+            var projectName = projectContext.Project?.Name ?? throw new InvalidOperationException("Not in a project");
+            return _entryUpdated
+                .Where(n => n.ProjectName == projectName)
+                .Select(n => n.Entry);
+        }
+    }
+
+    public void NotifyEntryUpdated(Entry entry)
+    {
+        _entryUpdated.OnNext(new ChangeNotification(entry,
+            projectContext.Project?.Name ?? throw new InvalidOperationException("Not in a project")));
+    }
+
+    public void Dispose()
+    {
+        _subscription?.Dispose();
+    }
+}

--- a/backend/FwLite/LocalWebApp/Services/LexboxProjectService.cs
+++ b/backend/FwLite/LocalWebApp/Services/LexboxProjectService.cs
@@ -1,8 +1,17 @@
-﻿using LocalWebApp.Auth;
+﻿using LcmCrdt;
+using LocalWebApp.Auth;
+using Microsoft.AspNetCore.SignalR.Client;
+using Microsoft.Extensions.Caching.Memory;
+using MiniLcm.Push;
 
 namespace LocalWebApp.Services;
 
-public class LexboxProjectService(AuthHelpersFactory helpersFactory, ILogger<LexboxProjectService> logger)
+public class LexboxProjectService(
+    AuthHelpersFactory helpersFactory,
+    ILogger<LexboxProjectService> logger,
+    IHttpMessageHandlerFactory httpMessageHandlerFactory,
+    BackgroundSyncService backgroundSyncService,
+    IMemoryCache cache)
 {
     public record LexboxCrdtProject(Guid Id, string Name);
 
@@ -34,5 +43,84 @@ public class LexboxProjectService(AuthHelpersFactory helpersFactory, ILogger<Lex
             logger.LogError(e, "Error getting lexbox project id");
             return null;
         }
+    }
+
+    public async Task ListenForProjectChanges(ProjectData projectData, CancellationToken stoppingToken)
+    {
+        if (string.IsNullOrEmpty(projectData.OriginDomain)) return;
+        var lexboxConnection = await StartLexboxProjectChangeListener(projectData.OriginDomain, stoppingToken);
+        if (lexboxConnection is null) return;
+        await lexboxConnection.SendAsync("ListenForProjectChanges", projectData.Id, stoppingToken);
+    }
+
+    private string CacheKey(string originDomain) => $"LexboxProjectChangeListener|{originDomain}";
+
+    public async Task<HubConnection?> StartLexboxProjectChangeListener(string originDomain,
+        CancellationToken stoppingToken)
+    {
+        HubConnection? connection;
+        if (cache.TryGetValue(CacheKey(originDomain), out connection) && connection is not null)
+        {
+            return connection;
+        }
+
+        if (await helpersFactory.GetHelper(new Uri(originDomain)).GetCurrentToken() is null)
+        {
+
+            logger.LogWarning("Unable to create signalR client, user is not authenticated to {OriginDomain}", originDomain);
+            return null;
+        }
+
+        connection = new HubConnectionBuilder()
+            //todo bridge logging to the aspnet logger
+            .ConfigureLogging(logging => logging.AddConsole())
+            .WithAutomaticReconnect()
+            .WithUrl($"{originDomain}/api/hub/crdt/project-changes",
+                connectionOptions =>
+                {
+                    connectionOptions.HttpMessageHandlerFactory = handler =>
+                    {
+                        //use a client that does not validate certs in dev
+                        return httpMessageHandlerFactory.CreateHandler(AuthHelpers.AuthHttpClientName);
+                    };
+                    connectionOptions.AccessTokenProvider =
+                        async () => await helpersFactory.GetHelper(new Uri(originDomain)).GetCurrentToken();
+                })
+            .Build();
+
+        //it would be cleaner to pass the callback in to this method however it's not supposed to be generic, it should always trigger a sync
+        connection.On(nameof(IProjectChangeListener.OnProjectUpdated),
+            (Guid projectId) =>
+            {
+                backgroundSyncService.TriggerSync(projectId);
+                return Task.CompletedTask;
+            });
+
+        try
+        {
+            //todo handle failure better, retry, maybe when a project sync is triggered.
+            await connection.StartAsync(stoppingToken);
+
+            connection.Closed += async (exception) =>
+            {
+                cache.Remove(CacheKey(originDomain));
+                await connection.DisposeAsync();
+            };
+            cache.CreateEntry(CacheKey(originDomain)).SetValue(connection).RegisterPostEvictionCallback(
+                static (key, value, reason, state) =>
+                {
+                    if (value is HubConnection con)
+                    {
+                        _ = con.DisposeAsync();
+                    }
+                });
+        }
+        catch (Exception e)
+        {
+            logger.LogWarning(e, "Failed to start Lexbox listener");
+            return null;
+        }
+
+        return connection;
     }
 }

--- a/backend/FwLite/LocalWebApp/Services/LexboxProjectService.cs
+++ b/backend/FwLite/LocalWebApp/Services/LexboxProjectService.cs
@@ -92,6 +92,7 @@ public class LexboxProjectService(
         connection.On(nameof(IProjectChangeListener.OnProjectUpdated),
             (Guid projectId) =>
             {
+                logger.LogInformation("Received project update for {ProjectId}, triggering sync", projectId);
                 backgroundSyncService.TriggerSync(projectId);
                 return Task.CompletedTask;
             });

--- a/backend/FwLite/LocalWebApp/Services/LexboxProjectService.cs
+++ b/backend/FwLite/LocalWebApp/Services/LexboxProjectService.cs
@@ -90,10 +90,10 @@ public class LexboxProjectService(
 
         //it would be cleaner to pass the callback in to this method however it's not supposed to be generic, it should always trigger a sync
         connection.On(nameof(IProjectChangeListener.OnProjectUpdated),
-            (Guid projectId) =>
+            (Guid projectId, Guid? clientId) =>
             {
                 logger.LogInformation("Received project update for {ProjectId}, triggering sync", projectId);
-                backgroundSyncService.TriggerSync(projectId);
+                backgroundSyncService.TriggerSync(projectId, clientId);
                 return Task.CompletedTask;
             });
 

--- a/backend/FwLite/LocalWebApp/SyncService.cs
+++ b/backend/FwLite/LocalWebApp/SyncService.cs
@@ -1,8 +1,9 @@
 ﻿using SIL.Harmony;
 using LcmCrdt;
-using LcmCrdt.Objects;
 using LocalWebApp.Auth;
 using LocalWebApp.Services;
+using MiniLcm;
+using Entry = LcmCrdt.Objects.Entry;
 
 namespace LocalWebApp;
 
@@ -11,18 +12,39 @@ public class SyncService(
     CrdtHttpSyncService remoteSyncServiceServer,
     AuthHelpersFactory factory,
     CurrentProjectService currentProjectService,
-    ChangeEventBus changeEventBus)
+    ChangeEventBus changeEventBus,
+    ILexboxApi lexboxApi,
+    ILogger<SyncService> logger)
 {
     public async Task<SyncResults> ExecuteSync()
     {
         var remoteModel = await remoteSyncServiceServer.CreateProjectSyncable(await currentProjectService.GetProjectData());
         var syncResults = await dataModel.SyncWith(remoteModel);
-        foreach (var entry in syncResults.MissingFromLocal
-                     .SelectMany(c => c.Snapshots, (commit, snapshot) => snapshot.Entity).OfType<Entry>()
-                     .DistinctBy(e => e.Id))
-        {
-            changeEventBus.NotifyEntryUpdated(entry);
-        }
+        await SendNotifications(syncResults);
         return syncResults;
+    }
+
+    private async Task SendNotifications(SyncResults syncResults)
+    {
+        //todo figure out how to make this fire and forget. Right now it blocks sync execution.
+        logger.LogInformation("Sending notifications for {Count} commits", syncResults.MissingFromLocal.Length);
+        foreach (var entryId in syncResults.MissingFromLocal
+                     .SelectMany(c => c.Snapshots, (commit, snapshot) => snapshot.Entity)
+                     .OfType<Entry>()
+                     .Select(e => e.Id)
+                     .Distinct())
+        {
+            var entry = await lexboxApi.GetEntry(entryId);
+            if (entry is Entry crdtEntry)
+            {
+                changeEventBus.NotifyEntryUpdated(crdtEntry);
+            }
+            else
+            {
+                logger.LogWarning("Failed to get entry {EntryId}, was not a crdt entry, was {Type}",
+                    entryId,
+                    entry?.GetType().FullName ?? "null");
+            }
+        }
     }
 }

--- a/backend/FwLite/LocalWebApp/SyncService.cs
+++ b/backend/FwLite/LocalWebApp/SyncService.cs
@@ -1,6 +1,8 @@
 ﻿using SIL.Harmony;
 using LcmCrdt;
+using LcmCrdt.Objects;
 using LocalWebApp.Auth;
+using LocalWebApp.Services;
 
 namespace LocalWebApp;
 
@@ -8,11 +10,19 @@ public class SyncService(
     DataModel dataModel,
     CrdtHttpSyncService remoteSyncServiceServer,
     AuthHelpersFactory factory,
-    CurrentProjectService currentProjectService)
+    CurrentProjectService currentProjectService,
+    ChangeEventBus changeEventBus)
 {
     public async Task<SyncResults> ExecuteSync()
     {
         var remoteModel = await remoteSyncServiceServer.CreateProjectSyncable(await currentProjectService.GetProjectData());
-        return await dataModel.SyncWith(remoteModel);
+        var syncResults = await dataModel.SyncWith(remoteModel);
+        foreach (var entry in syncResults.MissingFromLocal
+                     .SelectMany(c => c.Snapshots, (commit, snapshot) => snapshot.Entity).OfType<Entry>()
+                     .DistinctBy(e => e.Id))
+        {
+            changeEventBus.NotifyEntryUpdated(entry);
+        }
+        return syncResults;
     }
 }

--- a/backend/FwLite/MiniLcm/Push/IProjectChangeListener.cs
+++ b/backend/FwLite/MiniLcm/Push/IProjectChangeListener.cs
@@ -2,5 +2,5 @@
 
 public interface IProjectChangeListener
 {
-    Task OnProjectUpdated(Guid projectId);
+    Task OnProjectUpdated(Guid projectId, Guid? clientId);
 }

--- a/backend/FwLite/MiniLcm/Push/IProjectChangeListener.cs
+++ b/backend/FwLite/MiniLcm/Push/IProjectChangeListener.cs
@@ -1,0 +1,6 @@
+﻿namespace MiniLcm.Push;
+
+public interface IProjectChangeListener
+{
+    Task OnProjectUpdated(Guid projectId);
+}

--- a/backend/LexBoxApi/Controllers/CrdtController.cs
+++ b/backend/LexBoxApi/Controllers/CrdtController.cs
@@ -28,7 +28,7 @@ public class CrdtController(
     }
 
     [HttpPost("{projectId}/add")]
-    public async Task<ActionResult> Add(Guid projectId, [FromBody] ServerCommit[] commits)
+    public async Task<ActionResult> Add(Guid projectId, [FromBody] ServerCommit[] commits, Guid? clientId)
     {
         await permissionService.AssertCanSyncProject(projectId);
         foreach (var commit in commits)
@@ -38,7 +38,7 @@ public class CrdtController(
         }
 
         await dbContext.SaveChangesAsync();
-        await hubContext.Clients.Group(CrdtProjectChangeHub.ProjectGroup(projectId)).OnProjectUpdated(projectId);
+        await hubContext.Clients.Group(CrdtProjectChangeHub.ProjectGroup(projectId)).OnProjectUpdated(projectId, clientId);
         return Ok();
     }
 

--- a/backend/LexBoxApi/Hub/CrdtProjectChangeHub.cs
+++ b/backend/LexBoxApi/Hub/CrdtProjectChangeHub.cs
@@ -1,0 +1,17 @@
+﻿using LexBoxApi.Auth;
+using LexCore.ServiceInterfaces;
+using Microsoft.AspNetCore.SignalR;
+using MiniLcm.Push;
+
+namespace LexBoxApi.Hub;
+
+public class CrdtProjectChangeHub(LoggedInContext loggedInContext, IPermissionService permissionService) : Hub<IProjectChangeListener>
+{
+    public static string ProjectGroup(Guid projectId) => $"project-{projectId}";
+
+    public async Task ListenForProjectChanges(Guid projectId)
+    {
+        await permissionService.AssertCanSyncProject(projectId);
+        await Groups.AddToGroupAsync(Context.ConnectionId, ProjectGroup(projectId));
+    }
+}

--- a/backend/LexBoxApi/Program.cs
+++ b/backend/LexBoxApi/Program.cs
@@ -7,6 +7,7 @@ using LexBoxApi;
 using LexBoxApi.Auth;
 using LexBoxApi.Auth.Attributes;
 using LexBoxApi.ErrorHandling;
+using LexBoxApi.Hub;
 using LexBoxApi.Otel;
 using LexBoxApi.Services;
 using LexCore.Exceptions;
@@ -53,6 +54,7 @@ builder.Services.AddControllers(options =>
 {
     options.JsonSerializerOptions.Converters.Add(new JsonStringEnumConverter(JsonNamingPolicy.SnakeCaseUpper));
 }).AddControllersAsServices();
+builder.Services.AddSignalR();
 builder.Services.AddSingleton(services =>
     services.GetRequiredService<IOptions<JsonOptions>>().Value.JsonSerializerOptions);
 // Learn more about configuring Swagger/OpenAPI at https://aka.ms/aspnetcore/swashbuckle
@@ -168,6 +170,7 @@ app.MapTus("/api/tus-test",
 app.MapTus($"/api/project/upload-zip/{{{ProxyConstants.HgProjectCodeRouteKey}}}",
         async context => await context.RequestServices.GetRequiredService<TusService>().GetResetZipUploadConfig())
     .RequireAuthorization(new AdminRequiredAttribute());
+app.MapHub<CrdtProjectChangeHub>("/api/hub/crdt/project-changes").RequireAuthorization();
 // /api routes should never make it to this point, they should be handled by the controllers, so return 404
 app.Map("/api/{**catch-all}", () => Results.NotFound()).AllowAnonymous();
 

--- a/frontend/viewer/src/ProjectView.svelte
+++ b/frontend/viewer/src/ProjectView.svelte
@@ -13,7 +13,7 @@
   import {headword, pickBestAlternative} from './lib/utils';
   import {useLexboxApi} from './lib/services/service-provider';
   import type {IEntry} from './lib/mini-lcm';
-  import {onMount, setContext} from 'svelte';
+  import {onDestroy, onMount, setContext} from 'svelte';
   import {derived, writable, type Readable} from 'svelte/store';
   import {deriveAsync, makeDebouncer} from './lib/utils/time';
   import { type LexboxPermissions, type LexboxFeatures} from './lib/config-types';
@@ -35,8 +35,14 @@
   import {initView, initViewSettings} from './lib/services/view-service';
   import {views} from './lib/entry-editor/view-data';
   import {initWritingSystems} from './lib/writing-systems';
+  import {useEventBus} from './lib/services/event-bus';
 
   export let loading = false;
+
+  const changeEventBus = useEventBus();
+  onDestroy(changeEventBus.onEntryUpdated(entry => {
+    entries.update(list => list?.map(e => e.id === entry.id ? entry : e));
+  }));
 
   const lexboxApi = useLexboxApi();
   const features = writable<LexboxFeatures>(lexboxApi.SupportedFeatures());

--- a/frontend/viewer/src/lib/services/event-bus.ts
+++ b/frontend/viewer/src/lib/services/event-bus.ts
@@ -1,0 +1,32 @@
+﻿import {Entry} from '../mini-lcm';
+import type {CloseReason} from '../generated-signalr-client/TypedSignalR.Client/Lexbox.ClientServer.Hubs';
+
+
+export class EventBus {
+  private _onEntryUpdated = new Set<(entry: Entry) => void>();
+  private _onProjectClosed = new Set<(reason: CloseReason) => void>();
+
+  public onProjectClosed(callback: (reason: CloseReason) => void) {
+    this._onProjectClosed.add(callback);
+    return () => this._onProjectClosed.delete(callback);
+  }
+
+  public notifyProjectClosed(reason: CloseReason) {
+    this._onProjectClosed.forEach(callback => callback(reason));
+  }
+
+  public onEntryUpdated(callback: (entry: Entry) => void) {
+    this._onEntryUpdated.add(callback);
+    return () => this._onEntryUpdated.delete(callback);
+  }
+
+  public notifyEntryUpdated(entry: Entry) {
+    this._onEntryUpdated.forEach(callback => callback(entry));
+  }
+}
+
+const changeEventBus = new EventBus();
+
+export function useEventBus() {
+  return changeEventBus;
+}


### PR DESCRIPTION
this covers a couple things

- lexbox has a signalR hub which pushes sync notifications to clients
- fw lite listens to lexbox project change notifications, and triggers a sync for that project
- after a crdt sync, the updated entries are pushed to the frontend

todo

- [x] improve responsiveness. Right now it takes a few seconds for clients to receive changes, that's when running locally, it will get worse over the internet.