### PR TITLE
User typeahead enabled for non-admin project managers

### DIFF
--- a/backend/LexBoxApi/GraphQL/LexQueries.cs
+++ b/backend/LexBoxApi/GraphQL/LexQueries.cs
@@ -2,6 +2,7 @@ using HotChocolate.Resolvers;
 using LexBoxApi.Auth;
 using LexBoxApi.Auth.Attributes;
 using LexBoxApi.GraphQL.CustomTypes;
+using LexBoxApi.Services;
 using LexCore.Auth;
 using LexCore.Entities;
 using LexCore.ServiceInterfaces;
@@ -190,16 +191,9 @@ public class LexQueries
     [UseProjection]
     [UseFiltering]
     [UseSorting]
-    public IQueryable<User> UsersICanSee(LexBoxDbContext context, LoggedInContext loggedInContext)
+    public IQueryable<User> UsersICanSee(UserService userService, LoggedInContext loggedInContext)
     {
-        var myOrgIds = loggedInContext.User.Orgs.Select(o => o.OrgId).ToList();
-        var myProjectIds = loggedInContext.User.Projects.Select(p => p.ProjectId).ToList();
-        var myManagedProjectIds = loggedInContext.User.Projects.Where(p => p.Role == ProjectRole.Manager).Select(p => p.ProjectId).ToList();
-        return context.Users.Where(u =>
-            u.Organizations.Any(orgMember => myOrgIds.Contains(orgMember.OrgId)) ||
-            u.Projects.Any(projMember =>
-                myManagedProjectIds.Contains(projMember.ProjectId) ||
-                (projMember.Project != null && projMember.Project.IsConfidential == false && myProjectIds.Contains(projMember.ProjectId))));
+        return userService.UserQueryForTypeahead(loggedInContext.User);
     }
 
     [UseProjection]

--- a/backend/LexBoxApi/GraphQL/LexQueries.cs
+++ b/backend/LexBoxApi/GraphQL/LexQueries.cs
@@ -186,6 +186,19 @@ public class LexQueries
         return context.Users.Where(u => u.Organizations.Any(orgMember => myOrgIds.Contains(orgMember.OrgId)));
     }
 
+    [UseOffsetPaging]
+    [UseProjection]
+    [UseFiltering]
+    [UseSorting]
+    public IQueryable<User> UsersICanSee(LexBoxDbContext context, LoggedInContext loggedInContext)
+    {
+        var myOrgIds = loggedInContext.User.Orgs.Select(o => o.OrgId).ToList();
+        var myManagedProjectIds = loggedInContext.User.Projects.Where(p => p.Role == ProjectRole.Manager).Select(p => p.ProjectId).ToList();
+        return context.Users.Where(u =>
+            u.Organizations.Any(orgMember => myOrgIds.Contains(orgMember.OrgId)) ||
+            u.Projects.Any(projMember => myManagedProjectIds.Contains(projMember.ProjectId)));
+    }
+
     [UseProjection]
     [GraphQLType<OrgByIdGqlConfiguration>]
     public async Task<Organization?> OrgById(LexBoxDbContext dbContext,

--- a/backend/LexBoxApi/GraphQL/LexQueries.cs
+++ b/backend/LexBoxApi/GraphQL/LexQueries.cs
@@ -193,10 +193,13 @@ public class LexQueries
     public IQueryable<User> UsersICanSee(LexBoxDbContext context, LoggedInContext loggedInContext)
     {
         var myOrgIds = loggedInContext.User.Orgs.Select(o => o.OrgId).ToList();
+        var myProjectIds = loggedInContext.User.Projects.Select(p => p.ProjectId).ToList();
         var myManagedProjectIds = loggedInContext.User.Projects.Where(p => p.Role == ProjectRole.Manager).Select(p => p.ProjectId).ToList();
         return context.Users.Where(u =>
             u.Organizations.Any(orgMember => myOrgIds.Contains(orgMember.OrgId)) ||
-            u.Projects.Any(projMember => myManagedProjectIds.Contains(projMember.ProjectId)));
+            u.Projects.Any(projMember =>
+                myManagedProjectIds.Contains(projMember.ProjectId) ||
+                (projMember.Project != null && projMember.Project.IsConfidential == false && myProjectIds.Contains(projMember.ProjectId))));
     }
 
     [UseProjection]

--- a/backend/LexBoxApi/Services/DevGqlSchemaWriterService.cs
+++ b/backend/LexBoxApi/Services/DevGqlSchemaWriterService.cs
@@ -33,6 +33,7 @@ public class DevGqlSchemaWriterService : IHostedService
             .AddScoped<LexBoxDbContext>()
             .AddScoped<IPermissionService, PermissionService>()
             .AddScoped<ProjectService>()
+            .AddScoped<UserService>()
             .AddScoped<LexAuthService>()
             .AddLexGraphQL(builder.Environment, true);
         var host = builder.Build();

--- a/backend/LexBoxApi/Services/UserService.cs
+++ b/backend/LexBoxApi/Services/UserService.cs
@@ -91,6 +91,7 @@ public class UserService(LexBoxDbContext dbContext, IEmailService emailService)
         var myProjectIds = user.Projects.Select(p => p.ProjectId).ToList();
         var myManagedProjectIds = user.Projects.Where(p => p.Role == ProjectRole.Manager).Select(p => p.ProjectId).ToList();
         return dbContext.Users.Where(u =>
+            u.Id == user.Id ||
             u.Organizations.Any(orgMember => myOrgIds.Contains(orgMember.OrgId)) ||
             u.Projects.Any(projMember =>
                 myManagedProjectIds.Contains(projMember.ProjectId) ||

--- a/backend/LexBoxApi/Services/UserService.cs
+++ b/backend/LexBoxApi/Services/UserService.cs
@@ -1,13 +1,14 @@
 ﻿using System.Net.Mail;
-using LexBoxApi.Auth;
 using LexBoxApi.Services.Email;
+using LexCore.Auth;
+using LexCore.Entities;
 using LexCore.Exceptions;
 using LexData;
 using Microsoft.EntityFrameworkCore;
 
 namespace LexBoxApi.Services;
 
-public class UserService(LexBoxDbContext dbContext, IEmailService emailService, LexAuthService lexAuthService)
+public class UserService(LexBoxDbContext dbContext, IEmailService emailService)
 {
     public async Task ForgotPassword(string email)
     {
@@ -82,5 +83,17 @@ public class UserService(LexBoxDbContext dbContext, IEmailService emailService, 
             name = username;
         }
         return (name, email, username);
+    }
+
+    public IQueryable<User> UserQueryForTypeahead(LexAuthUser user)
+    {
+        var myOrgIds = user.Orgs.Select(o => o.OrgId).ToList();
+        var myProjectIds = user.Projects.Select(p => p.ProjectId).ToList();
+        var myManagedProjectIds = user.Projects.Where(p => p.Role == ProjectRole.Manager).Select(p => p.ProjectId).ToList();
+        return dbContext.Users.Where(u =>
+            u.Organizations.Any(orgMember => myOrgIds.Contains(orgMember.OrgId)) ||
+            u.Projects.Any(projMember =>
+                myManagedProjectIds.Contains(projMember.ProjectId) ||
+                (projMember.Project != null && projMember.Project.IsConfidential == false && myProjectIds.Contains(projMember.ProjectId))));
     }
 }

--- a/backend/LexBoxApi/Services/UserService.cs
+++ b/backend/LexBoxApi/Services/UserService.cs
@@ -94,6 +94,6 @@ public class UserService(LexBoxDbContext dbContext, IEmailService emailService)
             u.Organizations.Any(orgMember => myOrgIds.Contains(orgMember.OrgId)) ||
             u.Projects.Any(projMember =>
                 myManagedProjectIds.Contains(projMember.ProjectId) ||
-                (projMember.Project != null && projMember.Project.IsConfidential == false && myProjectIds.Contains(projMember.ProjectId))));
+                (projMember.Project != null && projMember.Project.IsConfidential != true && myProjectIds.Contains(projMember.ProjectId))));
     }
 }

