### PR TITLE
Update PNPM version to match Language Forge

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -2,9 +2,10 @@
 	"name": "frontend",
 	"version": "0.0.1",
 	"private": true,
-	"packageManager": "pnpm@8.15.1",
+	"packageManager": "pnpm@9.1.2",
 	"engines": {
-		"node": ">=20"
+		"node": ">=20",
+		"pnpm": ">=9"
 	},
 	"scripts": {
 		"dev": "vite dev",


### PR DESCRIPTION
Fixes #896.

For now, this just bumps the PNPM version to be 9.1.2, same as Language Forge. PNPM 9.8.0, which has [this interesting feature](https://github.com/pnpm/pnpm/releases/tag/v9.8.0), just came out yesterday:

> When executed in a project that has a `packageManager` field in its `package.json` file, pnpm will update its version in the `packageManager` field.

But we should do this one step at a time. First bump PNPM to 9, then make another PR to bump LexBox and Language Forge's PNPM versions together.