### PR TITLE
Allow admins to resend email verification to users

### DIFF
--- a/backend/LexBoxApi/GraphQL/UserMutations.cs
+++ b/backend/LexBoxApi/GraphQL/UserMutations.cs
@@ -77,6 +77,23 @@ public class UserMutations
 
     [Error<NotFoundException>]
     [Error<DbError>]
+    [Error<InvalidOperationException>]
+    [AdminRequired]
+    public async Task<User> SendNewVerificationEmailByAdmin(
+        Guid userId,
+        LexBoxDbContext dbContext,
+        IEmailService emailService
+    )
+    {
+        var user = await dbContext.Users.FindAsync(userId);
+        NotFoundException.ThrowIfNull(user);
+        if (string.IsNullOrEmpty(user.Email)) throw new InvalidOperationException("User account does not have an email address");
+        await emailService.SendVerifyAddressEmail(user);
+        return user;
+    }
+
+    [Error<NotFoundException>]
+    [Error<DbError>]
     [Error<UniqueValueException>]
     [Error<RequiredException>]
     [AdminRequired]

--- a/frontend/schema.graphql
+++ b/frontend/schema.graphql
@@ -266,6 +266,7 @@ type Mutation {
   softDeleteProject(input: SoftDeleteProjectInput!): SoftDeleteProjectPayload! @cost(weight: "10")
   changeUserAccountBySelf(input: ChangeUserAccountBySelfInput!): ChangeUserAccountBySelfPayload! @cost(weight: "10")
   changeUserAccountByAdmin(input: ChangeUserAccountByAdminInput!): ChangeUserAccountByAdminPayload! @authorize(policy: "AdminRequiredPolicy") @cost(weight: "10")
+  sendNewVerificationEmailByAdmin(input: SendNewVerificationEmailByAdminInput!): SendNewVerificationEmailByAdminPayload! @authorize(policy: "AdminRequiredPolicy") @cost(weight: "10")
   createGuestUserByAdmin(input: CreateGuestUserByAdminInput!): CreateGuestUserByAdminPayload! @authorize(policy: "AdminRequiredPolicy") @cost(weight: "10")
   deleteUserByAdminOrSelf(input: DeleteUserByAdminOrSelfInput!): DeleteUserByAdminOrSelfPayload! @cost(weight: "10")
   setUserLocked(input: SetUserLockedInput!): SetUserLockedPayload! @authorize(policy: "AdminRequiredPolicy") @cost(weight: "10")
@@ -459,6 +460,11 @@ type RequiredError implements Error {
   message: String!
 }
 
+type SendNewVerificationEmailByAdminPayload {
+  user: User
+  errors: [SendNewVerificationEmailByAdminError!]
+}
+
 type SetOrgMemberRolePayload {
   organization: Organization
   errors: [SetOrgMemberRoleError!]
@@ -600,6 +606,8 @@ union LeaveOrgError = NotFoundError | LastMemberCantLeaveError
 union LeaveProjectError = NotFoundError | LastMemberCantLeaveError
 
 union RemoveProjectFromOrgError = DbError | NotFoundError
+
+union SendNewVerificationEmailByAdminError = NotFoundError | DbError | UniqueValueError
 
 union SetOrgMemberRoleError = DbError | NotFoundError | OrgMemberInvitedByEmail
 
@@ -1032,6 +1040,10 @@ input RetentionPolicyOperationFilterInput {
   neq: RetentionPolicy @cost(weight: "10")
   in: [RetentionPolicy!] @cost(weight: "10")
   nin: [RetentionPolicy!] @cost(weight: "10")
+}
+
+input SendNewVerificationEmailByAdminInput {
+  userId: UUID!
 }
 
 input SetOrgMemberRoleInput {

--- a/frontend/src/lib/components/IconButton.svelte
+++ b/frontend/src/lib/components/IconButton.svelte
@@ -13,6 +13,7 @@
   let loadingSize = size === 'btn-sm' ? 'loading-xs' as const : undefined;
   export let outline = variant !== 'btn-ghost';
   export let fake = false; // for display purposes only
+  export let title: string | undefined = undefined;
 
   const xlIcons: IconString[] = ['i-mdi-refresh'];
   $: textSize = xlIcons.includes(icon) ? 'text-xl' : 'text-lg';
@@ -21,6 +22,7 @@
 <!-- type="button" ensures the button doen't act as a submit button when in a form -->
 <button type="button" on:click
   disabled={disabled && !loading}
+  {title}
   class:pointer-events-none={fake || loading}
   class="btn btn-square {variant ?? ''} {size ?? ''} {$$restProps.class ?? ''}"
   class:btn-outline={outline}

--- a/frontend/src/lib/components/IconButton.svelte
+++ b/frontend/src/lib/components/IconButton.svelte
@@ -13,7 +13,6 @@
   let loadingSize = size === 'btn-sm' ? 'loading-xs' as const : undefined;
   export let outline = variant !== 'btn-ghost';
   export let fake = false; // for display purposes only
-  export let title: string | undefined = undefined;
 
   const xlIcons: IconString[] = ['i-mdi-refresh'];
   $: textSize = xlIcons.includes(icon) ? 'text-xl' : 'text-lg';
@@ -22,7 +21,6 @@
 <!-- type="button" ensures the button doen't act as a submit button when in a form -->
 <button type="button" on:click
   disabled={disabled && !loading}
-  {title}
   class:pointer-events-none={fake || loading}
   class="btn btn-square {variant ?? ''} {size ?? ''} {$$restProps.class ?? ''}"
   class:btn-outline={outline}

--- a/frontend/src/lib/components/IconButton.svelte
+++ b/frontend/src/lib/components/IconButton.svelte
@@ -8,7 +8,7 @@
   export let loading = false;
   export let active = false;
   export let join = false;
-  export let variant: 'btn-success' | 'btn-ghost' | undefined = undefined;
+  export let variant: 'btn-success' | 'btn-ghost' | 'btn-primary' | undefined = undefined;
   export let size: 'btn-sm' | undefined = undefined;
   let loadingSize = size === 'btn-sm' ? 'loading-xs' as const : undefined;
   export let outline = variant !== 'btn-ghost';

--- a/frontend/src/lib/components/Users/UserModal.svelte
+++ b/frontend/src/lib/components/Users/UserModal.svelte
@@ -4,6 +4,8 @@
   import DevContent from '$lib/layout/DevContent.svelte';
   import UserLockedAlert from './UserLockedAlert.svelte';
   import { NULL_LABEL } from '$lib/i18n';
+  import IconButton from '$lib/components/IconButton.svelte';
+  import AdminContent from '$lib/layout/AdminContent.svelte';
 
   type User = {
     id: string;
@@ -27,6 +29,9 @@
     user = _user;
     await userDetailsModal.openModal(true, true);
   }
+
+  // eslint-disable-next-line func-style
+  export let sendVerificationEmail = (_: User): void => {};
 </script>
 
 <Modal bind:this={userDetailsModal} bottom>
@@ -50,6 +55,14 @@
                 data-tip={$t('admin_dashboard.email_not_verified')}>
                 <span class="i-mdi-help-circle-outline" />
               </span>
+              <AdminContent>
+                <IconButton
+                  size="btn-sm"
+                  icon="i-mdi-email"
+                  title={$t('admin_dashboard.resend_verification_email')}
+                  on:click={() => sendVerificationEmail(user)}
+                />
+              </AdminContent>
             {/if}
           {:else}
             –

--- a/frontend/src/lib/components/Users/UserModal.svelte
+++ b/frontend/src/lib/components/Users/UserModal.svelte
@@ -35,8 +35,11 @@
 
   const { notifySuccess } = useNotifications();
 
+  var sendingVerificationEmail = false;
   async function sendVerificationEmail(user: User): Promise<void> {
+    sendingVerificationEmail = true;
     await _sendNewVerificationEmailByAdmin(user.id as UUID);
+    sendingVerificationEmail = false;
     notifySuccess($t('admin_dashboard.notifications.verification_email_sent', { email: user.email ?? '' }));
   }
 </script>
@@ -69,6 +72,7 @@
                     icon="i-mdi-email-sync"
                     outline={false}
                     variant="btn-primary"
+                    loading={sendingVerificationEmail}
                     on:click={() => sendVerificationEmail(user)}
                   />
                 </div>

--- a/frontend/src/lib/components/Users/UserModal.svelte
+++ b/frontend/src/lib/components/Users/UserModal.svelte
@@ -66,7 +66,7 @@
                 <div class="tooltip" data-tip={$t('admin_dashboard.resend_verification_email')}>
                   <IconButton
                     size="btn-sm"
-                    icon="i-mdi-email"
+                    icon="i-mdi-email-sync"
                     on:click={() => sendVerificationEmail(user)}
                   />
                 </div>

--- a/frontend/src/lib/components/Users/UserModal.svelte
+++ b/frontend/src/lib/components/Users/UserModal.svelte
@@ -35,7 +35,6 @@
 
   const { notifySuccess } = useNotifications();
 
-  // eslint-disable-next-line func-style
   async function sendVerificationEmail(user: User): Promise<void> {
     await _sendNewVerificationEmailByAdmin(user.id as UUID);
     notifySuccess($t('admin_dashboard.notifications.verification_email_sent', { email: user.email ?? '' }));
@@ -64,12 +63,13 @@
                 <span class="i-mdi-help-circle-outline" />
               </span>
               <AdminContent>
-                <IconButton
-                  size="btn-sm"
-                  icon="i-mdi-email"
-                  title={$t('admin_dashboard.resend_verification_email')}
-                  on:click={() => sendVerificationEmail(user)}
-                />
+                <div class="tooltip" data-tip={$t('admin_dashboard.resend_verification_email')}>
+                  <IconButton
+                    size="btn-sm"
+                    icon="i-mdi-email"
+                    on:click={() => sendVerificationEmail(user)}
+                  />
+                </div>
               </AdminContent>
             {/if}
           {:else}

--- a/frontend/src/lib/components/Users/UserModal.svelte
+++ b/frontend/src/lib/components/Users/UserModal.svelte
@@ -6,6 +6,9 @@
   import { NULL_LABEL } from '$lib/i18n';
   import IconButton from '$lib/components/IconButton.svelte';
   import AdminContent from '$lib/layout/AdminContent.svelte';
+  import {_sendNewVerificationEmailByAdmin} from '../../../routes/(authenticated)/admin/+page';
+  import type {UUID} from 'crypto';
+  import {useNotifications} from '$lib/notify';
 
   type User = {
     id: string;
@@ -30,8 +33,13 @@
     await userDetailsModal.openModal(true, true);
   }
 
+  const { notifySuccess } = useNotifications();
+
   // eslint-disable-next-line func-style
-  export let sendVerificationEmail = (_: User): void => {};
+  async function sendVerificationEmail(user: User): Promise<void> {
+    await _sendNewVerificationEmailByAdmin(user.id as UUID);
+    notifySuccess($t('admin_dashboard.notifications.verification_email_sent', { email: user.email ?? '' }));
+  }
 </script>
 
 <Modal bind:this={userDetailsModal} bottom>

--- a/frontend/src/lib/components/Users/UserModal.svelte
+++ b/frontend/src/lib/components/Users/UserModal.svelte
@@ -67,6 +67,8 @@
                   <IconButton
                     size="btn-sm"
                     icon="i-mdi-email-sync"
+                    outline={false}
+                    variant="btn-primary"
                     on:click={() => sendVerificationEmail(user)}
                   />
                 </div>

--- a/frontend/src/lib/components/modals/Modal.svelte
+++ b/frontend/src/lib/components/modals/Modal.svelte
@@ -7,6 +7,7 @@
 
 <script lang="ts">
   import t from '$lib/i18n';
+  import Notify from '$lib/notify/Notify.svelte';
   import { OverlayContainer } from '$lib/overlay';
   import { createEventDispatcher } from 'svelte';
   import { writable } from 'svelte/store';
@@ -129,5 +130,6 @@
         <button>invisible</button>
       </form>
     {/if}
+    <Notify />
   </dialog>
 {/if}

--- a/frontend/src/lib/i18n/locales/en.json
+++ b/frontend/src/lib/i18n/locales/en.json
@@ -20,11 +20,13 @@
     "how_to_create_users": "How to Create Users",
     "is_draft": "Draft",
     "email_not_verified": "Not Verified",
+    "resend_verification_email": "Resend verification email",
     "notifications": {
       "user_deleted": "{name} has been deleted.",
       "user_updated": "{name} has been updated.",
       "user_created": "{name} has been created.",
-      "email_need_verification": "You've requested to change the e-mail address for {name} to {requestedEmail}. The change will only come into effect when the user verifies the new address. They can do so using the link in the e-mail we just sent them."
+      "email_need_verification": "You've requested to change the e-mail address for {name} to {requestedEmail}. The change will only come into effect when the user verifies the new address. They can do so using the link in the e-mail we just sent them.",
+      "verification_email_sent": "Verification email has been sent to {email}",
     },
     "user_is_locked": "This user is locked. They cannot log in or Send/Receive until an administrator unlocks them.",
     "form_modal": {

--- a/frontend/src/routes/(authenticated)/admin/+page.svelte
+++ b/frontend/src/routes/(authenticated)/admin/+page.svelte
@@ -9,7 +9,7 @@
   import { DialogResponse } from '$lib/components/modals';
   import { Duration } from '$lib/util/time';
   import { RefineFilterMessage } from '$lib/components/Table';
-  import { _sendNewVerificationEmailByAdmin, type AdminSearchParams, type User } from './+page';
+  import { type AdminSearchParams, type User } from './+page';
   import { getSearchParams, queryParam } from '$lib/util/query-params';
   import type { ProjectType } from '$lib/gql/types';
   import { derived } from 'svelte/store';
@@ -23,7 +23,6 @@
   import { browser } from '$app/environment';
   import UserTable from '$lib/components/Users/UserTable.svelte';
   import UserFilter, { type UserFilters, type UserType } from '$lib/components/Users/UserFilter.svelte';
-  import type {UUID} from 'crypto';
 
   export let data: PageData;
   $: projects = data.projects;
@@ -109,11 +108,6 @@
     notifySuccess($t('admin_dashboard.notifications.user_created', { name: user.name }), Duration.Long);
     $queryParamValues.userSearch = user.emailOrUsername;
   }
-
-  async function sendNewVerificationEmailByAdmin(user: User): Promise<void> {
-    await _sendNewVerificationEmailByAdmin(user.id as UUID);
-    notifySuccess($t('admin_dashboard.notifications.verification_email_sent', { email: user.email ?? '' }));
-  }
 </script>
 
 <svelte:head>
@@ -176,6 +170,6 @@
 
   <EditUserAccount bind:this={formModal} {deleteUser} currUser={data.user} />
   <DeleteUserModal bind:this={deleteUserModal} i18nScope="admin_dashboard.form_modal.delete_user" />
-  <UserModal bind:this={userModal} sendVerificationEmail={sendNewVerificationEmailByAdmin} />
+  <UserModal bind:this={userModal}/>
   <CreateUserModal handleSubmit={createGuestUserByAdmin} on:submitted={(e) => onUserCreated(e.detail)} bind:this={createUserModal}/>
 </main>

--- a/frontend/src/routes/(authenticated)/admin/+page.svelte
+++ b/frontend/src/routes/(authenticated)/admin/+page.svelte
@@ -9,7 +9,7 @@
   import { DialogResponse } from '$lib/components/modals';
   import { Duration } from '$lib/util/time';
   import { RefineFilterMessage } from '$lib/components/Table';
-  import type { AdminSearchParams, User } from './+page';
+  import { _sendNewVerificationEmailByAdmin, type AdminSearchParams, type User } from './+page';
   import { getSearchParams, queryParam } from '$lib/util/query-params';
   import type { ProjectType } from '$lib/gql/types';
   import { derived } from 'svelte/store';
@@ -23,6 +23,7 @@
   import { browser } from '$app/environment';
   import UserTable from '$lib/components/Users/UserTable.svelte';
   import UserFilter, { type UserFilters, type UserType } from '$lib/components/Users/UserFilter.svelte';
+  import type {UUID} from 'crypto';
 
   export let data: PageData;
   $: projects = data.projects;
@@ -108,6 +109,11 @@
     notifySuccess($t('admin_dashboard.notifications.user_created', { name: user.name }), Duration.Long);
     $queryParamValues.userSearch = user.emailOrUsername;
   }
+
+  async function sendNewVerificationEmailByAdmin(user: User): Promise<void> {
+    await _sendNewVerificationEmailByAdmin(user.id as UUID);
+    notifySuccess($t('admin_dashboard.notifications.verification_email_sent', { email: user.email ?? '' }));
+  }
 </script>
 
 <svelte:head>
@@ -170,6 +176,6 @@
 
   <EditUserAccount bind:this={formModal} {deleteUser} currUser={data.user} />
   <DeleteUserModal bind:this={deleteUserModal} i18nScope="admin_dashboard.form_modal.delete_user" />
-  <UserModal bind:this={userModal}/>
+  <UserModal bind:this={userModal} sendVerificationEmail={sendNewVerificationEmailByAdmin} />
   <CreateUserModal handleSubmit={createGuestUserByAdmin} on:submitted={(e) => onUserCreated(e.detail)} bind:this={createUserModal}/>
 </main>

--- a/frontend/src/routes/(authenticated)/admin/+page.ts
+++ b/frontend/src/routes/(authenticated)/admin/+page.ts
@@ -13,6 +13,7 @@ import type {
   CreateGuestUserByAdminMutation,
   DraftProjectFilterInput,
   ProjectFilterInput,
+  SendNewVerificationEmailByAdminMutation,
   SetUserLockedInput,
   SetUserLockedMutation,
   UserFilterInput,
@@ -202,6 +203,32 @@ export async function _changeUserAccountByAdmin(input: ChangeUserAccountByAdminI
         }
       `),
       { input: input }
+    )
+  return result;
+}
+
+export async function _sendNewVerificationEmailByAdmin(userId: UUID): $OpResult<SendNewVerificationEmailByAdminMutation> {
+  //language=GraphQL
+  const result = await getClient()
+    .mutation(
+      graphql(`
+        mutation SendNewVerificationEmailByAdmin($input: SendNewVerificationEmailByAdminInput!) {
+          sendNewVerificationEmailByAdmin(input: $input) {
+            user {
+              id
+              email
+              emailVerified
+            }
+            errors {
+                __typename
+              ... on Error {
+                message
+              }
+            }
+          }
+        }
+      `),
+      { input: { userId } }
     )
   return result;
 }

--- a/frontend/src/routes/(unauthenticated)/sandbox/+page.svelte
+++ b/frontend/src/routes/(unauthenticated)/sandbox/+page.svelte
@@ -11,6 +11,8 @@
   import ConfirmModal from '$lib/components/modals/ConfirmModal.svelte';
   import {delay} from '$lib/util/time';
   import DeleteModal from '$lib/components/modals/DeleteModal.svelte';
+  import {Modal} from '$lib/components/modals';
+  import {useNotifications} from '$lib/notify';
 
   function uploadFinished(): void {
     alert('upload done!');
@@ -34,9 +36,9 @@
   let {form, enhance, errors} = lexSuperForm(formSchema, async () => {
       console.log('submit', $form);
   });
-function preFillForm(): void {
-  form.update(f => ({...f, name: 'John'}), {taint: false});
-}
+  function preFillForm(): void {
+    form.update(f => ({...f, name: 'John'}), {taint: false});
+  }
 
   let disableDropdown = false;
 
@@ -44,8 +46,12 @@ function preFillForm(): void {
     await _gqlThrows500();
   }
 
-let modal: ConfirmModal;
-let deleteModal: DeleteModal;
+  const { notifySuccess } = useNotifications();
+
+  let modal: ConfirmModal;
+  let deleteModal: DeleteModal;
+  let notificationModal: Modal;
+  let notificationModalIsAtBottom = false;
 
 </script>
 <PageBreadcrumb>Hello from sandbox</PageBreadcrumb>
@@ -181,14 +187,9 @@ let deleteModal: DeleteModal;
       }}>
         Open Modal
       </Button>
-    </div>
-  </div>
 
-  <div class="card bg-base-200 shadow-lg">
-    <div class="card-body">
       <h2 class="card-title">Delete Modal</h2>
-      <DeleteModal bind:this={deleteModal}
-      entityName="Car">
+      <DeleteModal bind:this={deleteModal} entityName="Car">
         Would you like to delete this car?
       </DeleteModal>
       <Button variant="btn-primary" on:click={async () => {
@@ -196,6 +197,18 @@ let deleteModal: DeleteModal;
         if (result) alert('deleted')
       }}>
         Delete Car
+      </Button>
+
+      <h2 class="card-title">Notification modal</h2>
+      <Modal bind:this={notificationModal} bottom={notificationModalIsAtBottom}>
+        <h2 class="text-xl mb-2">Notification fun 🎉</h2>
+        <Button on:click={() => notifySuccess('Hurra you generated a notification! 😎')}>Generate notification</Button>
+        <Button on:click={() => notificationModalIsAtBottom = !notificationModalIsAtBottom}>Toggle position</Button>
+      </Modal>
+      <Button variant="btn-primary" on:click={() => {
+        notificationModal.openModal();
+      }}>
+        Play with notifications
       </Button>
     </div>
   </div>


### PR DESCRIPTION
Fix #1210.

User modal now has an admin-only button to resend verification email to any users who aren't verified. Button only shows up if an admin is logged in *and* the user is unverified.

![screenshot](https://github.com/user-attachments/assets/9a10be87-99df-484c-ba3a-2ba208d14b4a)