--- a/backend/Testing/ApiTests/UsersICanSeeQueryTests.cs
+++ b/backend/Testing/ApiTests/UsersICanSeeQueryTests.cs
@@ -1,0 +1,100 @@
+﻿using System.Text.Json.Nodes;
+using Shouldly;
+using Testing.Services;
+
+namespace Testing.ApiTests;
+
+[Trait("Category", "Integration")]
+public class UsersICanSeeQueryTests : ApiTestBase
+{
+    private async Task<JsonObject> QueryUsersICanSee(bool expectGqlError = false)
+    {
+        var json = await ExecuteGql(
+            $$"""
+              query {
+                usersICanSee(take: 10) {
+                  totalCount
+                  items {
+                    id
+                    name
+                  }
+                }
+              }
+              """,
+            expectGqlError, expectSuccessCode: false);
+        return json;
+    }
+
+    private async Task AddUserToProject(Guid projectId, string username)
+    {
+        await ExecuteGql(
+            $$"""
+              mutation {
+                  addProjectMember(input: {
+                      projectId: "{{projectId}}",
+                      usernameOrEmail: "{{username}}",
+                      role: EDITOR,
+                      canInvite: false
+                  }) {
+                      project {
+                          id
+                      }
+                      errors {
+                          __typename
+                          ... on Error {
+                              message
+                          }
+                      }
+                  }
+              }
+              """);
+    }
+
+    private JsonArray GetUsers(JsonObject json)
+    {
+        var users = json["data"]!["usersICanSee"]!["items"]!.AsArray();
+        users.ShouldNotBeNull();
+        return users;
+    }
+
+    private void MustHaveUser(JsonArray users, string userName)
+    {
+        users.ShouldNotBeNull().ShouldNotBeEmpty();
+        users.ShouldContain(node => node!["name"]!.GetValue<string>() == userName,
+            "user list " + users.ToJsonString());
+    }
+
+    private void MustNotHaveUser(JsonArray users, string userName)
+    {
+        users.ShouldNotBeNull().ShouldNotBeEmpty();
+        users.ShouldNotContain(node => node!["name"]!.GetValue<string>() == userName,
+            "user list " + users.ToJsonString());
+    }
+
+    [Fact]
+    public async Task ManagerCanSeeProjectMembersOfAllProjects()
+    {
+        await LoginAs("manager");
+        await using var publicProject = await this.RegisterProjectInLexBox(Utils.GetNewProjectConfig(isConfidential: false));
+        await using var privateProject = await this.RegisterProjectInLexBox(Utils.GetNewProjectConfig(isConfidential: true));
+        //refresh jwt
+        await LoginAs("manager");
+        await AddUserToProject(privateProject.Id, "qa@test.com");
+        var json = GetUsers(await QueryUsersICanSee());
+        MustHaveUser(json, "Qa Admin");
+    }
+
+    [Fact]
+    public async Task MemberCanSeeNotProjectMembersOfConfidentialProjects()
+    {
+        await LoginAs("manager");
+        await using var publicProject = await this.RegisterProjectInLexBox(Utils.GetNewProjectConfig(isConfidential: false));
+        await using var privateProject = await this.RegisterProjectInLexBox(Utils.GetNewProjectConfig(isConfidential: true));
+        //refresh jwt
+        await LoginAs("manager");
+        await AddUserToProject(privateProject.Id, "qa@test.com");
+        await LoginAs("editor");
+        var json = GetUsers(await QueryUsersICanSee());
+        MustNotHaveUser(json, "Qa Admin");
+    }
+}

--- a/backend/Testing/ApiTests/UsersICanSeeQueryTests.cs
+++ b/backend/Testing/ApiTests/UsersICanSeeQueryTests.cs
@@ -75,11 +75,10 @@ public class UsersICanSeeQueryTests : ApiTestBase
     public async Task ManagerCanSeeProjectMembersOfAllProjects()
     {
         await LoginAs("manager");
-        await using var publicProject = await this.RegisterProjectInLexBox(Utils.GetNewProjectConfig(isConfidential: false));
-        await using var privateProject = await this.RegisterProjectInLexBox(Utils.GetNewProjectConfig(isConfidential: true));
+        await using var project = await this.RegisterProjectInLexBox(Utils.GetNewProjectConfig(isConfidential: true));
         //refresh jwt
         await LoginAs("manager");
-        await AddUserToProject(privateProject.Id, "qa@test.com");
+        await AddUserToProject(project.Id, "qa@test.com");
         var json = GetUsers(await QueryUsersICanSee());
         MustHaveUser(json, "Qa Admin");
     }
