### PR TITLE
add a CI check to ensure there are no pending model changes that haven't been made into migrations

### DIFF
--- a/.github/workflows/lexbox-api.yaml
+++ b/.github/workflows/lexbox-api.yaml
@@ -50,8 +50,15 @@ jobs:
       - uses: actions/setup-dotnet@v4
         with:
           dotnet-version: '8.x'
+      - name: Install Task
+        uses: arduino/setup-task@v2
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Dotnet build
         run: dotnet build LexBoxOnly.slnf
+      - name: Check for pending EF model changes
+        run: task api:has-pending-model-changes
+
       - name: Unit tests
         run: dotnet test LexBoxOnly.slnf --logger:"xunit;LogFileName={assembly}.results.xml" --results-directory ./test-results --filter "Category!=Integration&Category!=FlakyIntegration" --blame-hang-timeout 10m
       - name: Publish unit test results

--- a/backend/Taskfile.yml
+++ b/backend/Taskfile.yml
@@ -8,29 +8,37 @@ tasks:
     cmds:
       - dotnet watch
 
+  tool-restore:
+    cmd: dotnet tool restore
+
   migrate-db:
+    deps: [ tool-restore ]
     dir: ./LexBoxApi
     cmds:
       - dotnet run migrate --environment "Development"
 
   add-migration:
     desc: 'usage: task add-migration -- "migration name". Often followed by `task database-update`.'
+    deps: [ tool-restore ]
     dir: ./LexBoxApi
     cmds:
       - dotnet ef migrations add --project ../LexData/LexData.csproj --startup-project LexBoxApi.csproj --context LexData.LexBoxDbContext --output-dir Migrations {{.CLI_ARGS}}
   has-pending-model-changes:
+    deps: [ tool-restore ]
     dir: ./LexBoxApi
     cmds:
       - dotnet ef migrations has-pending-model-changes --project ../LexData/LexData.csproj --startup-project LexBoxApi.csproj --context LexData.LexBoxDbContext
 
   remove-last-migration:
     desc: "This will remove the last migration, don't remove migrations that have been pushed to production, but you can remove ones you created locally."
+    deps: [ tool-restore ]
     dir: ./LexBoxApi
     cmds:
       - dotnet ef migrations remove --project ../LexData/LexData.csproj --startup-project LexBoxApi.csproj --context LexData.LexBoxDbContext
 
   db-update:
     desc: "Runs any migrations that haven't yet been applied or rolls back to the specified migration."
+    deps: [ tool-restore ]
     dir: ./LexBoxApi
     cmds:
       - dotnet ef database update {{.CLI_ARGS}} --project ../LexData/LexData.csproj --startup-project LexBoxApi.csproj --context LexData.LexBoxDbContext

--- a/backend/Taskfile.yml
+++ b/backend/Taskfile.yml
@@ -18,6 +18,10 @@ tasks:
     dir: ./LexBoxApi
     cmds:
       - dotnet ef migrations add --project ../LexData/LexData.csproj --startup-project LexBoxApi.csproj --context LexData.LexBoxDbContext --output-dir Migrations {{.CLI_ARGS}}
+  has-pending-model-changes:
+    dir: ./LexBoxApi
+    cmds:
+      - dotnet ef migrations has-pending-model-changes --project ../LexData/LexData.csproj --startup-project LexBoxApi.csproj --context LexData.LexBoxDbContext
 
   remove-last-migration:
     desc: "This will remove the last migration, don't remove migrations that have been pushed to production, but you can remove ones you created locally."


### PR DESCRIPTION
Right now, if you were to add a field to A db object and not create a migration, you would get no warning. You could even merge the PR and it won't be until someone else tries to add a migration that they might see your change, this has happened before, now CI will fail if there's pending model changes