### PR TITLE
Make about link absolute so it works on every page

### DIFF
--- a/frontend/src/lib/layout/Footer.svelte
+++ b/frontend/src/lib/layout/Footer.svelte
@@ -24,7 +24,7 @@
       </div>
     </div>
     <div class="grid grid-cols-2 gap-x-4 text-right">
-      <a class="hover:link" href="./about">{$t('about.title')}</a>
+      <a class="hover:link" href="/about">{$t('about.title')}</a>
       <a class="hover:link" href="https://software.sil.org/language-software-terms-of-use/">{$t('footer.terms_of_use')}</a>
       <a class="hover:link" href="mailto:admin@languagedepot.org" target="_blank">{$t('footer.contact')}</a>
       <a class="hover:link" href="https://software.sil.org/language-software-privacy-policy/">{$t('footer.privacy_policy')}</a>


### PR DESCRIPTION
The about link is currently relative, which makes no sense. Oops.