### PR TITLE
Make ProjectMembersVisibilityMiddleware more robust

### DIFF
--- a/backend/LexBoxApi/GraphQL/CustomTypes/ProjectMembersVisibilityMiddleware.cs
+++ b/backend/LexBoxApi/GraphQL/CustomTypes/ProjectMembersVisibilityMiddleware.cs
@@ -18,7 +18,9 @@ public class ProjectMembersVisibilityMiddleware(FieldDelegate next)
             if (!await permissionService.CanViewProjectMembers(projId))
             {
                 // Confidential project, and user doesn't have permission to see its users, so only show the current user's membership
-                context.Result = projectUsers.Where(pu => pu.User?.Id == loggedInContext.MaybeUser?.Id).ToList();
+                context.Result = projectUsers.Where(pu =>
+                    pu.User?.Id == loggedInContext.MaybeUser?.Id ||
+                    pu.UserId == loggedInContext.MaybeUser?.Id).ToList();
             }
         }
     }

--- a/backend/LexBoxApi/GraphQL/CustomTypes/ProjectMembersVisibilityMiddleware.cs
+++ b/backend/LexBoxApi/GraphQL/CustomTypes/ProjectMembersVisibilityMiddleware.cs
@@ -17,10 +17,9 @@ public class ProjectMembersVisibilityMiddleware(FieldDelegate next)
             var projId = contextProject?.Id ?? throw new RequiredException("Must include project ID in query if querying users");
             if (!await permissionService.CanViewProjectMembers(projId))
             {
+                var userId = loggedInContext.User.Id;
                 // Confidential project, and user doesn't have permission to see its users, so only show the current user's membership
-                context.Result = projectUsers.Where(pu =>
-                    pu.User?.Id == loggedInContext.MaybeUser?.Id ||
-                    pu.UserId == loggedInContext.MaybeUser?.Id).ToList();
+                context.Result = projectUsers.Where(pu => userId == pu.UserId || userId == pu.User?.Id).ToList();
             }
         }
     }


### PR DESCRIPTION
### TL;DR
Fixed project member visibility to include users even when their full user object hasn't been loaded.

### What changed?
Modified the project members visibility middleware to check both the User.Id and UserId properties when filtering project users. This ensures that project members are correctly shown even when the User navigation property hasn't been fully loaded.