### PR TITLE
Prevent error after hot reload: Operation is not valid due to the current state of the object. (DateTimeType)

### DIFF
--- a/backend/LexBoxApi/GraphQL/GraphQlSetupKernel.cs
+++ b/backend/LexBoxApi/GraphQL/GraphQlSetupKernel.cs
@@ -50,10 +50,6 @@ public static class GraphQlSetupKernel
                 options.IncludeExceptionDetails = true;
             })
             .AddType<DbErrorCode>()
-            .AddType(() => new DateTimeType("DateTime"))
-            .AddType(() => new UuidType("UUID"))
-            .AddType(() => new DateTimeType("timestamptz"))
-            .AddType(() => new UuidType("uuid"))
             .AddInstrumentation(options =>
             {
                 options.IncludeDocument = true;

--- a/backend/LexBoxApi/GraphQL/GraphQlSetupKernel.cs
+++ b/backend/LexBoxApi/GraphQL/GraphQlSetupKernel.cs
@@ -50,10 +50,10 @@ public static class GraphQlSetupKernel
                 options.IncludeExceptionDetails = true;
             })
             .AddType<DbErrorCode>()
-            .AddType(new DateTimeType("DateTime"))
-            .AddType(new UuidType("UUID"))
-            .AddType(new DateTimeType("timestamptz"))
-            .AddType(new UuidType("uuid"))
+            .AddType(() => new DateTimeType("DateTime"))
+            .AddType(() => new UuidType("UUID"))
+            .AddType(() => new DateTimeType("timestamptz"))
+            .AddType(() => new UuidType("uuid"))
             .AddInstrumentation(options =>
             {
                 options.IncludeDocument = true;

--- a/frontend/schema.graphql
+++ b/frontend/schema.graphql
@@ -1248,13 +1248,10 @@ directive @listSize("The `assumedSize` argument can be used to statically define
 "The `@specifiedBy` directive is used within the type system definition language to provide a URL for specifying the behavior of custom scalar definitions."
 directive @specifiedBy("The specifiedBy URL points to a human-readable specification. This field will only read a result for scalar types." url: String!) on SCALAR
 
+"The `DateTime` scalar represents an ISO-8601 compliant date time type."
 scalar DateTime @specifiedBy(url: "https:\/\/www.graphql-scalars.com\/date-time")
 
 "The `Long` scalar type represents non-fractional signed whole 64-bit numeric values. Long can represent values between -(2^63) and 2^63 - 1."
 scalar Long
 
-scalar UUID
-
-scalar timestamptz @specifiedBy(url: "https:\/\/www.graphql-scalars.com\/date-time")
-
-scalar uuid
+scalar UUID @specifiedBy(url: "https:\/\/tools.ietf.org\/html\/rfc4122")


### PR DESCRIPTION
Over the months we've seen Hot Chocolate start throwing exceptions after a hot reload.

Today, this was frustrating me again, so I did some googling and happened to stumble upon [this comment](https://github.com/ChilliCream/graphql-platform/pull/2985#issuecomment-772084224), which seems to have fixed it. 🥳 