### PR TITLE
rework auth to use a list of servers

### DIFF
--- a/backend/FwLite/FwLiteDesktop/FwLiteDesktopKernel.cs
+++ b/backend/FwLite/FwLiteDesktop/FwLiteDesktopKernel.cs
@@ -23,7 +23,10 @@ public static class FwLiteDesktopKernel
                 config.ProjectPath = FileSystem.AppDataDirectory;
             });
             webAppBuilder.Services.Configure<AuthConfig>(config =>
-                config.CacheFileName = Path.Combine(FileSystem.AppDataDirectory, "msal.cache"));
+            {
+                config.CacheFileName = Path.Combine(FileSystem.AppDataDirectory, "msal.cache");
+                config.SystemWebViewLogin = true;
+            });
         });
         //using a lambda here means that the serverManager will be disposed when the app is disposed
         services.AddSingleton<ServerManager>(_ => serverManager);

--- a/backend/FwLite/LocalWebApp/Auth/AuthConfig.cs
+++ b/backend/FwLite/LocalWebApp/Auth/AuthConfig.cs
@@ -5,8 +5,16 @@ namespace LocalWebApp.Auth;
 public class AuthConfig
 {
     [Required]
-    public required Uri DefaultAuthority { get; set; }
+    public required LexboxServer[] LexboxServers { get; set; }
     public required string ClientId { get; set; }
-    public string CacheFileName { get; set; } = Path.GetFullPath("msal.cache");
+    public string CacheFileName { get; set; } = Path.GetFullPath("msal.json");
     public bool SystemWebViewLogin { get; set; } = false;
+    public LexboxServer DefaultServer => LexboxServers.First();
+
+    public LexboxServer GetServer(string serverName)
+    {
+        return LexboxServers.FirstOrDefault(s => s.DisplayName == serverName) ?? throw new ArgumentException($"Server {serverName} not found");
+    }
 }
+
+public record LexboxServer(Uri Authority, string DisplayName);

--- a/backend/FwLite/LocalWebApp/Auth/AuthConfig.cs
+++ b/backend/FwLite/LocalWebApp/Auth/AuthConfig.cs
@@ -8,4 +8,5 @@ public class AuthConfig
     public required Uri DefaultAuthority { get; set; }
     public required string ClientId { get; set; }
     public string CacheFileName { get; set; } = Path.GetFullPath("msal.cache");
+    public bool SystemWebViewLogin { get; set; } = false;
 }

--- a/backend/FwLite/LocalWebApp/Auth/AuthHelpers.cs
+++ b/backend/FwLite/LocalWebApp/Auth/AuthHelpers.cs
@@ -43,18 +43,19 @@ public class AuthHelpers
         _logger = logger;
         (var hostUrl, _isRedirectHostGuess) = urlContext.GetUrl();
         _redirectHost = HostString.FromUriComponent(hostUrl);
-        var redirectUri = linkGenerator.GetUriByRouteValues(AuthRoutes.CallbackRoute, new RouteValueDictionary(), hostUrl.Scheme, _redirectHost);
-        var optionsValue = options.Value;
+        var redirectUri = options.Value.SystemWebViewLogin
+            ? "http://localhost" //system web view will always have no path, changing this will not do anything in that case
+            : linkGenerator.GetUriByRouteValues(AuthRoutes.CallbackRoute, new RouteValueDictionary(), hostUrl.Scheme, _redirectHost);
         //todo configure token cache as seen here
         //https://github.com/AzureAD/microsoft-authentication-extensions-for-dotnet/wiki/Cross-platform-Token-Cache
-        _application = PublicClientApplicationBuilder.Create(optionsValue.ClientId)
+        _application = PublicClientApplicationBuilder.Create(options.Value.ClientId)
             .WithExperimentalFeatures()
             .WithLogging(loggerAdapter, hostEnvironment.IsDevelopment())
             .WithHttpClientFactory(new HttpClientFactoryAdapter(httpMessageHandlerFactory))
             .WithRedirectUri(redirectUri)
             .WithOidcAuthority(authority.ToString())
             .Build();
