### PR TITLE
Have lexbox API container check fw-headless health

### DIFF
--- a/backend/FwHeadless/Services/AppVersionService.cs
+++ b/backend/FwHeadless/Services/AppVersionService.cs
@@ -1,0 +1,9 @@
+using System.Reflection;
+
+namespace FwHeadless;
+
+public static class AppVersionService
+{
+    public static readonly string Version = typeof(AppVersionService).Assembly
+        .GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion ?? "dev";
+}

--- a/backend/LexBoxApi/Config/HealthChecksConfig.cs
+++ b/backend/LexBoxApi/Config/HealthChecksConfig.cs
@@ -1,0 +1,7 @@
+namespace LexBoxApi.Config;
+
+public class HealthChecksConfig
+{
+    public bool RequireFwHeadlessContainerVersionMatch { get; init; } = true;
+    public bool RequireHealthyFwHeadlessContainer { get; init; } = true;
+}

--- a/backend/LexBoxApi/LexBoxKernel.cs
+++ b/backend/LexBoxApi/LexBoxKernel.cs
@@ -44,6 +44,10 @@ public static class LexBoxKernel
             .BindConfiguration("Tus")
             .ValidateDataAnnotations()
             .ValidateOnStart();
+        services.AddOptions<HealthChecksConfig>()
+            .BindConfiguration("HealthChecks")
+            .ValidateDataAnnotations()
+            .ValidateOnStart();
         services.AddHttpClient();
         services.AddHttpContextAccessor();
         services.AddMemoryCache();

--- a/backend/LexBoxApi/LexBoxKernel.cs
+++ b/backend/LexBoxApi/LexBoxKernel.cs
@@ -61,6 +61,7 @@ public static class LexBoxKernel
         services.AddScoped<IHgService, HgService>();
         services.AddHostedService<HgService>();
         services.AddTransient<HgWebHealthCheck>();
