### PR TITLE
Catch TryAgain Socket Exceptions when waiting for postgres in dev

### DIFF
--- a/backend/LexData/DbStartupService.cs
+++ b/backend/LexData/DbStartupService.cs
@@ -96,6 +96,10 @@ public class DbStartupService : IHostedService
         {
             return false;
         }
+        catch (SocketException ex) when (ex.SocketErrorCode == SocketError.TryAgain)
+        {
+            return false;
+        }
     }
 
     public Task StopAsync(CancellationToken cancellationToken)


### PR DESCRIPTION
I run into one of these exceptions about once a day, because Postgres isn't quite ready (the db container logs says that it is, but maybe it's not yet reachable?)
Maybe the Postgres ef-core package started throwing different exceptions at one point? 🤷 

Anyway, this seems to fix it for me.