### PR TITLE
Get FLEx model version from repo and store in metadata

### DIFF
--- a/backend/LexBoxApi/GraphQL/ProjectMutations.cs
+++ b/backend/LexBoxApi/GraphQL/ProjectMutations.cs
@@ -413,6 +413,25 @@ public class ProjectMutations
     }
 
     [Error<NotFoundException>]
+    [Error<DbError>]
+    [Error<UnauthorizedAccessException>]
+    [UseMutationConvention]
+    [UseFirstOrDefault]
+    [UseProjection]
+    public async Task<IQueryable<Project>> UpdateFLExModelVersion(string code,
+        IPermissionService permissionService,
+        [Service] ProjectService projectService,
+        LexBoxDbContext dbContext)
+    {
+        var projectId = await projectService.LookupProjectId(code);
+        await permissionService.AssertCanManageProject(projectId);
+        var project = await dbContext.Projects.FindAsync(projectId);
+        NotFoundException.ThrowIfNull(project);
+        await projectService.UpdateFLExModelVersion(projectId);
+        return dbContext.Projects.Where(p => p.Id == projectId);
+    }
+
+    [Error<NotFoundException>]
     [Error<LastMemberCantLeaveException>]
     [UseMutationConvention]
     [RefreshJwt]

--- a/backend/LexBoxApi/GraphQL/ProjectMutations.cs
+++ b/backend/LexBoxApi/GraphQL/ProjectMutations.cs
@@ -425,8 +425,6 @@ public class ProjectMutations
     {
         var projectId = await projectService.LookupProjectId(code);
         await permissionService.AssertCanManageProject(projectId);
-        var project = await dbContext.Projects.FindAsync(projectId);
-        NotFoundException.ThrowIfNull(project);
         await projectService.UpdateFLExModelVersion(projectId);
         return dbContext.Projects.Where(p => p.Id == projectId);
     }

--- a/backend/LexBoxApi/Services/HgService.cs
+++ b/backend/LexBoxApi/Services/HgService.cs
@@ -271,16 +271,8 @@ public partial class HgService : IHgService, IHostedService
     {
         var result = await ExecuteHgCommandServerCommand(code, "flexmodelversion", token);
         var text = await result.ReadAsStringAsync(token);
-        try
-        {
-            var json = JsonDocument.Parse(text);
-            return json.RootElement.GetProperty("modelversion").GetInt32();
-        }
-        catch
-        {
-            if (int.TryParse(text, out var num)) return num;
-        }
-        return null;
+        var json = JsonDocument.Parse(text);
+        return json.RootElement.GetProperty("modelversion").GetInt32();
     }
 
     public Task RevertRepo(ProjectCode code, string revHash)

--- a/backend/LexBoxApi/Services/HgService.cs
+++ b/backend/LexBoxApi/Services/HgService.cs
@@ -267,6 +267,22 @@ public partial class HgService : IHgService, IHostedService
         return null;
     }
 
