### PR TITLE
fix permissions when adding members to orgs

### DIFF
--- a/backend/LexBoxApi/GraphQL/LexQueries.cs
+++ b/backend/LexBoxApi/GraphQL/LexQueries.cs
@@ -153,6 +153,15 @@ public class LexQueries
     [GraphQLType<OrgByIdGqlConfiguration>]
     public async Task<Organization?> OrgById(LexBoxDbContext dbContext, Guid orgId, IPermissionService permissionService, IResolverContext context)
     {
+        return await QueryOrgById(dbContext, orgId, permissionService, context);
+    }
+
+    [GraphQLIgnore]
+    internal static async Task<Organization?> QueryOrgById(LexBoxDbContext dbContext,
+        Guid orgId,
+        IPermissionService permissionService,
+        IResolverContext context)
+    {
         var org = await dbContext.Orgs.Where(o => o.Id == orgId).AsNoTracking().Project(context).SingleOrDefaultAsync();
         if (org is null) return org;
         // Site admins and org admins can see everything

--- a/frontend/schema.graphql
+++ b/frontend/schema.graphql
@@ -18,7 +18,7 @@ type AddProjectToOrgPayload {
 }
 
 type AddProjectsToOrgPayload {
-  organization: Organization
+  orgById: OrgById
   errors: [AddProjectsToOrgError!]
 }
 

--- a/frontend/src/routes/(authenticated)/org/[org_id]/+page.ts
+++ b/frontend/src/routes/(authenticated)/org/[org_id]/+page.ts
@@ -140,7 +140,7 @@ export async function _addOrgMember(orgId: UUID, emailOrUsername: string, role: 
             }
           }
           addProjectsToOrg(input: $projectsInput) {
-            organization {
+            orgById {
               id
               projects {
                 id
@@ -321,7 +321,7 @@ export async function _addProjectsToOrg(orgId: UUID, projectIds: string[]): $OpR
       graphql(`
         mutation AddProjectsToOrg($input: AddProjectsToOrgInput!) {
           addProjectsToOrg(input: $input) {
-            organization {
+            orgById {
               id
               projects {
                 id


### PR DESCRIPTION
the mutation AddProjectsToOrg returned an Org, which non admins are not allowed to query the projects of. We need to use a custom type with some code to ensure we don't let users query data they don't have permission to access.