-        _ = MsalCacheHelper.CreateAsync(BuildCacheProperties(optionsValue.CacheFileName)).ContinueWith(
+        _ = MsalCacheHelper.CreateAsync(BuildCacheProperties(options.Value.CacheFileName)).ContinueWith(
             task =>
             {
                 var msalCacheHelper = task.Result;
@@ -63,23 +64,21 @@ public class AuthHelpers
     }
 
     public static readonly KeyValuePair<string, string> LinuxKeyRingAttr1 = new("Version", "1");
-
     public static readonly KeyValuePair<string, string> LinuxKeyRingAttr2 = new("ProductGroup", "Lexbox");
 
     private static StorageCreationProperties BuildCacheProperties(string cacheFileName)
     {
         if (!Path.IsPathFullyQualified(cacheFileName)) throw new ArgumentException("Cache file name must be fully qualified");
+        var propertiesBuilder = new StorageCreationPropertiesBuilder(cacheFileName, Path.GetDirectoryName(cacheFileName));
+#if DEBUG
+        propertiesBuilder.WithUnprotectedFile();
+#else
         const string KeyChainServiceName = "lexbox_msal_service";
         const string KeyChainAccountName = "lexbox_msal_account";
 
         const string LinuxKeyRingSchema = "org.sil.lexbox.tokencache";
         const string LinuxKeyRingCollection = MsalCacheHelper.LinuxKeyRingDefaultCollection;
         const string LinuxKeyRingLabel = "MSAL token cache for Lexbox.";
-
-        var propertiesBuilder = new StorageCreationPropertiesBuilder(cacheFileName, Directory.GetCurrentDirectory());
-#if DEBUG
-        propertiesBuilder.WithUnprotectedFile();
-#else
         propertiesBuilder.WithLinuxKeyring(LinuxKeyRingSchema,
                 LinuxKeyRingCollection,
                 LinuxKeyRingLabel,
@@ -104,10 +103,9 @@ public class AuthHelpers
         }
     }
 
-    public async Task<string> SignIn(CancellationToken cancellation = default)
+    public async Task<OAuthService.SignInResult> SignIn(CancellationToken cancellation = default)
     {
-        var authUri = await _oAuthService.SubmitLoginRequest(_application, cancellation);
-        return authUri.ToString();
+        return await _oAuthService.SubmitLoginRequest(_application, cancellation);
     }
 
     public async Task Logout()

--- a/backend/FwLite/LocalWebApp/Auth/AuthHelpersFactory.cs
+++ b/backend/FwLite/LocalWebApp/Auth/AuthHelpersFactory.cs
@@ -1,24 +1,14 @@
 ﻿using System.Collections.Concurrent;
 using LcmCrdt;
-using Microsoft.Extensions.Options;
 
 namespace LocalWebApp.Auth;
 
 public class AuthHelpersFactory(
     IServiceProvider provider,
     ProjectContext projectContext,
-    IHttpContextAccessor contextAccessor,
-    IOptions<AuthConfig> options)
+    IHttpContextAccessor contextAccessor)
 {
     private readonly ConcurrentDictionary<string, AuthHelpers> _helpers = new();
-
-    /// <summary>
-    /// gets the default (as configured in the options) Auth Helper, usually for lexbox.org
-    /// </summary>
-    public AuthHelpers GetDefault()
-    {
-        return GetHelper(options.Value.DefaultAuthority);
-    }
 
     private string AuthorityKey(Uri authority) =>
         authority.GetComponents(UriComponents.HostAndPort, UriFormat.Unescaped);
@@ -51,6 +41,11 @@ public class AuthHelpersFactory(
         var originDomain = project.OriginDomain;
         if (string.IsNullOrEmpty(originDomain)) throw new InvalidOperationException("No origin domain in project data");
         return GetHelper(new Uri(originDomain));
+    }
+
+    public AuthHelpers GetHelper(LexboxServer server)
+    {
+        return GetHelper(server.Authority);
     }
 
     /// <summary>

--- a/backend/FwLite/LocalWebApp/LocalWebApp.csproj
+++ b/backend/FwLite/LocalWebApp/LocalWebApp.csproj
@@ -20,7 +20,7 @@
         <PackageReference Include="icu.net" Version="2.10.1-beta.5" GeneratePathProperty="true" />
         <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="8.0.4"/>
         <PackageReference Include="Microsoft.Extensions.FileProviders.Embedded" Version="8.0.4" />
-        <PackageReference Include="Microsoft.Identity.Client.Extensions.Msal" Version="4.61.0" />
+        <PackageReference Include="Microsoft.Identity.Client.Extensions.Msal" Version="4.64.0" />
         <PackageReference Include="Refit" Version="7.0.0" />
         <PackageReference Include="Refit.HttpClientFactory" Version="7.0.0" />
         <PackageReference Include="Swashbuckle.AspNetCore" Version="6.4.0"/>

--- a/backend/FwLite/LocalWebApp/LocalWebAppServer.cs
+++ b/backend/FwLite/LocalWebApp/LocalWebAppServer.cs
@@ -26,10 +26,13 @@ public static class LocalWebAppServer
         }
 
         builder.ConfigureDev<AuthConfig>(config =>
-            config.DefaultAuthority = new("https://lexbox.dev.languagetechnology.org"));
+            config.LexboxServers = [
+                new (new("https://lexbox.dev.languagetechnology.org"), "Lexbox Dev"),
+                new (new("https://localhost:3000"), "Lexbox Local")
+            ]);
 //for now prod builds will also use lt dev until we deploy oauth to prod
         builder.ConfigureProd<AuthConfig>(config =>
-            config.DefaultAuthority = new("https://lexbox.dev.languagetechnology.org"));
+            config.LexboxServers = [new(new("https://lexbox.dev.languagetechnology.org"), "Lexbox Dev")]);
         builder.Services.Configure<AuthConfig>(c => c.ClientId = "becf2856-0690-434b-b192-a4032b72067f");
 
         builder.Services.AddLocalAppServices(builder.Environment);

