### PR TITLE
Use project ID, not code, in CrdtMerge API

### DIFF
--- a/backend/CrdtMerge/CrdtMerge.csproj
+++ b/backend/CrdtMerge/CrdtMerge.csproj
@@ -20,6 +20,7 @@
     <ProjectReference Include="../FwLite/LcmCrdt/LcmCrdt.csproj" />
     <ProjectReference Include="../FwLite/FwLiteProjectSync/FwLiteProjectSync.csproj" />
     <ProjectReference Include="../FixFwData/FixFwData.csproj" />
+    <ProjectReference Include="../LexData/LexData.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/backend/CrdtMerge/CrdtMergeKernel.cs
+++ b/backend/CrdtMerge/CrdtMergeKernel.cs
@@ -15,6 +15,7 @@ public static class CrdtMergeKernel
             .ValidateDataAnnotations()
             .ValidateOnStart();
         services.AddScoped<SendReceiveService>();
+        services.AddScoped<ProjectLookupService>();
         services
             .AddLcmCrdtClient()
             .AddFwDataBridge()

--- a/backend/CrdtMerge/Program.cs
+++ b/backend/CrdtMerge/Program.cs
@@ -62,6 +62,7 @@ static async Task<Results<Ok<CrdtFwdataProjectSyncService.SyncResult>, NotFound>
         logger.LogError("Project ID {projectId} not found", projectId);
         return TypedResults.NotFound();
     }
+    logger.LogInformation("Project code is {projectCode}", projectCode);
 
     var projectFolder = Path.Join(config.Value.ProjectStorageRoot, $"{projectCode}-{projectId}");
     if (!Directory.Exists(projectFolder)) Directory.CreateDirectory(projectFolder);

--- a/backend/CrdtMerge/Program.cs
+++ b/backend/CrdtMerge/Program.cs
@@ -46,20 +46,20 @@ static async Task<Results<Ok<CrdtFwdataProjectSyncService.SyncResult>, NotFound>
     ProjectsService projectsService,
     ProjectLookupService projectLookupService,
     CrdtFwdataProjectSyncService syncService,
