### PR TITLE
Fix reusing project-codes gets 404/undefined from GQL cache

### DIFF
--- a/frontend/src/lib/app.postcss
+++ b/frontend/src/lib/app.postcss
@@ -216,3 +216,10 @@ img[src*="onestory-editor-logo"] {
     border-bottom: var(--tab-border) solid var(--tab-border-color);
   }
 }
+
+.x-ellipsis {
+  max-width: 100%;
+  overflow: hidden;
+  overflow-x: clip;
+  text-overflow: ellipsis;
+}

--- a/frontend/src/lib/components/ProjectList.svelte
+++ b/frontend/src/lib/components/ProjectList.svelte
@@ -72,7 +72,7 @@
       hover:border-neutral
       hover:shadow-xl;
 
-    max-height: 50vh;
+    @apply max-xs:max-h-[50vh];
     max-width: 100%;
 
     .bg {

--- a/frontend/src/lib/components/Users/UserTable.svelte
+++ b/frontend/src/lib/components/Users/UserTable.svelte
@@ -35,7 +35,7 @@
         <td>
           <div class="flex items-center gap-2 max-w-40 @xl:max-w-52">
             <Button variant="btn-ghost" size="btn-sm" class="max-w-full" on:click={() => dispatch('openUserModal', user)}>
-              <span class="max-width-full overflow-x-clip text-ellipsis" title={user.name}>
+              <span class="x-ellipsis" title={user.name}>
                 {user.name}
               </span>
               <Icon icon="i-mdi-card-account-details-outline" />
@@ -66,7 +66,7 @@
         <td>
           <span class="inline-flex items-center gap-2 text-left max-w-40">
             {#if user.email}
-              <span class="max-width-full overflow-hidden text-ellipsis" title={user.email}>
+              <span class="x-ellipsis" title={user.email}>
                 {user.email}
               </span>
               {#if !user.emailVerified}

--- a/frontend/src/lib/gql/gql-client.ts
+++ b/frontend/src/lib/gql/gql-client.ts
@@ -59,6 +59,14 @@ function createGqlClient(_gqlEndpoint?: string): Client {
           'FlexProjectMetadata': (metaData) => metaData.projectId as string,
         },
         updates: {
+          Query: {
+            'projectByCode': (result, args, cache) => {
+              if (result.projectByCode === null) {
+                // Don't cache null project results
+                cache.invalidate('Query', 'projectByCode', args);
+              }
+            },
+          },
           Mutation: {
             createProject: (result: CreateProjectMutation, args: CreateProjectMutationVariables, cache, _info) => {
               if (args.input.orgId) {

--- a/frontend/src/routes/(authenticated)/org/[org_id]/OrgMemberTable.svelte
+++ b/frontend/src/routes/(authenticated)/org/[org_id]/OrgMemberTable.svelte
@@ -44,13 +44,13 @@
             <div class="flex items-center gap-2 max-w-40 @xl:max-w-52">
               {#if showEmailColumn}
                 <Button variant="btn-ghost" size="btn-sm" class="max-w-full" on:click={() => dispatch('openUserModal', user)}>
-                  <span class="max-width-full overflow-x-clip text-ellipsis" title={user.name}>
+                  <span class="x-ellipsis" title={user.name}>
                     {user.name}
                   </span>
                   <Icon icon="i-mdi-card-account-details-outline" />
                 </Button>
               {:else}
-                <span class="max-width-full overflow-x-clip text-ellipsis" title={user.name}>
+                <span class="x-ellipsis" title={user.name}>
                   {user.name}
                 </span>
               {/if}
@@ -59,7 +59,7 @@
           {#if showEmailColumn}
           <td>
             <span class="inline-flex items-center gap-2 text-left max-w-40">
-              <span class="max-width-full overflow-hidden text-ellipsis" title={user.email ?? user.username}>
+              <span class="x-ellipsis" title={user.email ?? user.username}>
                 {user.email ?? user.username}
               </span>
             </span>

--- a/frontend/src/routes/(authenticated)/project/[project_code]/+page.svelte
+++ b/frontend/src/routes/(authenticated)/project/[project_code]/+page.svelte
@@ -169,13 +169,24 @@
   let deleteProjectModal: ConfirmDeleteModal;
 
   async function softDeleteProject(): Promise<void> {
-    const result = await deleteProjectModal.open(project.name, async () => {
-      const { error } = await _deleteProject(project.id);
-      return error?.message;
-    });
-    if (result.response === DialogResponse.Submit) {
-      notifyWarning($t('delete_project_modal.success', { name: project.name, code: project.code }));
-      await goto(data.home);
+    projectStore.pause();
+    changesetStore.pause();
+    let deleted = false;
+    try {
+      const result = await deleteProjectModal.open(project.name, async () => {
+        const { error } = await _deleteProject(project.id);
+        return error?.message;
+      });
+      if (result.response === DialogResponse.Submit) {
+        deleted = true;
+        notifyWarning($t('delete_project_modal.success', { name: project.name, code: project.code }));
+        await goto(data.home);
+      }
+    } finally {
+      if (!deleted) {
+        projectStore.resume();
+        changesetStore.resume();
+      }
     }
   }
 

--- a/frontend/src/routes/+error.svelte
+++ b/frontend/src/routes/+error.svelte
@@ -3,6 +3,8 @@
   import UnexpectedError from '$lib/error/UnexpectedError.svelte';
   import t from '$lib/i18n';
   import { Layout, Page, HomeBreadcrumb, PageBreadcrumb } from '$lib/layout';
+
+  const status = $page.status;
 </script>
 
 {#if $page.data.user}
@@ -15,7 +17,7 @@
 <Layout>
   <Page>
     <div class="py-6">
-      {#if $page.status === 404}
+      {#if status === 404}
         <div class="flex flex-col gap-4 items-center">
           <div class="flex gap-2">
             <span class="i-mdi-emoticon-confused-outline text-3xl" />


### PR DESCRIPTION
Fixes #1051 

It does actually seem to be the case that GQL caching was the problem here (even though I bumped into some weird behaviour in our awaitedQueryStore that I thought was the root of the issue).

I've opened [a discussion](https://github.com/urql-graphql/urql/discussions/3683) In the hopes of finding a slightly more elegant solution, but I'm doubtful 🤷. So, for details see that discussion or the many comments in this PR.

There are several bonus fixes in this PR:
- Text ellipsis truncating wasn't working everywhere, so I fixed and standardized it
- Project tiles became very ugly with the dev tools open. And they still might on small screens, but meh. That's not as bothersome.
- The error page was no longer working well for 404 errors. It would start fine, but then immediately update using the 200 from the page load.