### PR TITLE
Detect and restart stuck hgresume containers

### DIFF
--- a/deployment/base/hg-deployment.yaml
+++ b/deployment/base/hg-deployment.yaml
@@ -149,6 +149,14 @@ spec:
         ports:
           - containerPort: 80
 
+        livenessProbe:
+          httpGet:
+            path: /api/v03/isAvailable
+            port: 80
+          failureThreshold: 5
+          periodSeconds: 120
+          initialDelaySeconds: 300
+
         volumeMounts:
         - name: cache
           mountPath: /var/cache/hgresume


### PR DESCRIPTION
Fix #1064.

Some testing needed; for example, we don't know if a container whose CPU is pegged at 100% will still manage to respond to the `/api/v03/isAvailable` request (which simply looks for the existence of one file on disk) quickly enough to look like the container is "alive". But this is a good start.