@@ -88,11 +87,10 @@ public class UsersICanSeeQueryTests : ApiTestBase
     public async Task MemberCanSeeNotProjectMembersOfConfidentialProjects()
     {
         await LoginAs("manager");
-        await using var publicProject = await this.RegisterProjectInLexBox(Utils.GetNewProjectConfig(isConfidential: false));
-        await using var privateProject = await this.RegisterProjectInLexBox(Utils.GetNewProjectConfig(isConfidential: true));
+        await using var project = await this.RegisterProjectInLexBox(Utils.GetNewProjectConfig(isConfidential: true));
         //refresh jwt
         await LoginAs("manager");
-        await AddUserToProject(privateProject.Id, "qa@test.com");
+        await AddUserToProject(project.Id, "qa@test.com");
         await LoginAs("editor");
         var json = GetUsers(await QueryUsersICanSee());
         MustNotHaveUser(json, "Qa Admin");

--- a/backend/Testing/Fixtures/TempProjectWithoutRepo.cs
+++ b/backend/Testing/Fixtures/TempProjectWithoutRepo.cs
@@ -1,0 +1,39 @@
+using LexCore.Entities;
+using LexData;
+using Testing.Services;
+
+namespace Testing.Fixtures;
+
+public class TempProjectWithoutRepo(LexBoxDbContext dbContext, Project project) : IAsyncDisposable
+{
+    public Project Project => project;
+    public static async Task<TempProjectWithoutRepo> Create(LexBoxDbContext dbContext, bool isConfidential = false, Guid? managerId = null)
+    {
+        var config = Utils.GetNewProjectConfig(isConfidential: isConfidential);
+        var project = new Project
+        {
+            Name = config.Name,
+            Code = config.Code,
+            IsConfidential = config.IsConfidential,
+            LastCommit = null,
+            Organizations = [],
+            Users = [],
+            RetentionPolicy = RetentionPolicy.Test,
+            Type = ProjectType.FLEx,
+            Id = config.Id,
+        };
+        if (managerId is Guid id)
+        {
+            project.Users.Add(new ProjectUsers { ProjectId = project.Id, UserId = id, Role = ProjectRole.Manager });
+        }
+        dbContext.Add(project);
+        await dbContext.SaveChangesAsync();
+        return new TempProjectWithoutRepo(dbContext, project);
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        dbContext.Remove(project);
+        await dbContext.SaveChangesAsync();
+    }
+}

--- a/backend/Testing/LexCore/Services/UserServiceTest.cs
+++ b/backend/Testing/LexCore/Services/UserServiceTest.cs
@@ -21,46 +21,16 @@ public class UserServiceTest
 {
     private readonly UserService _userService;
 
-    private LexBoxDbContext _lexBoxDbContext;
+    private readonly LexBoxDbContext _lexBoxDbContext;
 
     public UserServiceTest(TestingServicesFixture testing)
     {
         var serviceProvider = testing.ConfigureServices(s =>
         {
-            s.AddScoped<IEmailService>(_ => Mock.Of<IEmailService>());
-            s.AddScoped<IHttpContextAccessor>(_ => Mock.Of<IHttpContextAccessor>());
-            s.AddSingleton<IMemoryCache>(_ => Mock.Of<IMemoryCache>());
             s.AddScoped<UserService>();
-            s.AddScoped<ProjectService>();
         });
         _userService = serviceProvider.GetRequiredService<UserService>();
         _lexBoxDbContext = serviceProvider.GetRequiredService<LexBoxDbContext>();
-    }
-
-    public async Task<Project> CreateProject(bool isConfidential = false, Guid? managerId = null)
-    {
-        // TODO: Return some kind of disposable fixture with a .Project property, which
-        // deletes the project when disposed and can also add users with a single method call
-        var config = Testing.Services.Utils.GetNewProjectConfig(isConfidential: isConfidential);
-        var project = new Project
-        {
-            Name = config.Name,
-            Code = config.Code,
-            IsConfidential = config.IsConfidential,
-            LastCommit = null,
-            Organizations = [],
-            Users = [],
-            RetentionPolicy = RetentionPolicy.Test,
-            Type = ProjectType.FLEx,
-            Id = config.Id,
-        };
-        if (managerId is Guid id)
-        {
-            project.Users.Add(new ProjectUsers { ProjectId = project.Id, UserId = id, Role = ProjectRole.Manager });
-        }
-        _lexBoxDbContext.Add(project);
-        await _lexBoxDbContext.SaveChangesAsync();
-        return project;
     }
 
     [Fact]
@@ -68,23 +38,16 @@ public class UserServiceTest
     {
         var manager = await _lexBoxDbContext.Users.Include(u => u.Organizations).Include(u => u.Projects).FirstOrDefaultAsync(user => user.Email == "manager@test.com");
         manager.ShouldNotBeNull();
-        var privateProject = await CreateProject(true, manager.Id);
-        try {
-            privateProject.ShouldNotBeNull();
-            var qaAdmin = await _lexBoxDbContext.Users.Include(u => u.Organizations).Include(u => u.Projects).FirstOrDefaultAsync(user => user.Email == "qa@test.com");
-            qaAdmin.ShouldNotBeNull();
-            privateProject.Users.Add(new ProjectUsers() { UserId = qaAdmin.Id, Role = ProjectRole.Editor });
-            _lexBoxDbContext.SaveChanges();
-            var authUser = new LexAuthUser(manager);
-            var users = await _userService.UserQueryForTypeahead(authUser).ToArrayAsync();
-            users.ShouldNotBeEmpty();
-            users.ShouldContain(u => u.Id == qaAdmin.Id);
-        }
-        finally
-        {
-            _lexBoxDbContext.Projects.Remove(privateProject);
-            await _lexBoxDbContext.SaveChangesAsync();
-        }
+        await using var privateProject = await TempProjectWithoutRepo.Create(_lexBoxDbContext, true, manager.Id);
+        privateProject.Project.ShouldNotBeNull();
+        var qaAdmin = await _lexBoxDbContext.Users.Include(u => u.Organizations).Include(u => u.Projects).FirstOrDefaultAsync(user => user.Email == "qa@test.com");
+        qaAdmin.ShouldNotBeNull();
+        privateProject.Project.Users.Add(new ProjectUsers() { UserId = qaAdmin.Id, Role = ProjectRole.Editor });
+        await _lexBoxDbContext.SaveChangesAsync();
+        var authUser = new LexAuthUser(manager);
+        var users = await _userService.UserQueryForTypeahead(authUser).ToArrayAsync();
+        users.ShouldNotBeEmpty();
+        users.ShouldContain(u => u.Id == qaAdmin.Id);
     }
 
     [Fact]
@@ -94,21 +57,14 @@ public class UserServiceTest
         manager.ShouldNotBeNull();
         var editor = await _lexBoxDbContext.Users.Include(u => u.Organizations).Include(u => u.Projects).FirstOrDefaultAsync(user => user.Email == "editor@test.com");
         editor.ShouldNotBeNull();
-        var privateProject = await CreateProject(true, manager.Id);
-        try {
-            privateProject.ShouldNotBeNull();
-            var qaAdmin = await _lexBoxDbContext.Users.Include(u => u.Organizations).Include(u => u.Projects).FirstOrDefaultAsync(user => user.Email == "qa@test.com");
-            qaAdmin.ShouldNotBeNull();
-            privateProject.Users.Add(new ProjectUsers() { UserId = qaAdmin.Id, Role = ProjectRole.Editor });
-            _lexBoxDbContext.SaveChanges();
-            var authUser = new LexAuthUser(editor);
-            var users = await _userService.UserQueryForTypeahead(authUser).ToArrayAsync();
-            users.ShouldNotContain(u => u.Id == qaAdmin.Id);
-        }
-        finally
-        {
-            _lexBoxDbContext.Projects.Remove(privateProject);
-            await _lexBoxDbContext.SaveChangesAsync();
-        }
+        await using var privateProject = await TempProjectWithoutRepo.Create(_lexBoxDbContext, true, manager.Id);
+        privateProject.Project.ShouldNotBeNull();
+        var qaAdmin = await _lexBoxDbContext.Users.Include(u => u.Organizations).Include(u => u.Projects).FirstOrDefaultAsync(user => user.Email == "qa@test.com");
+        qaAdmin.ShouldNotBeNull();
+        privateProject.Project.Users.Add(new ProjectUsers() { UserId = qaAdmin.Id, Role = ProjectRole.Editor });
+        await _lexBoxDbContext.SaveChangesAsync();
+        var authUser = new LexAuthUser(editor);
+        var users = await _userService.UserQueryForTypeahead(authUser).ToArrayAsync();
+        users.ShouldNotContain(u => u.Id == qaAdmin.Id);
     }
 }

--- a/backend/Testing/LexCore/Services/UserServiceTest.cs
+++ b/backend/Testing/LexCore/Services/UserServiceTest.cs
@@ -27,6 +27,7 @@ public class UserServiceTest
     {
         var serviceProvider = testing.ConfigureServices(s =>
         {
+            s.AddScoped<IEmailService>(_ => Mock.Of<IEmailService>());
             s.AddScoped<UserService>();
         });
         _userService = serviceProvider.GetRequiredService<UserService>();

--- a/backend/Testing/LexCore/Services/UserServiceTest.cs
+++ b/backend/Testing/LexCore/Services/UserServiceTest.cs
@@ -92,7 +92,7 @@ public class UserServiceTest : IAsyncLifetime
         var authUser = new LexAuthUser(Robin!);
         var users = await _userService.UserQueryForTypeahead(authUser).ToArrayAsync();
         // John, who is in both the Outlaws org (user) and Sherwood project (member) is not duplicated
-        users.Should().BeEquivalentTo([Robin, Marian, John, Tuck]);
+        users.Should().BeEquivalentTo([Robin, Marian, John, Tuck], options => options.WithoutStrictOrdering());
     }
 
     [Fact]
