### PR TITLE
Fail LocalWebApp build if viewer not found to embed

### DIFF
--- a/.github/workflows/fw-lite.yaml
+++ b/.github/workflows/fw-lite.yaml
@@ -47,6 +47,14 @@ jobs:
           shortSha=$(echo ${{ github.sha }} | cut -c1-8)
           echo "VERSION=v$(date --rfc-3339=date)-$shortSha" >> ${GITHUB_OUTPUT}
           echo "SEMVER_VERSION=$(date +%Y.%-m.%-d)" >> ${GITHUB_OUTPUT}
+
+      - name: Build viewer
+        working-directory: frontend/viewer
+        run: |
+          corepack enable
+          pnpm install
+          pnpm run build-app
+
       - name: Dotnet build
         working-directory: backend/FwLite/FwLiteDesktop
         run: |
@@ -55,12 +63,6 @@ jobs:
       - name: Dotnet test
         run: dotnet test FwLiteOnly.slnf --configuration Release  --logger GitHubActions
 
-      - name: Build viewer
-        working-directory: frontend/viewer
-        run: |
-          corepack enable
-          pnpm install
-          pnpm run build-app
       - name: Upload viewer artifacts
         uses: actions/upload-artifact@v4
         with:

--- a/backend/FwLite/LocalWebApp/LocalWebApp.csproj
+++ b/backend/FwLite/LocalWebApp/LocalWebApp.csproj
@@ -50,6 +50,11 @@
         <EmbeddedResource Include="..\..\..\frontend\viewer\dist\**\*" />
     </ItemGroup>
 
+    <Target Name="FailIfViewerNotEmbedded" BeforeTargets="Build">
+        <Error Condition="@(EmbeddedResource->Count()) == 0"
+            Text="The viewer app was not found. Run 'pnpm run build-app' from the viewer folder." />
+    </Target>
+
     <ItemGroup Condition="$([MSBuild]::IsOsPlatform('macOS'))">
         <!--
           This assumes that icu4c libs are installed under "/opt/local/lib" on macOS. This is the default


### PR DESCRIPTION
The LocalWebApp will fail to start if the viewer isn't available when it gets built.
That's not obvious when e.g. spawning the LocalWebApp from inside our platform.bible extension.
So, failing early seems like a good idea.