+        services.AddTransient<FwHeadlessHealthCheck>();
         services.AddScoped<IIsLanguageForgeProjectDataLoader, IsLanguageForgeProjectDataLoader>();
         services.AddResiliencePipeline<string, IReadOnlyDictionary<string, bool>>(IsLanguageForgeProjectDataLoader.ResiliencePolicyName, (builder, context) =>
         {
@@ -73,7 +74,9 @@ public static class LexBoxKernel
         if (environment.IsDevelopment())
             services.AddHostedService<SwaggerValidationService>();
         services.AddScheduledTasks(configuration);
-        services.AddHealthChecks().AddCheck<HgWebHealthCheck>("hgweb", HealthStatus.Unhealthy, ["hg"], TimeSpan.FromSeconds(5));
+        services.AddHealthChecks()
+            .AddCheck<HgWebHealthCheck>("hgweb", HealthStatus.Unhealthy, ["hg"], TimeSpan.FromSeconds(5))
+            .AddCheck<FwHeadlessHealthCheck>("fw-headless", HealthStatus.Unhealthy, ["fw-headless"], TimeSpan.FromSeconds(5));
         services.AddSyncProxy();
         AuthKernel.AddLexBoxAuth(services, configuration, environment);
         services.AddLexGraphQL(environment);

--- a/backend/LexBoxApi/Services/FwHeadlessHealthCheck.cs
+++ b/backend/LexBoxApi/Services/FwHeadlessHealthCheck.cs
@@ -4,7 +4,7 @@ using Microsoft.Extensions.Options;
 
 namespace LexBoxApi.Services;
 
-public class FwHeadlessHealthCheckCheckHealthAsync(IHttpClientFactory clientFactory, IOptions<HealthChecksConfig> healthCheckOptions) : IHealthCheck
+public class FwHeadlessHealthCheck(IHttpClientFactory clientFactory, IOptions<HealthChecksConfig> healthCheckOptions) : IHealthCheck
 {
     public async Task<HealthCheckResult> CheckHealthAsync(HealthCheckContext context,
         CancellationToken cancellationToken = new())

--- a/backend/LexBoxApi/Services/FwHeadlessHealthCheck.cs
+++ b/backend/LexBoxApi/Services/FwHeadlessHealthCheck.cs
@@ -1,0 +1,32 @@
+﻿using LexCore.Config;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+using Microsoft.Extensions.Options;
+
+namespace LexBoxApi.Services;
+
+public class FwHeadlessHealthCheckCheckHealthAsync(IHttpClientFactory clientFactory, IOptions<HgConfig> hgOptions) : IHealthCheck
+{
+    public async Task<HealthCheckResult> CheckHealthAsync(HealthCheckContext context,
+        CancellationToken cancellationToken = new())
+    {
+        var http = clientFactory.CreateClient();
+        var fwHeadlessResponse = await http.GetAsync("http://fw-headless/api/healthz");
+        if (!fwHeadlessResponse.IsSuccessStatusCode)
+        {
+            return HealthCheckResult.Degraded("fw-headless not repsonding to health check");
+        }
+        var fwHeadlessVersion = fwHeadlessResponse.Headers.GetValues("lexbox-version").FirstOrDefault();
+        if (string.IsNullOrEmpty(fwHeadlessVersion))
+        {
+            return HealthCheckResult.Degraded("fw-headless version check failed to return a value");
+        }
+        // TODO: Decide if we would ever want fwHeadlessOptions.RequireContainerVersionMatch to be a different value than hgOptions
+        // If so, then create FwHeadlessOptions, even if it would only have one single value in it
+        if (hgOptions.Value.RequireContainerVersionMatch && fwHeadlessVersion != AppVersionService.Version)
+        {
+            return HealthCheckResult.Degraded(
+                $"api version: '{AppVersionService.Version}' fw-headless version: '{fwHeadlessVersion}' mismatch");
+        }
+        return HealthCheckResult.Healthy();
+    }
+}

--- a/backend/LexBoxApi/Services/FwHeadlessHealthCheck.cs
+++ b/backend/LexBoxApi/Services/FwHeadlessHealthCheck.cs
@@ -1,10 +1,10 @@
-﻿using LexCore.Config;
+﻿using LexBoxApi.Config;
 using Microsoft.Extensions.Diagnostics.HealthChecks;
 using Microsoft.Extensions.Options;
 
 namespace LexBoxApi.Services;
 
-public class FwHeadlessHealthCheckCheckHealthAsync(IHttpClientFactory clientFactory, IOptions<HgConfig> hgOptions) : IHealthCheck
+public class FwHeadlessHealthCheckCheckHealthAsync(IHttpClientFactory clientFactory, IOptions<HealthChecksConfig> healthCheckOptions) : IHealthCheck
 {
     public async Task<HealthCheckResult> CheckHealthAsync(HealthCheckContext context,
         CancellationToken cancellationToken = new())
@@ -13,16 +13,21 @@ public class FwHeadlessHealthCheckCheckHealthAsync(IHttpClientFactory clientFact
         var fwHeadlessResponse = await http.GetAsync("http://fw-headless/api/healthz");
         if (!fwHeadlessResponse.IsSuccessStatusCode)
         {
-            return HealthCheckResult.Degraded("fw-headless not repsonding to health check");
+            if (healthCheckOptions.Value.RequireHealthyFwHeadlessContainer)
+            {
+                return HealthCheckResult.Unhealthy("fw-headless not repsonding to health check");
+            }
+            else
+            {
+                return HealthCheckResult.Degraded("fw-headless not repsonding to health check");
+            }
         }
         var fwHeadlessVersion = fwHeadlessResponse.Headers.GetValues("lexbox-version").FirstOrDefault();
-        if (string.IsNullOrEmpty(fwHeadlessVersion))
+        if (healthCheckOptions.Value.RequireFwHeadlessContainerVersionMatch && string.IsNullOrEmpty(fwHeadlessVersion))
         {
             return HealthCheckResult.Degraded("fw-headless version check failed to return a value");
         }
-        // TODO: Decide if we would ever want fwHeadlessOptions.RequireContainerVersionMatch to be a different value than hgOptions
-        // If so, then create FwHeadlessOptions, even if it would only have one single value in it
-        if (hgOptions.Value.RequireContainerVersionMatch && fwHeadlessVersion != AppVersionService.Version)
+        if (healthCheckOptions.Value.RequireFwHeadlessContainerVersionMatch && fwHeadlessVersion != AppVersionService.Version)
         {
             return HealthCheckResult.Degraded(
                 $"api version: '{AppVersionService.Version}' fw-headless version: '{fwHeadlessVersion}' mismatch");

--- a/backend/LexBoxApi/appsettings.Development.json
+++ b/backend/LexBoxApi/appsettings.Development.json
@@ -49,6 +49,10 @@
     "LfMergeTrustToken": "lf-merge-dev-trust-token",
     "AutoUpdateLexEntryCountOnSendReceive": true
   },
+  "HealthChecks": {
+    "RequireFwHeadlessContainerVersionMatch": false,
+    "RequireHealthyFwHeadlessContainer": false
+  },
   "Authentication": {
     "Jwt": {
       "Secret": "d5cf1adc-16e6-4064-8041-4cfa00174210"

--- a/deployment/develop/lexbox-deployment.patch.yaml
+++ b/deployment/develop/lexbox-deployment.patch.yaml
@@ -26,3 +26,5 @@ spec:
               value: "https://develop.lexbox.org"
             - name: HgConfig__RequireContainerVersionMatch
               value: "false"
+            - name: HealthChecksConfig__RequireFwHeadlessContainerVersionMatch
+              value: "false"

--- a/deployment/local-dev/lexbox-deployment.patch.yaml
+++ b/deployment/local-dev/lexbox-deployment.patch.yaml
@@ -36,6 +36,10 @@ spec:
             valueFrom:
           - name: CloudFlare__AllowDomain
             value: "mailinator.com"
+          - name: HealthChecksConfig__RequireFwHeadlessContainerVersionMatch
+            value: "false"
+          - name: HealthChecksConfig__RequireHealthyFwHeadlessContainer
+            value: "false"
           - name: Email__SmtpUser
             value: 'maildev'
             valueFrom:


### PR DESCRIPTION
Fix #1185.

Health checks for fw-headless container now go through lexbox-api's health check endpoint.