### PR TITLE
CRDT sync handles semantic domains

### DIFF
--- a/backend/FwHeadless/FwHeadless.csproj
+++ b/backend/FwHeadless/FwHeadless.csproj
@@ -5,6 +5,8 @@
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <Mercurial4ChorusDestDir>$(MSBuildProjectDirectory)</Mercurial4ChorusDestDir>
+    <!-- MSBuild complains about duplicate Content item "Mercurial/contrib/asv.conf.json" without this -->
+    <EnableDefaultContentItems>false</EnableDefaultContentItems>
   </PropertyGroup>
 
   <ItemGroup>

--- a/backend/FwHeadless/FwHeadless.csproj
+++ b/backend/FwHeadless/FwHeadless.csproj
@@ -5,8 +5,6 @@
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <Mercurial4ChorusDestDir>$(MSBuildProjectDirectory)</Mercurial4ChorusDestDir>
-    <!-- MSBuild complains about duplicate Content item "Mercurial/contrib/asv.conf.json" without this -->
-    <EnableDefaultContentItems>false</EnableDefaultContentItems>
   </PropertyGroup>
 
   <ItemGroup>
@@ -26,6 +24,8 @@
   </ItemGroup>
 
   <ItemGroup>
+      <!-- json files get imported by default because this is a web project, so exclude those here so they aren't imported again below -->
+      <Content Remove="Mercurial\contrib\asv.conf.json"/>
       <Content Include="Mercurial\**" CopyToOutputDirectory="Always" Watch="false" />
       <Content Include="MercurialExtensions\**" CopyToOutputDirectory="Always" Watch="false" />
   </ItemGroup>

--- a/backend/FwLite/FwDataMiniLcmBridge/Api/FwDataMiniLcmApi.cs
+++ b/backend/FwLite/FwDataMiniLcmBridge/Api/FwDataMiniLcmApi.cs
@@ -253,6 +253,7 @@ public class FwDataMiniLcmApi(Lazy<LcmCache> cacheLazy, bool onCloseSave, ILogge
             Id = semanticDomain.Guid,
             Name = FromLcmMultiString(semanticDomain.Name),
             Code = semanticDomain.Abbreviation.UiString ?? "",
+            Predefined = true, // TODO: Look up in a GUID list of predefined data
         };
     }
 

--- a/backend/FwLite/FwDataMiniLcmBridge/Api/FwDataMiniLcmApi.cs
+++ b/backend/FwLite/FwDataMiniLcmBridge/Api/FwDataMiniLcmApi.cs
@@ -467,12 +467,7 @@ public class FwDataMiniLcmApi(Lazy<LcmCache> cacheLazy, bool onCloseSave, ILogge
             Definition = FromLcmMultiString(sense.Definition),
             PartOfSpeech = sense.MorphoSyntaxAnalysisRA?.GetPartOfSpeech()?.Name.get_String(enWs).Text ?? "",
             PartOfSpeechId = sense.MorphoSyntaxAnalysisRA?.GetPartOfSpeech()?.Guid,
-            SemanticDomains = sense.SemanticDomainsRC.Select(s => new SemanticDomain
-            {
-                Id = s.Guid,
-                Name = FromLcmMultiString(s.Name),
-                Code = s.OcmCodes
-            }).ToList(),
+            SemanticDomains = sense.SemanticDomainsRC.Select(FromLcmSemanticDomain).ToList(),
             ExampleSentences = sense.ExamplesOS.Select(sentence => FromLexExampleSentence(sense.Guid, sentence)).ToList()
         };
         return s;

--- a/backend/FwLite/FwDataMiniLcmBridge/Api/UpdateProxy/UpdateSemanticDomainProxy.cs
+++ b/backend/FwLite/FwDataMiniLcmBridge/Api/UpdateProxy/UpdateSemanticDomainProxy.cs
@@ -1,0 +1,30 @@
+using System.Diagnostics.CodeAnalysis;
+using MiniLcm.Models;
+using SIL.LCModel;
+
+namespace FwDataMiniLcmBridge.Api.UpdateProxy;
+
+public class UpdateSemanticDomainProxy : SemanticDomain
+{
+    private readonly ICmSemanticDomain _lcmSemanticDomain;
+    private readonly FwDataMiniLcmApi _lexboxLcmApi;
+
+    public UpdateSemanticDomainProxy(ICmSemanticDomain lcmSemanticDomain, FwDataMiniLcmApi lexboxLcmApi)
+    {
+        _lcmSemanticDomain = lcmSemanticDomain;
+        Id = lcmSemanticDomain.Guid;
+        _lexboxLcmApi = lexboxLcmApi;
+    }
+
+    public override MultiString Name
+    {
+        get => new UpdateMultiStringProxy(_lcmSemanticDomain.Name, _lexboxLcmApi);
+        set => throw new NotImplementedException();
+    }
+
+    public override string Code
+    {
+        get => _lcmSemanticDomain.Abbreviation.BestAnalysisVernacularAlternative.Text;
+        set => throw new NotImplementedException();
+    }
+}

