### PR TITLE
Try to bring VS Code formatting closer to JetBrains

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -30,5 +30,7 @@
     "files.associations": {
       "**/frontend/**/i18n/**/*.json": "json5", // Supports json5 syntax: https://svelte-intl-precompile.com/en/docs/getting-started
     },
-    "dotnet.defaultSolution": "LexBox.sln"
+    "dotnet.defaultSolution": "LexBox.sln",
+    "javascript.format.insertSpaceAfterOpeningAndBeforeClosingNonemptyBraces": false,
+    "typescript.format.insertSpaceAfterOpeningAndBeforeClosingNonemptyBraces": false
 }


### PR DESCRIPTION
Kevin's IDE removes whitespace inside braces. So, I'm hoping this will prevent some formatting differences.