### PR TITLE
Actually update language project ID correctly

### DIFF
--- a/backend/LexBoxApi/GraphQL/ProjectMutations.cs
+++ b/backend/LexBoxApi/GraphQL/ProjectMutations.cs
@@ -402,14 +402,13 @@ public class ProjectMutations
     public async Task<IQueryable<Project>> UpdateLangProjectId(string code,
         IPermissionService permissionService,
         [Service] ProjectService projectService,
-        [Service] IHgService hgService,
         LexBoxDbContext dbContext)
     {
         var projectId = await projectService.LookupProjectId(code);
         await permissionService.AssertCanManageProject(projectId);
         var project = await dbContext.Projects.FindAsync(projectId);
         NotFoundException.ThrowIfNull(project);
-        await hgService.GetProjectIdOfFlexProject(code);
+        await projectService.UpdateProjectLangProjectId(projectId);
         return dbContext.Projects.Where(p => p.Id == projectId);
     }
 


### PR DESCRIPTION
Fix #1079.

Noticed while working on #1082 that the `UpdateLangProjectId` method in ProjectMutations was calling the wrong service method and was therefore not actually *updating* the DB data. It's a very quick fix, though: we already had the code in ProjectService, it just had 0 references. Now it has 1 reference.