@@ -102,7 +102,7 @@ public class UserServiceTest : IAsyncLifetime
         var authUser = new LexAuthUser(John!);
         var users = await _userService.UserQueryForTypeahead(authUser).ToArrayAsync();
         // John can see Robin because he shares an org, but not Marian even though she's a manager of the Sherwood project
-        users.Should().BeEquivalentTo([Robin, John]);
+        users.Should().BeEquivalentTo([Robin, John], options => options.WithoutStrictOrdering());
     }
 
     [Fact]
@@ -112,7 +112,7 @@ public class UserServiceTest : IAsyncLifetime
         var authUser = new LexAuthUser(Marian!);
         var users = await _userService.UserQueryForTypeahead(authUser).ToArrayAsync();
         // Marian can see everyone in both projects; Tuck is not duplicated despite being in both projects
-        users.Should().BeEquivalentTo([Robin, Marian, John, Tuck, Sheriff]);
+        users.Should().BeEquivalentTo([Robin, Marian, John, Tuck, Sheriff], options => options.WithoutStrictOrdering());
     }
 
     [Fact]
@@ -126,7 +126,7 @@ public class UserServiceTest : IAsyncLifetime
             // ... but can still only see the users in Nottingham and LawEnforcement
             var authUser = new LexAuthUser(Sheriff!);
             var users = await _userService.UserQueryForTypeahead(authUser).ToArrayAsync();
-            users.Should().BeEquivalentTo([Sheriff, Guy, Marian, Tuck]);
+            users.Should().BeEquivalentTo([Sheriff, Guy, Marian, Tuck], options => options.WithoutStrictOrdering());
         }
         finally
         {
@@ -140,7 +140,7 @@ public class UserServiceTest : IAsyncLifetime
         // Bishop of Hereford is in Church org (admin) but no projects
         var authUser = new LexAuthUser(Bishop!);
         var users = await _userService.UserQueryForTypeahead(authUser).ToArrayAsync();
-        users.Should().BeEquivalentTo([Bishop, Tuck]);
+        users.Should().BeEquivalentTo([Bishop, Tuck], options => options.WithoutStrictOrdering());
     }
 
     [Fact]
@@ -149,7 +149,7 @@ public class UserServiceTest : IAsyncLifetime
         // Guy of Gisborne is in LawEnforcement org (user) but no projects
         var authUser = new LexAuthUser(Guy!);
         var users = await _userService.UserQueryForTypeahead(authUser).ToArrayAsync();
-        users.Should().BeEquivalentTo([Sheriff, Guy]);
+        users.Should().BeEquivalentTo([Sheriff, Guy], options => options.WithoutStrictOrdering());
     }
 
     [Fact]
@@ -159,7 +159,7 @@ public class UserServiceTest : IAsyncLifetime
         var authUser = new LexAuthUser(Tuck!);
         var users = await _userService.UserQueryForTypeahead(authUser).ToArrayAsync();
         // Tuck can see everyone in Church and Nottingham, but nobody in Sherwood because it's private — though he can see Marian because he shares a public project with her
-        users.Should().BeEquivalentTo([Bishop, Tuck, Sheriff, Marian]);
+        users.Should().BeEquivalentTo([Bishop, Tuck, Sheriff, Marian], options => options.WithoutStrictOrdering());
     }
 
     private User CreateUser(string name)

--- a/backend/Testing/LexCore/Services/UserServiceTest.cs
+++ b/backend/Testing/LexCore/Services/UserServiceTest.cs
@@ -1,27 +1,34 @@
-using LexBoxApi.Auth;
 using LexBoxApi.Services;
 using LexBoxApi.Services.Email;
 using LexCore.Auth;
 using LexCore.Entities;
-using LexCore.ServiceInterfaces;
 using LexData;
-using Microsoft.AspNetCore.Http;
 using Microsoft.EntityFrameworkCore;
-using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.DependencyInjection;
 using Moq;
-using Npgsql;
-using Shouldly;
 using Testing.Fixtures;
+using FluentAssertions;
 
 namespace Testing.LexCore.Services;
 
 [Collection(nameof(TestingServicesFixture))]