-    string projectCode,
+    Guid projectId,
     bool dryRun = false)
 {
-    logger.LogInformation("About to execute sync request for {projectCode}", projectCode);
+    logger.LogInformation("About to execute sync request for {projectId}", projectId);
     if (dryRun)
     {
         logger.LogInformation("Dry run, not actually syncing");
         return TypedResults.Ok(new CrdtFwdataProjectSyncService.SyncResult(0, 0));
     }
 
-    var projectId = await projectLookupService.GetProjectId(projectCode);
-    if (projectId is null)
+    var projectCode = await projectLookupService.GetProjectCode(projectId);
+    if (projectCode is null)
     {
-        logger.LogError("Project code {projectCode} not found", projectCode);
+        logger.LogError("Project ID {projectId} not found", projectId);
         return TypedResults.NotFound();
     }
 

--- a/backend/CrdtMerge/Program.cs
+++ b/backend/CrdtMerge/Program.cs
@@ -2,6 +2,8 @@ using CrdtMerge;
 using FwDataMiniLcmBridge;
 using FwLiteProjectSync;
 using LcmCrdt;
+using LexData;
+using Microsoft.AspNetCore.Http.HttpResults;
 using Microsoft.Extensions.Options;
 using MiniLcm;
 using Scalar.AspNetCore;
@@ -11,6 +13,11 @@ var builder = WebApplication.CreateBuilder(args);
 // Add services to the container.
 // Learn more about configuring OpenAPI at https://aka.ms/aspnet/openapi
 builder.Services.AddOpenApi();
+
+builder.Services.AddLexData(
+    autoApplyMigrations: false,
+    useOpenIddict: false
+);
 
 builder.Services.AddCrdtMerge();
 
@@ -30,56 +37,60 @@ app.MapPost("/sync", ExecuteMergeRequest);
 
 app.Run();
 
-static async Task<CrdtFwdataProjectSyncService.SyncResult> ExecuteMergeRequest(
+static async Task<Results<Ok<CrdtFwdataProjectSyncService.SyncResult>, NotFound>> ExecuteMergeRequest(
     ILogger<Program> logger,
     IServiceProvider services,
     SendReceiveService srService,
     IOptions<CrdtMergeConfig> config,
     FwDataFactory fwDataFactory,
     ProjectsService projectsService,
+    ProjectLookupService projectLookupService,
     CrdtFwdataProjectSyncService syncService,
     string projectCode,
-    // string projectName, // TODO: Add this to the API eventually
     bool dryRun = false)
 {
     logger.LogInformation("About to execute sync request for {projectCode}", projectCode);
     if (dryRun)
     {
         logger.LogInformation("Dry run, not actually syncing");
-        return new(0, 0);
+        return TypedResults.Ok(new CrdtFwdataProjectSyncService.SyncResult(0, 0));
     }
 
-    // TODO: Instead of projectCode here, we'll evetually look up project ID and use $"{projectName}-{projectId}" as the project folder
-    var projectFolder = Path.Join(config.Value.ProjectStorageRoot, projectCode);
+    var projectId = await projectLookupService.GetProjectId(projectCode);
+    if (projectId is null)
+    {
+        logger.LogError("Project code {projectCode} not found", projectCode);
+        return TypedResults.NotFound();
+    }
+
+    var projectFolder = Path.Join(config.Value.ProjectStorageRoot, $"{projectCode}-{projectId}");
     if (!Directory.Exists(projectFolder)) Directory.CreateDirectory(projectFolder);
 
-    // TODO: add projectName parameter and use it instead of projectCode here
-    var crdtFile = Path.Join(projectFolder, $"{projectCode}.sqlite");
+    var crdtFile = Path.Join(projectFolder, "crdt.sqlite");
 
-    var fwDataProject = new FwDataProject(projectCode, projectFolder); // TODO: use projectName (once we have it) instead of projectCode here
+    var fwDataProject = new FwDataProject("fw", projectFolder);
     logger.LogDebug("crdtFile: {crdtFile}", crdtFile);
     logger.LogDebug("fwDataFile: {fwDataFile}", fwDataProject.FilePath);
 
     if (File.Exists(fwDataProject.FilePath))
     {
-        var srResult = srService.SendReceive(fwDataProject);
+        var srResult = srService.SendReceive(fwDataProject, projectCode);
         logger.LogInformation("Send/Receive result: {srResult}", srResult.Output);
     }
     else
     {
-        var srResult = srService.Clone(fwDataProject);
+        var srResult = srService.Clone(fwDataProject, projectCode);
         logger.LogInformation("Send/Receive result: {srResult}", srResult.Output);
     }
     var fwdataApi = fwDataFactory.GetFwDataMiniLcmApi(fwDataProject, true);
-    // var crdtProject = projectsService.GetProject(crdtProjectName);
     var crdtProject = File.Exists(crdtFile) ?
-        new CrdtProject(projectCode, crdtFile) : // TODO: use projectName (once we have it) instead of projectCode here
-        await projectsService.CreateProject(new(projectCode, SeedNewProjectData: false, Path: projectFolder, FwProjectId: fwdataApi.ProjectId));
+        new CrdtProject("crdt", crdtFile) :
+        await projectsService.CreateProject(new("crdt", SeedNewProjectData: false, Path: projectFolder, FwProjectId: fwdataApi.ProjectId));
     var miniLcmApi = await services.OpenCrdtProject(crdtProject);
     var result = await syncService.Sync(miniLcmApi, fwdataApi, dryRun);
     logger.LogInformation("Sync result, CrdtChanges: {CrdtChanges}, FwdataChanges: {FwdataChanges}", result.CrdtChanges, result.FwdataChanges);
-    var srResult2 = srService.SendReceive(fwDataProject);
+    var srResult2 = srService.SendReceive(fwDataProject, projectCode);
     logger.LogInformation("Send/Receive result after CRDT sync: {srResult2}", srResult2.Output);
-    return result;
+    return TypedResults.Ok(result);
 }
 

--- a/backend/CrdtMerge/ProjectLookupService.cs
+++ b/backend/CrdtMerge/ProjectLookupService.cs
@@ -1,0 +1,16 @@
+using LexData;
+using Microsoft.EntityFrameworkCore;
+
+namespace CrdtMerge;
+
+public class ProjectLookupService(LexBoxDbContext dbContext)
+{
+    public async ValueTask<Guid?> GetProjectId(string projectCode)
+    {
+        var projectId = await dbContext.Projects
+            .Where(p => p.Code == projectCode)
+            .Select(p => p.Id)
+            .FirstOrDefaultAsync();
+        return projectId;
+    }
+}

--- a/backend/CrdtMerge/ProjectLookupService.cs
+++ b/backend/CrdtMerge/ProjectLookupService.cs
@@ -5,12 +5,12 @@ namespace CrdtMerge;
 
 public class ProjectLookupService(LexBoxDbContext dbContext)
 {
-    public async ValueTask<Guid?> GetProjectId(string projectCode)
+    public async ValueTask<string?> GetProjectCode(Guid projectId)
     {
-        var projectId = await dbContext.Projects
-            .Where(p => p.Code == projectCode)
-            .Select(p => p.Id)
+        var projectCode = await dbContext.Projects
+            .Where(p => p.Id == projectId)
+            .Select(p => p.Code)
             .FirstOrDefaultAsync();
-        return projectId;
+        return projectCode;
     }
 }

--- a/backend/CrdtMerge/SendReceiveHelpers.cs
+++ b/backend/CrdtMerge/SendReceiveHelpers.cs
@@ -45,14 +45,14 @@ public static class SendReceiveHelpers
         return builder.Uri;
     }
 
-    public static LfMergeBridgeResult SendReceive(FwDataProject project, string baseUrl = "http://localhost", SendReceiveAuth? auth = null, string fdoDataModelVersion = "7000072", string? commitMessage = null)
+    public static LfMergeBridgeResult SendReceive(FwDataProject project, string? projectCode = null, string baseUrl = "http://localhost", SendReceiveAuth? auth = null, string fdoDataModelVersion = "7000072", string? commitMessage = null)
     {
-        // If projectCode not given, calculate it from the fwdataPath
+        projectCode ??= project.Name;
         var fwdataInfo = new FileInfo(project.FilePath);
         if (fwdataInfo.Directory is null) throw new InvalidOperationException(
             $"Not allowed to Send/Receive root-level directories like C:\\, was '{project.FilePath}'");
 
-        var repoUrl = BuildSendReceiveUrl(baseUrl, project.Name, auth);
+        var repoUrl = BuildSendReceiveUrl(baseUrl, projectCode, auth);
 
         var flexBridgeOptions = new Dictionary<string, string>
         {
@@ -68,13 +68,13 @@ public static class SendReceiveHelpers
         return CallLfMergeBridge("Language_Forge_Send_Receive", flexBridgeOptions);
     }
 
-    public static LfMergeBridgeResult CloneProject(FwDataProject project, string baseUrl = "http://localhost", SendReceiveAuth? auth = null, string fdoDataModelVersion = "7000072")
+    public static LfMergeBridgeResult CloneProject(FwDataProject project, string? projectCode = null, string baseUrl = "http://localhost", SendReceiveAuth? auth = null, string fdoDataModelVersion = "7000072")
     {
-        // If projectCode not given, calculate it from the fwdataPath
+        projectCode ??= project.Name;
         var fwdataInfo = new FileInfo(project.FilePath);
         if (fwdataInfo.Directory is null) throw new InvalidOperationException($"Not allowed to Send/Receive root-level directories like C:\\ '{project.FilePath}'");
 
-        var repoUrl = BuildSendReceiveUrl(baseUrl, project.Name, auth);
+        var repoUrl = BuildSendReceiveUrl(baseUrl, projectCode, auth);
 
         var flexBridgeOptions = new Dictionary<string, string>
         {

--- a/backend/CrdtMerge/SendReceiveService.cs
+++ b/backend/CrdtMerge/SendReceiveService.cs
@@ -5,10 +5,11 @@ namespace CrdtMerge;
 
 public class SendReceiveService(IOptions<CrdtMergeConfig> config)
 {
-    public SendReceiveHelpers.LfMergeBridgeResult SendReceive(FwDataProject project, string? commitMessage = null)
+    public SendReceiveHelpers.LfMergeBridgeResult SendReceive(FwDataProject project, string? projectCode, string? commitMessage = null)
     {
         return SendReceiveHelpers.SendReceive(
             project: project,
+            projectCode: projectCode,
             baseUrl: config.Value.HgWebUrl,
             auth: new SendReceiveHelpers.SendReceiveAuth(config.Value),
             fdoDataModelVersion: config.Value.FdoDataModelVersion,
@@ -16,10 +17,11 @@ public class SendReceiveService(IOptions<CrdtMergeConfig> config)
         );
     }
 
-    public SendReceiveHelpers.LfMergeBridgeResult Clone(FwDataProject project)
+    public SendReceiveHelpers.LfMergeBridgeResult Clone(FwDataProject project, string? projectCode)
     {
         return SendReceiveHelpers.CloneProject(
             project: project,
+            projectCode: projectCode,
             baseUrl: config.Value.HgWebUrl,
             auth: new SendReceiveHelpers.SendReceiveAuth(config.Value),
             fdoDataModelVersion: config.Value.FdoDataModelVersion

--- a/backend/CrdtMerge/appsettings.Development.json
+++ b/backend/CrdtMerge/appsettings.Development.json
@@ -6,6 +6,9 @@
     "LexboxPassword": "pass",
     "FdoDataModelVersion": "7000072"
   },
+  "DbConfig": {
+    "LexBoxConnectionString": "Host=localhost;Port=5433;Username=postgres;Password=972b722e63f549938d07bd8c4ee5086c;Database=lexbox;Include Error Detail=true"
+  },
   "Logging": {
     "LogLevel": {
       "Default": "Information",

--- a/backend/FwLite/FwDataMiniLcmBridge/FwDataFactory.cs
+++ b/backend/FwLite/FwDataMiniLcmBridge/FwDataFactory.cs
@@ -38,7 +38,7 @@ public class FwDataFactory(
         return GetFwDataMiniLcmApi(project, saveOnDispose);
     }
 
-    private string CacheKey(FwDataProject project) => $"{nameof(FwDataFactory)}|{project.FileName}";
+    private string CacheKey(FwDataProject project) => $"{nameof(FwDataFactory)}|{project.FilePath}";
 
     public FwDataMiniLcmApi GetFwDataMiniLcmApi(FwDataProject project, bool saveOnDispose)
     {

--- a/backend/FwLite/FwLiteProjectSync/CrdtFwdataProjectSyncService.cs
+++ b/backend/FwLite/FwLiteProjectSync/CrdtFwdataProjectSyncService.cs
@@ -22,6 +22,7 @@ public class CrdtFwdataProjectSyncService(IOptions<LcmCrdtConfig> lcmCrdtConfig,
         }
         var projectSnapshot = await GetProjectSnapshot(fwdataApi.Project.Name, fwdataApi.Project.ProjectsPath);
         SyncResult result = await Sync(crdtApi, fwdataApi, dryRun, fwdataApi.EntryCount, projectSnapshot);
+        fwdataApi.Save();
 
         if (!dryRun)
         {

--- a/backend/FwLite/LcmCrdt.Tests/LcmCrdt.Tests.csproj
+++ b/backend/FwLite/LcmCrdt.Tests/LcmCrdt.Tests.csproj
@@ -14,7 +14,7 @@
           <PrivateAssets>all</PrivateAssets>
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="8.0.0" />
+        <PackageReference Include="Microsoft.Extensions.Hosting" Version="8.0.1" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.0" />
         <PackageReference Include="FluentAssertions" Version="6.12.0"/>
         <PackageReference Include="Soenneker.Utils.AutoBogus" Version="2.1.278" />

--- a/backend/FwLite/LcmCrdt.Tests/OpenProjectTests.cs
+++ b/backend/FwLite/LcmCrdt.Tests/OpenProjectTests.cs
@@ -1,0 +1,26 @@
+﻿using Microsoft.Data.Sqlite;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+
+namespace LcmCrdt.Tests;
+
+public class OpenProjectTests
+{
+    [Fact]
+    public async Task OpeningAProjectWorks()
+    {
+        var sqliteConnectionString = "OpeningAProjectWorks.sqlite";
+        var builder = Host.CreateEmptyApplicationBuilder(null);
+        builder.Services.AddLcmCrdtClient();
+        using var host = builder.Build();
+        var services = host.Services;
+        var asyncScope = services.CreateAsyncScope();
+        await asyncScope.ServiceProvider.GetRequiredService<ProjectsService>()
+            .CreateProject(new(Name: "OpeningAProjectWorks", Path: ""));
+
+        var miniLcmApi = (CrdtMiniLcmApi)await asyncScope.ServiceProvider.OpenCrdtProject(new CrdtProject("OpeningAProjectWorks", sqliteConnectionString));
+        miniLcmApi.ProjectData.Name.Should().Be("OpeningAProjectWorks");
+
+        await asyncScope.ServiceProvider.GetRequiredService<LcmCrdtDbContext>().Database.EnsureDeletedAsync();
+    }
+}

--- a/backend/FwLite/LcmCrdt/CurrentProjectService.cs
+++ b/backend/FwLite/LcmCrdt/CurrentProjectService.cs
@@ -27,7 +27,7 @@ public class CurrentProjectService(LcmCrdtDbContext dbContext, ProjectContext pr
 
     private static string CacheKey(CrdtProject project)
     {
-        return project.Name + "|ProjectData";
+        return project.DbPath + "|ProjectData";
     }
 
     private static string CacheKey(Guid projectId)

--- a/backend/FwLite/LcmCrdt/LcmCrdtKernel.cs
+++ b/backend/FwLite/LcmCrdt/LcmCrdtKernel.cs
@@ -152,10 +152,15 @@ public static class LcmCrdtKernel
             .Add<CreateComplexFormType>();
     }
 
-    public static async Task<IMiniLcmApi> OpenCrdtProject(this IServiceProvider services, CrdtProject project)
+    public static Task<IMiniLcmApi> OpenCrdtProject(this IServiceProvider services, CrdtProject project)
     {
         var projectsService = services.GetRequiredService<ProjectsService>();
         projectsService.SetProjectScope(project);
+        return LoadMiniLcmApi(services);
+    }
+
+    private static async Task<IMiniLcmApi> LoadMiniLcmApi(IServiceProvider services)
+    {
         await services.GetRequiredService<CurrentProjectService>().PopulateProjectDataCache();
         return services.GetRequiredService<IMiniLcmApi>();
     }

--- a/backend/FwLite/LcmCrdt/LcmCrdtKernel.cs
+++ b/backend/FwLite/LcmCrdt/LcmCrdtKernel.cs
@@ -154,6 +154,9 @@ public static class LcmCrdtKernel
 
     public static Task<IMiniLcmApi> OpenCrdtProject(this IServiceProvider services, CrdtProject project)
     {
+        //this method must not be async, otherwise Setting the project scope will not work as expected.
+        //the project is stored in the async scope, if a new scope is created in this method then it will be gone once the method returns
+        //making the lcm api unusable
         var projectsService = services.GetRequiredService<ProjectsService>();
         projectsService.SetProjectScope(project);
         return LoadMiniLcmApi(services);

--- a/backend/LexData/DataKernel.cs
+++ b/backend/LexData/DataKernel.cs
@@ -9,6 +9,7 @@ public static class DataKernel
 {
     public static void AddLexData(this IServiceCollection services,
         bool autoApplyMigrations,
+        bool useOpenIddict = true,
         ServiceLifetime dbContextLifeTime = ServiceLifetime.Scoped)
     {
         services.AddScoped<SeedingData>();
@@ -17,7 +18,7 @@ public static class DataKernel
             options.EnableDetailedErrors();
             options.UseNpgsql(serviceProvider.GetRequiredService<IOptions<DbConfig>>().Value.LexBoxConnectionString);
             options.UseProjectables();
-            options.UseOpenIddict();
+            if (useOpenIddict) options.UseOpenIddict();
 #if DEBUG
             options.EnableSensitiveDataLogging();
 #endif


### PR DESCRIPTION
Fix #1168.

We now use project code and ID in root folder name, use "crdt" and "fw" inside root folder no matter what the project's actual code or name is.

We also use project ID rather than code in the API request parameters. So now instead of POSTing to `/sync/?projectCode=sena-3`, you would POST to `/sync/?projectId=0ebc5976-058d-4447-aaa7-297f8569f968`.