### PR TITLE
Promote guest users once they verify email

### DIFF
--- a/backend/LexBoxApi/Controllers/LoginController.cs
+++ b/backend/LexBoxApi/Controllers/LoginController.cs
@@ -161,6 +161,8 @@ public class LoginController(
 
         user.Email = loggedInContext.User.Email;
         user.EmailVerified = true;
+        // Guest ussers are promoted to "regular" users once they verify an email address
+        user.CreatedById = null;
         user.UpdateUpdatedDate();
         await lexBoxDbContext.SaveChangesAsync();
         await RefreshJwt();


### PR DESCRIPTION
Fixes #936.

Guest users who add an email address to their account and verify it get promoted from "guest" user status to "regular" user status, so they can now do things like becoming project managers, and so on.

Not much code here, but I believe this is all it takes. Any currently-existing guest users who have verified their email will not be affected by this PR, though, and will need some manual intervention to fix their status.