### PR TITLE
FixFwData now does real work

### DIFF
--- a/backend/FixFwData/FixFwData.csproj
+++ b/backend/FixFwData/FixFwData.csproj
@@ -7,10 +7,9 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
-  <Target Name="CreateExe" AfterTargets="Build" Condition="Exists('$(OutputPath)/FixFwData') And !Exists('$(OutputPath)/FixFwData.exe')">
-    <Message Text="Creating FixFwData.exe in $(OutputPath) on Linux since FLExBridge requires the .exe extension" />
-    <Exec Command="ln FixFwData FixFwData.exe"
-          WorkingDirectory="$(OutputPath)" />
-  </Target>
-
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="8.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="8.0.1" />
+    <PackageReference Include="SIL.LCModel.FixData" Version="11.0.0-beta0109" />
+  </ItemGroup>
 </Project>

--- a/backend/FixFwData/Program.cs
+++ b/backend/FixFwData/Program.cs
@@ -1,2 +1,69 @@
-﻿bool doNothing; // Basic FixFwData program that does nothing
-doNothing = true;
+﻿// Copyright (c) 2011-2024 SIL International
+// This software is licensed under the LGPL, version 2.1 or later
+// (http://www.gnu.org/licenses/lgpl-2.1.html)
+
+using System.ComponentModel;
+using Microsoft.Extensions.Logging;
+using SIL.LCModel.FixData;
+using SIL.LCModel.Utils;
+
+namespace FixFwData;
+
+internal class Program
+{
+    private static int Main(string[] args)
+    {
+        using var loggerFactory = LoggerFactory.Create(builder => builder.AddConsole());
+        logger = loggerFactory.CreateLogger("FixFwData");
+        var pathname = args[0];
+        var prog = new LoggingProgress(logger);
+        var data = new FwDataFixer(pathname, prog, logError, getErrorCount);
+        data.FixErrorsAndSave();
+        return errorsOccurred ? 1 : 0;
+    }
+
+    private static bool errorsOccurred = false;
+    private static int errorCount = 0;
+    private static ILogger? logger;
+
+    private static void logError(string description, bool errorFixed)
+    {
+        logger?.LogError(description);
+
+        errorsOccurred = true;
+        if (errorFixed)
+            ++errorCount;
+    }
+
+    private static int getErrorCount()
+    {
+        return errorCount;
+    }
+
+    private sealed class LoggingProgress(ILogger logger) : IProgress
+    {
+        public string Message { get => ""; set => logger.LogInformation(value); }
+
+        #region Do-nothing implementation of IProgress GUI methods
+        // IProgress methods required by the interface that don't make sense in a console app
+        public event CancelEventHandler? Canceling;
+        public void Step(int amount)
+        {
+            if (Canceling != null)
+            {
+                // don't do anything -- this just shuts up the compiler about the
+                // event handler never being used.
+            }
+        }
+
+        public string Title { get => ""; set { } }
+        public int Position { get; set; }
+        public int StepSize { get; set; }
+        public int Minimum { get; set; }
+        public int Maximum { get; set; }
+        public ISynchronizeInvoke? SynchronizeInvoke { get => null; private set { } }
+        public bool IsIndeterminate { get => false; set { } }
+        public bool AllowCancel { get => false; set { } }
+        #endregion
+    }
+}

--- a/backend/FwLite/FwLiteDesktop/FwLiteDesktop.csproj
+++ b/backend/FwLite/FwLiteDesktop/FwLiteDesktop.csproj
@@ -22,6 +22,7 @@
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
         <SelfContained>true</SelfContained>
+        <EnableWindowsTargeting Condition="$([MSBuild]::IsOSPlatform('linux'))">true</EnableWindowsTargeting>
 
 		<!-- controls display name in Package.appxmanifest -->
 		<ApplicationTitle>FieldWorks Lite</ApplicationTitle>

--- a/backend/Testing/Testing.csproj
+++ b/backend/Testing/Testing.csproj
@@ -38,7 +38,7 @@
         <PackageReference Include="Moq.Contrib.HttpClient" Version="1.4.0" />
         <PackageReference Include="Shouldly" Version="4.2.1" />
         <PackageReference Include="SIL.ChorusPlugin.LfMergeBridge" Version="4.1.0" />
-        <PackageReference Include="SIL.Core" Version="13.0.0-beta0074" />
+        <PackageReference Include="SIL.Core" Version="14.2.0-*" />
         <PackageReference Include="xunit" Version="2.9.0" />
         <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>


### PR DESCRIPTION
Fix #1155.

Our FixFwData program was a do-nothing implementation, there only because FlexBridge requires a program called FixFwData to exist and be runnable. This was fine as long as the only Send/Receives we were triggering in Lexbox code were in integration tests, where no merge conflicts could happen. However, once we start allowing CrdtMerge to do real Send/Receives of user data, merge conflicts can happen, and FixFwData is there to take the merge decisions made by ChorusMerge and fix them when they would produce invalid .fwdata files. (For example, two people might add the same part of speech to a project, and the merge resolution would keep both. That would be valid XML but invalid .fwdata because they would both have the same GUID, so FixFwData would keep just one of the two parts of speech with that GUID).

The guts of FixFwData are provided by liblcm, so all we have to do here is write a wrapper program. I've chosen to copy the LfMerge implementation, and change its LoggingProgress implementation to use Microsoft's ILogger interface instead of Console.WriteLine. Which means, since I copied the implementation from LfMerge's LGPL'ed implementation, that this FixFwData implementation is also LGPL'ed. Since it's a separate .exe from the rest of our code, this has no implications for the license of the rest of the Lexbox code, which is MIT licensed.