### PR TITLE
Don't show membership confidential icon on non-confidential project

### DIFF
--- a/frontend/src/lib/i18n/locales/en.json
+++ b/frontend/src/lib/i18n/locales/en.json
@@ -428,7 +428,7 @@ the [Linguistics Institute at Payap University](https://li.payap.ac.th/) in Chia
     },
     "members": {
       "title": "Members",
-      "membership_confidentail": "Membership is confidential",
+      "membership_confidential": "Membership is confidential",
       "filter_members_placeholder": "Filter members...",
       "show_all": "Show all...",
       "show_less": "Show less",

--- a/frontend/src/routes/(authenticated)/project/[project_code]/+page.svelte
+++ b/frontend/src/routes/(authenticated)/project/[project_code]/+page.svelte
@@ -105,10 +105,16 @@
     loadingLanguageList = false;
   }
 
+  $: orgRoles = project.organizations
+    ?.map((o) => user.orgs?.find((org) => org.orgId === o.id)?.role)
+    .filter(r => !!r) ?? [];
+  $: projectRole = project?.users?.find((u) => u.user.id == user.id)?.role;
+
   // Mirrors PermissionService.CanViewProjectMembers() in C#
   $: canViewProjectMembers = user.isAdmin
-    || user.orgs.find((o) => project.organizations?.find((org) => org.id === o.orgId))?.role === OrgRole.Admin
-    || project?.users?.find((u) => u.user.id == user.id)?.role == ProjectRole.Manager;
+    || projectRole == ProjectRole.Manager
+    || projectRole == ProjectRole.Editor && !project.isConfidential
+    || orgRoles.some(role => role === OrgRole.Admin);
 
   let resetProjectModal: ResetProjectModal;
   async function resetProject(): Promise<void> {

--- a/frontend/src/routes/(authenticated)/project/[project_code]/MembersList.svelte
+++ b/frontend/src/routes/(authenticated)/project/[project_code]/MembersList.svelte
@@ -84,7 +84,7 @@
       {#if !canViewMembers}
         <span
           class="tooltip tooltip-warning text-warning shrink-0 leading-0"
-          data-tip={$t('project_page.members.membership_confidentail')}>
+          data-tip={$t('project_page.members.membership_confidential')}>
           <Icon icon="i-mdi-shield-lock-outline" size="text-xl" />
         </span>
       {/if}


### PR DESCRIPTION
When I wrote this code, I forgot the most obvious case: when the project is not confidential!

Found this bug on staging:
![image](https://github.com/user-attachments/assets/bbab8d86-126a-4811-a629-5273a67b4a73)

