### PR TITLE
Copy all .csproj files in backend dev.Dockerfile

### DIFF
--- a/backend/LexBoxApi/dev.Dockerfile
+++ b/backend/LexBoxApi/dev.Dockerfile
@@ -11,7 +11,15 @@ WORKDIR /src/backend
 # Copy the main source project files
 COPY */*.csproj *.sln ./
 # move them into the proper sub folders, based on the name of the project
-RUN for file in $(ls *.csproj); do dir=${file%.*} mkdir -p ${file%.*}/ && mv $file ${file%.*}/; done; dotnet restore FixFwData/FixFwData.csproj; dotnet restore LexBoxApi/LexBoxApi.csproj
+RUN for file in $(ls *.csproj); do dir=${file%.*}; mkdir -p ${dir}/ && mv -v $file ${dir}/; done
+# Do the same for csproj files in slightly different hierarchies
+COPY harmony/src/*/*.csproj ./
+RUN for file in $(ls *.csproj); do dir=${file%.*}; mkdir -p harmony/src/${dir}/ && mv -v $file harmony/src/${dir}/; done
+COPY harmony/src/Directory.Build.props ./harmony/src/
+COPY FwLite/*/*.csproj ./
+RUN for file in $(ls *.csproj); do dir=${file%.*}; mkdir -p FwLite/${dir}/ && mv -v $file FwLite/${dir}/; done
+# Now that all csproj files are in place, restore them
+RUN dotnet restore FixFwData/FixFwData.csproj; dotnet restore LexBoxApi/LexBoxApi.csproj
 
 COPY --chown=www-data . .
 WORKDIR /src/backend/LexBoxApi


### PR DESCRIPTION
Fix #917.

Now that SIL.Harmony and FwLite are in the backend directory, the previous Dockerfile lines to copy all the .csproj files need to be updated to include the files nested deeper in the directory tree.

In addition to copying the .csproj files, the backend/harmony/src/Directory.Build.props file needs to be copied otherwise `dotnet restore` complains about the empty string being an invalid framework identifier (because TargetFramework is defined in Directory.Build.props).

Tested by running `task up`, and the resulting Dockerfile built and ran correctly.