### PR TITLE
Chore/update dotnet deps sep 2024

### DIFF
--- a/backend/Directory.Build.props
+++ b/backend/Directory.Build.props
@@ -14,6 +14,6 @@
         <WarningsAsErrors>Nullable</WarningsAsErrors>
     </PropertyGroup>
     <ItemGroup>
-        <PackageReference Include="Microsoft.VisualStudio.Threading.Analyzers" Version="17.8.14" PrivateAssets="all"/>
+        <PackageReference Include="Microsoft.VisualStudio.Threading.Analyzers" Version="17.11.20" PrivateAssets="all"/>
     </ItemGroup>
 </Project>

--- a/backend/FwLite/FwDataMiniLcmBridge.Tests/FwDataMiniLcmBridge.Tests.csproj
+++ b/backend/FwLite/FwDataMiniLcmBridge.Tests/FwDataMiniLcmBridge.Tests.csproj
@@ -10,8 +10,11 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="coverlet.collector" Version="6.0.0"/>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0"/>
+        <PackageReference Include="coverlet.collector" Version="6.0.2">
+          <PrivateAssets>all</PrivateAssets>
+          <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+        </PackageReference>
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.0" />
         <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="8.0.0"/>
         <PackageReference Include="FluentAssertions" Version="6.12.0"/>
         <PackageReference Include="xunit" Version="2.5.3"/>

--- a/backend/FwLite/FwLiteProjectSync.Tests/FwLiteProjectSync.Tests.csproj
+++ b/backend/FwLite/FwLiteProjectSync.Tests/FwLiteProjectSync.Tests.csproj
@@ -10,8 +10,11 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="coverlet.collector" Version="6.0.0"/>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0"/>
+        <PackageReference Include="coverlet.collector" Version="6.0.2">
+          <PrivateAssets>all</PrivateAssets>
+          <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+        </PackageReference>
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.0" />
         <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="8.0.0"/>
         <PackageReference Include="FluentAssertions" Version="6.12.0"/>
         <PackageReference Include="Soenneker.Utils.AutoBogus" Version="2.1.278" />

--- a/backend/FwLite/LcmCrdt.Tests/LcmCrdt.Tests.csproj
+++ b/backend/FwLite/LcmCrdt.Tests/LcmCrdt.Tests.csproj
@@ -10,14 +10,16 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="coverlet.collector" Version="6.0.0"/>
+        <PackageReference Include="coverlet.collector" Version="6.0.2">
+          <PrivateAssets>all</PrivateAssets>
+          <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+        </PackageReference>
         <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="8.0.0" />
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0"/>
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.0" />
         <PackageReference Include="FluentAssertions" Version="6.12.0"/>
         <PackageReference Include="Soenneker.Utils.AutoBogus" Version="2.1.278" />
         <PackageReference Include="xunit" Version="2.5.3"/>
         <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3"/>
-        <PackageReference Include="XunitXml.TestLogger" Version="3.1.20" />
         <PackageReference Include="GitHubActionsTestLogger" Version="2.4.1">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/backend/FwLite/LocalWebApp/LocalWebApp.csproj
+++ b/backend/FwLite/LocalWebApp/LocalWebApp.csproj
@@ -18,13 +18,13 @@
     <ItemGroup>
         <PackageReference Include="Humanizer.Core" Version="2.14.1" />
         <PackageReference Include="icu.net" Version="2.10.1-beta.5" GeneratePathProperty="true" />
-        <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="8.0.4"/>
+        <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="8.0.8" />
         <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="8.0.8" />
-        <PackageReference Include="Microsoft.Extensions.FileProviders.Embedded" Version="8.0.4" />
-        <PackageReference Include="Microsoft.Identity.Client.Extensions.Msal" Version="4.63.0" />
-        <PackageReference Include="Refit" Version="7.0.0" />
-        <PackageReference Include="Refit.HttpClientFactory" Version="7.0.0" />
-        <PackageReference Include="Swashbuckle.AspNetCore" Version="6.4.0"/>
+        <PackageReference Include="Microsoft.Extensions.FileProviders.Embedded" Version="8.0.8" />
+        <PackageReference Include="Microsoft.Identity.Client.Extensions.Msal" Version="4.64.0" />
+        <PackageReference Include="Refit" Version="7.1.2" />
+        <PackageReference Include="Refit.HttpClientFactory" Version="7.1.2" />
+        <PackageReference Include="Swashbuckle.AspNetCore" Version="6.7.3" />
         <PackageReference Include="System.Reactive" Version="6.0.1" />
     </ItemGroup>
 

--- a/backend/FwLite/MiniLcm/MiniLcm.csproj
+++ b/backend/FwLite/MiniLcm/MiniLcm.csproj
@@ -8,7 +8,7 @@
 
     <ItemGroup>
       <PackageReference Include="System.Text.Json" Version="8.0.4" />
