### PR TITLE
Allow project managers to always remove their projects from orgs

### DIFF
--- a/backend/LexBoxApi/GraphQL/OrgMutations.cs
+++ b/backend/LexBoxApi/GraphQL/OrgMutations.cs
@@ -145,11 +145,7 @@ public class OrgMutations
             .Include(p => p.Organizations)
             .SingleOrDefaultAsync();
         NotFoundException.ThrowIfNull(project);
-        // Org managers can kick projects out and project managers can pull projects out
-        if (!permissionService.CanEditOrg(orgId) && !await permissionService.CanManageProject(projectId))
-        {
-            throw new UnauthorizedAccessException();
-        }
+        await permissionService.AssertCanRemoveProjectFromOrg(org, projectId);
         var foundOrg = project.Organizations.FirstOrDefault(o => o.Id == orgId);
         if (foundOrg is not null)
         {

--- a/backend/LexBoxApi/Services/PermissionService.cs
+++ b/backend/LexBoxApi/Services/PermissionService.cs
@@ -234,4 +234,13 @@ public class PermissionService(
         if (org.Members.Any(m => m.UserId == User.Id)) return;
         throw new UnauthorizedAccessException();
     }
+
+    public async ValueTask AssertCanRemoveProjectFromOrg(Organization org, Guid projectId)
+    {
+        // Org managers can kick projects out and project managers can pull projects out
+        if (!CanEditOrg(org.Id) && !await CanManageProject(projectId))
+        {
+            throw new UnauthorizedAccessException();
+        }
+    }
 }

--- a/backend/LexCore/ServiceInterfaces/IPermissionService.cs
+++ b/backend/LexCore/ServiceInterfaces/IPermissionService.cs
@@ -43,4 +43,5 @@ public interface IPermissionService
     void AssertCanEditOrg(Organization org);
     void AssertCanEditOrg(Guid orgId);
     void AssertCanAddProjectToOrg(Organization org);
+    ValueTask AssertCanRemoveProjectFromOrg(Organization org, Guid projectId);
 }


### PR DESCRIPTION
In short, to **remove** a project from an org...

**Before this change**
You needed to be an org **member** AND a project manager
**Now**
You can be an org **manager** OR a project manager

It seems to me that a project manager should always be able to remove their project from an org, even if they're not a member of the org. It looks like the current logic was just copied from the `AddProjectToOrg` mutation. But, I think my change makes more sense.

