### PR TITLE
Don't throw NullReferenceException when inviting guest users to project

### DIFF
--- a/backend/LexBoxApi/Services/EmailService.cs
+++ b/backend/LexBoxApi/Services/EmailService.cs
@@ -217,7 +217,8 @@ public class EmailService(
     }
     public async Task SendUserAddedEmail(User user, string projectName, string projectCode)
     {
-        var email = StartUserEmail(user) ?? throw new ArgumentNullException("emailAddress");
+        var email = StartUserEmail(user);
+        if (email is null) return; // Guest users have no email address, so we won't notify them by email and that's not an error
         await RenderEmail(email, new UserAddedEmail(user.Name, user.Email!, projectName, projectCode), user.LocalizationCode);
         await SendEmailWithRetriesAsync(email);
     }


### PR DESCRIPTION
Fix #1044.

Guest users don't have email addresses, but they can be invited to projects. So when sending the "You've been invited to project X" email, if the user doesn't have an email address, that's not an error that should cause an exception to be thrown. It just means that that user is a guest user without an email, so we should just skip emailing them.