+    public async Task<int?> GetModelVersionOfFlexProject(ProjectCode code, CancellationToken token = default)
+    {
+        var result = await ExecuteHgCommandServerCommand(code, "flexmodelversion", token);
+        var text = await result.ReadAsStringAsync(token);
+        try
+        {
+            var json = JsonDocument.Parse(text);
+            return json.RootElement.GetProperty("modelversion").GetInt32();
+        }
+        catch
+        {
+            if (int.TryParse(text, out var num)) return num;
+        }
+        return null;
+    }
+
     public Task RevertRepo(ProjectCode code, string revHash)
     {
         throw new NotImplementedException();

--- a/backend/LexBoxApi/Services/ProjectService.cs
+++ b/backend/LexBoxApi/Services/ProjectService.cs
@@ -81,6 +81,18 @@ public class ProjectService(LexBoxDbContext dbContext, IHgService hgService, IOp
         await dbContext.SaveChangesAsync();
     }
 
+    public async Task UpdateFLExModelVersion(Guid projectId)
+    {
+        var project = await dbContext.Projects.FindAsync(projectId);
+        if (project is null || project.Type != ProjectType.FLEx) return;
+        await dbContext.Entry(project).Reference(p => p.FlexProjectMetadata).LoadAsync();
+        var modelVersion = await hgService.GetModelVersionOfFlexProject(project.Code);
+        if (modelVersion is null) return;
+        project.FlexProjectMetadata ??= new FlexProjectMetadata();
+        project.FlexProjectMetadata.FlexModelVersion = modelVersion;
+        await dbContext.SaveChangesAsync();
+    }
+
     public async Task<Guid> CreateDraftProject(CreateProjectInput input)
     {
         // No need for a transaction if we're just saving a single item

--- a/backend/LexCore/Entities/FlexProjectMetadata.cs
+++ b/backend/LexCore/Entities/FlexProjectMetadata.cs
@@ -10,6 +10,7 @@ public class FlexProjectMetadata
     /// </summary>
     public Guid? LangProjectId { get; set; }
     public ProjectWritingSystems? WritingSystems { get; set; }
+    public int? FlexModelVersion { get; set; }
 }
 
 public class ProjectWritingSystems

--- a/backend/LexCore/ServiceInterfaces/IHgService.cs
+++ b/backend/LexCore/ServiceInterfaces/IHgService.cs
@@ -13,6 +13,7 @@ public interface IHgService
     Task SoftDeleteRepo(ProjectCode code, string deletedRepoSuffix);
     Task<ProjectWritingSystems?> GetProjectWritingSystems(ProjectCode code, CancellationToken token = default);
     Task<Guid?> GetProjectIdOfFlexProject(ProjectCode code, CancellationToken token = default);
+    Task<int?> GetModelVersionOfFlexProject(ProjectCode code, CancellationToken token = default);
     BackupExecutor? BackupRepo(ProjectCode code);
     Task ResetRepo(ProjectCode code);
     Task FinishReset(ProjectCode code, Stream zipFile);

--- a/backend/LexData/Migrations/20240926093530_AddModelVersionToFlexMetadata.Designer.cs
+++ b/backend/LexData/Migrations/20240926093530_AddModelVersionToFlexMetadata.Designer.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using LexData;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -12,9 +13,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace LexData.Migrations
 {
     [DbContext(typeof(LexBoxDbContext))]
-    partial class LexBoxDbContextModelSnapshot : ModelSnapshot
+    [Migration("20240926093530_AddModelVersionToFlexMetadata")]
+    partial class AddModelVersionToFlexMetadata
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/backend/LexData/Migrations/20240926093530_AddModelVersionToFlexMetadata.cs
+++ b/backend/LexData/Migrations/20240926093530_AddModelVersionToFlexMetadata.cs
@@ -1,0 +1,28 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace LexData.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddModelVersionToFlexMetadata : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<int>(
+                name: "FlexModelVersion",
+                table: "FlexProjectMetadata",
+                type: "integer",
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "FlexModelVersion",
+                table: "FlexProjectMetadata");
+        }
+    }
+}

