### PR TITLE
Keep field help icon attached to field name

### DIFF
--- a/frontend/viewer/src/lib/entry-editor/FieldTitle.svelte
+++ b/frontend/viewer/src/lib/entry-editor/FieldTitle.svelte
@@ -1,15 +1,12 @@
 <script lang="ts">
-  import { mdiEyeOffOutline } from '@mdi/js';
-  import { Icon, Tooltip } from 'svelte-ux';
-  import { fieldName } from '../i18n';
+  import {fieldName} from '../i18n';
+  import {useCurrentView} from '../services/view-service';
   import FieldHelpIcon from './FieldHelpIcon.svelte';
   import {fieldData} from './field-data';
-  import {useCurrentView} from '../services/view-service';
 
   export let id: string;
   export let helpId: string | undefined = undefined;
   export let name: string | undefined = undefined;
-  export let extra: boolean | undefined = undefined;
   $: if (!helpId) helpId = fieldData[id]?.helpId;
 
   const currentView = useCurrentView();
@@ -18,14 +15,11 @@
 
 <div>
   <span class="inline-flex items-center relative">
-    {#if extra}
-      <Tooltip title="Extra / hidden field" delay={0} placement="top" offset={4}>
-        <Icon classes={{root: 'absolute -left-[1.3em] opacity-50'}} data={mdiEyeOffOutline} size="1em" />
-      </Tooltip>
-    {/if}
-    <span class="name" title={`${id}: ${fieldName({name, id})}`}>{fieldName({name, id}, $currentView.i18nKey)}</span>
+    <span class="name" title={`${id}: ${fieldName({name, id})}`}>
+      {fieldName({name, id}, $currentView.i18nKey)}
+      {#if helpId}
+        <FieldHelpIcon helpId={helpId}/>
+      {/if}
+    </span>
   </span>
-  {#if helpId}
-    <FieldHelpIcon helpId={helpId}/>
-  {/if}
 </div>


### PR DESCRIPTION
- Keeps the help icon from getting too far away from the field name (in edge cases)
- Removes dead "Hidden fields" code