--- a/backend/FwLite/FwLiteProjectSync.Tests/SyncTests.cs
+++ b/backend/FwLite/FwLiteProjectSync.Tests/SyncTests.cs
@@ -214,6 +214,43 @@ public class SyncTests : IClassFixture<SyncFixture>, IAsyncLifetime
     }
 
     [Fact]
+    public async Task SemanticDomainsSyncBothWays()
+    {
+        var crdtApi = _fixture.CrdtApi;
+        var fwdataApi = _fixture.FwDataApi;
+        await _syncService.Sync(crdtApi, fwdataApi);
+
+        var semdom3 = new SemanticDomain()
+        {
+            Id = new Guid("f4491f9b-3c5e-42ab-afc0-f22e19d0fff5"),
+            Name = new MultiString() { { "en", "Language and thought" } },
+            Code = "3",
+            Predefined = true,
+        };
+        await fwdataApi.CreateSemanticDomain(semdom3);
+
+        var semdom4 = new SemanticDomain()
+        {
+            Id = new Guid("62b4ae33-f3c2-447a-9ef7-7e41805b6a02"),
+            Name = new MultiString() { { "en", "Social behavior" } },
+            Code = "4",
+            Predefined = true,
+        };
+        await crdtApi.CreateSemanticDomain(semdom4);
+
+        await _syncService.Sync(crdtApi, fwdataApi);
+
+        var crdtSemanticDomains = await crdtApi.GetSemanticDomains().ToArrayAsync();
+        var fwdataSemanticDomains = await fwdataApi.GetSemanticDomains().ToArrayAsync();
+        crdtSemanticDomains.Should().ContainEquivalentOf(semdom3);
+        crdtSemanticDomains.Should().ContainEquivalentOf(semdom4);
+        fwdataSemanticDomains.Should().ContainEquivalentOf(semdom3);
+        fwdataSemanticDomains.Should().ContainEquivalentOf(semdom4);
+
+        crdtSemanticDomains.Should().BeEquivalentTo(fwdataSemanticDomains);
+    }
+
+    [Fact]
     public async Task UpdatingAnEntryInEachProjectSyncsAcrossBoth()
     {
         var crdtApi = _fixture.CrdtApi;

--- a/backend/FwLite/FwLiteProjectSync.Tests/SyncTests.cs
+++ b/backend/FwLite/FwLiteProjectSync.Tests/SyncTests.cs
@@ -251,6 +251,48 @@ public class SyncTests : IClassFixture<SyncFixture>, IAsyncLifetime
     }
 
     [Fact]
+    public async Task SemanticDomainsSyncInEntries()
+    {
+        var crdtApi = _fixture.CrdtApi;
+        var fwdataApi = _fixture.FwDataApi;
+        await _syncService.Sync(crdtApi, fwdataApi);
+
+        var semdom3 = new SemanticDomain()
+        {
+            Id = new Guid("f4491f9b-3c5e-42ab-afc0-f22e19d0fff5"),
+            Name = new MultiString() { { "en", "Language and thought" } },
+            Code = "3",
+            Predefined = true,
+        };
+        await fwdataApi.CreateSemanticDomain(semdom3);
+        // Note we do *not* call crdtApi.CreateSemanticDomain(semdom3);
+
+        await fwdataApi.CreateEntry(new Entry()
+        {
+            LexemeForm = { { "en", "Pear" } },
+            Senses =
+            [
+                new Sense() { Gloss = { { "en", "Pear" } }, SemanticDomains = [ semdom3 ] }
+            ]
+        });
+        await crdtApi.CreateEntry(new Entry()
+        {
+            LexemeForm = { { "en", "Banana" } },
+            Senses =
+            [
+                new Sense() { Gloss = { { "en", "Banana" } }, SemanticDomains = [ semdom3 ] }
+            ]
+        });
+        await _syncService.Sync(crdtApi, fwdataApi);
+
+        var crdtEntries = await crdtApi.GetEntries().ToArrayAsync();
+        var fwdataEntries = await fwdataApi.GetEntries().ToArrayAsync();
+        crdtEntries.Should().BeEquivalentTo(fwdataEntries,
+            options => options.For(e => e.Components).Exclude(c => c.Id)
+                .For(e => e.ComplexForms).Exclude(c => c.Id));
+    }
+
+    [Fact]
     public async Task UpdatingAnEntryInEachProjectSyncsAcrossBoth()
     {
         var crdtApi = _fixture.CrdtApi;

--- a/backend/FwLite/FwLiteProjectSync/DryRunMiniLcmApi.cs
+++ b/backend/FwLite/FwLiteProjectSync/DryRunMiniLcmApi.cs
@@ -1,4 +1,4 @@
-﻿using MiniLcm;
+using MiniLcm;
 using MiniLcm.Models;
 
 namespace FwLiteProjectSync;
@@ -49,6 +49,7 @@ public class DryRunMiniLcmApi(IMiniLcmApi api) : IMiniLcmApi
         DryRunRecords.Add(new DryRunRecord(nameof(CreatePartOfSpeech), $"Create part of speech {partOfSpeech.Name}"));
         return Task.FromResult(partOfSpeech); // Since this is a dry run, api.GetPartOfSpeech would return null
     }
