### PR TITLE
Fix compiler warning about no await operators

### DIFF
--- a/backend/FwLite/FwDataMiniLcmBridge.Tests/PartOfSpeechTests.cs
+++ b/backend/FwLite/FwDataMiniLcmBridge.Tests/PartOfSpeechTests.cs
@@ -38,9 +38,10 @@ public class PartOfSpeechTests(ProjectLoaderFixture fixture) : IAsyncLifetime
         }});
     }
 
-    public async Task DisposeAsync()
+    public Task DisposeAsync()
     {
         _api.Dispose();
+        return Task.CompletedTask;
     }
 
     [Fact]

--- a/backend/FwLite/FwDataMiniLcmBridge.Tests/SemanticDomainTests.cs
+++ b/backend/FwLite/FwDataMiniLcmBridge.Tests/SemanticDomainTests.cs
@@ -34,9 +34,10 @@ public class SemanticDomainTests(ProjectLoaderFixture fixture) : IAsyncLifetime
         });
     }
 
-    public async Task DisposeAsync()
+    public Task DisposeAsync()
     {
         _api.Dispose();
+        return Task.CompletedTask;
     }
 
     [Fact]

--- a/backend/FwLite/FwDataMiniLcmBridge.Tests/WritingSystemTests.cs
+++ b/backend/FwLite/FwDataMiniLcmBridge.Tests/WritingSystemTests.cs
@@ -25,9 +25,10 @@ public class WritingSystemTests(ProjectLoaderFixture fixture) : IAsyncLifetime
         });
     }
 
-    public async Task DisposeAsync()
+    public Task DisposeAsync()
     {
         _api.Dispose();
+        return Task.CompletedTask;
     }
 
     [Fact]


### PR DESCRIPTION
Fix #1042.

This PR fixes the compiler warning "This async method lacks 'await' operators and will run synchronously" by changing the `foreach (var foo in SomeEnumerable) yield return new Foo { ... }` code to use LINQ instead, i.e. `SomeEnumerable.ToAsyncEnumerable().Select(foo => new Foo { ... }`.
