### PR TITLE
Fix typo that was producing incorrect HTML

### DIFF
--- a/frontend/src/routes/(authenticated)/org/[org_id]/+page.svelte
+++ b/frontend/src/routes/(authenticated)/org/[org_id]/+page.svelte
@@ -156,7 +156,7 @@
               </ul>
             </Dropdown>
           {/if}
-        <td/>
+        </td>
       </ProjectTable>
       <DeleteModal
         bind:this={removeProjectFromOrgModal}


### PR DESCRIPTION
Fixes #1133.

The cause of the "unexpected slot" error turned out to be a simple typo: `<td/>` instead of `</td>`. So instead of closing the `<td slot="actions">` passed to ProjectTable, this was counting as a new (self-closing) td element with no slot attribute, therefore being assigned to the default slot — and since ProjectTable doesn't have a default slot, Svelte printed a console error which eventually led me to find this invalid HTML.