--- a/frontend/schema.graphql
+++ b/frontend/schema.graphql
@@ -1,4 +1,4 @@
-﻿schema {
+schema {
   query: Query
   mutation: Mutation
 }
@@ -179,6 +179,7 @@ type FlexProjectMetadata {
   lexEntryCount: Int
   langProjectId: UUID
   writingSystems: ProjectWritingSystems
+  flexModelVersion: Int
 }
 
 type InvalidEmailError implements Error {
@@ -246,6 +247,7 @@ type Mutation {
   updateProjectLexEntryCount(input: UpdateProjectLexEntryCountInput!): UpdateProjectLexEntryCountPayload!
   updateProjectLanguageList(input: UpdateProjectLanguageListInput!): UpdateProjectLanguageListPayload!
   updateLangProjectId(input: UpdateLangProjectIdInput!): UpdateLangProjectIdPayload!
+  updateFLExModelVersion(input: UpdateFLExModelVersionInput!): UpdateFLExModelVersionPayload!
   leaveProject(input: LeaveProjectInput!): LeaveProjectPayload!
   removeProjectMember(input: RemoveProjectMemberInput!): RemoveProjectMemberPayload!
   deleteDraftProject(input: DeleteDraftProjectInput!): DeleteDraftProjectPayload! @authorize(policy: "AdminRequiredPolicy")
@@ -478,6 +480,11 @@ type UniqueValueError implements Error {
   message: String!
 }
 
+type UpdateFLExModelVersionPayload {
+  project: Project
+  errors: [UpdateFLExModelVersionError!]
+}
+
 type UpdateLangProjectIdPayload {
   project: Project
   errors: [UpdateLangProjectIdError!]
@@ -587,6 +594,8 @@ union SetRetentionPolicyError = NotFoundError | DbError
 union SetUserLockedError = NotFoundError
 
 union SoftDeleteProjectError = NotFoundError | DbError
+
+union UpdateFLExModelVersionError = NotFoundError | DbError | UnauthorizedAccessError
 
 union UpdateLangProjectIdError = NotFoundError | DbError | UnauthorizedAccessError
 
@@ -769,12 +778,14 @@ input FlexProjectMetadataFilterInput {
   lexEntryCount: IntOperationFilterInput
   langProjectId: UuidOperationFilterInput
   writingSystems: ProjectWritingSystemsFilterInput
+  flexModelVersion: IntOperationFilterInput
 }
 
 input FlexProjectMetadataSortInput {
   projectId: SortEnumType
   lexEntryCount: SortEnumType
   langProjectId: SortEnumType
+  flexModelVersion: SortEnumType
 }
 
 input IntOperationFilterInput {
@@ -1039,6 +1050,10 @@ input StringOperationFilterInput {
   nendsWith: String
   icontains: String
   ieq: String
+}
+
+input UpdateFLExModelVersionInput {
+  code: String!
 }
 
 input UpdateLangProjectIdInput {

--- a/frontend/src/lib/components/Projects/FlexModelVersionText.svelte
+++ b/frontend/src/lib/components/Projects/FlexModelVersionText.svelte
@@ -28,4 +28,4 @@
   $: fwModel = versionLookupTable[modelVersion] ?? 'Unknown FieldWorks version';
 </script>
 
-<span class={extraClass}>{fwModel}</span>
+<span title="FLEx data model {modelVersion}" class={extraClass}>{fwModel}</span>

--- a/frontend/src/lib/components/Projects/FlexModelVersionText.svelte
+++ b/frontend/src/lib/components/Projects/FlexModelVersionText.svelte
@@ -1,0 +1,31 @@
+<script context="module" lang="ts">
+  import { NULL_LABEL } from '$lib/i18n';
+
+  const versionLookupTable: Record<number, string> = {
+    0: NULL_LABEL,
+    7000058: "FieldWorks 7.2",
+    7000059: "FieldWorks 7.2",
+    7000060: "FieldWorks 7.2",
+    7000061: "FieldWorks 7.2",
+    7000062: "FieldWorks 7.3",
+    7000063: "FieldWorks 7.3",
+    7000064: "FieldWorks 7.3",
+    7000065: "FieldWorks 7.3",
+    7000066: "FieldWorks 8.0",
+    7000067: "FieldWorks 8.0",
+    7000068: "FieldWorks 8.0-8.2",
+    7000069: "FieldWorks 8.2",
+    7000070: "FieldWorks 8.3",
+    7000071: "FieldWorks 8.3",
+    7000072: "FieldWorks 9",
+  }
+</script>
+
+<script lang="ts">
+
+  export let modelVersion: number;
+  export let extraClass = "";
+  $: fwModel = versionLookupTable[modelVersion] ?? "Unknown FieldWorks version";
+</script>
+
+<span class={extraClass}>{fwModel}</span>

--- a/frontend/src/lib/components/Projects/FlexModelVersionText.svelte
+++ b/frontend/src/lib/components/Projects/FlexModelVersionText.svelte
@@ -3,29 +3,29 @@
 
   const versionLookupTable: Record<number, string> = {
     0: NULL_LABEL,
-    7000058: "FieldWorks 7.2",
-    7000059: "FieldWorks 7.2",
-    7000060: "FieldWorks 7.2",
-    7000061: "FieldWorks 7.2",
-    7000062: "FieldWorks 7.3",
-    7000063: "FieldWorks 7.3",
-    7000064: "FieldWorks 7.3",
-    7000065: "FieldWorks 7.3",
-    7000066: "FieldWorks 8.0",
-    7000067: "FieldWorks 8.0",
-    7000068: "FieldWorks 8.0-8.2",
-    7000069: "FieldWorks 8.2",
-    7000070: "FieldWorks 8.3",
-    7000071: "FieldWorks 8.3",
-    7000072: "FieldWorks 9",
+    7000058: 'FieldWorks 7.2',
+    7000059: 'FieldWorks 7.2',
+    7000060: 'FieldWorks 7.2',
+    7000061: 'FieldWorks 7.2',
+    7000062: 'FieldWorks 7.3',
+    7000063: 'FieldWorks 7.3',
+    7000064: 'FieldWorks 7.3',
+    7000065: 'FieldWorks 7.3',
+    7000066: 'FieldWorks 8.0',
+    7000067: 'FieldWorks 8.0',
+    7000068: 'FieldWorks 8.0-8.2',
+    7000069: 'FieldWorks 8.2',
+    7000070: 'FieldWorks 8.3',
+    7000071: 'FieldWorks 8.3',
+    7000072: 'FieldWorks 9',
   }
 </script>
 
 <script lang="ts">
 
   export let modelVersion: number;
-  export let extraClass = "";
-  $: fwModel = versionLookupTable[modelVersion] ?? "Unknown FieldWorks version";
+  export let extraClass = '';
+  $: fwModel = versionLookupTable[modelVersion] ?? 'Unknown FieldWorks version';
 </script>
 
 <span class={extraClass}>{fwModel}</span>

--- a/frontend/src/lib/i18n/locales/en.json
+++ b/frontend/src/lib/i18n/locales/en.json
@@ -420,6 +420,7 @@ the [Linguistics Institute at Payap University](https://li.payap.ac.th/) in Chia
     "description": "Description",
     "created_at": "Created",
     "last_commit": "Last Commit",
+    "model_version": "Model Version",
     "vernacular_langs": "Vernacular writing systems",
     "analysis_langs": "Analysis writing systems",
     "organization": {

--- a/frontend/src/routes/(authenticated)/project/[project_code]/+page.svelte
+++ b/frontend/src/routes/(authenticated)/project/[project_code]/+page.svelte
@@ -389,7 +389,6 @@
           </AdminContent>
         </DetailItem>
       {/if}
-      <!-- Only show model version to project managers and admins, too technical to show to regular members -->
       {#if project.type === ProjectType.FlEx}
         <DetailItem title={$t('project_page.model_version')}>
           <FlexModelVersionText modelVersion={flexModelVersion ?? 0} />

--- a/frontend/src/routes/(authenticated)/project/[project_code]/+page.svelte
+++ b/frontend/src/routes/(authenticated)/project/[project_code]/+page.svelte
@@ -5,7 +5,7 @@
   import FormatRetentionPolicy from '$lib/components/FormatRetentionPolicy.svelte';
   import HgLogView from '$lib/components/HgLogView.svelte';
   import DeleteModal from '$lib/components/modals/DeleteModal.svelte';
-  import t, { date, number } from '$lib/i18n';
+  import t, { date, NULL_LABEL, number } from '$lib/i18n';
   import { z } from 'zod';
   import type { PageData } from './$types';
   import {
@@ -14,6 +14,7 @@
     _deleteProjectUser,
     _leaveProject,
     _removeProjectFromOrg,
+    _updateFLExModelVersion,
     _updateProjectLanguageList,
     _updateProjectLexEntryCount,
     type ProjectUser,
@@ -70,6 +71,7 @@
   });
 
   $: lexEntryCount = project.flexProjectMetadata?.lexEntryCount;
+  $: flexModelVersion = project.flexProjectMetadata?.flexModelVersion;
   $: vernacularLangTags = project.flexProjectMetadata?.writingSystems?.vernacularWss;
   $: analysisLangTags = project.flexProjectMetadata?.writingSystems?.analysisWss;
 
@@ -96,6 +98,13 @@
     loadingEntryCount = true;
     await _updateProjectLexEntryCount(project.code);
     loadingEntryCount = false;
+  }
+
+  let loadingModelVersion = false;
+  async function updateModelVersion(): Promise<void> {
+    loadingModelVersion = true;
+    await _updateFLExModelVersion(project.code);
+    loadingModelVersion = false;
   }
 
   let loadingLanguageList = false;
@@ -377,6 +386,20 @@
               on:click={updateEntryCount}
             />
           </AdminContent>
+        </DetailItem>
+      {/if}
+      <!-- Only show model version to project managers and admins, too technical to show to regular members -->
+      {#if project.type === ProjectType.FlEx && canManage}
+        <DetailItem title={$t('project_page.model_version')} text={flexModelVersion?.toString() ?? NULL_LABEL}>
+          <IconButton
+            slot="extras"
+            loading={loadingModelVersion}
+            icon="i-mdi-refresh"
+            size="btn-sm"
+            variant="btn-ghost"
+            outline={false}
+            on:click={updateModelVersion}
+          />
         </DetailItem>
       {/if}
       {#if project.type === ProjectType.FlEx}

--- a/frontend/src/routes/(authenticated)/project/[project_code]/+page.svelte
+++ b/frontend/src/routes/(authenticated)/project/[project_code]/+page.svelte
@@ -5,7 +5,7 @@
   import FormatRetentionPolicy from '$lib/components/FormatRetentionPolicy.svelte';
   import HgLogView from '$lib/components/HgLogView.svelte';
   import DeleteModal from '$lib/components/modals/DeleteModal.svelte';
-  import t, { date, NULL_LABEL, number } from '$lib/i18n';
+  import t, { date, number } from '$lib/i18n';
   import { z } from 'zod';
   import type { PageData } from './$types';
   import {

--- a/frontend/src/routes/(authenticated)/project/[project_code]/+page.svelte
+++ b/frontend/src/routes/(authenticated)/project/[project_code]/+page.svelte
@@ -53,6 +53,7 @@
   import WritingSystemList from '$lib/components/Projects/WritingSystemList.svelte';
   import { onMount } from 'svelte';
   import { getSearchParamValues } from '$lib/util/query-params';
+  import FlexModelVersionText from '$lib/components/Projects/FlexModelVersionText.svelte';
 
   export let data: PageData;
   $: user = data.user;
@@ -389,17 +390,19 @@
         </DetailItem>
       {/if}
       <!-- Only show model version to project managers and admins, too technical to show to regular members -->
-      {#if project.type === ProjectType.FlEx && canManage}
-        <DetailItem title={$t('project_page.model_version')} text={flexModelVersion?.toString() ?? NULL_LABEL}>
-          <IconButton
-            slot="extras"
-            loading={loadingModelVersion}
-            icon="i-mdi-refresh"
-            size="btn-sm"
-            variant="btn-ghost"
-            outline={false}
-            on:click={updateModelVersion}
-          />
+      {#if project.type === ProjectType.FlEx}
+        <DetailItem title={$t('project_page.model_version')}>
+          <FlexModelVersionText modelVersion={flexModelVersion ?? 0} />
+          <AdminContent slot="extras">
+            <IconButton
+              loading={loadingModelVersion}
+              icon="i-mdi-refresh"
+              size="btn-sm"
+              variant="btn-ghost"
+              outline={false}
+              on:click={updateModelVersion}
+            />
+          </AdminContent>
         </DetailItem>
       {/if}
       {#if project.type === ProjectType.FlEx}

--- a/frontend/src/routes/(authenticated)/project/[project_code]/+page.ts
+++ b/frontend/src/routes/(authenticated)/project/[project_code]/+page.ts
@@ -91,6 +91,7 @@ export async function load(event: PageLoadEvent) {
             }
             flexProjectMetadata {
               lexEntryCount
+              flexModelVersion
               writingSystems {
                 vernacularWss {
                   tag
@@ -288,6 +289,33 @@ export async function _updateProjectLexEntryCount(code: string): $OpResult<Updat
               id
               flexProjectMetadata {
                 lexEntryCount
+              }
+            }
+            errors {
+              __typename
+              ... on Error {
+                message
+              }
+            }
+          }
+        }
+      `),
+      { input: { code } },
+    );
+  return result;
+}
+
+export async function _updateFLExModelVersion(code: string): Promise<unknown> { // $OpResult<UpdateFLExModelVersionMutation> {
+  //language=GraphQL
+  const result = await getClient()
+    .mutation(
+      graphql(`
+        mutation UpdateFLExModelVersion($input: UpdateFLExModelVersionInput!) {
+          updateFLExModelVersion(input: $input) {
+            project {
+              id
+              flexProjectMetadata {
+                flexModelVersion
               }
             }
             errors {

--- a/hgweb/command-runner.sh
+++ b/hgweb/command-runner.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # Define the list of allowed commands
-allowed_commands=("verify" "tip" "tipdate" "wesaylexentrycount" "lexentrycount" "flexprojectid" "flexwritingsystems" "recover" "healthz" "invalidatedircache")
+allowed_commands=("verify" "tip" "tipdate" "wesaylexentrycount" "lexentrycount" "flexprojectid" "flexwritingsystems" "flexmodelversion" "recover" "healthz" "invalidatedircache")
 
 # Get the project code and command name from the URL
 IFS='/' read -ra PATH_SEGMENTS <<< "$PATH_INFO"
@@ -72,6 +72,10 @@ case $command_name in
 
     flexwritingsystems)
         chg cat -r tip General/LanguageProject.langproj | sed -n -e '/<AnalysisWss>/,/<\/AnalysisWss>/p' -e '/<VernWss>/,/<\/VernWss>/p' -e '/<CurAnalysisWss>/,/<\/CurAnalysisWss>/p' -e '/<CurVernWss>/,/<\/CurVernWss>/p' -e '/<CurPronunWss>/,/<\/CurPronunWss>/p'
+        ;;
+
+    flexmodelversion)
+        chg cat -r tip FLExProject.ModelVersion
         ;;
 
     tip)


### PR DESCRIPTION
Fix #1022.

This PR adds a command to our command runner to extract the FLEx project's model version from the repo and store it in the FlexProjectMetadata table. It also adds a GraphQL mutation to update the model version; that mutation returns the project, so that the frontend calling that mutation can also query `flexProjectMetadata { flexModelVersion }` as part of the mutation results, and get the updated model version in a single step.