+
     public Task<PartOfSpeech> UpdatePartOfSpeech(Guid id, UpdateObjectInput<PartOfSpeech> update)
     {
         DryRunRecords.Add(new DryRunRecord(nameof(UpdatePartOfSpeech), $"Update part of speech {id}"));
@@ -66,10 +67,27 @@ public class DryRunMiniLcmApi(IMiniLcmApi api) : IMiniLcmApi
         return api.GetSemanticDomains();
     }
 
-    public Task CreateSemanticDomain(SemanticDomain semanticDomain)
+    public Task<SemanticDomain?> GetSemanticDomain(Guid id)
+    {
+        return api.GetSemanticDomain(id);
+    }
+
+    public Task<SemanticDomain> CreateSemanticDomain(SemanticDomain semanticDomain)
     {
         DryRunRecords.Add(new DryRunRecord(nameof(CreateSemanticDomain),
             $"Create semantic domain {semanticDomain.Name}"));
+        return Task.FromResult(semanticDomain);
+    }
+
+    public Task<SemanticDomain> UpdateSemanticDomain(Guid id, UpdateObjectInput<SemanticDomain> update)
+    {
+        DryRunRecords.Add(new DryRunRecord(nameof(UpdateSemanticDomain), $"Update part of speech {id}"));
+        return GetSemanticDomain(id)!;
+    }
+
+    public Task DeleteSemanticDomain(Guid id)
+    {
+        DryRunRecords.Add(new DryRunRecord(nameof(DeleteSemanticDomain), $"Delete part of speech {id}"));
         return Task.CompletedTask;
     }
 

--- a/backend/FwLite/LcmCrdt/Objects/JsonPatchChangeExtractor.cs
+++ b/backend/FwLite/LcmCrdt/Objects/JsonPatchChangeExtractor.cs
@@ -1,4 +1,4 @@
-﻿using LcmCrdt.Changes;
+using LcmCrdt.Changes;
 using LcmCrdt.Changes.Entries;
 using LcmCrdt.Utils;
 using SIL.Harmony.Changes;
@@ -153,5 +153,11 @@ public static class JsonPatchChangeExtractor
     {
         if (patch.Operations.Count > 0)
             yield return new JsonPatchChange<PartOfSpeech>(pos.Id, patch);
+    }
+
+    public static IEnumerable<IChange> ToChanges(this SemanticDomain semDom, JsonPatchDocument<SemanticDomain> patch)
+    {
+        if (patch.Operations.Count > 0)
+            yield return new JsonPatchChange<SemanticDomain>(semDom.Id, patch);
     }
 }

--- a/backend/FwLite/MiniLcm/IMiniLcmReadApi.cs
+++ b/backend/FwLite/MiniLcm/IMiniLcmReadApi.cs
@@ -1,4 +1,4 @@
-﻿using System.Text.Json.Serialization;
+using System.Text.Json.Serialization;
 using MiniLcm.Models;
 
 namespace MiniLcm;
@@ -13,6 +13,7 @@ public interface IMiniLcmReadApi
     IAsyncEnumerable<Entry> SearchEntries(string query, QueryOptions? options = null);
     Task<Entry?> GetEntry(Guid id);
     Task<PartOfSpeech?> GetPartOfSpeech(Guid id);
