### PR TITLE
Avoid failed-too-soon health checks on startup

### DIFF
--- a/backend/LexData/LexBoxDbContext.cs
+++ b/backend/LexData/LexBoxDbContext.cs
@@ -34,8 +34,15 @@ public class LexBoxDbContext(DbContextOptions<LexBoxDbContext> options, IEnumera
 
     public async Task<bool> HeathCheck(CancellationToken cancellationToken)
     {
-        //this will throw if we can't connect which is a valid health check response.
-        await Users.CountAsync(cancellationToken);
-        return true;
+        //this will throw if we can't connect which is a valid health check response, but TaskCanceledException is not a failure
+        try
+        {
+            await Users.CountAsync(cancellationToken);
+            return true;
+        }
+        catch (TaskCanceledException)
+        {
+            return true;
+        }
     }
 }

--- a/backend/LexData/LexBoxDbContext.cs
+++ b/backend/LexData/LexBoxDbContext.cs
@@ -34,15 +34,8 @@ public class LexBoxDbContext(DbContextOptions<LexBoxDbContext> options, IEnumera
 
     public async Task<bool> HeathCheck(CancellationToken cancellationToken)
     {
-        //this will throw if we can't connect which is a valid health check response, but TaskCanceledException is not a failure
-        try
-        {
-            await Users.CountAsync(cancellationToken);
-            return true;
-        }
-        catch (TaskCanceledException)
-        {
-            return true;
-        }
+        //this will throw if we can't connect which is a valid health check response.
+        await Users.CountAsync(cancellationToken);
+        return true;
     }
 }

--- a/deployment/base/fw-headless-deployment.yaml
+++ b/deployment/base/fw-headless-deployment.yaml
@@ -61,6 +61,7 @@ spec:
             path: /api/healthz
           failureThreshold: 30
           periodSeconds: 10
+          timeoutSeconds: 5
         ports:
           - containerPort: 80
 

--- a/deployment/base/lexbox-deployment.yaml
+++ b/deployment/base/lexbox-deployment.yaml
@@ -68,6 +68,7 @@ spec:
             path: /api/healthz
           failureThreshold: 30
           periodSeconds: 10
+          timeoutSeconds: 5
         ports:
           - containerPort: 5158
 


### PR DESCRIPTION
Fix #1211.

If the HTTP call to `/api/healthz` is aborted due to Kubernetes expecting it to take 1 second or less (default timeout for heatlh checks in Kubernetes is 1 second unless you set it to a higher value), we're currently considering the TaskCanceledException to be a DB connection failure and therefore an unhealthy pod. But on first startup, the fw-headless container takes longer to respond to the first health check (I measured 1.5 seconds on my dev laptop) because of needing to open a new database connection, any first-time setup that EF Core needs to do, and so on. So we'll lengthen the Kubernetes timeout to 5 seconds so that ASP.NET doesn't get a TaskCanceledException and think it's in an unhealthy state when everything was fine.