### PR TITLE
implement project reset cleanup

### DIFF
--- a/backend/LexBoxApi/Controllers/TestingController.cs
+++ b/backend/LexBoxApi/Controllers/TestingController.cs
@@ -3,6 +3,7 @@ using LexBoxApi.Auth.Attributes;
 using LexBoxApi.Services;
 using LexCore.Auth;
 using LexCore.Exceptions;
+using LexCore.ServiceInterfaces;
 using LexData;
 using LexData.Entities;
 using Microsoft.AspNetCore.Authorization;
@@ -16,6 +17,7 @@ namespace LexBoxApi.Controllers;
 public class TestingController(
     LexAuthService lexAuthService,
     LexBoxDbContext lexBoxDbContext,
+    IHgService hgService,
     SeedingData seedingData)
     : ControllerBase
 {
@@ -84,4 +86,11 @@ public class TestingController(
     [AllowAnonymous]
     [ProducesResponseType(StatusCodes.Status500InternalServerError)]
     public ActionResult Test500NoError() => StatusCode(500);
+
+    [HttpGet("test-cleanup-reset-backups")]
+    [AdminRequired]
+    public async Task<string[]> TestCleanupResetBackups(bool dryRun = true)
+    {
+        return await hgService.CleanupResetBackups(dryRun);
+    }
 }

--- a/backend/LexBoxApi/Jobs/CleanupResetBackupJob.cs
+++ b/backend/LexBoxApi/Jobs/CleanupResetBackupJob.cs
@@ -12,8 +12,7 @@ public class CleanupResetBackupJob(IHgService hgService, ILogger<CleanupResetBac
     {
         logger.LogInformation("Starting cleanup reset backup job");
 
-        //todo implement job
-        await Task.Delay(TimeSpan.FromSeconds(1));
+        await hgService.CleanupResetBackups();
 
         logger.LogInformation("Finished cleanup reset backup job");
     }

--- a/backend/LexCore/Config/HgConfig.cs
+++ b/backend/LexCore/Config/HgConfig.cs
@@ -17,4 +17,5 @@ public class HgConfig
     public required string HgResumableUrl { get; init; }
     public bool AutoUpdateLexEntryCountOnSendReceive { get; init; } = false;
     public bool RequireContainerVersionMatch { get; init; } = true;
+    public int ResetCleanupAgeDays { get; init; } = 31;
 }

--- a/backend/LexCore/ServiceInterfaces/IHgService.cs
+++ b/backend/LexCore/ServiceInterfaces/IHgService.cs
@@ -24,4 +24,6 @@ public interface IHgService
     Task<HttpContent> InvalidateDirCache(ProjectCode code, CancellationToken token = default);
     bool HasAbandonedTransactions(ProjectCode projectCode);
     Task<string> HgCommandHealth();
+
+    Task<string[]> CleanupResetBackups(bool dryRun = false);
 }

--- a/backend/LexCore/Utils/FileUtils.cs
+++ b/backend/LexCore/Utils/FileUtils.cs
@@ -10,7 +10,7 @@ public static class FileUtils
     {
         var timestamp = dateTime.ToUniversalTime().ToString(TimestampPattern);
         // make it file-system friendly
-        return timestamp.Replace(':', '-');
+        return timestamp;
     }
 
     public static DateTimeOffset? ToDateTimeOffset(string timestamp)

--- a/backend/LexCore/Utils/FileUtils.cs
+++ b/backend/LexCore/Utils/FileUtils.cs
@@ -5,11 +5,22 @@ namespace LexCore.Utils;
 
 public static class FileUtils
 {
+    private static readonly string TimestampPattern = DateTimeFormatInfo.InvariantInfo.SortableDateTimePattern.Replace(':', '-');
     public static string ToTimestamp(DateTimeOffset dateTime)
     {
-        var timestamp = dateTime.ToString(DateTimeFormatInfo.InvariantInfo.SortableDateTimePattern);
+        var timestamp = dateTime.ToUniversalTime().ToString(TimestampPattern);
         // make it file-system friendly
         return timestamp.Replace(':', '-');
+    }
+
+    public static DateTimeOffset? ToDateTimeOffset(string timestamp)
+    {
+        if (DateTimeOffset.TryParseExact(timestamp, TimestampPattern, null, DateTimeStyles.AssumeUniversal, out var dateTime))
+        {
+            return dateTime;
+        }
+
+        return null;
     }
 
     public static void CopyFilesRecursively(DirectoryInfo source, DirectoryInfo target, UnixFileMode? permissions = null)

--- a/backend/Testing/Services/CleanupResetProjectsTests.cs
+++ b/backend/Testing/Services/CleanupResetProjectsTests.cs
@@ -1,0 +1,53 @@
+﻿using LexBoxApi.Services;
+using LexCore.Utils;
+using Shouldly;
+
+namespace Testing.Services;
+
+public class CleanupResetProjectsTests
+{
+    [Fact]
+    public void ResetRegexCanFindTimestampFromResetRepoName()
+    {
+        var date = DateTimeOffset.UtcNow;
+        var repoName = HgService.DeletedRepoName("test", HgService.ResetSoftDeleteSuffix(date));
+        var match = HgService.ResetProjectsRegex().Match(repoName);
+        match.Success.ShouldBeTrue();
+        match.Groups[1].Value.ShouldBe(FileUtils.ToTimestamp(date));
+    }
+
+    [Fact]
+    public void CanGetDateFromResetRepoName()
+    {
+        var expected = DateTimeOffset.Now;
+        var repoName = HgService.DeletedRepoName("test", HgService.ResetSoftDeleteSuffix(expected));
+        var actual = HgService.GetResetDate(repoName);
+        actual.ShouldNotBeNull();
+        TruncateToMinutes(actual.Value).ShouldBe(TruncateToMinutes(expected));
+    }
+
+    private DateTimeOffset TruncateToMinutes(DateTimeOffset date)
+    {
+        return new DateTimeOffset(date.Year, date.Month, date.Day, date.Hour, date.Minute, 0, date.Offset);
+    }
+
+    [Theory]
+    [InlineData("grobish-test-flex__2023-11-29T16-52-38__reset", "2023-11-29T16-52-38")]
+    public void ResetRegexCanFindTimestamp(string repoName, string timestamp)
+    {
+        var match = HgService.ResetProjectsRegex().Match(repoName);
+        match.Success.ShouldBeTrue();
+        match.Groups[1].Value.ShouldBe(timestamp);
+    }
+
+    [Theory]
+    [InlineData("grobish-test-flex__2023-11-29T16-52-38")]
+    //even if the code has a pattern that would match the reset with timestamp it mush be at the end
+    [InlineData("code-with-bad-name-2023-11-29T16-52-38__reset__2023-11-29T16-52-38")]
+    public void ResetRegexDoesNotMatchNonResets(string repoName)
+    {
+        var match = HgService.ResetProjectsRegex().Match(repoName);
+        match.Success.ShouldBeFalse();
+    }
+
+}


### PR DESCRIPTION
closes #663

this works by parsing the folder names in the deleted folder and pulling out the timestamp. If it can't get a time stamp it does nothing, if it can then it will make sure the project was reset greater than the cleanup threshold (default 31 days).

Right now this only cleans up reset project backups. Should we also include normal deleted projects and do they need a different threshold?