+    Task<SemanticDomain?> GetSemanticDomain(Guid id);
 }
 
 public record QueryOptions(

--- a/backend/FwLite/MiniLcm/IMiniLcmWriteApi.cs
+++ b/backend/FwLite/MiniLcm/IMiniLcmWriteApi.cs
@@ -1,4 +1,4 @@
-﻿using System.Linq.Expressions;
+using System.Linq.Expressions;
 using MiniLcm.Models;
 using SystemTextJsonPatch;
 
@@ -13,10 +13,18 @@ public interface IMiniLcmWriteApi
         UpdateObjectInput<WritingSystem> update);
 
 
+    #region PartOfSpeech
     Task<PartOfSpeech> CreatePartOfSpeech(PartOfSpeech partOfSpeech);
     Task<PartOfSpeech> UpdatePartOfSpeech(Guid id, UpdateObjectInput<PartOfSpeech> update);
     Task DeletePartOfSpeech(Guid id);
-    Task CreateSemanticDomain(SemanticDomain semanticDomain);
+    #endregion
+
+    #region SemanticDomain
+    Task<SemanticDomain> CreateSemanticDomain(SemanticDomain semanticDomain);
+    Task<SemanticDomain> UpdateSemanticDomain(Guid id, UpdateObjectInput<SemanticDomain> update);
+    Task DeleteSemanticDomain(Guid id);
+    #endregion
+
     Task<ComplexFormType> CreateComplexFormType(ComplexFormType complexFormType);
 
     #region Entry

