### PR TITLE
Log verbose progress messages in S/R at debug level

### DIFF
--- a/backend/FwHeadless/FwHeadlessKernel.cs
+++ b/backend/FwHeadless/FwHeadlessKernel.cs
@@ -16,6 +16,8 @@ public static class FwHeadlessKernel
             .ValidateOnStart();
         services.AddScoped<SendReceiveService>();
         services.AddScoped<ProjectLookupService>();
+        services.AddScoped<LogSanitizerService>();
+        services.AddScoped<SafeLoggingProgress>();
         services
             .AddLcmCrdtClient()
             .AddFwDataBridge()

--- a/backend/FwHeadless/FwHeadlessKernel.cs
+++ b/backend/FwHeadless/FwHeadlessKernel.cs
@@ -1,4 +1,5 @@
 using FwDataMiniLcmBridge;
+using FwHeadless.Services;
 using FwLiteProjectSync;
 using LcmCrdt;
 

--- a/backend/FwHeadless/SendReceiveHelpers.cs
+++ b/backend/FwHeadless/SendReceiveHelpers.cs
@@ -17,11 +17,11 @@ public static class SendReceiveHelpers
 
     public record LfMergeBridgeResult(string Output, string ProgressMessages);
 
-    private static LfMergeBridgeResult CallLfMergeBridge(string method, IDictionary<string, string> flexBridgeOptions)
+    private static LfMergeBridgeResult CallLfMergeBridge(string method, IDictionary<string, string> flexBridgeOptions, IProgress? progress = null)
     {
-        var progress = new StringBuilderProgress();
-        LfMergeBridge.LfMergeBridge.Execute(method, progress, flexBridgeOptions.ToDictionary(), out var lfMergeBridgeOutputForClient);
-        return new LfMergeBridgeResult(lfMergeBridgeOutputForClient, progress.ToString());
+        var sbProgress = new StringBuilderProgress();
+        LfMergeBridge.LfMergeBridge.Execute(method, progress ?? sbProgress, flexBridgeOptions.ToDictionary(), out var lfMergeBridgeOutputForClient);
+        return new LfMergeBridgeResult(lfMergeBridgeOutputForClient, progress == null ? sbProgress.ToString() : "");
     }
 
     private static Uri BuildSendReceiveUrl(string baseUrl, string projectCode, SendReceiveAuth? auth)
@@ -45,7 +45,7 @@ public static class SendReceiveHelpers
         return builder.Uri;
     }
 
-    public static LfMergeBridgeResult SendReceive(FwDataProject project, string? projectCode = null, string baseUrl = "http://localhost", SendReceiveAuth? auth = null, string fdoDataModelVersion = "7000072", string? commitMessage = null)
+    public static LfMergeBridgeResult SendReceive(FwDataProject project, string? projectCode = null, string baseUrl = "http://localhost", SendReceiveAuth? auth = null, string fdoDataModelVersion = "7000072", string? commitMessage = null, IProgress? progress = null)
     {
         projectCode ??= project.Name;
         var fwdataInfo = new FileInfo(project.FilePath);
@@ -65,10 +65,10 @@ public static class SendReceiveHelpers
             { "user", "LexBox" },
         };
         if (commitMessage is not null) flexBridgeOptions["commitMessage"] = commitMessage;
-        return CallLfMergeBridge("Language_Forge_Send_Receive", flexBridgeOptions);
+        return CallLfMergeBridge("Language_Forge_Send_Receive", flexBridgeOptions, progress);
     }
 
-    public static LfMergeBridgeResult CloneProject(FwDataProject project, string? projectCode = null, string baseUrl = "http://localhost", SendReceiveAuth? auth = null, string fdoDataModelVersion = "7000072")
+    public static LfMergeBridgeResult CloneProject(FwDataProject project, string? projectCode = null, string baseUrl = "http://localhost", SendReceiveAuth? auth = null, string fdoDataModelVersion = "7000072", IProgress? progress = null)
     {
         projectCode ??= project.Name;
         var fwdataInfo = new FileInfo(project.FilePath);
@@ -84,6 +84,6 @@ public static class SendReceiveHelpers
             { "languageDepotRepoUri", repoUrl.ToString() },
             { "deleteRepoIfNoSuchBranch", "false" },
         };