-      <PackageReference Include="SystemTextJsonPatch" Version="3.1.0" />
+      <PackageReference Include="SystemTextJsonPatch" Version="3.2.1" />
     </ItemGroup>
 
 </Project>

--- a/backend/LexBoxApi/GraphQL/ProjectMutations.cs
+++ b/backend/LexBoxApi/GraphQL/ProjectMutations.cs
@@ -283,7 +283,7 @@ public class ProjectMutations
         LexBoxDbContext dbContext)
     {
         await permissionService.AssertCanManageProject(input.ProjectId);
-        if (input.Name.IsNullOrEmpty()) throw new RequiredException("Project name cannot be empty");
+        if (string.IsNullOrEmpty(input.Name)) throw new RequiredException("Project name cannot be empty");
 
         var project = await dbContext.Projects.FindAsync(input.ProjectId);
         NotFoundException.ThrowIfNull(project);

--- a/backend/LexBoxApi/GraphQL/UserMutations.cs
+++ b/backend/LexBoxApi/GraphQL/UserMutations.cs
@@ -135,7 +135,7 @@ public class UserMutations
         var user = await dbContext.Users.FindAsync(input.UserId);
         NotFoundException.ThrowIfNull(user);
 
-        if (!input.Name.IsNullOrEmpty())
+        if (!string.IsNullOrEmpty(input.Name))
         {
             user.Name = input.Name;
         }
@@ -162,7 +162,7 @@ public class UserMutations
         }
         else if (input is ChangeUserAccountBySelfInput selfInput)
         {
-            if (!selfInput.Locale.IsNullOrEmpty())
+            if (!string.IsNullOrEmpty(selfInput.Locale))
             {
                 user.LocalizationCode = selfInput.Locale;
             }

--- a/backend/LexBoxApi/LexBoxApi.csproj
+++ b/backend/LexBoxApi/LexBoxApi.csproj
@@ -24,7 +24,7 @@
         <PackageReference Include="HotChocolate.Data.EntityFramework" Version="13.9.11" />
         <PackageReference Include="HotChocolate.Diagnostics" Version="13.9.11" />
         <PackageReference Include="Humanizer.Core" Version="2.14.1" />
-        <PackageReference Include="MailKit" Version="4.3.0" />
+        <PackageReference Include="MailKit" Version="4.7.1.1" />
         <PackageReference Include="Microsoft.AspNetCore.Authentication.Google" Version="8.0.8" />
         <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.8" />
         <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="8.0.8" />

--- a/backend/LexBoxApi/LexBoxApi.csproj
+++ b/backend/LexBoxApi/LexBoxApi.csproj
@@ -11,46 +11,46 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="AppAny.Quartz.EntityFrameworkCore.Migrations.PostgreSQL" Version="0.5.0" />
+        <PackageReference Include="AppAny.Quartz.EntityFrameworkCore.Migrations.PostgreSQL" Version="0.5.1" />
         <PackageReference Include="CrystalQuartz.AspNetCore" Version="7.2.0-beta" />
-        <PackageReference Include="DataAnnotatedModelValidations" Version="5.1.0" />
-        <PackageReference Include="HotChocolate.Analyzers" Version="13.8.1" />
-        <PackageReference Include="HotChocolate.Types.Analyzers" Version="13.8.1">
+        <PackageReference Include="DataAnnotatedModelValidations" Version="5.2.0" />
+        <PackageReference Include="HotChocolate.Analyzers" Version="13.9.11" />
+        <PackageReference Include="HotChocolate.Types.Analyzers" Version="13.9.11">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>
-        <PackageReference Include="HotChocolate.AspNetCore" Version="13.8.1" />
-        <PackageReference Include="HotChocolate.AspNetCore.Authorization" Version="13.8.1" />
-        <PackageReference Include="HotChocolate.Data.EntityFramework" Version="13.8.1" />
-        <PackageReference Include="HotChocolate.Diagnostics" Version="13.8.1" />
+        <PackageReference Include="HotChocolate.AspNetCore" Version="13.9.11" />
+        <PackageReference Include="HotChocolate.AspNetCore.Authorization" Version="13.9.11" />
+        <PackageReference Include="HotChocolate.Data.EntityFramework" Version="13.9.11" />
+        <PackageReference Include="HotChocolate.Diagnostics" Version="13.9.11" />
         <PackageReference Include="Humanizer.Core" Version="2.14.1" />
         <PackageReference Include="MailKit" Version="4.3.0" />
-        <PackageReference Include="Microsoft.AspNetCore.Authentication.Google" Version="8.0.2" />
-        <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.2" />
-        <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="8.0.2" />
-        <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.2">
+        <PackageReference Include="Microsoft.AspNetCore.Authentication.Google" Version="8.0.8" />
+        <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.8" />
+        <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="8.0.8" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.8">
           <PrivateAssets>all</PrivateAssets>
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="Microsoft.IdentityModel.Protocols.OpenIdConnect" Version="7.5.2" />
+        <PackageReference Include="Microsoft.IdentityModel.Protocols.OpenIdConnect" Version="8.0.2" />
         <PackageReference Include="Nito.AsyncEx.Coordination" Version="5.1.2" />
         <PackageReference Include="Npgsql.OpenTelemetry" Version="8.0.3" />
-        <PackageReference Include="OpenIddict.AspNetCore" Version="5.6.0" />
-        <PackageReference Include="OpenIddict.EntityFrameworkCore" Version="5.6.0" />
-        <PackageReference Include="OpenIddict.Quartz" Version="5.6.0" />
-        <PackageReference Include="OpenTelemetry.Exporter.Console" Version="1.8.1" />
-        <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.8.1" />
-        <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.8.1" />
-        <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.8.1" />
+        <PackageReference Include="OpenIddict.AspNetCore" Version="5.8.0" />
+        <PackageReference Include="OpenIddict.EntityFrameworkCore" Version="5.8.0" />
+        <PackageReference Include="OpenIddict.Quartz" Version="5.8.0" />
+        <PackageReference Include="OpenTelemetry.Exporter.Console" Version="1.9.0" />
+        <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.9.0" />
+        <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.9.0" />
+        <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.9.0" />
         <PackageReference Include="OpenTelemetry.Instrumentation.EntityFrameworkCore" Version="1.0.0-beta.8" />
-        <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.8.1" />
+        <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.9.0" />
         <PackageReference Include="OpenTelemetry.Instrumentation.Process" Version="0.5.0-beta.3" />
         <PackageReference Include="OpenTelemetry.Instrumentation.Quartz" Version="1.0.0-beta.1" />
-        <PackageReference Include="OpenTelemetry.Instrumentation.Runtime" Version="1.8.0" />
-        <PackageReference Include="Quartz.AspNetCore" Version="3.8.0" />
-        <PackageReference Include="Quartz.Serialization.Json" Version="3.8.0" />
-        <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
-        <PackageReference Include="tusdotnet" Version="2.7.2" />
+        <PackageReference Include="OpenTelemetry.Instrumentation.Runtime" Version="1.9.0" />
+        <PackageReference Include="Quartz.AspNetCore" Version="3.13.0" />
+        <PackageReference Include="Quartz.Serialization.SystemTextJson" Version="3.13.0" />
+        <PackageReference Include="Swashbuckle.AspNetCore" Version="6.7.3" />
+        <PackageReference Include="tusdotnet" Version="2.8.0" />
         <PackageReference Include="zxcvbn-core" Version="7.0.92" />
     </ItemGroup>
 

--- a/backend/LexBoxApi/Otel/OtelKernel.cs
+++ b/backend/LexBoxApi/Otel/OtelKernel.cs
@@ -29,7 +29,7 @@ public static class OtelKernel
                 {
                     configuration.Bind("Otel", options);
                 })
