### PR TITLE
Standardize FW Lite ProjectData.Id

### DIFF
--- a/backend/CrdtMerge/Program.cs
+++ b/backend/CrdtMerge/Program.cs
@@ -74,7 +74,7 @@ static async Task<CrdtFwdataProjectSyncService.SyncResult> ExecuteMergeRequest(
     // var crdtProject = projectsService.GetProject(crdtProjectName);
     var crdtProject = File.Exists(crdtFile) ?
         new CrdtProject(projectCode, crdtFile) : // TODO: use projectName (once we have it) instead of projectCode here
-        await projectsService.CreateProject(new(projectCode, fwdataApi.ProjectId, SeedNewProjectData: false, Path: projectFolder));
+        await projectsService.CreateProject(new(projectCode, SeedNewProjectData: false, Path: projectFolder, FwProjectId: fwdataApi.ProjectId));
     var miniLcmApi = await services.OpenCrdtProject(crdtProject);
     var result = await syncService.Sync(miniLcmApi, fwdataApi, dryRun);
     logger.LogInformation("Sync result, CrdtChanges: {CrdtChanges}, FwdataChanges: {FwdataChanges}", result.CrdtChanges, result.FwdataChanges);

--- a/backend/FwLite/FwLiteProjectSync.Tests/Fixtures/SyncFixture.cs
+++ b/backend/FwLite/FwLiteProjectSync.Tests/Fixtures/SyncFixture.cs
@@ -1,4 +1,5 @@
-﻿using FwDataMiniLcmBridge;
+﻿using System.Runtime.CompilerServices;
+using FwDataMiniLcmBridge;
 using FwDataMiniLcmBridge.Api;
 using FwDataMiniLcmBridge.LcmUtils;
 using FwDataMiniLcmBridge.Tests.Fixtures;
@@ -21,7 +22,7 @@ public class SyncFixture : IAsyncLifetime
     private readonly string _projectName;
     private readonly MockProjectContext _projectContext = new(null);
 
-    public static SyncFixture Create(string projectName) => new(projectName);
+    public static SyncFixture Create([CallerMemberName] string projectName = "") => new(projectName);
 
     private SyncFixture(string projectName)
     {
@@ -58,9 +59,7 @@ public class SyncFixture : IAsyncLifetime
         Directory.CreateDirectory(crdtProjectsFolder);
         var crdtProject = await _services.ServiceProvider.GetRequiredService<ProjectsService>()
             .CreateProject(new(_projectName, FwProjectId: FwDataApi.ProjectId));
-        _projectContext.Project = crdtProject;
-        await _services.ServiceProvider.GetRequiredService<CurrentProjectService>().PopulateProjectDataCache();
-        CrdtApi = (CrdtMiniLcmApi) _services.ServiceProvider.GetRequiredService<IMiniLcmApi>();
+        CrdtApi = (CrdtMiniLcmApi) await _services.ServiceProvider.OpenCrdtProject(crdtProject);
     }
 
     public async Task DisposeAsync()

--- a/backend/FwLite/FwLiteProjectSync.Tests/SyncFixtureTests.cs
+++ b/backend/FwLite/FwLiteProjectSync.Tests/SyncFixtureTests.cs
@@ -7,7 +7,7 @@ public class SyncFixtureTests
     [Fact]
     public async Task CanStart()
     {
-        var fixture = SyncFixture.Create("test-sync-fixture");
+        var fixture = SyncFixture.Create();
         await fixture.InitializeAsync();
         await fixture.DisposeAsync();
     }

--- a/backend/FwLite/FwLiteProjectSync/CrdtFwdataProjectSyncService.cs
+++ b/backend/FwLite/FwLiteProjectSync/CrdtFwdataProjectSyncService.cs
@@ -16,6 +16,10 @@ public class CrdtFwdataProjectSyncService(IOptions<LcmCrdtConfig> lcmCrdtConfig,
 
     public async Task<SyncResult> Sync(IMiniLcmApi crdtApi, FwDataMiniLcmApi fwdataApi, bool dryRun = false)
     {
+        if (crdtApi is CrdtMiniLcmApi crdt && crdt.ProjectData.FwProjectId != fwdataApi.ProjectId)
+        {
+            throw new InvalidOperationException($"Project id mismatch, CRDT Id: {crdt.ProjectData.FwProjectId}, FWData Id: {fwdataApi.ProjectId}");
+        }
         var projectSnapshot = await GetProjectSnapshot(fwdataApi.Project.Name, fwdataApi.Project.ProjectsPath);
         SyncResult result = await Sync(crdtApi, fwdataApi, dryRun, fwdataApi.EntryCount, projectSnapshot);
 

--- a/backend/FwLite/FwLiteProjectSync/Program.cs
+++ b/backend/FwLite/FwLiteProjectSync/Program.cs
@@ -56,7 +56,7 @@ public class Program
                 var crdtProject = projectsService.GetProject(crdtProjectName);
                 if (crdtProject is null)
                 {
-                    crdtProject = await projectsService.CreateProject(new(crdtProjectName, fwdataApi.ProjectId, SeedNewProjectData: false));
+                    crdtProject = await projectsService.CreateProject(new(crdtProjectName, FwProjectId:fwdataApi.ProjectId, SeedNewProjectData: false));
                 }
                 var syncService = services.GetRequiredService<CrdtFwdataProjectSyncService>();
 

--- a/backend/FwLite/LcmCrdt.Tests/DataModelSnapshotTests.VerifyDbModel.verified.txt
+++ b/backend/FwLite/LcmCrdt.Tests/DataModelSnapshotTests.VerifyDbModel.verified.txt
@@ -3,6 +3,7 @@
     Properties: 
       Id (Guid) Required PK AfterSave:Throw ValueGenerated.OnAdd
       ClientId (Guid) Required
+      FwProjectId (Guid?)
       Name (string) Required
       OriginDomain (string)
     Keys: 

--- a/backend/FwLite/LcmCrdt/CrdtMiniLcmApi.cs
+++ b/backend/FwLite/LcmCrdt/CrdtMiniLcmApi.cs
@@ -13,7 +13,7 @@ namespace LcmCrdt;
 public class CrdtMiniLcmApi(DataModel dataModel, CurrentProjectService projectService) : IMiniLcmApi
 {
     private Guid ClientId { get; } = projectService.ProjectData.ClientId;
-
+    public ProjectData ProjectData => projectService.ProjectData;
 
     private IQueryable<Entry> Entries => dataModel.GetLatestObjects<Entry>();
     private IQueryable<ComplexFormComponent> ComplexFormComponents => dataModel.GetLatestObjects<ComplexFormComponent>();

--- a/backend/FwLite/LcmCrdt/CrdtProject.cs
+++ b/backend/FwLite/LcmCrdt/CrdtProject.cs
@@ -8,7 +8,15 @@ public class CrdtProject(string name, string dbPath) : IProjectIdentifier
     public ProjectData? Data { get; set; }
 }
 
-public record ProjectData(string Name, Guid Id, string? OriginDomain, Guid ClientId)
+/// <summary>
+///
+/// </summary>
+/// <param name="Name">Name of the project</param>
+/// <param name="Id">Id, consistent across all clients, matches the project Id in Lexbox</param>
+/// <param name="OriginDomain">Server to sync with, null if not synced</param>
+/// <param name="ClientId">Unique id for this client machine</param>
+/// <param name="FwProjectId">FieldWorks project id, aka LangProjectId</param>
+public record ProjectData(string Name, Guid Id, string? OriginDomain, Guid ClientId, Guid? FwProjectId = null)
 {
     public static string? GetOriginDomain(Uri? uri)
     {

--- a/backend/FwLite/LcmCrdt/CurrentProjectService.cs
+++ b/backend/FwLite/LcmCrdt/CurrentProjectService.cs
@@ -45,8 +45,9 @@ public class CurrentProjectService(LcmCrdtDbContext dbContext, ProjectContext pr
         return memoryCache.Get<ProjectData>(CacheKey(projectId));
     }
 
-    public async ValueTask<ProjectData> PopulateProjectDataCache()
+    public async ValueTask<ProjectData> PopulateProjectDataCache(bool force = false)
     {
+        if (force) RemoveProjectDataCache();
         var projectData = await GetProjectData();
         return projectData;
     }

--- a/backend/FwLite/LcmCrdt/ProjectsService.cs
+++ b/backend/FwLite/LcmCrdt/ProjectsService.cs
@@ -39,7 +39,8 @@ public class ProjectsService(IServiceProvider provider, ProjectContext projectCo
         Uri? Domain = null,
         Func<IServiceProvider, CrdtProject, Task>? AfterCreate = null,
         bool SeedNewProjectData = true,
-        string? Path = null);
+        string? Path = null,
+        Guid? FwProjectId = null);
 
     public async Task<CrdtProject> CreateProject(CreateProjectRequest request)
     {
@@ -55,7 +56,7 @@ public class ProjectsService(IServiceProvider provider, ProjectContext projectCo
             var projectData = new ProjectData(name,
                 request.Id ?? Guid.NewGuid(),
                 ProjectData.GetOriginDomain(request.Domain),
-                Guid.NewGuid());
+                Guid.NewGuid(), request.FwProjectId);
             await InitProjectDb(db, projectData);
             await serviceScope.ServiceProvider.GetRequiredService<CurrentProjectService>().PopulateProjectDataCache();
             if (request.SeedNewProjectData)

--- a/backend/FwLite/LocalWebApp/Services/ImportFwdataService.cs
+++ b/backend/FwLite/LocalWebApp/Services/ImportFwdataService.cs
@@ -25,18 +25,18 @@ public class ImportFwdataService(
         }
         try
         {
+            using var fwDataApi = fwDataFactory.GetFwDataMiniLcmApi(fwDataProject, false);
             var project = await projectsService.CreateProject(new(fwDataProject.Name,
                 SeedNewProjectData: false,
+                FwProjectId: fwDataApi.ProjectId,
                 AfterCreate: async (provider, project) =>
                 {
-                    using var fwDataApi = fwDataFactory.GetFwDataMiniLcmApi(fwDataProject, false);
                     var crdtApi = provider.GetRequiredService<IMiniLcmApi>();
                     await miniLcmImport.ImportProject(crdtApi, fwDataApi, fwDataApi.EntryCount);
                 }));
             var timeSpent = Stopwatch.GetElapsedTime(startTime);
             logger.LogInformation("Import of {ProjectName} complete, took {TimeSpend}", fwDataProject.Name, timeSpent.Humanize(2));
             return project;
-
         }
         catch
         {


### PR DESCRIPTION
Previously it was a mix of LangProjectId or Lexbox project Id, or a random guid, depending on how the project was created, now it'll match the lexbox project Id, unless it was created locally. Additionally there will be a sync error if the projects don't have a matching FwProjectId