### PR TITLE
Remove circular module dependency

### DIFF
--- a/frontend/src/lib/forms/superforms.ts
+++ b/frontend/src/lib/forms/superforms.ts
@@ -5,7 +5,8 @@ import type { SuperValidated, ZodValidation } from 'sveltekit-superforms';
 import { superValidateSync } from 'sveltekit-superforms/client';
 import type { AnyZodObject, z } from 'zod';
 import type { ErrorMessage } from './types';
-import { randomFormId } from '.';
+import { randomFormId } from './utils';
+// NOTE: Don't import randomFormId from '.' as that creates a circular module dependency in any component that imports lexSuperForm
 
 export type LexFormState<S extends ZodValidation<AnyZodObject>> = Required<{ [field in (keyof z.infer<S>)]: {
   tainted: boolean; // has ever been touched/edited

--- a/frontend/src/lib/forms/superforms.ts
+++ b/frontend/src/lib/forms/superforms.ts
@@ -6,7 +6,6 @@ import { superValidateSync } from 'sveltekit-superforms/client';
 import type { AnyZodObject, z } from 'zod';
 import type { ErrorMessage } from './types';
 import { randomFormId } from './utils';
-// NOTE: Don't import randomFormId from '.' as that creates a circular module dependency in any component that imports lexSuperForm
 
 export type LexFormState<S extends ZodValidation<AnyZodObject>> = Required<{ [field in (keyof z.infer<S>)]: {
   tainted: boolean; // has ever been touched/edited


### PR DESCRIPTION
Fix #814.

The build warnings ultimately came from the fact that `$lib/forms/superforms.ts` imports a single function from `.` (which in context is `$lib/forms/index.ts`), while at the same time `$lib/forms/index.ts` is importing and re-exporting everything, including the `lexSuperForm` function that's used all over our Svelte components.

There were three possible solutions:

1. Configure Rollup (via vite.config.ts) to use the `manualChunks` option, requiring us to make decisions about what goes in every chunk. Not worth the cost and effort at this point.
2. Change every place that imports `lexSuperForm` to import it from `$lib/forms/superforms` instead of from `$lib/forms`. This would have touched about a dozen files.
3. Change one single import in `$lib/forms/superforms.ts` to import from `./utils` instead of from `.`, thereby eliminating the circular import situation. This touches only a single line in a single file, but it eliminates the issue.

Obviously, I went with option 3.