-                .AddSource(ServiceName)
+                .AddSource(ServiceName, MailKit.Telemetry.SmtpClient.ActivitySourceName)
                 .AddProcessor<UserEnricher>()
                 .SetResourceBuilder(appResourceBuilder)
                 // could potentially add baggage to the trace as done in

--- a/backend/LexBoxApi/ScheduledTasksKernel.cs
+++ b/backend/LexBoxApi/ScheduledTasksKernel.cs
@@ -25,7 +25,7 @@ public static class ScheduledTasksKernel
             q.UsePersistentStore(options =>
             {
                 options.UseProperties = true;
-                options.UseNewtonsoftJsonSerializer();
+                options.UseSystemTextJsonSerializer();
                 var connectionString = configuration.GetSection(nameof(DbConfig))
                     .GetValue<string>(nameof(DbConfig.LexBoxConnectionString));
                 ArgumentNullException.ThrowIfNull(connectionString);

--- a/backend/LexBoxApi/Services/TurnstileService.cs
+++ b/backend/LexBoxApi/Services/TurnstileService.cs
@@ -13,7 +13,7 @@ public class TurnstileService(IHttpClientFactory httpClientFactory, IOptionsSnap
         if (email is not null)
         {
             var allowDomain = options.Value.AllowDomain;
-            if (!allowDomain.IsNullOrEmpty() && email.EndsWith($"@{allowDomain}"))
+            if (!string.IsNullOrEmpty(allowDomain) && email.EndsWith($"@{allowDomain}"))
             {
                 return true;
             }

--- a/backend/LexData/LexData.csproj
+++ b/backend/LexData/LexData.csproj
@@ -10,18 +10,18 @@
     <ItemGroup>
       <PackageReference Include="EntityFrameworkCore.Projectables" Version="3.0.4" />
       <PackageReference Include="Humanizer.Core" Version="2.14.1" />
-      <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.5">
+      <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.8">
         <PrivateAssets>all</PrivateAssets>
         <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       </PackageReference>
       <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0" />
-      <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore" Version="8.0.5" />
+      <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore" Version="8.0.8" />
       <PackageReference Include="Microsoft.Extensions.Hosting" Version="8.0.0" />
       <PackageReference Include="Microsoft.Extensions.Options" Version="8.0.2" />
       <PackageReference Include="Microsoft.Extensions.Options.DataAnnotations" Version="8.0.0" />
       <PackageReference Include="Npgsql" Version="8.0.3" />
       <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="8.0.4" />
-      <PackageReference Include="OpenIddict.EntityFrameworkCore" Version="5.6.0" />
+      <PackageReference Include="OpenIddict.EntityFrameworkCore" Version="5.8.0" />
 </ItemGroup>
 
     <ItemGroup>

--- a/backend/LfClassicData/LfClassicData.csproj
+++ b/backend/LfClassicData/LfClassicData.csproj
@@ -8,11 +8,11 @@
 
     <ItemGroup>
         <FrameworkReference Include="Microsoft.AspNetCore.App"/>
-        <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="8.0.1"/>
+        <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="8.0.2" />
         <PackageReference Include="Microsoft.Extensions.Options" Version="8.0.2"/>
-        <PackageReference Include="MongoDB.Analyzer" Version="1.3.0"/>
-        <PackageReference Include="MongoDB.Driver" Version="2.24.0"/>
-        <PackageReference Include="MongoDB.Driver.Core.Extensions.DiagnosticSources" Version="1.4.0" />
+        <PackageReference Include="MongoDB.Analyzer" Version="1.5.0" />
+        <PackageReference Include="MongoDB.Driver" Version="2.28.0" />
+        <PackageReference Include="MongoDB.Driver.Core.Extensions.DiagnosticSources" Version="1.5.0" />
         <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     </ItemGroup>
 

--- a/backend/SyncReverseProxy/SyncReverseProxy.csproj
+++ b/backend/SyncReverseProxy/SyncReverseProxy.csproj
@@ -10,17 +10,17 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="8.0.1" />
+        <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="8.0.8" />
         <PackageReference Include="Microsoft.Extensions.Options" Version="8.0.1" />
-        <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
-        <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="7.3.0" />
+        <PackageReference Include="Swashbuckle.AspNetCore" Version="6.7.3" />
+        <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="8.0.2" />
         <PackageReference Include="Yarp.ReverseProxy" Version="2.1.0" />
 
-        <PackageReference Include="OpenTelemetry.Exporter.Console" Version="1.8.1" />
-        <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.8.1" />
-        <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.8.1" />
-        <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.8.1" />
-        <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.8.1" />
+        <PackageReference Include="OpenTelemetry.Exporter.Console" Version="1.9.0" />
+        <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.9.0" />
+        <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.9.0" />
+        <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.9.0" />
+        <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.9.0" />
         <PackageReference Include="Yarp.Telemetry.Consumption" Version="2.1.0" />
 
     </ItemGroup>

--- a/backend/Testing/Testing.csproj
+++ b/backend/Testing/Testing.csproj
@@ -16,7 +16,7 @@
         <When Condition=" '$(MercurialVersion)' == '6' ">
             <ItemGroup>
                 <PackageReference Include="SIL.Chorus.LibChorus" Version="6.0.0-beta0049" />
-                <PackageReference Include="SIL.Chorus.Mercurial" Version="6.*" />
+                <PackageReference Include="SIL.Chorus.Mercurial" Version="6.5.1.36" />
             </ItemGroup>
         </When>
         <Otherwise>
@@ -31,9 +31,7 @@
         <PackageReference Include="Microsoft.Extensions.Configuration" Version="8.0.0" />
         <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0" />
         <PackageReference Include="Microsoft.Extensions.Options" Version="8.0.2" />
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
-        <PackageReference Include="Microsoft.Playwright" Version="1.41.2" />
-        <PackageReference Include="Microsoft.Playwright.TestAdapter" Version="1.41.2" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.0" />
         <PackageReference Include="Moq" Version="4.20.70" />
         <PackageReference Include="Moq.Contrib.HttpClient" Version="1.4.0" />
         <PackageReference Include="Shouldly" Version="4.2.1" />
@@ -44,7 +42,7 @@
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>
-        <PackageReference Include="coverlet.collector" Version="6.0.0">
+        <PackageReference Include="coverlet.collector" Version="6.0.2">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>


### PR DESCRIPTION
upgrade dotnet dependencies. This includes some upgrades that were enabled by new package versions:

- use system.text.json for quartz serialization instead of Newtonsoft.
- add Mailkit smtp OTEL trace source