--- a/backend/FwLite/LocalWebApp/Routes/AuthRoutes.cs
+++ b/backend/FwLite/LocalWebApp/Routes/AuthRoutes.cs
@@ -10,7 +10,16 @@ public static class AuthRoutes
     public static IEndpointConventionBuilder MapAuthRoutes(this WebApplication app)
     {
         var group = app.MapGroup("/api/auth").WithOpenApi();
-        group.MapGet("/login/default", async (AuthHelpersFactory factory) => Results.Redirect(await factory.GetDefault().SignIn()));
+        group.MapGet("/login/default", async (AuthHelpersFactory factory) =>
+        {
+            var result = await factory.GetDefault().SignIn();
+            if (result.HandledBySystemWebView)
+            {
+                return Results.Redirect("/");
+            }
+            if (result.AuthUri is null) throw new InvalidOperationException("AuthUri is null");
+            return Results.Redirect(result.AuthUri.ToString());
+        });
         group.MapGet("/oauth-callback",
             async (OAuthService oAuthService, HttpContext context) =>
             {

--- a/backend/FwLite/LocalWebApp/Routes/AuthRoutes.cs
+++ b/backend/FwLite/LocalWebApp/Routes/AuthRoutes.cs
@@ -1,40 +1,62 @@
 using System.Security.AccessControl;
 using System.Web;
 using LocalWebApp.Auth;
+using Microsoft.Extensions.Options;
 
 namespace LocalWebApp.Routes;
 
 public static class AuthRoutes
 {
     public const string CallbackRoute = "AuthRoutes_Callback";
+    public record ServerStatus(string DisplayName, bool LoggedIn, string? LoggedInAs);
     public static IEndpointConventionBuilder MapAuthRoutes(this WebApplication app)
     {
         var group = app.MapGroup("/api/auth").WithOpenApi();
-        group.MapGet("/login/default", async (AuthHelpersFactory factory) =>
+        group.MapGet("/servers", (IOptions<AuthConfig> options, AuthHelpersFactory factory) =>
         {
-            var result = await factory.GetDefault().SignIn();
-            if (result.HandledBySystemWebView)
+            return options.Value.LexboxServers.ToAsyncEnumerable().SelectAwait(async s =>
             {
-                return Results.Redirect("/");
-            }
-            if (result.AuthUri is null) throw new InvalidOperationException("AuthUri is null");
-            return Results.Redirect(result.AuthUri.ToString());
+                var currentName = await factory.GetHelper(s).GetCurrentName();
+                return new ServerStatus(s.DisplayName,
+                    !string.IsNullOrEmpty(currentName),
+                    currentName);
+            });
         });
+        group.MapGet("/login/{server}",
+            async (AuthHelpersFactory factory, string server, IOptions<AuthConfig> options) =>
+            {
+                var result = await factory.GetHelper(options.Value.GetServer(server)).SignIn();
+                if (result.HandledBySystemWebView)
+                {
+                    return Results.Redirect("/");
+                }
+
+                if (result.AuthUri is null) throw new InvalidOperationException("AuthUri is null");
+                return Results.Redirect(result.AuthUri.ToString());
+            });
         group.MapGet("/oauth-callback",
             async (OAuthService oAuthService, HttpContext context) =>
             {
-                var uriBuilder = new UriBuilder(context.Request.Scheme, context.Request.Host.Host, context.Request.Host.Port ?? 80, context.Request.Path);
+                var uriBuilder = new UriBuilder(context.Request.Scheme,
+                    context.Request.Host.Host,
+                    context.Request.Host.Port ?? 80,
+                    context.Request.Path);
                 uriBuilder.Query = context.Request.QueryString.ToUriComponent();
 
                 await oAuthService.FinishLoginRequest(uriBuilder.Uri);
                 return Results.Redirect("/");
             }).WithName(CallbackRoute);
-        group.MapGet("/me", async (AuthHelpersFactory factory) => new { name = await factory.GetDefault().GetCurrentName() });
-        group.MapGet("/logout/default", async (AuthHelpersFactory factory) =>
-        {
-            await factory.GetDefault().Logout();
-            return Results.Redirect("/");
-        });
+        group.MapGet("/me/{server}",
+            async (AuthHelpersFactory factory, string server, IOptions<AuthConfig> options) =>
+            {
+                return new { name = await factory.GetHelper(options.Value.GetServer(server)).GetCurrentName() };
+            });
+        group.MapGet("/logout/{server}",
+            async (AuthHelpersFactory factory, string server, IOptions<AuthConfig> options) =>
+            {
+                await factory.GetHelper(options.Value.GetServer(server)).Logout();
+                return Results.Redirect("/");
+            });
         return group;
     }
 }

--- a/backend/FwLite/LocalWebApp/Routes/ProjectRoutes.cs
+++ b/backend/FwLite/LocalWebApp/Routes/ProjectRoutes.cs
@@ -15,37 +15,42 @@ public static partial class ProjectRoutes
     {
         var group = app.MapGroup("/api").WithOpenApi();
         group.MapGet("/projects",
-            async (ProjectsService projectService, LexboxProjectService lexboxProjectService, FieldWorksProjectList fieldWorksProjectList) =>
-        {
-            var crdtProjects = await projectService.ListProjects();
-            var projects = crdtProjects.ToDictionary(p => p.Name, p => new ProjectModel(p.Name, true, false));
-            //basically populate projects and indicate if they are lexbox or fwdata
-            foreach (var p in fieldWorksProjectList.EnumerateProjects())
+            async (ProjectsService projectService,
+                LexboxProjectService lexboxProjectService,
+                FieldWorksProjectList fieldWorksProjectList,
+                IOptions<AuthConfig> options) =>
             {
-                if (projects.TryGetValue(p.Name, out var project))
+                var crdtProjects = await projectService.ListProjects();
+                var projects = crdtProjects.ToDictionary(p => p.Name, p => new ProjectModel(p.Name, true, false));
+                //basically populate projects and indicate if they are lexbox or fwdata
+                foreach (var p in fieldWorksProjectList.EnumerateProjects())
                 {
-                    projects[p.Name] = project with { Fwdata = true };
+                    if (projects.TryGetValue(p.Name, out var project))
+                    {
+                        projects[p.Name] = project with { Fwdata = true };
+                    }
+                    else
+                    {
+                        projects.Add(p.Name, new ProjectModel(p.Name, false, true));
+                    }
                 }
-                else
-                {
-                    projects.Add(p.Name, new ProjectModel(p.Name, false, true));
-                }
-            }
-            //todo split this out into it's own request so we can return other project types right away
-            foreach (var lexboxProject in await lexboxProjectService.GetLexboxProjects())
-            {
-                if (projects.TryGetValue(lexboxProject.Name, out var project))
-                {
-                    projects[lexboxProject.Name] = project with { Lexbox = true };
-                }
-                else
-                {
-                    projects.Add(lexboxProject.Name, new ProjectModel(lexboxProject.Name, false, false, true));
-                }
-            }
 
-            return projects.Values;
-        });
+                //todo split this out into it's own request so we can return other project types right away
+                var server = options.Value.DefaultServer;
+                foreach (var lexboxProject in await lexboxProjectService.GetLexboxProjects(server))
+                {
+                    if (projects.TryGetValue(lexboxProject.Name, out var project))
+                    {
+                        projects[lexboxProject.Name] = project with { Lexbox = true, Server = server.DisplayName };
+                    }
+                    else
+                    {
+                        projects.Add(lexboxProject.Name, new ProjectModel(lexboxProject.Name, false, false, true, server.DisplayName));
+                    }
+                }
+
+                return projects.Values;
+            });
         group.MapPost("/project",
             async (ProjectsService projectService, string name) =>
             {
@@ -58,45 +63,51 @@ public static partial class ProjectRoutes
                 await projectService.CreateProject(new(name, AfterCreate: AfterCreate));
                 return TypedResults.Ok();
             });
-        group.MapPost($"/upload/crdt/{{{CrdtMiniLcmApiHub.ProjectRouteKey}}}",
+        group.MapPost($"/upload/crdt/{{serverName}}/{{{CrdtMiniLcmApiHub.ProjectRouteKey}}}",
             async (LexboxProjectService lexboxProjectService,
                 SyncService syncService,
                 IOptions<AuthConfig> options,
-                CurrentProjectService currentProjectService) =>
+                CurrentProjectService currentProjectService,
+                string serverName) =>
             {
-                //todo let the user pick a project to upload to instead of matching the name with the project code.
+                var server = options.Value.GetServer(serverName);
                 var foundProjectGuid =
-                    await lexboxProjectService.GetLexboxProjectId(currentProjectService.ProjectData.Name);
+                    await lexboxProjectService.GetLexboxProjectId(server, currentProjectService.ProjectData.Name);
                 if (foundProjectGuid is null)
                     return Results.BadRequest(
                         $"Project code {currentProjectService.ProjectData.Name} not found on lexbox");
-                await currentProjectService.SetProjectSyncOrigin(options.Value.DefaultAuthority, foundProjectGuid);
+                await currentProjectService.SetProjectSyncOrigin(server.Authority, foundProjectGuid);
                 await syncService.ExecuteSync();
                 return TypedResults.Ok();
             });
-        group.MapPost("/download/crdt/{newProjectName}",
+        group.MapPost("/download/crdt/{serverName}/{newProjectName}",
             async (LexboxProjectService lexboxProjectService,
                 IOptions<AuthConfig> options,
                 ProjectsService projectService,
-                string newProjectName
-                ) =>
+                string newProjectName,
+                string serverName
+            ) =>
             {
                 if (!ProjectName().IsMatch(newProjectName))
                     return Results.BadRequest("Project name is invalid");
-                var foundProjectGuid = await lexboxProjectService.GetLexboxProjectId(newProjectName);
+                var server = options.Value.GetServer(serverName);
+                var foundProjectGuid = await lexboxProjectService.GetLexboxProjectId(server,newProjectName);
                 if (foundProjectGuid is null)
                     return Results.BadRequest($"Project code {newProjectName} not found on lexbox");
-                await projectService.CreateProject(new(newProjectName, foundProjectGuid.Value, options.Value.DefaultAuthority,
+                await projectService.CreateProject(new(newProjectName,
+                    foundProjectGuid.Value,
+                    server.Authority,
                     async (provider, project) =>
                     {
                         await provider.GetRequiredService<SyncService>().ExecuteSync();
-                    }, SeedNewProjectData: false));
+                    },
+                    SeedNewProjectData: false));
                 return TypedResults.Ok();
             });
         return group;
     }
 
