### PR TITLE
Change 'bool CanSyncProject' to 'bool IsProjectMember'

### DIFF
--- a/backend/LexBoxApi/Controllers/IntegrationController.cs
+++ b/backend/LexBoxApi/Controllers/IntegrationController.cs
@@ -35,7 +35,7 @@ public class IntegrationController(
     [ProducesResponseType(StatusCodes.Status302Found)]
     public async Task<ActionResult> OpenWithFlex(Guid projectId)
     {
-        if (!await permissionService.CanSyncProjectAsync(projectId)) return Unauthorized();
+        if (!await permissionService.CanSyncProject(projectId)) return Unauthorized();
         var project = await lexBoxDbContext.Projects.FirstOrDefaultAsync(p => p.Id == projectId);
         if (project is null) return NotFound();
         var repoId = await hgService.GetRepositoryIdentifier(project);

--- a/backend/LexBoxApi/GraphQL/LexQueries.cs
+++ b/backend/LexBoxApi/GraphQL/LexQueries.cs
@@ -229,7 +229,7 @@ public class LexQueries
             }
         });
         // Members and non-members alike can see all public projects plus their own
-        org.Projects = org.Projects?.Where(p => p.IsConfidential == false || permissionService.CanSyncProject(p.Id))?.ToList() ?? [];
+        org.Projects = org.Projects?.Where(p => p.IsConfidential == false || permissionService.IsProjectMember(p.Id, updatedUser))?.ToList() ?? [];
         if (!permissionService.IsOrgMember(orgId, updatedUser))
         {
             // Non-members also cannot see membership, only org admins

--- a/backend/LexCore/Auth/LexAuthUser.cs
+++ b/backend/LexCore/Auth/LexAuthUser.cs
@@ -237,6 +237,8 @@ public record LexAuthUser
 
     public bool IsProjectMember(Guid projectId, ProjectRole? role = null)
     {
+        if (Projects is null) return false;
+
         if (role is not null)
         {
             return Projects.Any(p => p.ProjectId == projectId && p.Role == role);

--- a/backend/LexCore/ServiceInterfaces/IPermissionService.cs
+++ b/backend/LexCore/ServiceInterfaces/IPermissionService.cs
@@ -6,15 +6,8 @@ namespace LexCore.ServiceInterfaces;
 public interface IPermissionService
 {
     ValueTask<bool> CanSyncProject(string projectCode);
-    /// <summary>
-    /// Does NOT check permissions for org managers, because that requires async DB access.
-    /// Use CanSyncProject(projectCode) or CanSyncProjectAsync(projectId) if org manager permissions also need to be checked.
-    /// </summary>
-    bool CanSyncProject(Guid projectId);
-    /// <summary>
-    /// Does all the checks from CanSyncProject, plus allows org managers to access the org as well.
-    /// </summary>
-    ValueTask<bool> CanSyncProjectAsync(Guid projectId);
+    bool IsProjectMember(Guid projectId, LexAuthUser? overrideUser = null);
+    ValueTask<bool> CanSyncProject(Guid projectId);
     ValueTask AssertCanSyncProject(string projectCode);
     ValueTask AssertCanSyncProject(Guid projectId);
     ValueTask<bool> CanViewProject(Guid projectId, LexAuthUser? overrideUser = null);


### PR DESCRIPTION
So, I didn't remove LexAuthUser.IsProjectMember like [I said I would](https://github.com/sillsdev/languageforge-lexbox/pull/1218#discussion_r1840151443). LexAuthUser seems like a nice place for that.

But I think this refactor makes the PermissionService API less confusing.

The old `bool CanSyncProject` and the new `bool IsProjectMember` are not equivalent. But there were only 2 places that use `bool CanSyncProject` and only 1 needed adapting.

- I also found a place where I had forgotten to pass an `overrideUser`.
- I removed the comments from `IPermissionService`, because they're not necessary now that the API is more intuitive.