-public class UserServiceTest
+public class UserServiceTest : IAsyncLifetime
 {
     private readonly UserService _userService;
 
     private readonly LexBoxDbContext _lexBoxDbContext;
+    private List<Project> ManagedProjects { get; } = [];
+    private List<User> ManagedUsers { get; } = [];
+
+    // Users created for this test
+    private User? Robin { get; set; }
+    private User? John { get; set; }
+    private User? Marian { get; set; }
+    private User? Tuck { get; set; }
+    private User? Sheriff { get; set; }
+    // Projects created for this test
+    private Project? Sherwood { get; set; }
+    private Project? Nottingham { get; set; }
 
     public UserServiceTest(TestingServicesFixture testing)
     {
@@ -34,38 +41,132 @@ public class UserServiceTest
         _lexBoxDbContext = serviceProvider.GetRequiredService<LexBoxDbContext>();
     }
 
+    public Task InitializeAsync()
+    {
+        Robin = CreateUser("Robin Hood");
+        John = CreateUser("Little John");
+        Marian = CreateUser("Maid Marian");
+        Tuck = CreateUser("Friar Tuck");
+        Sheriff = CreateUser("Sheriff of Nottingham");
+
+        Nottingham = CreateProject([Sheriff.Id], [Marian.Id]);
+        Sherwood = CreateConfidentialProject([Robin.Id, Marian.Id], [John.Id]);
+
+        return _lexBoxDbContext.SaveChangesAsync();
+    }
+
+    public Task DisposeAsync()
+    {
+        foreach (var project in ManagedProjects)
+        {
+            _lexBoxDbContext.Remove(project);
+        }
+        foreach (var user in ManagedUsers)
+        {
+            _lexBoxDbContext.Remove(user);
+        }
+        return _lexBoxDbContext.SaveChangesAsync();
+    }
+
     [Fact]
     public async Task ManagerCanSeeAllUsersEvenInConfidentialProjects()
     {
-        var manager = await _lexBoxDbContext.Users.Include(u => u.Organizations).Include(u => u.Projects).FirstOrDefaultAsync(user => user.Email == "manager@test.com");
-        manager.ShouldNotBeNull();
-        await using var privateProject = await TempProjectWithoutRepo.Create(_lexBoxDbContext, true, manager.Id);
-        privateProject.Project.ShouldNotBeNull();
-        var qaAdmin = await _lexBoxDbContext.Users.Include(u => u.Organizations).Include(u => u.Projects).FirstOrDefaultAsync(user => user.Email == "qa@test.com");
-        qaAdmin.ShouldNotBeNull();
-        privateProject.Project.Users.Add(new ProjectUsers() { UserId = qaAdmin.Id, Role = ProjectRole.Editor });
-        await _lexBoxDbContext.SaveChangesAsync();
-        var authUser = new LexAuthUser(manager);
+        var authUser = new LexAuthUser(Robin!);
         var users = await _userService.UserQueryForTypeahead(authUser).ToArrayAsync();
-        users.ShouldNotBeEmpty();
-        users.ShouldContain(u => u.Id == qaAdmin.Id);
+        users.Should().BeEquivalentTo([Robin, Marian, John]);
     }
 
     [Fact]
     public async Task NonManagerCanNotSeeUsersInConfidentialProjects()
     {
-        var manager = await _lexBoxDbContext.Users.Include(u => u.Organizations).Include(u => u.Projects).FirstOrDefaultAsync(user => user.Email == "manager@test.com");
-        manager.ShouldNotBeNull();
-        var editor = await _lexBoxDbContext.Users.Include(u => u.Organizations).Include(u => u.Projects).FirstOrDefaultAsync(user => user.Email == "editor@test.com");
-        editor.ShouldNotBeNull();
-        await using var privateProject = await TempProjectWithoutRepo.Create(_lexBoxDbContext, true, manager.Id);
-        privateProject.Project.ShouldNotBeNull();
-        var qaAdmin = await _lexBoxDbContext.Users.Include(u => u.Organizations).Include(u => u.Projects).FirstOrDefaultAsync(user => user.Email == "qa@test.com");
-        qaAdmin.ShouldNotBeNull();
-        privateProject.Project.Users.Add(new ProjectUsers() { UserId = qaAdmin.Id, Role = ProjectRole.Editor });
-        await _lexBoxDbContext.SaveChangesAsync();
-        var authUser = new LexAuthUser(editor);
+        var authUser = new LexAuthUser(John!);
         var users = await _userService.UserQueryForTypeahead(authUser).ToArrayAsync();
-        users.ShouldNotContain(u => u.Id == qaAdmin.Id);
+        users.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task ManagerOfOneProjectAndMemberOfAnotherPublicProjectCanSeeUsersInBoth()
+    {
+        var authUser = new LexAuthUser(Marian!);
+        var users = await _userService.UserQueryForTypeahead(authUser).ToArrayAsync();
+        users.Should().BeEquivalentTo([Robin, Marian, John, Sheriff]);
+    }
+
+    [Fact]
+    public async Task ManagerOfOneProjectAndMemberOfAnotherConfidentialProjectCanNotSeeUsersInConfidentialProject()
+    {
+        try
+        {
+            // Sheriff tries to sneak into Sherwood...
+            await AddUserToProject(Sherwood!, Sheriff!);
+            // ... but can still only see the users in Nottingham
+            var authUser = new LexAuthUser(Sheriff!);
+            var users = await _userService.UserQueryForTypeahead(authUser).ToArrayAsync();
+            users.Should().BeEquivalentTo([Sheriff, Marian]);
+        }
+        finally
+        {
+            await RemoveUserFromProject(Sherwood!, Sheriff!);
+        }
+    }
+
+    private User CreateUser(string name)
+    {
+        var email = name.ToLowerInvariant().Replace(' ', '_') + "@example.com";
+        var user = new User
+        {
+            Name = name,
+            Email = email,
+            CanCreateProjects = true,
+            EmailVerified = true,
+            IsAdmin = name.Contains("Admin"),
+            PasswordHash = "",
+            Salt = ""
+        };
+        _lexBoxDbContext.Add(user);
+        ManagedUsers.Add(user);
+        return user; // Caller must call SaveChanges after all users and projects are added
+    }
+
+    private Project CreateProject(IEnumerable<Guid> managers, IEnumerable<Guid> members, bool isConfidential = false)
+    {
+        var config = Testing.Services.Utils.GetNewProjectConfig();
+        var project = new Project
+        {
+            Name = config.Name,
+            Code = config.Code,
+            IsConfidential = isConfidential,
+            LastCommit = null,
+            Organizations = [],
+            Users = [],
+            RetentionPolicy = RetentionPolicy.Test,
+            Type = ProjectType.FLEx,
+            Id = config.Id,
+        };
+        project.Users.AddRange(managers.Select(userId => new ProjectUsers { UserId = userId, Role = ProjectRole.Manager }));
+        project.Users.AddRange(members.Select(userId => new ProjectUsers { UserId = userId, Role = ProjectRole.Editor }));
+        _lexBoxDbContext.Add(project);
+        ManagedProjects.Add(project);
+        return project; // Caller must call SaveChanges after all users and projects are added
+    }
+
+    private Project CreateConfidentialProject(IEnumerable<Guid> managers, IEnumerable<Guid> members)
+    {
+        return CreateProject(managers, members, true);
+    }
+
+    private async Task AddUserToProject(Project project, User user, ProjectRole role = ProjectRole.Editor)
+    {
+        var pu = project.Users.FirstOrDefault(pu => pu.UserId == user.Id);
+        if (pu is null) project.Users.Add(new ProjectUsers { UserId = user.Id, Role = role });
+        else pu.Role = role;
+        await _lexBoxDbContext.SaveChangesAsync();
+    }
+
+    private async Task RemoveUserFromProject(Project project, User user)
+    {
+        var pu = project.Users.FirstOrDefault(pu => pu.UserId == user.Id);
+        if (pu is not null) project.Users.Remove(pu);
+        await _lexBoxDbContext.SaveChangesAsync();
     }
 }

--- a/backend/Testing/LexCore/Services/UserServiceTest.cs
+++ b/backend/Testing/LexCore/Services/UserServiceTest.cs
@@ -49,8 +49,8 @@ public class UserServiceTest : IAsyncLifetime
         Tuck = CreateUser("Friar Tuck");
         Sheriff = CreateUser("Sheriff of Nottingham");
 
-        Nottingham = CreateProject([Sheriff.Id], [Marian.Id]);
-        Sherwood = CreateConfidentialProject([Robin.Id, Marian.Id], [John.Id]);
+        Nottingham = CreateProject([Sheriff.Id], [Marian.Id, Tuck.Id]);
+        Sherwood = CreateConfidentialProject([Robin.Id, Marian.Id], [John.Id, Tuck.Id]);
 
         return _lexBoxDbContext.SaveChangesAsync();
     }
@@ -73,7 +73,7 @@ public class UserServiceTest : IAsyncLifetime
     {
         var authUser = new LexAuthUser(Robin!);
         var users = await _userService.UserQueryForTypeahead(authUser).ToArrayAsync();
-        users.Should().BeEquivalentTo([Robin, Marian, John]);
+        users.Should().BeEquivalentTo([Robin, Marian, John, Tuck]);
     }
 
     [Fact]
@@ -89,7 +89,7 @@ public class UserServiceTest : IAsyncLifetime
     {
         var authUser = new LexAuthUser(Marian!);
         var users = await _userService.UserQueryForTypeahead(authUser).ToArrayAsync();
-        users.Should().BeEquivalentTo([Robin, Marian, John, Sheriff]);
+        users.Should().BeEquivalentTo([Robin, Marian, John, Tuck, Sheriff]);
     }
 
     [Fact]
@@ -102,7 +102,7 @@ public class UserServiceTest : IAsyncLifetime
             // ... but can still only see the users in Nottingham
             var authUser = new LexAuthUser(Sheriff!);
             var users = await _userService.UserQueryForTypeahead(authUser).ToArrayAsync();
