### PR TITLE
Allow listing user's projects when adding to an org

### DIFF
--- a/backend/LexBoxApi/GraphQL/OrgMutations.cs
+++ b/backend/LexBoxApi/GraphQL/OrgMutations.cs
@@ -112,11 +112,9 @@ public class OrgMutations
         // Now exclude any projects that don't actually exist or the org already has or that don't exist
         var alreadyInOrg = org.Projects.Select(o => o.Id).ToHashSet();
         var filteredIds = projectIds.Where(id => !alreadyInOrg.Contains(id));
-        // Also filter out any project IDs that don't really exist
-        var existingIds = await dbContext.Projects.Where(p => filteredIds.Contains(p.Id)).Select(p => p.Id).ToListAsync() ?? [];
-        var updates = existingIds.Select(projectId => new OrgProjects { OrgId = orgId, ProjectId = projectId });
+        var updates = filteredIds.Select(projectId => new OrgProjects { OrgId = orgId, ProjectId = projectId });
         dbContext.OrgProjects.AddRange(updates);
-        dbContext.Projects.Where(p => existingIds.Contains(p.Id)).ExecuteUpdate(p => p.SetProperty(p => p.UpdatedDate, DateTime.UtcNow));
+        dbContext.Projects.Where(p => filteredIds.Contains(p.Id)).ExecuteUpdate(p => p.SetProperty(p => p.UpdatedDate, DateTime.UtcNow));
         org.UpdateUpdatedDate();
         foreach (var projectId in projectIds)
         {

--- a/backend/LexBoxApi/GraphQL/OrgMutations.cs
+++ b/backend/LexBoxApi/GraphQL/OrgMutations.cs
@@ -117,7 +117,7 @@ public class OrgMutations
         var filteredIds = projectIds.Where(id => !alreadyInOrg.Contains(id)).ToHashSet();
         var updates = filteredIds.Select(projectId => new OrgProjects { OrgId = orgId, ProjectId = projectId });
         dbContext.OrgProjects.AddRange(updates);
-        dbContext.Projects.Where(p => filteredIds.Contains(p.Id)).ExecuteUpdate(p => p.SetProperty(p => p.UpdatedDate, DateTime.UtcNow));
+        await dbContext.Projects.Where(p => filteredIds.Contains(p.Id)).ExecuteUpdateAsync(p => p.SetProperty(p => p.UpdatedDate, DateTime.UtcNow));
         org.UpdateUpdatedDate();
         foreach (var projectId in projectIds)
         {

--- a/backend/LexBoxApi/GraphQL/OrgMutations.cs
+++ b/backend/LexBoxApi/GraphQL/OrgMutations.cs
@@ -110,7 +110,7 @@ public class OrgMutations
             await permissionService.AssertCanManageProject(projectId);
         }
         // Now exclude any projects that don't actually exist or the org already has or that don't exist
-        var alreadyInOrg = dbContext.OrgProjects.Where(op => op.OrgId == orgId).Select(op => op.ProjectId).ToHashSet() ?? [];
+        var alreadyInOrg = org.Projects.Select(o => o.Id).ToHashSet();
         var filteredIds = projectIds.Where(id => !alreadyInOrg.Contains(id));
         // Also filter out any project IDs that don't really exist
         var existingIds = await dbContext.Projects.Where(p => filteredIds.Contains(p.Id)).Select(p => p.Id).ToListAsync() ?? [];

--- a/backend/LexBoxApi/GraphQL/OrgMutations.cs
+++ b/backend/LexBoxApi/GraphQL/OrgMutations.cs
@@ -114,7 +114,7 @@ public class OrgMutations
         }
         // Now exclude any projects that don't actually exist or the org already has or that don't exist
         var alreadyInOrg = org.Projects.Select(o => o.Id).ToHashSet();
-        var filteredIds = projectIds.Where(id => !alreadyInOrg.Contains(id)).ToHashSet();
+        var filteredIds = projectIds.Where(id => !alreadyInOrg.Contains(id)).ToArray();
         var updates = filteredIds.Select(projectId => new OrgProjects { OrgId = orgId, ProjectId = projectId });
         dbContext.OrgProjects.AddRange(updates);
         await dbContext.Projects.Where(p => filteredIds.Contains(p.Id)).ExecuteUpdateAsync(p => p.SetProperty(p => p.UpdatedDate, DateTime.UtcNow));

--- a/frontend/schema.graphql
+++ b/frontend/schema.graphql
@@ -17,6 +17,11 @@ type AddProjectToOrgPayload {
   errors: [AddProjectToOrgError!]
 }
 