-    public record ProjectModel(string Name, bool Crdt, bool Fwdata, bool Lexbox = false);
+    public record ProjectModel(string Name, bool Crdt, bool Fwdata, bool Lexbox = false, string? Server = null);
 
     private static async Task AfterCreate(IServiceProvider provider, CrdtProject project)
     {
@@ -112,7 +123,16 @@ public static partial class ProjectRoutes
                 new()
                 {
                     Gloss = { Values = { { "en", "Fruit" } } },
-                    Definition = { Values = { { "en", "fruit with red, yellow, or green skin with a sweet or tart crispy white flesh" } } },
+                    Definition =
+                    {
+                        Values =
+                        {
+                            {
+                                "en",
+                                "fruit with red, yellow, or green skin with a sweet or tart crispy white flesh"
+                            }
+                        }
+                    },
                     SemanticDomains = [],
                     ExampleSentences = [new() { Sentence = { Values = { { "en", "We ate an apple" } } } }]
                 }

--- a/backend/FwLite/LocalWebApp/Services/LexboxProjectService.cs
+++ b/backend/FwLite/LocalWebApp/Services/LexboxProjectService.cs
@@ -1,4 +1,5 @@
 ﻿using LocalWebApp.Auth;
+using Microsoft.Extensions.Options;
 
 namespace LocalWebApp.Services;
 
@@ -6,9 +7,9 @@ public class LexboxProjectService(AuthHelpersFactory helpersFactory, ILogger<Lex
 {
     public record LexboxCrdtProject(Guid Id, string Name);
 
-    public async Task<LexboxCrdtProject[]> GetLexboxProjects()
+    public async Task<LexboxCrdtProject[]> GetLexboxProjects(LexboxServer server)
     {
-        var httpClient = await helpersFactory.GetDefault().CreateClient();
+        var httpClient = await helpersFactory.GetHelper(server).CreateClient();
         if (httpClient is null) return [];
         try
         {
@@ -21,9 +22,9 @@ public class LexboxProjectService(AuthHelpersFactory helpersFactory, ILogger<Lex
         }
     }
 
-    public async Task<Guid?> GetLexboxProjectId(string code)
+    public async Task<Guid?> GetLexboxProjectId(LexboxServer server, string code)
     {
-        var httpClient = await helpersFactory.GetDefault().CreateClient();
+        var httpClient = await helpersFactory.GetHelper(server).CreateClient();
         if (httpClient is null) return null;
         try
         {

--- a/backend/LexData/SeedingData.cs
+++ b/backend/LexData/SeedingData.cs
@@ -298,7 +298,11 @@ public class SeedingData(
                 OpenIddictConstants.Permissions.Scopes.Profile
             },
             // port is dynamic due to the nature of the native app
-            RedirectUris = { new Uri("http://localhost/api/auth/oauth-callback"), new Uri("http://127.0.0.1/api/auth/oauth-callback") }
+            RedirectUris = {
+                new Uri("http://localhost/api/auth/oauth-callback"),
+                new Uri("http://127.0.0.1/api/auth/oauth-callback"),
+                new Uri("http://localhost")//handles system web view case
+            }
         }
     ], a => a.ClientId ?? throw new InvalidOperationException("ClientId is null"));
 

--- a/backend/Testing/Services/JwtHelper.cs
+++ b/backend/Testing/Services/JwtHelper.cs
@@ -2,14 +2,21 @@ using System.Net;
 using System.Net.Http.Json;
 using System.Text.Json;
 using LexBoxApi.Auth;
+using Microsoft.Extensions.Http.Resilience;
+using Polly;
 using Shouldly;
+using Testing.ApiTests;
 
 namespace Testing.Services;
 
 public class JwtHelper
 {
-    private static readonly HttpClientHandler Handler = new();
-    private static readonly HttpClient Client = new(Handler);
+    private static readonly SocketsHttpHandler Handler;
+    private static readonly HttpClient Client;
+    static JwtHelper()
+    {
+        (Handler, Client) = ApiTestBase.NewHttpClient();
+    }
 
     public static async Task<string> GetJwtForUser(SendReceiveAuth auth)
     {
@@ -58,7 +65,7 @@ public class JwtHelper
         return jwt;
     }
 
-    public static void ClearCookies(HttpClientHandler httpClientHandler)
+    public static void ClearCookies(SocketsHttpHandler httpClientHandler)
     {
         foreach (Cookie cookie in httpClientHandler.CookieContainer.GetAllCookies())
         {

--- a/backend/Testing/SyncReverseProxy/LegacyProjectApiTests.cs
+++ b/backend/Testing/SyncReverseProxy/LegacyProjectApiTests.cs
@@ -4,6 +4,7 @@ using System.Text;
 using System.Text.Json;
 using System.Text.Json.Nodes;
 using Shouldly;
+using Testing.ApiTests;
 using Testing.Services;
 
 namespace Testing.SyncReverseProxy;
@@ -12,7 +13,7 @@ namespace Testing.SyncReverseProxy;
 public class LegacyProjectApiTests
 {
     private readonly string _baseUrl = TestingEnvironmentVariables.ServerBaseUrl;
-    private static readonly HttpClient Client = new();
+    private static readonly HttpClient Client = ApiTestBase.NewHttpClient().Client;
 
     private const string SampleRequest = """
 POST https://admin.languageforge.org/api/user/{userName}/projects HTTP/1.1

--- a/backend/Testing/SyncReverseProxy/ProxyHgRequestTests.cs
+++ b/backend/Testing/SyncReverseProxy/ProxyHgRequestTests.cs
@@ -4,6 +4,7 @@ using System.Net.Http.Json;
 using System.Text;
 using LexBoxApi.Auth;
 using Shouldly;
+using Testing.ApiTests;
 using Testing.Services;
 
 namespace Testing.SyncReverseProxy;
@@ -12,11 +13,7 @@ namespace Testing.SyncReverseProxy;
 public class ProxyHgRequests
 {
     private string _baseUrl = TestingEnvironmentVariables.StandardHgBaseUrl;
-    private static readonly HttpClientHandler Handler = new HttpClientHandler()
-    {
-        UseCookies = false
-    };
-    private static readonly HttpClient Client = new(Handler);
+    private static readonly HttpClient Client = ApiTestBase.NewHttpClient(useCookies: false).Client;
 
     private void ShouldBeValidResponse(HttpResponseMessage responseMessage)
     {

--- a/backend/Testing/SyncReverseProxy/ResumableTests.cs
+++ b/backend/Testing/SyncReverseProxy/ResumableTests.cs
@@ -3,6 +3,7 @@ using System.Net;
 using System.Net.Http.Headers;
 using System.Text;
 using Shouldly;
+using Testing.ApiTests;
 using Testing.Services;
 
 namespace Testing.SyncReverseProxy;
@@ -11,7 +12,7 @@ namespace Testing.SyncReverseProxy;
 public class ResumableTests
 {
     private readonly string _baseUrl = TestingEnvironmentVariables.ResumableBaseUrl;
-    private static readonly HttpClient Client = new();
+    private static readonly HttpClient Client = ApiTestBase.NewHttpClient().Client;
 
     [Theory]
     [InlineData("admin")]

--- a/backend/Testing/Testing.csproj
+++ b/backend/Testing/Testing.csproj
@@ -27,6 +27,7 @@
         </Otherwise>
     </Choose>
     <ItemGroup>
+        <PackageReference Include="Microsoft.Extensions.Http.Resilience" Version="8.8.0" />
         <PackageReference Include="Squidex.Assets.TusClient" Version="6.6.4" />
         <PackageReference Include="Microsoft.Extensions.Configuration" Version="8.0.0" />
         <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0" />

--- a/frontend/viewer/src/HomeView.svelte
+++ b/frontend/viewer/src/HomeView.svelte
@@ -8,7 +8,7 @@
     mdiTestTube,
   } from '@mdi/js';
   import {links} from 'svelte-routing';
-  import {Button, Card, type ColumnDef, ListItem, Table, TextField, tableCell, Icon} from 'svelte-ux';
+  import {Button, Card, type ColumnDef, Table, TextField, tableCell, Icon, ProgressCircle} from 'svelte-ux';
   import flexLogo from './lib/assets/flex-logo.png';
   import DevContent, {isDev} from './lib/layout/DevContent.svelte';
 
@@ -92,9 +92,12 @@
   }
 
   let remoteProjects: { [server: string]: Project[] } = {};
+  let loadingRemoteProjects = false;
   async function fetchRemoteProjects() {
+    loadingRemoteProjects = true;
     let r = await fetch('/api/remoteProjects');
     remoteProjects = (await r.json()) as { [server: string]: Project[] };
+    loadingRemoteProjects = false;
   }
   fetchRemoteProjects();
 
@@ -242,7 +245,11 @@
             <p>Error: {error.message}</p>
           {/await}
           <div class="mt-4">
-            <span class="text-lg font-bold"><Icon path={mdiCloudSync}/> Remote projects</span>
+            <div class="text-lg font-bold"><Icon path={mdiCloudSync}/> Remote projects
+              {#if loadingRemoteProjects}
+                  <ProgressCircle class="text-surface-content" indeterminate={true}/>
+              {/if}
+            </div>
             {#each servers as server}
               <div class="border my-1"/>
               <div class="flex flex-row items-center">

--- a/frontend/viewer/src/ProjectView.svelte
+++ b/frontend/viewer/src/ProjectView.svelte
@@ -64,11 +64,12 @@
   const connected = writable(false);
   const search = writable<string>(getSearchParam(ViewerSearchParam.Search));
   setContext('listSearch', search);
-  $: updateSearchParam(ViewerSearchParam.Search, $search);
+  $: updateSearchParam(ViewerSearchParam.Search, $search, true);
 
+  //todo listen for changes to the url, for example when back/forward is pressed
   const selectedIndexExemplar = writable<string | undefined>(getSearchParam(ViewerSearchParam.IndexCharacter));
   setContext('selectedIndexExamplar', selectedIndexExemplar);
-  $: updateSearchParam(ViewerSearchParam.IndexCharacter, $selectedIndexExemplar);
+  $: updateSearchParam(ViewerSearchParam.IndexCharacter, $selectedIndexExemplar, false);
 
   const writingSystems = initWritingSystems(deriveAsync(connected, isConnected => {
     if (!isConnected) return Promise.resolve(null);
@@ -120,7 +121,7 @@
   const unsubSelectedEntry = selectedEntry.subscribe(updateEntryIdSearchParam);
   $: { pickedEntry; updateEntryIdSearchParam(); }
   function updateEntryIdSearchParam() {
-    updateSearchParam(ViewerSearchParam.EntryId, navigateToEntryIdOnLoad ?? (pickedEntry ? $selectedEntry?.id : undefined));
+    updateSearchParam(ViewerSearchParam.EntryId, navigateToEntryIdOnLoad ?? (pickedEntry ? $selectedEntry?.id : undefined), true);
   }
 
   $: {

--- a/frontend/viewer/src/lib/utils/search-params.ts
+++ b/frontend/viewer/src/lib/utils/search-params.ts
@@ -11,12 +11,13 @@ export function getSearchParam(param: ViewerSearchParam): string | undefined {
   return urlSearchParams.get(param) ?? undefined;
 }
 
-export function updateSearchParam(param: ViewerSearchParam, value: string | undefined) {
+export function updateSearchParam(param: ViewerSearchParam, value: string | undefined, replace: boolean) {
   const current = urlSearchParams.get(param) ?? undefined;
   if (current == value) return;
   if (value) urlSearchParams.set(param, value);
   else urlSearchParams.delete(param);
   let paramString = urlSearchParams.toString();
   if (paramString.length) paramString = `?${paramString}`;
-  window.history.pushState({}, '', `${window.location.pathname}${paramString}`);
+  if (replace) window.history.replaceState({}, '', `${window.location.pathname}${paramString}`);
+  else window.history.pushState({}, '', `${window.location.pathname}${paramString}`);
 }

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -9,8 +9,9 @@ import { sveltekit } from '@sveltejs/kit/vite';
 
 const inDocker = process.env['DockerDev'] === 'true';
 const exposeServer = false;
+const ssl = exposeServer && !inDocker;
 const lexboxServer: ProxyOptions = {
-  target: 'http://localhost:5158',
+  target: ssl ? 'https://localhost:7075' : 'http://localhost:5158',
   secure: false,
 };
 
@@ -31,7 +32,7 @@ export default defineConfig({
     codegen(gqlOptions),
     precompileIntl('src/lib/i18n/locales'),
     sveltekit(),
-    exposeServer ? basicSsl() : null, // crypto.subtle is only available on secure connections
+    ssl ? basicSsl() : null, // crypto.subtle is only available on secure connections
   ],
   optimizeDeps: {
   },


### PR DESCRIPTION
new home page
![image](https://github.com/user-attachments/assets/03922fe7-042a-4e64-8b46-ccefba761395)


As you can see there's now a list of servers to login to, this list is defined as a configuration value, so devs can add whatever servers they want, by default users will use lexbox.org, but they could override that if they wanted (todo on how exactly to implement that). Each of those servers we fetch a list of CRDT projects from, we then match that with the local project list (for now it's just name based, but we can match on project Id in the future). 

The big question is how to handle uploading new projects. Previously there was just one button and it would upload to the one server. Should we instead have the upload handled on the project page? then the user can pick the server to upload (unless there's only 1). The question then is how to handle creating that project server side. Should we do it for the user? should we only allow uploading to an empty project?