--- a/backend/FwLite/MiniLcm/Models/SemanticDomain.cs
+++ b/backend/FwLite/MiniLcm/Models/SemanticDomain.cs
@@ -1,10 +1,10 @@
-﻿namespace MiniLcm.Models;
+namespace MiniLcm.Models;
 
 public class SemanticDomain : IObjectWithId
 {
-    public virtual required Guid Id { get; set; }
-    public virtual required MultiString Name { get; set; }
-    public virtual required string Code { get; set; }
+    public virtual Guid Id { get; set; }
+    public virtual MultiString Name { get; set; } = new();
+    public virtual string Code { get; set; } = string.Empty;
     public DateTimeOffset? DeletedAt { get; set; }
     public bool Predefined { get; set; }
 

--- a/backend/FwLite/MiniLcm/SyncHelpers/SemanticDomainSync.cs
+++ b/backend/FwLite/MiniLcm/SyncHelpers/SemanticDomainSync.cs
@@ -1,0 +1,47 @@
+using MiniLcm;
+using MiniLcm.Models;
+using MiniLcm.SyncHelpers;
+using SystemTextJsonPatch;
+
+public static class SemanticDomainSync
+{
+    public static async Task<int> Sync(SemanticDomain[] currentSemanticDomains,
+        SemanticDomain[] previousSemanticDomains,
+        IMiniLcmApi api)
+    {
+        return await DiffCollection.Diff(api,
+            previousSemanticDomains,
+            currentSemanticDomains,
+            pos => pos.Id,
+            async (api, currentPos) =>
+            {
+                await api.CreateSemanticDomain(currentPos);
+                return 1;
+            },
+            async (api, previousPos) =>
+            {
+                await api.DeleteSemanticDomain(previousPos.Id);
+                return 1;
+            },
+            async (api, previousPos, currentPos) =>
+            {
+                var updateObjectInput = SemanticDomainDiffToUpdate(previousPos, currentPos);
+                if (updateObjectInput is not null) await api.UpdateSemanticDomain(currentPos.Id, updateObjectInput);
+                return updateObjectInput is null ? 0 : 1;
+            });
+    }
+
+    public static UpdateObjectInput<SemanticDomain>? SemanticDomainDiffToUpdate(SemanticDomain previousSemanticDomain, SemanticDomain currentSemanticDomain)
+    {
+        JsonPatchDocument<SemanticDomain> patchDocument = new();
+        patchDocument.Operations.AddRange(MultiStringDiff.GetMultiStringDiff<SemanticDomain>(nameof(SemanticDomain.Name),
+            previousSemanticDomain.Name,
+            currentSemanticDomain.Name));
+        // TODO: Once we add abbreviations to MiniLcm's SemanticDomain objects, then:
+        // patchDocument.Operations.AddRange(GetMultiStringDiff<SemanticDomain>(nameof(SemanticDomain.Abbreviation),
+        //     previousSemanticDomain.Abbreviation,
+        //     currentSemanticDomain.Abbreviation));
+        if (patchDocument.Operations.Count == 0) return null;
+        return new UpdateObjectInput<SemanticDomain>(patchDocument);
+    }
+}

--- a/backend/LfClassicData/LfClassicMiniLcmApi.cs
+++ b/backend/LfClassicData/LfClassicMiniLcmApi.cs
@@ -78,15 +78,7 @@ public class LfClassicMiniLcmApi(string projectCode, ProjectDbContext dbContext,
 
         foreach (var item in optionListItems)
         {
-            yield return new PartOfSpeech
-            {
-                Id = item.Guid ?? Guid.Empty,
-                Name = new MultiString
-                {
-                    { "en", item.Value ?? item.Abbreviation ?? string.Empty },
-                    { "__key", item.Key ?? string.Empty } // The key is all that senses have on them, so we need it client-side to find the display name
-                }
-            };
+            yield return ToPartOfSpeech(item);
         }
     }
 
@@ -276,12 +268,16 @@ public class LfClassicMiniLcmApi(string projectCode, ProjectDbContext dbContext,
         return ms;
     }
 
-    private static PartOfSpeech ToPartOfSpeech(Entities.PartOfSpeech pos)
+    private static PartOfSpeech ToPartOfSpeech(Entities.OptionListItem item)
     {
         return new PartOfSpeech
         {
-            Id = pos.Guid,
-            Name = ToMultiString(pos.Name),
+            Id = item.Guid ?? Guid.Empty,
+            Name = new MultiString
+            {
+                { "en", item.Value ?? item.Abbreviation ?? string.Empty },
+                { "__key", item.Key ?? string.Empty } // The key is all that senses have on them, so we need it client-side to find the display name
+            },
             // TODO: Abbreviation
             Predefined = false,
         };
@@ -292,14 +288,6 @@ public class LfClassicMiniLcmApi(string projectCode, ProjectDbContext dbContext,
         var entry = await Entries.Find(e => e.Guid == id).FirstOrDefaultAsync();
         if (entry is null) return null;
         return ToEntry(entry);
-    }
-
-    public async Task<PartOfSpeech?> GetPartOfSpeech(Guid id)
-    {
-        // TODO: Construct a Mongo query more directly for this, so we're no longer searching the entire list
-        var partsOfSpeech = await GetPartsOfSpeech();
-        var found = partsOfSpeech.FirstOrDefaultAsync(p => p.Id == id);
-        return found == null ? null : ToPartOfSpeech(found);
     }
 
     public async Task<SemanticDomain?> GetSemanticDomain(Guid id)

--- a/backend/LfClassicData/LfClassicMiniLcmApi.cs
+++ b/backend/LfClassicData/LfClassicMiniLcmApi.cs
@@ -276,10 +276,34 @@ public class LfClassicMiniLcmApi(string projectCode, ProjectDbContext dbContext,
         return ms;
     }
 
+    private static PartOfSpeech ToPartOfSpeech(Entities.PartOfSpeech pos)
+    {
+        return new PartOfSpeech
+        {
+            Id = pos.Guid,
+            Name = ToMultiString(pos.Name),
+            // TODO: Abbreviation
+            Predefined = false,
+        };
+    }
+
     public async Task<Entry?> GetEntry(Guid id)
     {
         var entry = await Entries.Find(e => e.Guid == id).FirstOrDefaultAsync();
         if (entry is null) return null;
         return ToEntry(entry);
+    }
+
+    public async Task<PartOfSpeech?> GetPartOfSpeech(Guid id)
+    {
+        // TODO: Construct a Mongo query more directly for this, so we're no longer searching the entire list
+        var partsOfSpeech = await GetPartsOfSpeech();
+        var found = partsOfSpeech.FirstOrDefaultAsync(p => p.Id == id);
+        return found == null ? null : ToPartOfSpeech(found);
+    }
+
+    public async Task<SemanticDomain?> GetSemanticDomain(Guid id)
+    {
+        return null; // TODO: Once GetSemanticDomains() is implemented, use it
     }
 }


### PR DESCRIPTION
Fix #1216.

Currently this PR is based on top of #1203 for convenience so I can more easily bootstrap the semantic domain implementation using the parts of speech sync. Once #1203 is merged, this PR should auto-base onto develop instead.

We now sync semantic domains just like we sync parts of speech. There are similar issues with deciding how Predefined should be set; I'm currently setting it to `true` for any semantic domain coming from FW, because custom semantic domains will be rare. But ultimately we'll want to keep a list of GUIDs around and match the incoming semdom against that list of GUIDs; if it's not on the list then Predefined should be false instead.