### PR TITLE
Store repo size (in kB) in database

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -3,7 +3,7 @@
   "isRoot": true,
   "tools": {
     "dotnet-ef": {
-      "version": "8.0.8",
+      "version": "8.0.10",
       "commands": [
         "dotnet-ef"
       ]

--- a/backend/LexBoxApi/GraphQL/ProjectMutations.cs
+++ b/backend/LexBoxApi/GraphQL/ProjectMutations.cs
@@ -361,6 +361,24 @@ public class ProjectMutations
     [UseMutationConvention]
     [UseFirstOrDefault]
     [UseProjection]
+    public async Task<IQueryable<Project>> UpdateProjectRepoSizeInKb(string code,
+        IPermissionService permissionService,
+        ProjectService projectService,
+        LexBoxDbContext dbContext)
+    {
+        var projectId = await projectService.LookupProjectId(code);
+        await permissionService.AssertCanViewProject(projectId);
+        if (projectId == default) throw NotFoundException.ForType<Project>();
+        await projectService.UpdateRepoSizeInKb(code);
+        return dbContext.Projects.Where(p => p.Id == projectId);
+    }
+
+    [Error<NotFoundException>]
+    [Error<DbError>]
+    [Error<UnauthorizedAccessException>]
+    [UseMutationConvention]
+    [UseFirstOrDefault]
+    [UseProjection]
     public async Task<IQueryable<Project>> UpdateProjectLexEntryCount(string code,
         IPermissionService permissionService,
         ProjectService projectService,

--- a/backend/LexBoxApi/Services/HgService.cs
+++ b/backend/LexBoxApi/Services/HgService.cs
@@ -426,6 +426,13 @@ public partial class HgService : IHgService, IHostedService
         return await content.ReadAsStringAsync();
     }
 
+    public async Task<int?> GetRepoSizeInKb(ProjectCode code, CancellationToken token = default)
+    {
+        var content = await ExecuteHgCommandServerCommand(code, "reposizeinkb", token);
+        var sizeStr = await content.ReadAsStringAsync();
+        return int.TryParse(sizeStr, out var size) ? size : null;
+    }
+
     private async Task WaitForRepoEmptyState(ProjectCode code, RepoEmptyState expectedState, int timeoutMs = 30_000, CancellationToken token = default)
     {
         // Set timeout so unforeseen errors can't cause an infinite loop

--- a/backend/LexBoxApi/Services/ProjectService.cs
+++ b/backend/LexBoxApi/Services/ProjectService.cs
@@ -244,6 +244,16 @@ public class ProjectService(LexBoxDbContext dbContext, IHgService hgService, IOp
         // Caller is responsible for caling dbContext.SaveChangesAsync()
     }
 
+    public async Task<int?> UpdateRepoSizeInKb(string projectCode)
+    {
+        var project = await dbContext.Projects.FirstOrDefaultAsync(p => p.Code == projectCode);
+        if (project is null) return null;
+        var size = await hgService.GetRepoSizeInKb(projectCode);
+        project.RepoSizeInKb = size;
+        await dbContext.SaveChangesAsync();
+        return size;
+    }
+
     public async Task ResetLexEntryCount(string projectCode)
     {
         var project = await dbContext.Projects

--- a/backend/LexBoxApi/Services/ProjectService.cs
+++ b/backend/LexBoxApi/Services/ProjectService.cs
@@ -151,6 +151,7 @@ public class ProjectService(LexBoxDbContext dbContext, IHgService hgService, IOp
         var rowsAffected = await dbContext.Projects.Where(p => p.Code == input.Code && p.ResetStatus == ResetStatus.None)
             .ExecuteUpdateAsync(u => u
                 .SetProperty(p => p.ResetStatus, ResetStatus.InProgress)
+                .SetProperty(p => p.RepoSizeInKb, 0)
                 .SetProperty(p => p.LastCommit, null as DateTimeOffset?));
         if (rowsAffected == 0) throw new NotFoundException($"project {input.Code} not ready for reset, either already reset or not found", nameof(Project));
         await ResetLexEntryCount(input.Code);
@@ -239,6 +240,7 @@ public class ProjectService(LexBoxDbContext dbContext, IHgService hgService, IOp
         }
 
         project.LastCommit = await hgService.GetLastCommitTimeFromHg(project.Code);
+        project.RepoSizeInKb = await hgService.GetRepoSizeInKb(project.Code);
         // Caller is responsible for caling dbContext.SaveChangesAsync()
     }
 

--- a/backend/LexCore/Entities/Project.cs
+++ b/backend/LexCore/Entities/Project.cs
@@ -20,6 +20,7 @@ public class Project : EntityBase
     public required List<ProjectUsers> Users { get; set; }
     public required List<Organization> Organizations { get; set; }
     public required DateTimeOffset? LastCommit { get; set; }
+    public int? RepoSizeInKb { get; set; }
     public DateTimeOffset? DeletedDate { get; set; }
     public ResetStatus ResetStatus { get; set; } = ResetStatus.None;
 

--- a/backend/LexCore/ServiceInterfaces/IHgService.cs
+++ b/backend/LexCore/ServiceInterfaces/IHgService.cs
@@ -19,6 +19,7 @@ public interface IHgService
     Task FinishReset(ProjectCode code, Stream zipFile);
     Task<HttpContent> VerifyRepo(ProjectCode code, CancellationToken token);
     Task<string> GetTipHash(ProjectCode code, CancellationToken token = default);
+    Task<int?> GetRepoSizeInKb(ProjectCode code, CancellationToken token = default);
     Task<int?> GetLexEntryCount(ProjectCode code, ProjectType projectType);
     Task<string?> GetRepositoryIdentifier(Project project);
     Task<HttpContent> ExecuteHgRecover(ProjectCode code, CancellationToken token);

--- a/backend/LexData/Migrations/20241111072046_AddRepoSizeInKbColumnToProjects.Designer.cs
+++ b/backend/LexData/Migrations/20241111072046_AddRepoSizeInKbColumnToProjects.Designer.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using LexData;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -12,9 +13,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace LexData.Migrations
 {
     [DbContext(typeof(LexBoxDbContext))]
-    partial class LexBoxDbContextModelSnapshot : ModelSnapshot
+    [Migration("20241111072046_AddRepoSizeInKbColumnToProjects")]
+    partial class AddRepoSizeInKbColumnToProjects
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/backend/LexData/Migrations/20241111072046_AddRepoSizeInKbColumnToProjects.cs
+++ b/backend/LexData/Migrations/20241111072046_AddRepoSizeInKbColumnToProjects.cs
@@ -1,0 +1,28 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace LexData.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddRepoSizeInKbColumnToProjects : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<int>(
+                name: "RepoSizeInKb",
+                table: "Projects",
+                type: "integer",
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "RepoSizeInKb",
+                table: "Projects");
+        }
+    }
+}

--- a/frontend/schema.graphql
+++ b/frontend/schema.graphql
@@ -256,6 +256,7 @@ type Mutation {
   changeProjectDescription(input: ChangeProjectDescriptionInput!): ChangeProjectDescriptionPayload! @cost(weight: "10")
   setProjectConfidentiality(input: SetProjectConfidentialityInput!): SetProjectConfidentialityPayload! @cost(weight: "10")
   setRetentionPolicy(input: SetRetentionPolicyInput!): SetRetentionPolicyPayload! @cost(weight: "10")
+  updateProjectRepoSizeInKb(input: UpdateProjectRepoSizeInKbInput!): UpdateProjectRepoSizeInKbPayload! @cost(weight: "10")
   updateProjectLexEntryCount(input: UpdateProjectLexEntryCountInput!): UpdateProjectLexEntryCountPayload! @cost(weight: "10")
   updateProjectLanguageList(input: UpdateProjectLanguageListInput!): UpdateProjectLanguageListPayload! @cost(weight: "10")
   updateLangProjectId(input: UpdateLangProjectIdInput!): UpdateLangProjectIdPayload! @cost(weight: "10")
@@ -384,6 +385,7 @@ type Project {
   flexProjectMetadata: FlexProjectMetadata
   organizations: [Organization!]!
   lastCommit: DateTime
+  repoSizeInKb: Int
   deletedDate: DateTime
   resetStatus: ResetStatus!
   projectOrigin: ProjectMigrationStatus!
@@ -512,6 +514,11 @@ type UpdateProjectLexEntryCountPayload {
   errors: [UpdateProjectLexEntryCountError!]
 }
 
+type UpdateProjectRepoSizeInKbPayload {
+  project: Project
+  errors: [UpdateProjectRepoSizeInKbError!]
+}
+
 type User {
   email: String @authorize(policy: "AdminRequiredPolicy")
   emailVerified: Boolean! @authorize(policy: "AdminRequiredPolicy")
@@ -618,6 +625,8 @@ union UpdateLangProjectIdError = NotFoundError | DbError | UnauthorizedAccessErr
 union UpdateProjectLanguageListError = NotFoundError | DbError | UnauthorizedAccessError
 
 union UpdateProjectLexEntryCountError = NotFoundError | DbError | UnauthorizedAccessError
+
+union UpdateProjectRepoSizeInKbError = NotFoundError | DbError | UnauthorizedAccessError
 
 input AddProjectMemberInput {
   projectId: UUID!
@@ -930,6 +939,7 @@ input ProjectFilterInput {
   users: ListFilterInputTypeOfProjectUsersFilterInput
   organizations: ListFilterInputTypeOfOrganizationFilterInput
   lastCommit: DateTimeOperationFilterInput
+  repoSizeInKb: IntOperationFilterInput
   deletedDate: DateTimeOperationFilterInput
   resetStatus: ResetStatusOperationFilterInput
   projectOrigin: ProjectMigrationStatusOperationFilterInput
@@ -964,6 +974,7 @@ input ProjectSortInput {
   isConfidential: SortEnumType @cost(weight: "10")
   flexProjectMetadata: FlexProjectMetadataSortInput @cost(weight: "10")
   lastCommit: SortEnumType @cost(weight: "10")
+  repoSizeInKb: SortEnumType @cost(weight: "10")
   deletedDate: SortEnumType @cost(weight: "10")
   resetStatus: SortEnumType @cost(weight: "10")
   projectOrigin: SortEnumType @cost(weight: "10")
@@ -1090,6 +1101,10 @@ input UpdateProjectLanguageListInput {
 }
 
 input UpdateProjectLexEntryCountInput {
+  code: String!
+}
+
+input UpdateProjectRepoSizeInKbInput {
   code: String!
 }
 

--- a/frontend/src/lib/i18n/locales/en.json
+++ b/frontend/src/lib/i18n/locales/en.json
@@ -448,6 +448,7 @@ Lexbox is free and [open source](https://github.com/sillsdev/languageforge-lexbo
     "history": "History",
     "project_code": "Project Code",
     "summary": "Summary",
+    "repo_size": "Size on disk",
     "num_entries": "Entries",
     "description": "Description",
     "created_at": "Created",

--- a/frontend/src/lib/layout/DetailItem.svelte
+++ b/frontend/src/lib/layout/DetailItem.svelte
@@ -1,13 +1,22 @@
 <script lang="ts">
   import CopyToClipboardButton from '$lib/components/CopyToClipboardButton.svelte';
+  import Loader from '$lib/components/Loader.svelte';
 
   export let title: string;
   export let text: string | null | undefined = undefined;
   export let copyToClipboard = false;
+  export let loading = false;
 </script>
 
-<div class="text-lg flex items-center gap-1">
-  {title}: {#if text}<span class="text-secondary">{text}</span>{:else}<slot/>{/if}
+<div class="text-lg flex items-center gap-2">
+  {title}:
+  {#if loading}
+    <Loader loading size="loading-xs" />
+  {:else if text}
+    <span class="text-secondary">{text}</span>
+  {:else}
+    <slot/>
+  {/if}
   {#if copyToClipboard}
     <CopyToClipboardButton textToCopy={text ?? ''} size="btn-sm" outline={false} />
   {/if}

--- a/frontend/src/routes/(authenticated)/project/[project_code]/+page.svelte
+++ b/frontend/src/routes/(authenticated)/project/[project_code]/+page.svelte
@@ -55,7 +55,6 @@
   import { onMount } from 'svelte';
   import { getSearchParamValues } from '$lib/util/query-params';
   import FlexModelVersionText from '$lib/components/Projects/FlexModelVersionText.svelte';
-  import Loader from '$lib/components/Loader.svelte';
 
   export let data: PageData;
   $: user = data.user;
@@ -415,11 +414,7 @@
       <DetailItem title={$t('project_page.project_code')} text={project.code} copyToClipboard={true} />
       <DetailItem title={$t('project_page.created_at')} text={$date(project.createdDate)} />
       <DetailItem title={$t('project_page.last_commit')} text={$date(project.lastCommit)} />
-      {#if loadingRepoSize}
-        <Loader loading={loadingRepoSize} size="loading-xs" />
-      {:else}
-        <DetailItem title={$t('project_page.repo_size')} text={sizeStrInMb(project.repoSizeInKb ?? 0)} />
-      {/if}
+      <DetailItem title={$t('project_page.repo_size')} loading={loadingRepoSize} text={sizeStrInMb(project.repoSizeInKb ?? 0)} />
       {#if project.type === ProjectType.FlEx || project.type === ProjectType.WeSay}
         <DetailItem title={$t('project_page.num_entries')} text={$number(lexEntryCount)}>
           <AdminContent slot="extras">

--- a/frontend/src/routes/(authenticated)/project/[project_code]/+page.svelte
+++ b/frontend/src/routes/(authenticated)/project/[project_code]/+page.svelte
@@ -104,7 +104,7 @@
   }
 
   $: if (project.repoSizeInKb == null) {
-    updateRepoSize();
+    void updateRepoSize();
   }
 
   let loadingEntryCount = false;

--- a/frontend/src/routes/(authenticated)/project/[project_code]/+page.svelte
+++ b/frontend/src/routes/(authenticated)/project/[project_code]/+page.svelte
@@ -90,6 +90,10 @@
     if (urlValues.addUserId && urlValues.addUserName && addProjectMember) {
       void addProjectMember.openModal(urlValues.addUserId, urlValues.addUserName);
     }
+
+    if (project && project.repoSizeInKb == null) {
+      void updateRepoSize();
+    }
   });
 
   let addProjectMember: AddProjectMember;
@@ -101,10 +105,6 @@
     loadingRepoSize = true;
     await _updateProjectRepoSizeInKb(project.code);
     loadingRepoSize = false;
-  }
-
-  $: if (project.repoSizeInKb == null) {
-    void updateRepoSize();
   }
 
   function sizeStrInMb(sizeInKb: number): string {

--- a/frontend/src/routes/(authenticated)/project/[project_code]/+page.svelte
+++ b/frontend/src/routes/(authenticated)/project/[project_code]/+page.svelte
@@ -107,6 +107,10 @@
     void updateRepoSize();
   }
 
+  function sizeStrInMb(sizeInKb: number): string {
+    return `${$number(sizeInKb / 1024, {maximumFractionDigits: 1})} MB`;
+  }
+
   let loadingEntryCount = false;
   async function updateEntryCount(): Promise<void> {
     loadingEntryCount = true;
@@ -414,8 +418,7 @@
       {#if loadingRepoSize}
         <Loader loading={loadingRepoSize} size="loading-xs" />
       {:else}
-        <!-- TODO: Might be nice to create a size formatter that will convert to megabytes/gigabytes as appropriate -->
-        <DetailItem title={$t('project_page.repo_size')} text={$number(project.repoSizeInKb) + ' kB'} />
+        <DetailItem title={$t('project_page.repo_size')} text={sizeStrInMb(project.repoSizeInKb ?? 0)} />
       {/if}
       {#if project.type === ProjectType.FlEx || project.type === ProjectType.WeSay}
         <DetailItem title={$t('project_page.num_entries')} text={$number(lexEntryCount)}>

--- a/frontend/src/routes/(authenticated)/project/[project_code]/+page.ts
+++ b/frontend/src/routes/(authenticated)/project/[project_code]/+page.ts
@@ -24,6 +24,7 @@ import type {
   UpdateLangProjectIdMutation,
   UpdateProjectLanguageListMutation,
   UpdateProjectLexEntryCountMutation,
+  UpdateProjectRepoSizeInKbMutation,
 } from '$lib/gql/types';
 import { getClient, graphql } from '$lib/gql';
 
@@ -56,6 +57,7 @@ export async function load(event: PageLoadEvent) {
 						type
             resetStatus
 						lastCommit
+						repoSizeInKb
 						createdDate
 						retentionPolicy
 						isConfidential
@@ -274,6 +276,31 @@ export async function _bulkAddProjectMembers(input: BulkAddProjectMembersInput):
         }
       `),
       { input: input }
+    );
+  return result;
+}
+
+export async function _updateProjectRepoSizeInKb(code: string): $OpResult<UpdateProjectRepoSizeInKbMutation> {
+  //language=GraphQL
+  const result = await getClient()
+    .mutation(
+      graphql(`
+        mutation UpdateProjectRepoSizeInKb($input: UpdateProjectRepoSizeInKbInput!) {
+          updateProjectRepoSizeInKb(input: $input) {
+            project {
+              id
+              repoSizeInKb
+            }
+            errors {
+              __typename
+              ... on Error {
+                message
+              }
+            }
+          }
+        }
+      `),
+      { input: { code } },
     );
   return result;
 }

--- a/hgweb/command-runner.sh
+++ b/hgweb/command-runner.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # Define the list of allowed commands
-allowed_commands=("verify" "tip" "tipdate" "wesaylexentrycount" "lexentrycount" "flexprojectid" "flexwritingsystems" "flexmodelversion" "recover" "healthz" "invalidatedircache")
+allowed_commands=("verify" "tip" "tipdate" "reposizeinkb" "wesaylexentrycount" "lexentrycount" "flexprojectid" "flexwritingsystems" "flexmodelversion" "recover" "healthz" "invalidatedircache")
 
 # Get the project code and command name from the URL
 IFS='/' read -ra PATH_SEGMENTS <<< "$PATH_INFO"
@@ -84,6 +84,10 @@ case $command_name in
 
     tipdate)
         chg tip --template '{date|hgdate}'
+        ;;
+
+    reposizeinkb)
+        du -ks .hg | cut -f1
         ;;
 
     verify)


### PR DESCRIPTION
Fix #1088.

Work completed:

- hg command runner command to get the repo size in kilobytes (it'll always be a multiple of 4 kb, so getting it in bytes isn't really necessary).
- store size in Project table
- update size after each Send/Receive
- GQL mutation to update project size
- frontend updates project size automatically if it's null
  - GQL mutation has CanViewProject permissions, so this will work no matter who's viewing the project page

Screenshot:

![image](https://github.com/user-attachments/assets/d05cd3a1-fc89-4131-91fa-dfca371a9f11)

![image](https://github.com/user-attachments/assets/bf7a4889-89d1-442e-abc7-dbb746021361)