-        return CallLfMergeBridge("Language_Forge_Clone", flexBridgeOptions);
+        return CallLfMergeBridge("Language_Forge_Clone", flexBridgeOptions, progress);
     }
 }

--- a/backend/FwHeadless/SendReceiveService.cs
+++ b/backend/FwHeadless/SendReceiveService.cs
@@ -1,4 +1,5 @@
 using FwDataMiniLcmBridge;
+using FwHeadless.Services;
 using Microsoft.Extensions.Options;
 
 namespace FwHeadless;

--- a/backend/FwHeadless/SendReceiveService.cs
+++ b/backend/FwHeadless/SendReceiveService.cs
@@ -3,7 +3,7 @@ using Microsoft.Extensions.Options;
 
 namespace FwHeadless;
 
-public class SendReceiveService(IOptions<FwHeadlessConfig> config)
+public class SendReceiveService(IOptions<FwHeadlessConfig> config, SafeLoggingProgress progress)
 {
     public SendReceiveHelpers.LfMergeBridgeResult SendReceive(FwDataProject project, string? projectCode, string? commitMessage = null)
     {
@@ -13,7 +13,8 @@ public class SendReceiveService(IOptions<FwHeadlessConfig> config)
             baseUrl: config.Value.HgWebUrl,
             auth: new SendReceiveHelpers.SendReceiveAuth(config.Value),
             fdoDataModelVersion: config.Value.FdoDataModelVersion,
-            commitMessage: commitMessage
+            commitMessage: commitMessage,
+            progress: progress
         );
     }
 
@@ -24,7 +25,8 @@ public class SendReceiveService(IOptions<FwHeadlessConfig> config)
             projectCode: projectCode,
             baseUrl: config.Value.HgWebUrl,
             auth: new SendReceiveHelpers.SendReceiveAuth(config.Value),
-            fdoDataModelVersion: config.Value.FdoDataModelVersion
+            fdoDataModelVersion: config.Value.FdoDataModelVersion,
+            progress: progress
         );
     }
 }

--- a/backend/FwHeadless/Services/LogSanitizerService.cs
+++ b/backend/FwHeadless/Services/LogSanitizerService.cs
@@ -1,0 +1,29 @@
+using System.Text;
+using Microsoft.Extensions.Options;
+
+namespace FwHeadless;
+
+public class LogSanitizerService
+{
+    private string Password { get; init; }
+    private string Base64Password { get; init; }
+    private string Base64UrlPassword { get; init; }
+    private bool ShouldSanitize { get; init; }
+
+    public LogSanitizerService(IOptions<FwHeadlessConfig> config)
+    {
+        Password = config.Value.LexboxPassword;
+        Base64Password = Convert.ToBase64String(Encoding.UTF8.GetBytes(Password));
+        Base64UrlPassword = Convert.ToBase64String(Encoding.UTF8.GetBytes(Password)).Replace('+', '-').Replace('/', '_').TrimEnd('=');
+        ShouldSanitize = Password != "pass";
+    }
+
+    public string SanitizeLogMessage(string original)
+    {
+        if (!ShouldSanitize) return original;
+        return original
+            .Replace(Password, "***")
+            .Replace(Base64Password, "***")
+            .Replace(Base64UrlPassword, "***");
+    }
+}

--- a/backend/FwHeadless/Services/LogSanitizerService.cs
+++ b/backend/FwHeadless/Services/LogSanitizerService.cs
@@ -1,7 +1,7 @@
 using System.Text;
 using Microsoft.Extensions.Options;
 