-            users.Should().BeEquivalentTo([Sheriff, Marian]);
+            users.Should().BeEquivalentTo([Sheriff, Marian, Tuck]);
         }
         finally
         {

--- a/backend/Testing/LexCore/Services/UserServiceTest.cs
+++ b/backend/Testing/LexCore/Services/UserServiceTest.cs
@@ -1,0 +1,114 @@
+using LexBoxApi.Auth;
+using LexBoxApi.Services;
+using LexBoxApi.Services.Email;
+using LexCore.Auth;
+using LexCore.Entities;
+using LexCore.ServiceInterfaces;
+using LexData;
+using Microsoft.AspNetCore.Http;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.DependencyInjection;
+using Moq;
+using Npgsql;
+using Shouldly;
+using Testing.Fixtures;
+
+namespace Testing.LexCore.Services;
+
+[Collection(nameof(TestingServicesFixture))]
+public class UserServiceTest
+{
+    private readonly UserService _userService;
+
+    private LexBoxDbContext _lexBoxDbContext;
+
+    public UserServiceTest(TestingServicesFixture testing)
+    {
+        var serviceProvider = testing.ConfigureServices(s =>
+        {
+            s.AddScoped<IEmailService>(_ => Mock.Of<IEmailService>());
+            s.AddScoped<IHttpContextAccessor>(_ => Mock.Of<IHttpContextAccessor>());
+            s.AddSingleton<IMemoryCache>(_ => Mock.Of<IMemoryCache>());
+            s.AddScoped<UserService>();
+            s.AddScoped<ProjectService>();
+        });
+        _userService = serviceProvider.GetRequiredService<UserService>();
+        _lexBoxDbContext = serviceProvider.GetRequiredService<LexBoxDbContext>();
+    }
+
+    public async Task<Project> CreateProject(bool isConfidential = false, Guid? managerId = null)
+    {
+        // TODO: Return some kind of disposable fixture with a .Project property, which
+        // deletes the project when disposed and can also add users with a single method call
+        var config = Testing.Services.Utils.GetNewProjectConfig(isConfidential: isConfidential);
+        var project = new Project
+        {
+            Name = config.Name,
+            Code = config.Code,
+            IsConfidential = config.IsConfidential,
+            LastCommit = null,
+            Organizations = [],
+            Users = [],
+            RetentionPolicy = RetentionPolicy.Test,
+            Type = ProjectType.FLEx,
+            Id = config.Id,
+        };
+        if (managerId is Guid id)
+        {
+            project.Users.Add(new ProjectUsers { ProjectId = project.Id, UserId = id, Role = ProjectRole.Manager });
+        }
+        _lexBoxDbContext.Add(project);
+        await _lexBoxDbContext.SaveChangesAsync();
+        return project;
+    }
+
+    [Fact]
+    public async Task ManagerCanSeeAllUsersEvenInConfidentialProjects()
+    {
+        var manager = await _lexBoxDbContext.Users.Include(u => u.Organizations).Include(u => u.Projects).FirstOrDefaultAsync(user => user.Email == "manager@test.com");
+        manager.ShouldNotBeNull();
+        var privateProject = await CreateProject(true, manager.Id);
+        try {
+            privateProject.ShouldNotBeNull();
+            var qaAdmin = await _lexBoxDbContext.Users.Include(u => u.Organizations).Include(u => u.Projects).FirstOrDefaultAsync(user => user.Email == "qa@test.com");
+            qaAdmin.ShouldNotBeNull();
+            privateProject.Users.Add(new ProjectUsers() { UserId = qaAdmin.Id, Role = ProjectRole.Editor });
+            _lexBoxDbContext.SaveChanges();
+            var authUser = new LexAuthUser(manager);
+            var users = await _userService.UserQueryForTypeahead(authUser).ToArrayAsync();
+            users.ShouldNotBeEmpty();
+            users.ShouldContain(u => u.Id == qaAdmin.Id);
+        }
+        finally
+        {
+            _lexBoxDbContext.Projects.Remove(privateProject);
+            await _lexBoxDbContext.SaveChangesAsync();
+        }
+    }
+
+    [Fact]
+    public async Task NonManagerCanNotSeeUsersInConfidentialProjects()
+    {
+        var manager = await _lexBoxDbContext.Users.Include(u => u.Organizations).Include(u => u.Projects).FirstOrDefaultAsync(user => user.Email == "manager@test.com");
+        manager.ShouldNotBeNull();
+        var editor = await _lexBoxDbContext.Users.Include(u => u.Organizations).Include(u => u.Projects).FirstOrDefaultAsync(user => user.Email == "editor@test.com");
+        editor.ShouldNotBeNull();
+        var privateProject = await CreateProject(true, manager.Id);
+        try {
+            privateProject.ShouldNotBeNull();
+            var qaAdmin = await _lexBoxDbContext.Users.Include(u => u.Organizations).Include(u => u.Projects).FirstOrDefaultAsync(user => user.Email == "qa@test.com");
+            qaAdmin.ShouldNotBeNull();
+            privateProject.Users.Add(new ProjectUsers() { UserId = qaAdmin.Id, Role = ProjectRole.Editor });
+            _lexBoxDbContext.SaveChanges();
+            var authUser = new LexAuthUser(editor);
+            var users = await _userService.UserQueryForTypeahead(authUser).ToArrayAsync();
+            users.ShouldNotContain(u => u.Id == qaAdmin.Id);
+        }
+        finally
+        {
+            _lexBoxDbContext.Projects.Remove(privateProject);
+            await _lexBoxDbContext.SaveChangesAsync();
+        }
+    }
+}

--- a/backend/Testing/Testing.csproj
+++ b/backend/Testing/Testing.csproj
@@ -27,6 +27,7 @@
         </Otherwise>
     </Choose>
     <ItemGroup>
+        <PackageReference Include="FluentAssertions" Version="6.12.0"/>
         <PackageReference Include="Microsoft.Extensions.Http.Resilience" Version="8.8.0" />
         <PackageReference Include="Microsoft.Extensions.TimeProvider.Testing" Version="8.9.1" />
         <PackageReference Include="Squidex.Assets.TusClient" Version="6.6.4" />

--- a/frontend/schema.graphql
+++ b/frontend/schema.graphql
@@ -192,6 +192,10 @@ type InvalidEmailError implements Error {
   address: String!
 }
 
+type InvalidOperationError implements Error {
+  message: String!
+}
+
 type IsAdminResponse {
   value: Boolean!
 }
@@ -439,6 +443,7 @@ type Query {
   orgs(where: OrganizationFilterInput @cost(weight: "10") orderBy: [OrganizationSortInput!] @cost(weight: "10")): [Organization!]! @cost(weight: "10")
   myOrgs(where: OrganizationFilterInput @cost(weight: "10") orderBy: [OrganizationSortInput!] @cost(weight: "10")): [Organization!]! @cost(weight: "10")
   usersInMyOrg(skip: Int take: Int where: UserFilterInput @cost(weight: "10") orderBy: [UserSortInput!] @cost(weight: "10")): UsersInMyOrgCollectionSegment @listSize(assumedSize: 1000, slicingArguments: [ "take" ], sizedFields: [ "items" ]) @cost(weight: "10")
+  usersICanSee(skip: Int take: Int where: UserFilterInput @cost(weight: "10") orderBy: [UserSortInput!] @cost(weight: "10")): UsersICanSeeCollectionSegment @listSize(assumedSize: 1000, slicingArguments: [ "take" ], sizedFields: [ "items" ]) @cost(weight: "10")
   orgById(orgId: UUID!): OrgById @cost(weight: "10")
   users(skip: Int take: Int where: UserFilterInput @cost(weight: "10") orderBy: [UserSortInput!] @cost(weight: "10")): UsersCollectionSegment @authorize(policy: "AdminRequiredPolicy") @listSize(assumedSize: 1000, slicingArguments: [ "take" ], sizedFields: [ "items" ]) @cost(weight: "10")
   me: MeDto @cost(weight: "10")
@@ -556,6 +561,15 @@ type UsersCollectionSegment {
 }
 
 "A segment of a collection."
+type UsersICanSeeCollectionSegment {
+  "Information to aid in pagination."
+  pageInfo: CollectionSegmentInfo!
+  "A flattened list of the items."
+  items: [User!]
+  totalCount: Int! @cost(weight: "10")
+}
+
+"A segment of a collection."
 type UsersInMyOrgCollectionSegment {
   "Information to aid in pagination."
   pageInfo: CollectionSegmentInfo!
@@ -608,7 +622,7 @@ union LeaveProjectError = NotFoundError | LastMemberCantLeaveError
 
 union RemoveProjectFromOrgError = DbError | NotFoundError
 
-union SendNewVerificationEmailByAdminError = NotFoundError | DbError | UniqueValueError
+union SendNewVerificationEmailByAdminError = NotFoundError | DbError | InvalidOperationError
 
 union SetOrgMemberRoleError = DbError | NotFoundError | OrgMemberInvitedByEmail
 

--- a/frontend/src/lib/forms/UserTypeahead.svelte
+++ b/frontend/src/lib/forms/UserTypeahead.svelte
@@ -14,6 +14,7 @@
   export let value: string;
   export let debounceMs = 200;
   export let isAdmin: boolean = false;
+  export let exclude: string[] = [];
 
   let input = writable('');
   $: $input = value;
@@ -22,6 +23,8 @@
     isAdmin ? _userTypeaheadSearch : _usersTypeaheadSearch,
     [],
     debounceMs);
+
+  $: filteredResults = $typeaheadResults.filter(user => !exclude.includes(user.id));
 
   const dispatch = createEventDispatcher<{
       selectedUserId: string | null;
@@ -62,7 +65,7 @@
     />
     <div class="overlay-content">
       <ul class="menu p-0">
-      {#each $typeaheadResults as user}
+      {#each filteredResults as user}
         <li class="p-0"><button class="whitespace-nowrap" on:click={() => {
           setTimeout(() => {
             if ('id' in user && user.id) {

--- a/frontend/src/lib/forms/UserTypeahead.svelte
+++ b/frontend/src/lib/forms/UserTypeahead.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import { FormField, PlainInput, randomFormId } from '$lib/forms';
-  import { _userTypeaheadSearch, _orgMemberTypeaheadSearch, type SingleUserTypeaheadResult, type SingleUserICanSeeTypeaheadResult } from '$lib/gql/typeahead-queries';
+  import { _userTypeaheadSearch, _usersTypeaheadSearch, type SingleUserTypeaheadResult, type SingleUserICanSeeTypeaheadResult } from '$lib/gql/typeahead-queries';
   import { overlay } from '$lib/overlay';
   import { deriveAsync } from '$lib/util/time';
   import { derived, writable } from 'svelte/store';
@@ -19,7 +19,7 @@
   $: $input = value;
   let typeaheadResults = deriveAsync(
     input,
-    isAdmin ? _userTypeaheadSearch : _orgMemberTypeaheadSearch,
+    isAdmin ? _userTypeaheadSearch : _usersTypeaheadSearch,
     [],
     debounceMs);
 

--- a/frontend/src/lib/forms/UserTypeahead.svelte
+++ b/frontend/src/lib/forms/UserTypeahead.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import { FormField, PlainInput, randomFormId } from '$lib/forms';
-  import { _userTypeaheadSearch, _orgMemberTypeaheadSearch, type SingleUserTypeaheadResult, type SingleUserInMyOrgTypeaheadResult } from '$lib/gql/typeahead-queries';
+  import { _userTypeaheadSearch, _orgMemberTypeaheadSearch, type SingleUserTypeaheadResult, type SingleUserICanSeeTypeaheadResult } from '$lib/gql/typeahead-queries';
   import { overlay } from '$lib/overlay';
   import { deriveAsync } from '$lib/util/time';
   import { derived, writable } from 'svelte/store';
@@ -25,15 +25,15 @@
 
   const dispatch = createEventDispatcher<{
       selectedUserId: string | null;
-      selectedUser: SingleUserTypeaheadResult | SingleUserInMyOrgTypeaheadResult | null;
+      selectedUser: SingleUserTypeaheadResult | SingleUserICanSeeTypeaheadResult | null;
   }>();
 
-  let selectedUser = writable<SingleUserTypeaheadResult | SingleUserInMyOrgTypeaheadResult | null>(null);
+  let selectedUser = writable<SingleUserTypeaheadResult | SingleUserICanSeeTypeaheadResult | null>(null);
   let selectedUserId = derived(selectedUser, user => user?.id ?? null);
   $: dispatch('selectedUserId', $selectedUserId);
   $: dispatch('selectedUser', $selectedUser);
 
-  function formatResult(user: SingleUserTypeaheadResult | SingleUserInMyOrgTypeaheadResult): string {
+  function formatResult(user: SingleUserTypeaheadResult | SingleUserICanSeeTypeaheadResult): string {
     const extra = 'username' in user && user.username && 'email' in user && user.email ? ` (${user.username}, ${user.email})`
                 : 'username' in user && user.username ? ` (${user.username})`
                 : 'email' in user && user.email ? ` (${user.email})`
@@ -41,7 +41,7 @@
     return `${user.name}${extra}`;
   }
 
-  function getInputValue(user: SingleUserTypeaheadResult | SingleUserInMyOrgTypeaheadResult): string {
+  function getInputValue(user: SingleUserTypeaheadResult | SingleUserICanSeeTypeaheadResult): string {
     if ('email' in user && user.email) return user.email;
     if ('username' in user && user.username) return user.username;
     if ('name' in user && user.name) return user.name;

--- a/frontend/src/lib/gql/typeahead-queries.ts
+++ b/frontend/src/lib/gql/typeahead-queries.ts
@@ -58,15 +58,15 @@ export async function _userTypeaheadSearch(userSearch: string, limit = 10): Prom
   return users;
 }
 
-export type UsersInMyOrgTypeaheadResult = NonNullable<NonNullable<LoadOrgMembersTypeaheadQuery['usersInMyOrg']>['items']>;
-export type SingleUserInMyOrgTypeaheadResult = UsersInMyOrgTypeaheadResult[number];
+export type UsersICanSeeTypeaheadResult = NonNullable<NonNullable<LoadOrgMembersTypeaheadQuery['usersICanSee']>['items']>;
+export type SingleUserICanSeeTypeaheadResult = UsersICanSeeTypeaheadResult[number];
 
-export async function _orgMemberTypeaheadSearch(orgMemberSearch: string, limit = 10): Promise<UsersInMyOrgTypeaheadResult> {
+export async function _orgMemberTypeaheadSearch(orgMemberSearch: string, limit = 10): Promise<UsersICanSeeTypeaheadResult> {
   if (!orgMemberSearch) return [];
   const client = getClient();
   const users = await client.query(graphql(`
     query loadOrgMembersTypeahead($filter: UserFilterInput, $take: Int!) {
-      usersInMyOrg(where: $filter, orderBy: {name: ASC}, take: $take) {
+      usersICanSee(where: $filter, orderBy: {name: ASC}, take: $take) {
         totalCount
         items {
           id
@@ -76,5 +76,5 @@ export async function _orgMemberTypeaheadSearch(orgMemberSearch: string, limit =
     }
   `), { filter: userFilter(orgMemberSearch), take: limit });
 
-  return users.data?.usersInMyOrg?.items ?? [];
+  return users.data?.usersICanSee?.items ?? [];
 }

--- a/frontend/src/lib/gql/typeahead-queries.ts
+++ b/frontend/src/lib/gql/typeahead-queries.ts
@@ -1,7 +1,7 @@
-import type { LoadAdminUsersTypeaheadQuery, LoadOrgMembersTypeaheadQuery, UserFilterInput } from './types';
+import type {LoadAdminUsersTypeaheadQuery, LoadUsersICanSeeTypeaheadQuery, UserFilterInput} from './types';
 
-import { getClient } from './gql-client';
-import { graphql } from './generated';
+import {getClient} from './gql-client';
+import {graphql} from './generated';
 
 export function userFilter(userSearch: string): UserFilterInput {
   return {
@@ -58,14 +58,14 @@ export async function _userTypeaheadSearch(userSearch: string, limit = 10): Prom
   return users;
 }
 
-export type UsersICanSeeTypeaheadResult = NonNullable<NonNullable<LoadOrgMembersTypeaheadQuery['usersICanSee']>['items']>;
+export type UsersICanSeeTypeaheadResult = NonNullable<NonNullable<LoadUsersICanSeeTypeaheadQuery['usersICanSee']>['items']>;
 export type SingleUserICanSeeTypeaheadResult = UsersICanSeeTypeaheadResult[number];
 
-export async function _orgMemberTypeaheadSearch(orgMemberSearch: string, limit = 10): Promise<UsersICanSeeTypeaheadResult> {
+export async function _usersTypeaheadSearch(orgMemberSearch: string, limit = 10): Promise<UsersICanSeeTypeaheadResult> {
   if (!orgMemberSearch) return [];
   const client = getClient();
   const users = await client.query(graphql(`
-    query loadOrgMembersTypeahead($filter: UserFilterInput, $take: Int!) {
+    query loadUsersICanSeeTypeahead($filter: UserFilterInput, $take: Int!) {
       usersICanSee(where: $filter, orderBy: {name: ASC}, take: $take) {
         totalCount
         items {

--- a/frontend/src/routes/(authenticated)/org/[org_id]/AddOrgMemberModal.svelte
+++ b/frontend/src/routes/(authenticated)/org/[org_id]/AddOrgMemberModal.svelte
@@ -10,7 +10,7 @@
   import { SupHelp, helpLinks } from '$lib/components/help';
   import type { UUID } from 'crypto';
   import { _addOrgMember, type Org } from './+page';
-  import type { SingleUserInMyOrgTypeaheadResult, SingleUserTypeaheadResult } from '$lib/gql/typeahead-queries';
+  import type { SingleUserICanSeeTypeaheadResult, SingleUserTypeaheadResult } from '$lib/gql/typeahead-queries';
   import UserProjects, { type Project } from '$lib/components/Users/UserProjects.svelte';
 
   export let org: Org;
@@ -37,7 +37,7 @@
     selectedProjects = [];
   }
 
-  function populateUserProjects(user: SingleUserTypeaheadResult | SingleUserInMyOrgTypeaheadResult | null): void {
+  function populateUserProjects(user: SingleUserTypeaheadResult | SingleUserICanSeeTypeaheadResult | null): void {
     resetProjects();
     if (user && 'projects' in user) {
       const userProjects = [...user.projects.map(p => ({memberRole: p.role, id: p.project.id, code: p.project.code, name: p.project.name}))];

--- a/frontend/src/routes/(authenticated)/org/[org_id]/AddOrgMemberModal.svelte
+++ b/frontend/src/routes/(authenticated)/org/[org_id]/AddOrgMemberModal.svelte
@@ -102,6 +102,7 @@
       error={errors.usernameOrEmail}
       on:selectedUser={(event) => populateUserProjects(event.detail)}
       autofocus
+      exclude={org.members.map(m => m.user.id)}
       />
   {:else}
     <Input

--- a/frontend/src/routes/(authenticated)/project/[project_code]/+page.svelte
+++ b/frontend/src/routes/(authenticated)/project/[project_code]/+page.svelte
@@ -500,7 +500,7 @@
               {$t('project_page.add_user.add_button')}
             </BadgeButton>
 
-            <AddProjectMember bind:this={addProjectMember} projectId={project.id} />
+            <AddProjectMember bind:this={addProjectMember} {project} />
             <BulkAddProjectMembers projectId={project.id} />
           </svelte:fragment>
           <UserModal bind:this={userModal}/>

--- a/frontend/src/routes/(authenticated)/project/[project_code]/AddProjectMember.svelte
+++ b/frontend/src/routes/(authenticated)/project/[project_code]/AddProjectMember.svelte
@@ -4,14 +4,14 @@
   import { ProjectRole } from '$lib/gql/types';
   import t from '$lib/i18n';
   import { z } from 'zod';
-  import { _addProjectMember } from './+page';
+  import { _addProjectMember, type Project } from './+page';
   import { useNotifications } from '$lib/notify';
   import { page } from '$app/stores'
   import UserTypeahead from '$lib/forms/UserTypeahead.svelte';
   import { SupHelp, helpLinks } from '$lib/components/help';
   import Checkbox from '$lib/forms/Checkbox.svelte';
 
-  export let projectId: string;
+  export let project: Project;
   const schema = z.object({
     usernameOrEmail: z.string().trim()
       .min(1, $t('project_page.add_user.empty_user_field'))
@@ -31,7 +31,7 @@
     if (initialUserId) selectedUserId = initialUserId;
     const { response, formState } = await formModal.open(initialValue, async () => {
       const { error } = await _addProjectMember({
-        projectId,
+        projectId: project.id,
         usernameOrEmail: $form.usernameOrEmail ?? '',
         userId: selectedUserId,
         role: $form.role,
@@ -86,6 +86,7 @@
     on:selectedUserId={({ detail }) => {
         selectedUserId = detail;
     }}
+    exclude={project.users.map(m => m.user.id)}
   />
   <ProjectRoleSelect bind:value={$form.role} error={errors.role} />
   <svelte:fragment slot="extraActions">


### PR DESCRIPTION
Fix #1152.

This PR adds a new `usersICanSee` GQL query, which looks for:

* All users in one of my orgs
* All users in one of the projects I manage
* All users in one of the **non-confidential** projects I'm a member of

The "Add Project Member" typeahead is now updated to use that query, which allows project managers who aren't site admins to use the typeahead to find users whose email address they don't know. E.g. if Test Manager has Test Editor as part of project A, and he also manages project B, then when he clicks on "Add Members" in project B, he can type Test Editor's name and select him to add, without knowing his email address.