+type AddProjectsToOrgPayload {
+  organization: Organization
+  errors: [AddProjectsToOrgError!]
+}
+
 type AlreadyExistsError implements Error {
   message: String!
 }
@@ -229,6 +234,7 @@ type Mutation {
   createOrganization(input: CreateOrganizationInput!): CreateOrganizationPayload!
   deleteOrg(input: DeleteOrgInput!): DeleteOrgPayload! @authorize(policy: "AdminRequiredPolicy")
   addProjectToOrg(input: AddProjectToOrgInput!): AddProjectToOrgPayload!
+  addProjectsToOrg(input: AddProjectsToOrgInput!): AddProjectsToOrgPayload!
   removeProjectFromOrg(input: RemoveProjectFromOrgInput!): RemoveProjectFromOrgPayload!
   setOrgMemberRole(input: SetOrgMemberRoleInput!): SetOrgMemberRolePayload!
   changeOrgMemberRole(input: ChangeOrgMemberRoleInput!): ChangeOrgMemberRolePayload!
@@ -542,6 +548,8 @@ union AddProjectMemberError = NotFoundError | DbError | ProjectMembersMustBeVeri
 
 union AddProjectToOrgError = DbError | NotFoundError
 
+union AddProjectsToOrgError = DbError | NotFoundError
+
 union AskToJoinProjectError = NotFoundError | DbError | ProjectMembersMustBeVerified | ProjectMembersMustBeVerifiedForRole
 
 union BulkAddOrgMembersError = NotFoundError | DbError | UnauthorizedAccessError
@@ -605,6 +613,11 @@ input AddProjectMemberInput {
 input AddProjectToOrgInput {
   orgId: UUID!
   projectId: UUID!
+}
+
+input AddProjectsToOrgInput {
+  orgId: UUID!
+  projectIds: [UUID!]!
 }
 
 input AskToJoinProjectInput {

--- a/frontend/src/lib/components/Users/UserProjects.svelte
+++ b/frontend/src/lib/components/Users/UserProjects.svelte
@@ -25,7 +25,7 @@
     if (allSelected) {
       selectedProjects = [];
     } else {
-      selectedProjects = [...projects.map(proj => proj.code)];
+      selectedProjects = [...projects.map(proj => proj.id)];
     }
   }
 
@@ -37,7 +37,7 @@
   $: projectsStore = writable(projects);
   onMount(() => projectsStore.subscribe(projects => {
     if (projects && projects.length > 0) {
-      selectedProjects = [... projects.filter(isManager).map(proj => proj.code)];
+      selectedProjects = [... projects.filter(isManager).map(proj => proj.id)];
     }
   }));
 </script>
@@ -51,7 +51,7 @@
   {/if}
   {#each projects as proj}
     <li>
-      <input type="checkbox" bind:group={selectedProjects} value={proj.code} />
+      <input type="checkbox" bind:group={selectedProjects} value={proj.id} />
       {proj.name}
       {#if proj.memberRole == ProjectRole.Manager}
       <Badge variant="badge-info">Manager</Badge>

--- a/frontend/src/lib/components/Users/UserProjects.svelte
+++ b/frontend/src/lib/components/Users/UserProjects.svelte
@@ -1,6 +1,7 @@
 <script  context="module" lang="ts">
   // We define the Project type that we'll want in here, and export it so that callers can know they're passing in the right type
   export type Project = {
+    id: string
     name: string
     code: string
     role: ProjectRole

--- a/frontend/src/lib/components/Users/UserProjects.svelte
+++ b/frontend/src/lib/components/Users/UserProjects.svelte
@@ -1,0 +1,33 @@
+<script  context="module" lang="ts">
+  import type { User as AdminDashboardUser } from '../../../routes/(authenticated)/admin/+page';
+
+  // We define User type that we'll want in here, and export it so that callers can know they're passing in the right type
+  export type User = Pick<AdminDashboardUser, 'id' | 'projects'> & {
+    projects: {
+      name: string
+      code: string
+      role: string
+    }
+  };
+  // TODO: That's not the correct way to expand the projects type in AdminDashboardUser. Figure out correct Typescripty way to do it.
+
+</script>
+
+<script lang="ts">
+  // List of projects that a given user is member of
+  // Shows "manager" badge if user is manager of project
+  // Includes confidential projects only if currently logged in user is site admin OR is same user as the one whose project we're looking at
+  // Has checkbox beside each project so they can be selected
+  // Projects the given user is managing are automatically pre-selected
+  // Exposes bindable prop with list of project codes (or project objects) that are selected
+  // TODO: Determine if list of project objects or project codes would be more useful / easier to implement
+
+  // export let userId: string; // GUID
+  export let user: User;
+</script>
+
+<ul>
+  {#each user.projects as proj}
+    <li>{proj.name} (proj.code)</li>
+  {/each}
+</ul>

--- a/frontend/src/lib/components/Users/UserProjects.svelte
+++ b/frontend/src/lib/components/Users/UserProjects.svelte
@@ -4,7 +4,7 @@
     id: string
     name: string
     code: string
-    role: ProjectRole
+    memberRole: ProjectRole
   };
 </script>
 
@@ -29,7 +29,7 @@
   }
 
   function isManager(proj: Project): boolean {
-    return proj.role === ProjectRole.Manager;
+    return proj.memberRole === ProjectRole.Manager;
   }
 
   // Projects managed by the given user come pre-checked, to save time in typical uses of this component
@@ -51,7 +51,7 @@
     <li>
       <input type="checkbox" bind:group={selectedProjects} value={proj.code} />
       {proj.name}
-      {#if proj.role == ProjectRole.Manager}
+      {#if proj.memberRole == ProjectRole.Manager}
       <Badge variant="badge-info">Manager</Badge>
       {/if}
     </li>

--- a/frontend/src/lib/components/Users/UserProjects.svelte
+++ b/frontend/src/lib/components/Users/UserProjects.svelte
@@ -1,33 +1,43 @@
 <script  context="module" lang="ts">
-  import type { User as AdminDashboardUser } from '../../../routes/(authenticated)/admin/+page';
-
-  // We define User type that we'll want in here, and export it so that callers can know they're passing in the right type
-  export type User = Pick<AdminDashboardUser, 'id' | 'projects'> & {
-    projects: {
-      name: string
-      code: string
-      role: string
-    }
+  // We define the Project type that we'll want in here, and export it so that callers can know they're passing in the right type
+  export type Project = {
+    id: string
+    name: string
+    code: string
+    role: ProjectRole
   };
-  // TODO: That's not the correct way to expand the projects type in AdminDashboardUser. Figure out correct Typescripty way to do it.
-
 </script>
 
 <script lang="ts">
-  // List of projects that a given user is member of
-  // Shows "manager" badge if user is manager of project
-  // Includes confidential projects only if currently logged in user is site admin OR is same user as the one whose project we're looking at
-  // Has checkbox beside each project so they can be selected
-  // Projects the given user is managing are automatically pre-selected
-  // Exposes bindable prop with list of project codes (or project objects) that are selected
-  // TODO: Determine if list of project objects or project codes would be more useful / easier to implement
+  import { ProjectRole } from '$lib/gql/types';
+  import { writable } from 'svelte/store';
+  import Badge from '../Badges/Badge.svelte';
+  import { onMount } from 'svelte';
 
-  // export let userId: string; // GUID
-  export let user: User;
+  export let projects: Project[] = [];
+  export let selectedProjects: string[] = [];
+
+  function isManager(proj: Project): boolean {
+    return proj.role === ProjectRole.Manager;
+  }
+
+  // Projects managed by the given user come pre-checked, to save time in typical uses of this component
+  $: projectsStore = writable(projects);
+  onMount(() => projectsStore.subscribe(projects => {
+    if (projects && projects.length > 0) {
+      selectedProjects = [... projects.filter(isManager).map(proj => proj.code)];
+    }
+  }));
 </script>
 
 <ul>
-  {#each user.projects as proj}
-    <li>{proj.name} (proj.code)</li>
+  {#each projects as proj}
+    <li>
+      <input type="checkbox" bind:group={selectedProjects} value={proj.code} />
+      {proj.name}
+      {#if proj.role == ProjectRole.Manager}
+      <Badge variant="badge-info">Manager</Badge>
+      {/if}
+    </li>
   {/each}
 </ul>

--- a/frontend/src/lib/components/Users/UserProjects.svelte
+++ b/frontend/src/lib/components/Users/UserProjects.svelte
@@ -19,7 +19,7 @@
 
   $: allSelected = projects && selectedProjects && selectedProjects.length === projects.length;
 
-  function handleSelectAllClick() {
+  function handleSelectAllClick(): void {
     if (!selectedProjects || !projects) return;
     if (allSelected) {
       selectedProjects = [];

--- a/frontend/src/lib/components/Users/UserProjects.svelte
+++ b/frontend/src/lib/components/Users/UserProjects.svelte
@@ -1,7 +1,6 @@
 <script  context="module" lang="ts">
   // We define the Project type that we'll want in here, and export it so that callers can know they're passing in the right type
   export type Project = {
-    id: string
     name: string
     code: string
     role: ProjectRole
@@ -17,6 +16,17 @@
   export let projects: Project[] = [];
   export let selectedProjects: string[] = [];
 
+  $: allSelected = projects && selectedProjects && selectedProjects.length === projects.length;
+
+  function handleSelectAllClick() {
+    if (!selectedProjects || !projects) return;
+    if (allSelected) {
+      selectedProjects = [];
+    } else {
+      selectedProjects = [...projects.map(proj => proj.code)];
+    }
+  }
+
   function isManager(proj: Project): boolean {
     return proj.role === ProjectRole.Manager;
   }
@@ -31,6 +41,11 @@
 </script>
 
 <ul>
+  {#if projects && projects.length > 1}
+    <li>
+      <input type="checkbox" checked={allSelected} on:change={handleSelectAllClick} />
+    </li>
+  {/if}
   {#each projects as proj}
     <li>
       <input type="checkbox" bind:group={selectedProjects} value={proj.code} />

--- a/frontend/src/lib/components/Users/UserProjects.svelte
+++ b/frontend/src/lib/components/Users/UserProjects.svelte
@@ -13,6 +13,7 @@
   import { writable } from 'svelte/store';
   import Badge from '../Badges/Badge.svelte';
   import { onMount } from 'svelte';
+  import t from '$lib/i18n';
 
   export let projects: Project[] = [];
   export let selectedProjects: string[] = [];
@@ -45,6 +46,7 @@
   {#if projects && projects.length > 1}
     <li>
       <input type="checkbox" checked={allSelected} on:change={handleSelectAllClick} />
+      {$t('org_page.add_user.select_all')}
     </li>
   {/if}
   {#each projects as proj}

--- a/frontend/src/lib/forms/UserTypeahead.svelte
+++ b/frontend/src/lib/forms/UserTypeahead.svelte
@@ -25,19 +25,13 @@
 
   const dispatch = createEventDispatcher<{
       selectedUserId: string | null;
-      selectedUserWithProjects: SingleUserTypeaheadResult;
+      selectedUser: SingleUserTypeaheadResult | SingleUserInMyOrgTypeaheadResult | null;
   }>();
 
   let selectedUser = writable<SingleUserTypeaheadResult | SingleUserInMyOrgTypeaheadResult | null>(null);
   let selectedUserId = derived(selectedUser, user => user?.id ?? null);
   $: dispatch('selectedUserId', $selectedUserId);
-  $: if ($selectedUser) {
-    if ('projects' in $selectedUser) {
-      if ($selectedUser.projects && $selectedUser.projects.length) {
-        dispatch('selectedUserWithProjects', $selectedUser);
-      }
-    }
-  }
+  $: dispatch('selectedUser', $selectedUser);
 
   function formatResult(user: SingleUserTypeaheadResult): string {
     const extra = user.username && user.email ? ` (${user.username}, ${user.email})`

--- a/frontend/src/lib/forms/UserTypeahead.svelte
+++ b/frontend/src/lib/forms/UserTypeahead.svelte
@@ -33,10 +33,10 @@
   $: dispatch('selectedUserId', $selectedUserId);
   $: dispatch('selectedUser', $selectedUser);
 
-  function formatResult(user: SingleUserTypeaheadResult): string {
-    const extra = user.username && user.email ? ` (${user.username}, ${user.email})`
-                : user.username ? ` (${user.username})`
-                : user.email ? ` (${user.email})`
+  function formatResult(user: SingleUserTypeaheadResult | SingleUserInMyOrgTypeaheadResult): string {
+    const extra = 'username' in user && user.username && 'email' in user && user.email ? ` (${user.username}, ${user.email})`
+                : 'username' in user && user.username ? ` (${user.username})`
+                : 'email' in user && user.email ? ` (${user.email})`
                 : '';
     return `${user.name}${extra}`;
   }

--- a/frontend/src/lib/gql/gql-client.ts
+++ b/frontend/src/lib/gql/gql-client.ts
@@ -103,7 +103,7 @@ function createGqlClient(_gqlEndpoint?: string): Client {
               cache.invalidate({__typename: 'OrgById', id: args.input.orgId});
             },
             setOrgMemberRole: (result, args: AddOrgMemberMutationVariables, cache, _info) => {
-              cache.invalidate({__typename: 'OrgById', id: args.input.orgId});
+              cache.invalidate({__typename: 'OrgById', id: args.memberInput.orgId});
             },
             leaveProject: (result, args: LeaveProjectMutationVariables, cache, _info) => {
               cache.invalidate({__typename: 'Project', id: args.input.projectId});

--- a/frontend/src/lib/gql/gql-client.ts
+++ b/frontend/src/lib/gql/gql-client.ts
@@ -16,25 +16,23 @@ import {isObject} from '../util/types';
 import {tracingExchange} from '$lib/otel';
 import {
   type $OpResult,
-  type ChangeUserAccountBySelfMutationVariables,
-  type DeleteUserByAdminOrSelfMutationVariables,
   type ExtractErrorTypename,
   type GenericData,
   type GqlInputError,
   isErrorResult,
-  type LeaveProjectMutationVariables,
   LexGqlError,
-  type SoftDeleteProjectMutationVariables,
-  type BulkAddProjectMembersMutationVariables,
-  type DeleteDraftProjectMutationVariables,
   type MutationAddProjectToOrgArgs,
   type MutationRemoveProjectFromOrgArgs,
-  type BulkAddOrgMembersMutationVariables,
-  type ChangeOrgMemberRoleMutationVariables,
-  type AddOrgMemberMutationVariables,
-  type CreateProjectMutationVariables,
   type CreateProjectMutation,
   CreateProjectResult,
+  type MutationSetOrgMemberRoleArgs,
+  type MutationChangeOrgMemberRoleArgs,
+  type MutationLeaveProjectArgs,
+  type MutationBulkAddOrgMembersArgs,
+  type MutationBulkAddProjectMembersArgs,
+  type MutationChangeUserAccountBySelfArgs,
+  type MutationDeleteUserByAdminOrSelfArgs,
+  type MutationDeleteDraftProjectArgs, type MutationSoftDeleteProjectArgs, type MutationCreateProjectArgs,
 } from './types';
 import type {Readable, Unsubscriber} from 'svelte/store';
 import {derived} from 'svelte/store';
@@ -68,7 +66,7 @@ function createGqlClient(_gqlEndpoint?: string): Client {
             },
           },
           Mutation: {
-            createProject: (result: CreateProjectMutation, args: CreateProjectMutationVariables, cache, _info) => {
+            createProject: (result: CreateProjectMutation, args: MutationCreateProjectArgs, cache, _info) => {
               if (args.input.orgId) {
                 cache.invalidate({__typename: 'OrgById', id: args.input.orgId}, 'projects');
               }
@@ -79,33 +77,33 @@ function createGqlClient(_gqlEndpoint?: string): Client {
                 .filter(field => field.fieldName === dashboardQuery || field.fieldName === adminDashboardQuery)
                 .forEach(field => cache.invalidate('Query', field.fieldKey));
             },
-            softDeleteProject: (result, args: SoftDeleteProjectMutationVariables, cache, _info) => {
+            softDeleteProject: (result, args: MutationSoftDeleteProjectArgs, cache, _info) => {
               cache.invalidate({__typename: 'Project', id: args.input.projectId});
             },
-            deleteDraftProject: (result, args: DeleteDraftProjectMutationVariables, cache, _info) => {
+            deleteDraftProject: (result, args: MutationDeleteDraftProjectArgs, cache, _info) => {
               cache.invalidate({__typename: 'DraftProject', id: args.input.draftProjectId});
             },
-            deleteUserByAdminOrSelf: (result, args: DeleteUserByAdminOrSelfMutationVariables, cache, _info) => {
+            deleteUserByAdminOrSelf: (result, args: MutationDeleteUserByAdminOrSelfArgs, cache, _info) => {
               cache.invalidate({__typename: 'User', id: args.input.userId});
             },
-            changeUserAccountBySelf: (result, args: ChangeUserAccountBySelfMutationVariables, cache, _info) => {
+            changeUserAccountBySelf: (result, args: MutationChangeUserAccountBySelfArgs, cache, _info) => {
               cache.invalidate({__typename: 'User', id: args.input.userId});
             },
-            bulkAddProjectMembers: (result, args: BulkAddProjectMembersMutationVariables, cache, _info) => {
+            bulkAddProjectMembers: (result, args: MutationBulkAddProjectMembersArgs, cache, _info) => {
               if (args.input.projectId) {
                 cache.invalidate({__typename: 'Project', id: args.input.projectId});
               }
             },
-            bulkAddOrgMembers: (result, args: BulkAddOrgMembersMutationVariables, cache, _info) => {
+            bulkAddOrgMembers: (result, args: MutationBulkAddOrgMembersArgs, cache, _info) => {
               cache.invalidate({__typename: 'OrgById', id: args.input.orgId});
             },
-            changeOrgMemberRole: (result, args: ChangeOrgMemberRoleMutationVariables, cache, _info) => {
+            changeOrgMemberRole: (result, args: MutationChangeOrgMemberRoleArgs, cache, _info) => {
               cache.invalidate({__typename: 'OrgById', id: args.input.orgId});
             },
-            setOrgMemberRole: (result, args: AddOrgMemberMutationVariables, cache, _info) => {
-              cache.invalidate({__typename: 'OrgById', id: args.memberInput.orgId});
+            setOrgMemberRole: (result, args: MutationSetOrgMemberRoleArgs, cache, _info) => {
+              cache.invalidate({__typename: 'OrgById', id: args.input.orgId});
             },
-            leaveProject: (result, args: LeaveProjectMutationVariables, cache, _info) => {
+            leaveProject: (result, args: MutationLeaveProjectArgs, cache, _info) => {
               cache.invalidate({__typename: 'Project', id: args.input.projectId});
             },
             addProjectToOrg: (result, args: MutationAddProjectToOrgArgs, cache, _info) => {

--- a/frontend/src/lib/gql/typeahead-queries.ts
+++ b/frontend/src/lib/gql/typeahead-queries.ts
@@ -29,6 +29,15 @@ export async function _userTypeaheadSearch(userSearch: string, limit = 10): Prom
           name
           email
           username
+          projects {
+            id
+            role
+            project {
+              id
+              code
+              name
+            }
+          }
         }
       }
     }

--- a/frontend/src/lib/i18n/locales/en.json
+++ b/frontend/src/lib/i18n/locales/en.json
@@ -264,6 +264,7 @@ the [Linguistics Institute at Payap University](https://li.payap.ac.th/) in Chia
       "__comment_modal_title": "Should become 'Add or invite a Member ...' once email invitations implemented for orgs",
       "submit_button": "Add Member",
       "empty_user_field": "Please enter an email address or login",
+      "also_add_projects": "Do you want to also add the following projects to the organization?",
       "submit_button_email": "Add/Invite Member",
       "org_not_found": "Organization not found. Please refresh the page.",
       "username_not_found": "No user was found with this login",

--- a/frontend/src/lib/i18n/locales/en.json
+++ b/frontend/src/lib/i18n/locales/en.json
@@ -265,6 +265,7 @@ the [Linguistics Institute at Payap University](https://li.payap.ac.th/) in Chia
       "submit_button": "Add Member",
       "empty_user_field": "Please enter an email address or login",
       "also_add_projects": "Do you want to also add the following projects to the organization?",
+      "select_all": "Select all",
       "submit_button_email": "Add/Invite Member",
       "org_not_found": "Organization not found. Please refresh the page.",
       "username_not_found": "No user was found with this login",

--- a/frontend/src/routes/(authenticated)/org/[org_id]/+page.ts
+++ b/frontend/src/routes/(authenticated)/org/[org_id]/+page.ts
@@ -123,7 +123,7 @@ export async function _deleteOrgUser(orgId: string, userId: string): $OpResult<D
   return result;
 }
 
-export async function _addOrgMember(orgId: UUID, emailOrUsername: string, role: OrgRole, canInvite: boolean, withProjects: Project[]): $OpResult<AddOrgMemberMutation> {
+export async function _addOrgMember(orgId: UUID, emailOrUsername: string, role: OrgRole, canInvite: boolean, projectIds: string[]): $OpResult<AddOrgMemberMutation> {
   //language=GraphQL
   const result = await getClient()
     .mutation(
@@ -144,8 +144,8 @@ export async function _addOrgMember(orgId: UUID, emailOrUsername: string, role: 
       `),
       { input: { orgId, emailOrUsername, role, canInvite} },
     );
-  if (withProjects && withProjects.length > 0) {
-    await _addProjectsToOrg({ orgId, projectIds: [...withProjects.map(p => p.id)]})
+  if (projectIds && projectIds.length > 0) {
+    await _addProjectsToOrg({ orgId, projectIds });
   }
   return result;
 }

--- a/frontend/src/routes/(authenticated)/org/[org_id]/+page.ts
+++ b/frontend/src/routes/(authenticated)/org/[org_id]/+page.ts
@@ -1,8 +1,6 @@
 import type {
   $OpResult,
   AddOrgMemberMutation,
-  AddProjectsToOrgInput,
-  AddProjectsToOrgMutation,
   BulkAddOrgMembersMutation,
   ChangeOrgMemberRoleMutation,
   ChangeOrgNameInput,
@@ -21,7 +19,6 @@ import type { PageLoadEvent } from './$types';
 import type { UUID } from 'crypto';
 import { error } from '@sveltejs/kit';
 import { tryMakeNonNullable } from '$lib/util/store';
-import type { Project } from '$lib/components/Users/UserProjects.svelte';
 
 export type Org = NonNullable<OrgPageQuery['orgById']>;
 export type OrgUser = Org['members'][number];

--- a/frontend/src/routes/(authenticated)/org/[org_id]/AddOrgMemberModal.svelte
+++ b/frontend/src/routes/(authenticated)/org/[org_id]/AddOrgMemberModal.svelte
@@ -10,7 +10,7 @@
   import { SupHelp, helpLinks } from '$lib/components/help';
   import type { UUID } from 'crypto';
   import { _addOrgMember } from './+page';
-  import type { SingleUserTypeaheadResult } from '$lib/gql/typeahead-queries';
+  import type { SingleUserTypeaheadResult, UsersInMyOrgTypeaheadResult } from '$lib/gql/typeahead-queries';
   import UserProjects from '$lib/components/Users/UserProjects.svelte';
 
   export let orgId: string;
@@ -27,8 +27,12 @@
   const { notifySuccess } = useNotifications();
 
   let projects = [];
-  function populateUserProjects(user: SingleUserTypeaheadResult): void {
-    projects = [...user.projects.map(p => ({role: p.role, code: p.project.code, name: p.project.name}))];
+  function populateUserProjects(user: SingleUserTypeaheadResult | UsersInMyOrgTypeaheadResult | null): void {
+    if (!user || !('projects' in user)) {
+      projects = [];
+    } else {
+      projects = [...user.projects.map(p => ({role: p.role, code: p.project.code, name: p.project.name}))];
+    }
   }
 
   export async function openModal(): Promise<void> {
@@ -75,10 +79,9 @@
       isAdmin={$page.data.user?.isAdmin}
       bind:value={$form.usernameOrEmail}
       error={errors.usernameOrEmail}
-      on:selectedUserWithProjects={(event) => populateUserProjects(event.detail)}
+      on:selectedUser={(event) => populateUserProjects(event.detail)}
       autofocus
       />
-      <!-- TODO: Clear user projects list if typeahead is modified; might need typeahead to send `selectedUserWithProjects(null)` in that case -->
   {:else}
     <Input
       id="usernameOrEmail"

--- a/frontend/src/routes/(authenticated)/org/[org_id]/AddOrgMemberModal.svelte
+++ b/frontend/src/routes/(authenticated)/org/[org_id]/AddOrgMemberModal.svelte
@@ -45,6 +45,7 @@
         $form.canInvite,
         projects,
       );
+      projects = [];
 
       if (error?.byType('NotFoundError')) {
         if (error.message === 'Org not found') {

--- a/frontend/src/routes/(authenticated)/org/[org_id]/AddOrgMemberModal.svelte
+++ b/frontend/src/routes/(authenticated)/org/[org_id]/AddOrgMemberModal.svelte
@@ -31,7 +31,7 @@
     if (!user || !('projects' in user)) {
       projects = [];
     } else {
-      projects = [...user.projects.map(p => ({role: p.role, id: p.project.id, code: p.project.code, name: p.project.name}))];
+      projects = [...user.projects.map(p => ({memberRole: p.role, id: p.project.id, code: p.project.code, name: p.project.name}))];
     }
   }
 

--- a/frontend/src/routes/(authenticated)/org/[org_id]/AddOrgMemberModal.svelte
+++ b/frontend/src/routes/(authenticated)/org/[org_id]/AddOrgMemberModal.svelte
@@ -11,7 +11,7 @@
   import type { UUID } from 'crypto';
   import { _addOrgMember } from './+page';
   import type { SingleUserTypeaheadResult, UsersInMyOrgTypeaheadResult } from '$lib/gql/typeahead-queries';
-  import UserProjects from '$lib/components/Users/UserProjects.svelte';
+  import UserProjects, { type Project } from '$lib/components/Users/UserProjects.svelte';
 
   export let orgId: string;
   const schema = z.object({
@@ -26,12 +26,12 @@
 
   const { notifySuccess } = useNotifications();
 
-  let projects = [];
+  let projects: Project[] = [];
   function populateUserProjects(user: SingleUserTypeaheadResult | UsersInMyOrgTypeaheadResult | null): void {
     if (!user || !('projects' in user)) {
       projects = [];
     } else {
-      projects = [...user.projects.map(p => ({role: p.role, code: p.project.code, name: p.project.name}))];
+      projects = [...user.projects.map(p => ({role: p.role, id: p.project.id, code: p.project.code, name: p.project.name}))];
     }
   }
 

--- a/frontend/src/routes/(authenticated)/org/[org_id]/AddOrgMemberModal.svelte
+++ b/frontend/src/routes/(authenticated)/org/[org_id]/AddOrgMemberModal.svelte
@@ -43,6 +43,7 @@
         $form.usernameOrEmail,
         $form.role,
         $form.canInvite,
+        projects,
       );
 
       if (error?.byType('NotFoundError')) {

--- a/frontend/src/routes/(authenticated)/org/[org_id]/AddOrgMemberModal.svelte
+++ b/frontend/src/routes/(authenticated)/org/[org_id]/AddOrgMemberModal.svelte
@@ -10,7 +10,7 @@
   import { SupHelp, helpLinks } from '$lib/components/help';
   import type { UUID } from 'crypto';
   import { _addOrgMember } from './+page';
-  import type { SingleUserTypeaheadResult, UsersInMyOrgTypeaheadResult } from '$lib/gql/typeahead-queries';
+  import type { SingleUserInMyOrgTypeaheadResult, SingleUserTypeaheadResult } from '$lib/gql/typeahead-queries';
   import UserProjects, { type Project } from '$lib/components/Users/UserProjects.svelte';
 
   export let orgId: string;
@@ -27,7 +27,7 @@
   const { notifySuccess } = useNotifications();
 
   let projects: Project[] = [];
-  function populateUserProjects(user: SingleUserTypeaheadResult | UsersInMyOrgTypeaheadResult | null): void {
+  function populateUserProjects(user: SingleUserTypeaheadResult | SingleUserInMyOrgTypeaheadResult | null): void {
     if (!user || !('projects' in user)) {
       projects = [];
     } else {

--- a/frontend/src/routes/(authenticated)/org/[org_id]/AddOrgMemberModal.svelte
+++ b/frontend/src/routes/(authenticated)/org/[org_id]/AddOrgMemberModal.svelte
@@ -27,9 +27,11 @@
   const { notifySuccess } = useNotifications();
 
   let projects: Project[] = [];
+  let selectedProjects: string[] = [];
   function populateUserProjects(user: SingleUserTypeaheadResult | SingleUserInMyOrgTypeaheadResult | null): void {
     if (!user || !('projects' in user)) {
       projects = [];
+      selectedProjects = [];
     } else {
       projects = [...user.projects.map(p => ({memberRole: p.role, id: p.project.id, code: p.project.code, name: p.project.name}))];
     }
@@ -43,9 +45,10 @@
         $form.usernameOrEmail,
         $form.role,
         $form.canInvite,
-        projects,
+        selectedProjects,
       );
       projects = [];
+      selectedProjects = [];
 
       if (error?.byType('NotFoundError')) {
         if (error.message === 'Org not found') {
@@ -97,7 +100,7 @@
   <OrgRoleSelect bind:value={$form.role} error={errors.role} />
   {#if projects && projects.length}
     {$t('org_page.add_user.also_add_projects')}
-    <UserProjects {projects} />
+    <UserProjects {projects} bind:selectedProjects />
   {/if}
   <svelte:fragment slot="extraActions">
     <Checkbox


### PR DESCRIPTION
Fix #1096.

When a user is selected from the typeahead in the "add members" modal on the org page, that user's projects are also shown in the modal, with any projects that the user manages automatically pre-checked. There's a new GraphQL mutation called AddProjectsToOrg (projects, plural) which will add all the projects at once.

The modal currently does **not** attempt to check which projects are already in the org; instead, the backend handles projects that are already in the org and doesn't try to add them again.

**Screenshot:**

![add-projects-with-member](https://github.com/user-attachments/assets/4aa4d5ef-34c2-4276-ab0b-1396294eec39)
