### PR TITLE
Always project and cache project confidentiality

### DIFF
--- a/backend/LexBoxApi/GraphQL/CustomTypes/ProjectConfidentialityCachingMiddleware.cs
+++ b/backend/LexBoxApi/GraphQL/CustomTypes/ProjectConfidentialityCachingMiddleware.cs
@@ -1,0 +1,23 @@
+using HotChocolate.Resolvers;
+using LexBoxApi.Auth;
+using LexBoxApi.Services;
+using LexCore.Auth;
+using LexCore.Entities;
+
+namespace LexBoxApi.GraphQL.CustomTypes;
+
+public class ProjectConfidentialityCachingMiddleware(FieldDelegate next)
+{
+    public async Task InvokeAsync(IMiddlewareContext context, ProjectService projectService, LoggedInContext loggedInContext)
+    {
+        await next(context);
+
+        if (loggedInContext.MaybeUser is { Role: UserRole.admin }) return;
+
+        var project = context.Parent<Project>();
+        var projectId = project.Id;
+        if (projectId == default) return;
+        var isConfidential = project.IsConfidential;
+        projectService.UpdateProjectConfidentialityCache(projectId, isConfidential);
+    }
+}

--- a/backend/LexBoxApi/GraphQL/CustomTypes/ProjectGqlConfiguration.cs
+++ b/backend/LexBoxApi/GraphQL/CustomTypes/ProjectGqlConfiguration.cs
@@ -1,5 +1,4 @@
-﻿using LexBoxApi.Auth.Attributes;
-using LexCore.Entities;
+﻿using LexCore.Entities;
 
 namespace LexBoxApi.GraphQL.CustomTypes;
 
@@ -10,8 +9,11 @@ public class ProjectGqlConfiguration : ObjectType<Project>
     {
         descriptor.Field(p => p.Code).IsProjected();
         descriptor.Field(p => p.CreatedDate).IsProjected();
-        descriptor.Field(p => p.Id).Use<RefreshJwtProjectMembershipMiddleware>();
-        descriptor.Field(p => p.Users).Use<RefreshJwtProjectMembershipMiddleware>().Use<ProjectMembersVisibilityMiddleware>();
-        // descriptor.Field("userCount").Resolve(ctx => ctx.Parent<Project>().UserCount);
+        descriptor.Field(p => p.Id).IsProjected().Use<RefreshJwtProjectMembershipMiddleware>();
+        descriptor.Field(p => p.Users)
+            .Use<RefreshJwtProjectMembershipMiddleware>()
+            .Use<ProjectMembersVisibilityMiddleware>()
+            .Use<ProjectConfidentialityCachingMiddleware>();
+        descriptor.Field(p => p.IsConfidential).IsProjected();
     }
 }

--- a/backend/LexBoxApi/Services/ProjectService.cs
+++ b/backend/LexBoxApi/Services/ProjectService.cs
@@ -203,6 +203,11 @@ public class ProjectService(LexBoxDbContext dbContext, IHgService hgService, IOp
         return project?.IsConfidential;
     }
 
+    public void UpdateProjectConfidentialityCache(Guid projectId, bool? isConfidential)
+    {
+        memoryCache.Set($"ProjectConfidentiality:{projectId}", isConfidential, TimeSpan.FromHours(1));
+    }
+
     public void InvalidateProjectConfidentialityCache(Guid projectId)
     {
         try { memoryCache.Remove($"ProjectConfidentiality:{projectId}"); }

--- a/frontend/schema.graphql
+++ b/frontend/schema.graphql
@@ -372,6 +372,7 @@ type Project {
   createdDate: DateTime!
   id: UUID!
   users: [ProjectUsers!]!
+  isConfidential: Boolean
   changesets: [Changeset!]! @cost(weight: "10")
   hasAbandonedTransactions: Boolean!
   isLanguageForgeProject: Boolean! @cost(weight: "10")
@@ -380,7 +381,6 @@ type Project {
   description: String
   retentionPolicy: RetentionPolicy!
   type: ProjectType!
-  isConfidential: Boolean
   flexProjectMetadata: FlexProjectMetadata
   organizations: [Organization!]!
   lastCommit: DateTime


### PR DESCRIPTION
### TL;DR
Improved project confidentiality caching and permission checks for project member visibility.

### What changed?
- Added a new `ProjectConfidentialityCachingMiddleware` to manage project confidentiality state
- Refined permissions checks to prioritize confidentiality lookups over other async checks, because it's now likely cheaper

### Why make this change?
To reduce db hits