-namespace FwHeadless;
+namespace FwHeadless.Services;
 
 public class LogSanitizerService
 {

--- a/backend/FwHeadless/Services/SafeLoggingProgress.cs
+++ b/backend/FwHeadless/Services/SafeLoggingProgress.cs
@@ -1,0 +1,52 @@
+using SIL.Progress;
+
+namespace FwHeadless;
+
+public class SafeLoggingProgress(ILogger<SafeLoggingProgress> logger, LogSanitizerService sanitizer) : IProgress
+{
+    public bool ShowVerbose { get; set; }
+    public bool CancelRequested { get; set; }
+    public bool ErrorEncountered { get; set; }
+    public IProgressIndicator ProgressIndicator { get; set; } = null!;
+    public SynchronizationContext SyncContext { get; set; } = null!;
+
+    private string Sanitize(string message, params object[] args)
+    {
+        return sanitizer.SanitizeLogMessage(GenericProgress.SafeFormat(message, args));
+    }
+
+    public void WriteError(string message, params object[] args)
+    {
+        logger.LogError(Sanitize(message, args));
+    }
+
+    public void WriteException(Exception error)
+    {
+        WriteError(error.ToString());
+    }
+
+    public void WriteMessage(string message, params object[] args)
+    {
+        logger.LogInformation(Sanitize(message, args));
+    }
+
+    public void WriteMessageWithColor(string colorName, string message, params object[] args)
+    {
+        WriteMessage(message, args);
+    }
+
+    public void WriteStatus(string message, params object[] args)
+    {
+        WriteMessage(message, args);
+    }
+
+    public void WriteVerbose(string message, params object[] args)
+    {
+        logger.LogDebug(Sanitize(message, args));
+    }
+
+    public void WriteWarning(string message, params object[] args)
+    {
+        logger.LogWarning(Sanitize(message, args));
+    }
+}

--- a/backend/FwHeadless/Services/SafeLoggingProgress.cs
+++ b/backend/FwHeadless/Services/SafeLoggingProgress.cs
@@ -1,9 +1,10 @@
 using SIL.Progress;
 
-namespace FwHeadless;
+namespace FwHeadless.Services;
 
-public class SafeLoggingProgress(ILogger<SafeLoggingProgress> logger, LogSanitizerService sanitizer) : IProgress
+public class SafeLoggingProgress(ILoggerFactory loggerFactory, LogSanitizerService sanitizer) : IProgress
 {
+    private readonly ILogger logger = loggerFactory.CreateLogger("SendReceive");
     public bool ShowVerbose { get; set; }
     public bool CancelRequested { get; set; }
     public bool ErrorEncountered { get; set; }

--- a/backend/FwHeadless/appsettings.Development.json
+++ b/backend/FwHeadless/appsettings.Development.json
@@ -11,8 +11,7 @@
   },
   "Logging": {
     "LogLevel": {
-      "Default": "Information",
-      "Microsoft.AspNetCore": "Warning"
+      "Default": "Information"
     }
   }
 }

--- a/backend/FwHeadless/appsettings.json
+++ b/backend/FwHeadless/appsettings.json
@@ -5,7 +5,8 @@
   "Logging": {
     "LogLevel": {
       "Default": "Information",
-      "Microsoft.AspNetCore": "Warning"
+      "Microsoft.AspNetCore": "Information",
+      "SendReceive": "Debug"
     }
   },
   "AllowedHosts": "*"


### PR DESCRIPTION
Fix #1162.

The stripping out of passwords might be redundant because Chorus is supposed to already do this, but I've seen a few cases of passwords in logs recently, apparently due to a Chorus bug that's not yet *completely* squashed. Once we're confident that Chorus is no longer logging passwords we can remove the extra sanitization step, but for now let's keep it to be safe.

Tested locally and it works: change `LogLevel.Default` in backend/FwHeadless/appsettings.Development.json from "Information" to "Debug" and you'll start seeing debug logs showing every step of the Send/Receive process when you do a CRDT sync with FwHeadless.