### PR TITLE
Implement new update API for writing systems

### DIFF
--- a/backend/FwLite/FwDataMiniLcmBridge/Api/FwDataMiniLcmApi.cs
+++ b/backend/FwLite/FwDataMiniLcmBridge/Api/FwDataMiniLcmApi.cs
@@ -190,7 +190,10 @@ public class FwDataMiniLcmApi(Lazy<LcmCache> cacheLazy, bool onCloseSave, ILogge
 
     public async Task<WritingSystem> UpdateWritingSystem(WritingSystemId id, WritingSystemType type, UpdateObjectInput<WritingSystem> update)
     {
-        Cache.ServiceLocator.WritingSystemManager.GetOrSet(id.Code, out var lcmWritingSystem);
+        if (!Cache.ServiceLocator.WritingSystemManager.TryGet(id.Code, out var lcmWritingSystem))
+        {
+            throw new InvalidOperationException($"Writing system {id.Code} not found");
+        }
         await Cache.DoUsingNewOrCurrentUOW("Update WritingSystem",
             "Revert WritingSystem",
             async () =>
@@ -214,7 +217,7 @@ public class FwDataMiniLcmApi(Lazy<LcmCache> cacheLazy, bool onCloseSave, ILogge
             {
                 await WritingSystemSync.Sync(after, before, this);
             });
-        return await GetWritingSystem(after.WsId, after.Type) ?? throw new NullReferenceException("unable to find writing system with id " + after.Id);
+        return await GetWritingSystem(after.WsId, after.Type) ?? throw new NullReferenceException($"unable to find {after.Type} writing system with id {after.WsId}");
     }
 
     public IAsyncEnumerable<PartOfSpeech> GetPartsOfSpeech()

--- a/backend/FwLite/FwDataMiniLcmBridge/Api/FwDataMiniLcmApi.cs
+++ b/backend/FwLite/FwDataMiniLcmBridge/Api/FwDataMiniLcmApi.cs
@@ -195,7 +195,11 @@ public class FwDataMiniLcmApi(Lazy<LcmCache> cacheLazy, bool onCloseSave, ILogge
             "Revert WritingSystem",
             async () =>
             {
-                var updateProxy = new UpdateWritingSystemProxy(lcmWritingSystem, this) { Type = type }; // TODO: Doesn't compile, wants Font to be set. Also wants a GUID Id which we don't have...
+                var updateProxy = new UpdateWritingSystemProxy(lcmWritingSystem, this)
+                {
+                    Id = Guid.Empty,
+                    Type = type,
+                };
                 update.Apply(updateProxy);
                 updateProxy.CommitUpdate(Cache);
             });

--- a/backend/FwLite/FwDataMiniLcmBridge/Api/FwDataMiniLcmApi.cs
+++ b/backend/FwLite/FwDataMiniLcmBridge/Api/FwDataMiniLcmApi.cs
@@ -132,6 +132,11 @@ public class FwDataMiniLcmApi(Lazy<LcmCache> cacheLazy, bool onCloseSave, ILogge
         };
     }
 
+    public Task<WritingSystem> GetWritingSystem(WritingSystemId id, WritingSystemType type)
+    {
+        throw new NotImplementedException();
+    }
+
     internal void CompleteExemplars(WritingSystems writingSystems)
     {
         var wsExemplars = writingSystems.Vernacular.Concat(writingSystems.Analysis)
@@ -185,7 +190,18 @@ public class FwDataMiniLcmApi(Lazy<LcmCache> cacheLazy, bool onCloseSave, ILogge
 
     public Task<WritingSystem> UpdateWritingSystem(WritingSystemId id, WritingSystemType type, UpdateObjectInput<WritingSystem> update)
     {
-        throw new NotImplementedException();
+        throw new NotImplementedException(); // TODO: This needs to be implemented now, because UpdateWritingSystem(before, after) needs to call this
+    }
+
+    public async Task<WritingSystem> UpdateWritingSystem(WritingSystem before, WritingSystem after)
+    {
+        await Cache.DoUsingNewOrCurrentUOW("Update WritingSystem",
+            "Revert WritingSystem",
+            async () =>
+            {
+                await WritingSystemSync.Sync(after, before, this);
+            });
+        return await GetWritingSystem(after.WsId, after.Type) ?? throw new NullReferenceException("unable to find writing system with id " + after.Id);
     }
 
     public IAsyncEnumerable<PartOfSpeech> GetPartsOfSpeech()

--- a/backend/FwLite/FwDataMiniLcmBridge/Api/UpdateProxy/UpdateWritingSystemProxy.cs
+++ b/backend/FwLite/FwDataMiniLcmBridge/Api/UpdateProxy/UpdateWritingSystemProxy.cs
@@ -1,7 +1,9 @@
+using System.Diagnostics.CodeAnalysis;
 using MiniLcm.Models;
 using SIL.LCModel;
 using SIL.LCModel.Core.WritingSystems;
 using SIL.LCModel.DomainServices;
+using SIL.WritingSystems;
 
 namespace FwDataMiniLcmBridge.Api.UpdateProxy;
 
@@ -11,10 +13,14 @@ public record UpdateWritingSystemProxy : WritingSystem
     private readonly CoreWritingSystemDefinition _workingLcmWritingSystem;
     private readonly FwDataMiniLcmApi _lexboxLcmApi;
 
+    [SetsRequiredMembers]
     public UpdateWritingSystemProxy(CoreWritingSystemDefinition lcmWritingSystem, FwDataMiniLcmApi lexboxLcmApi)
     {
         _origLcmWritingSystem = lcmWritingSystem;
         _workingLcmWritingSystem = new CoreWritingSystemDefinition(lcmWritingSystem, cloneId: true);
+        base.Abbreviation = Abbreviation = _origLcmWritingSystem.Abbreviation ?? "";
+        base.Name = Name = _origLcmWritingSystem.LanguageName ?? "";
+        base.Font = Font = _origLcmWritingSystem.DefaultFontName ?? "";
         _lexboxLcmApi = lexboxLcmApi;
     }
 
@@ -49,10 +55,15 @@ public record UpdateWritingSystemProxy : WritingSystem
         set => _workingLcmWritingSystem.Abbreviation = value;
     }
 
-    // TODO: Change WritingSystem Font property to be a list of strings instead of a single string, then do something like this
-    // public override required List<string> Fonts
-    // {
-    //     get => _workingLcmWritingSystem.Fonts.Select(f => f.Name).ToList();
-    //     set => throw new NotImplementedException();
-    // }
+    public override required string Font
+    {
+        get => _workingLcmWritingSystem.DefaultFontName;
+        set
+        {
+            if (value != _workingLcmWritingSystem.DefaultFontName)
+            {
+                _workingLcmWritingSystem.DefaultFont = new FontDefinition(value);
+            }
+        }
+    }
 }

--- a/backend/FwLite/FwDataMiniLcmBridge/Api/UpdateProxy/UpdateWritingSystemProxy.cs
+++ b/backend/FwLite/FwDataMiniLcmBridge/Api/UpdateProxy/UpdateWritingSystemProxy.cs
@@ -1,0 +1,58 @@
+using MiniLcm.Models;
+using SIL.LCModel;
+using SIL.LCModel.Core.WritingSystems;
+using SIL.LCModel.DomainServices;
+
+namespace FwDataMiniLcmBridge.Api.UpdateProxy;
+
+public record UpdateWritingSystemProxy : WritingSystem
+{
+    private readonly CoreWritingSystemDefinition _origLcmWritingSystem;
+    private readonly CoreWritingSystemDefinition _workingLcmWritingSystem;
+    private readonly FwDataMiniLcmApi _lexboxLcmApi;
+
+    public UpdateWritingSystemProxy(CoreWritingSystemDefinition lcmWritingSystem, FwDataMiniLcmApi lexboxLcmApi)
+    {
+        _origLcmWritingSystem = lcmWritingSystem;
+        _workingLcmWritingSystem = new CoreWritingSystemDefinition(lcmWritingSystem, cloneId: true);
+        _lexboxLcmApi = lexboxLcmApi;
+    }
+
+    public void CommitUpdate(LcmCache cache)
+    {
+        if (_workingLcmWritingSystem.Id == _origLcmWritingSystem.Id)
+        {
+            cache.ServiceLocator.WritingSystemManager.Set(_workingLcmWritingSystem);
+        }
+        else
+        {
+            // Changing the ID of a writing system requires LCM to do a lot of work, so only go through that process if absolutely required
+            WritingSystemServices.MergeWritingSystems(cache, _workingLcmWritingSystem, _origLcmWritingSystem);
+        }
+    }
+
+    public override required WritingSystemId WsId
+    {
+        get => _workingLcmWritingSystem.Id;
+        set => _workingLcmWritingSystem.Id = value;
+    }
+
+    public override required string Name
+    {
+        get => _workingLcmWritingSystem.LanguageName;
+        set { } // Silently do nothing; name should be derived from WsId at all times, so if the name should change then so should the WsId
+    }
+
+    public override required string Abbreviation
+    {
+        get => _workingLcmWritingSystem.Abbreviation;
+        set => _workingLcmWritingSystem.Abbreviation = value;
+    }
+
+    // TODO: Change WritingSystem Font property to be a list of strings instead of a single string, then do something like this
+    // public override required List<string> Fonts
+    // {
+    //     get => _workingLcmWritingSystem.Fonts.Select(f => f.Name).ToList();
+    //     set => throw new NotImplementedException();
+    // }
+}

--- a/backend/FwLite/FwLiteProjectSync/DryRunMiniLcmApi.cs
+++ b/backend/FwLite/FwLiteProjectSync/DryRunMiniLcmApi.cs
@@ -34,6 +34,12 @@ public class DryRunMiniLcmApi(IMiniLcmApi api) : IMiniLcmApi
         }).First(w => w.WsId == id);
     }
 
+    public Task<WritingSystem> UpdateWritingSystem(WritingSystem before, WritingSystem after)
+    {
+        DryRunRecords.Add(new DryRunRecord(nameof(UpdateEntry), $"Update {after.Type} writing system {after.Id}"));
+        return Task.FromResult(after);
+    }
+
     public IAsyncEnumerable<PartOfSpeech> GetPartsOfSpeech()
     {
         return api.GetPartsOfSpeech();

--- a/backend/FwLite/FwLiteProjectSync/DryRunMiniLcmApi.cs
+++ b/backend/FwLite/FwLiteProjectSync/DryRunMiniLcmApi.cs
@@ -36,7 +36,7 @@ public class DryRunMiniLcmApi(IMiniLcmApi api) : IMiniLcmApi
 
     public Task<WritingSystem> UpdateWritingSystem(WritingSystem before, WritingSystem after)
     {
-        DryRunRecords.Add(new DryRunRecord(nameof(UpdateEntry), $"Update {after.Type} writing system {after.Id}"));
+        DryRunRecords.Add(new DryRunRecord(nameof(UpdateEntry), $"Update {after.Type} writing system {after.WsId}"));
         return Task.FromResult(after);
     }
 

--- a/backend/FwLite/LcmCrdt/CrdtMiniLcmApi.cs
+++ b/backend/FwLite/LcmCrdt/CrdtMiniLcmApi.cs
@@ -56,6 +56,12 @@ public class CrdtMiniLcmApi(DataModel dataModel, CurrentProjectService projectSe
         return await dataModel.GetLatest<WritingSystem>(ws.Id) ?? throw new NullReferenceException();
     }
 
+    public async Task<WritingSystem> UpdateWritingSystem(WritingSystem before, WritingSystem after)
+    {
+        await WritingSystemSync.Sync(after, before, this);
+        return await GetWritingSystem(after.WsId, after.Type) ?? throw new NullReferenceException("unable to find writing system with id " + after.WsId);
+    }
+
     private WritingSystem? _defaultVernacularWs;
     private WritingSystem? _defaultAnalysisWs;
     private async Task<WritingSystem?> GetWritingSystem(WritingSystemId id, WritingSystemType type)

--- a/backend/FwLite/MiniLcm/IMiniLcmWriteApi.cs
+++ b/backend/FwLite/MiniLcm/IMiniLcmWriteApi.cs
@@ -11,7 +11,8 @@ public interface IMiniLcmWriteApi
     Task<WritingSystem> UpdateWritingSystem(WritingSystemId id,
         WritingSystemType type,
         UpdateObjectInput<WritingSystem> update);
-
+    Task<WritingSystem> UpdateWritingSystem(WritingSystem before, WritingSystem after);
+    // Note there's no Task DeleteWritingSystem(Guid id) because deleting writing systems needs careful consideration, as it can cause a massive cascade of data deletion
 
     #region PartOfSpeech
     Task<PartOfSpeech> CreatePartOfSpeech(PartOfSpeech partOfSpeech);

--- a/backend/FwLite/MiniLcm/Models/WritingSystem.cs
+++ b/backend/FwLite/MiniLcm/Models/WritingSystem.cs
@@ -3,10 +3,11 @@
 public record WritingSystem: IObjectWithId
 {
     public required Guid Id { get; set; }
-    public required WritingSystemId WsId { get; set; }
-    public required string Name { get; set; }
-    public required string Abbreviation { get; set; }
-    public required string Font { get; set; }
+    public virtual required WritingSystemId WsId { get; set; }
+    public virtual required string Name { get; set; }
+    public virtual required string Abbreviation { get; set; }
+    // TODO: Font will need to become Fonts, a list or array of strings, to better match the LCM model
+    public virtual required string Font { get; set; }
 
     public DateTimeOffset? DeletedAt { get; set; }
     public required WritingSystemType Type { get; set; }

--- a/backend/FwLite/MiniLcm/Models/WritingSystem.cs
+++ b/backend/FwLite/MiniLcm/Models/WritingSystem.cs
@@ -6,7 +6,6 @@ public record WritingSystem: IObjectWithId
     public virtual required WritingSystemId WsId { get; set; }
     public virtual required string Name { get; set; }
     public virtual required string Abbreviation { get; set; }
-    // TODO: Font will need to become Fonts, a list or array of strings, to better match the LCM model
     public virtual required string Font { get; set; }
 
     public DateTimeOffset? DeletedAt { get; set; }

--- a/backend/FwLite/MiniLcm/SyncHelpers/PartOfSpeechSync.cs
+++ b/backend/FwLite/MiniLcm/SyncHelpers/PartOfSpeechSync.cs
@@ -1,7 +1,7 @@
-using MiniLcm;
 using MiniLcm.Models;
-using MiniLcm.SyncHelpers;
 using SystemTextJsonPatch;
+
+namespace MiniLcm.SyncHelpers;
 
 public static class PartOfSpeechSync
 {

--- a/backend/FwLite/MiniLcm/SyncHelpers/SemanticDomainSync.cs
+++ b/backend/FwLite/MiniLcm/SyncHelpers/SemanticDomainSync.cs
@@ -1,7 +1,7 @@
-using MiniLcm;
 using MiniLcm.Models;
-using MiniLcm.SyncHelpers;
 using SystemTextJsonPatch;
+
+namespace MiniLcm.SyncHelpers;
 
 public static class SemanticDomainSync
 {

--- a/backend/FwLite/MiniLcm/SyncHelpers/SimpleStringDiff.cs
+++ b/backend/FwLite/MiniLcm/SyncHelpers/SimpleStringDiff.cs
@@ -1,0 +1,16 @@
+﻿using SystemTextJsonPatch.Operations;
+
+namespace MiniLcm.SyncHelpers;
+
+public static class SimpleStringDiff
+{
+    public static IEnumerable<Operation<T>> GetStringDiff<T>(string path,
+        string before,
+        string after) where T : class
+    {
+        if (before == after) yield break;
+        if (after is null) yield return new Operation<T>("remove", $"/{path}", null);
+        else if (before is null) yield return new Operation<T>("add", $"/{path}", null);
+        else yield return new Operation<T>("replace", $"/{path}", null, after);
+    }
+}

--- a/backend/FwLite/MiniLcm/SyncHelpers/SimpleStringDiff.cs
+++ b/backend/FwLite/MiniLcm/SyncHelpers/SimpleStringDiff.cs
@@ -5,8 +5,8 @@ namespace MiniLcm.SyncHelpers;
 public static class SimpleStringDiff
 {
     public static IEnumerable<Operation<T>> GetStringDiff<T>(string path,
-        string before,
-        string after) where T : class
+        string? before,
+        string? after) where T : class
     {
         if (before == after) yield break;
         if (after is null) yield return new Operation<T>("remove", $"/{path}", null);

--- a/backend/FwLite/MiniLcm/SyncHelpers/WritingSystemSync.cs
+++ b/backend/FwLite/MiniLcm/SyncHelpers/WritingSystemSync.cs
@@ -1,0 +1,59 @@
+using MiniLcm;
+using MiniLcm.Models;
+using MiniLcm.SyncHelpers;
+using SystemTextJsonPatch;
+
+public static class WritingSystemSync
+{
+    public static async Task<int> Sync(WritingSystem[] currentWritingSystems,
+        WritingSystem[] previousWritingSystems,
+        IMiniLcmApi api)
+    {
+        return await DiffCollection.Diff(api,
+            previousWritingSystems,
+            currentWritingSystems,
+            ws => ws.Id,
+            async (api, currentWs) =>
+            {
+                await api.CreateWritingSystem(currentWs.Type, currentWs);
+                return 1;
+            },
+            async (api, previousWs) =>
+            {
+                // await api.DeleteWritingSystem(previousWs.Id); // Deleting writing systems is dangerous as it causes cascading data deletion. Needs careful thought.
+                // TODO: should we throw an exception?
+                return 0;
+            },
+            async (api, previousWs, currentWs) =>
+            {
+                return await Sync(currentWs, previousWs, api);
+            });
+    }
+
+    public static async Task<int> Sync(WritingSystem afterWs, WritingSystem beforeWs, IMiniLcmApi api)
+    {
+        var updateObjectInput = WritingSystemDiffToUpdate(beforeWs, afterWs);
+        if (updateObjectInput is not null) await api.UpdateWritingSystem(afterWs.WsId, afterWs.Type, updateObjectInput);
+        return updateObjectInput is null ? 0 : 1;
+    }
+
+    public static UpdateObjectInput<WritingSystem>? WritingSystemDiffToUpdate(WritingSystem previousWritingSystem, WritingSystem currentWritingSystem)
+    {
+        JsonPatchDocument<WritingSystem> patchDocument = new();
+        patchDocument.Operations.AddRange(SimpleStringDiff.GetStringDiff<WritingSystem>(nameof(WritingSystem.WsId),
+            previousWritingSystem.WsId,
+            currentWritingSystem.WsId));
+        patchDocument.Operations.AddRange(SimpleStringDiff.GetStringDiff<WritingSystem>(nameof(WritingSystem.Name),
+            previousWritingSystem.Name,
+            currentWritingSystem.Name));
+        patchDocument.Operations.AddRange(SimpleStringDiff.GetStringDiff<WritingSystem>(nameof(WritingSystem.Abbreviation),
+            previousWritingSystem.Abbreviation,
+            currentWritingSystem.Abbreviation));
+        patchDocument.Operations.AddRange(SimpleStringDiff.GetStringDiff<WritingSystem>(nameof(WritingSystem.Font),
+            previousWritingSystem.Font,
+            currentWritingSystem.Font));
+        // TODO: Exemplars, Order, and do we need DeletedAt?
+        if (patchDocument.Operations.Count == 0) return null;
+        return new UpdateObjectInput<WritingSystem>(patchDocument);
+    }
+}

--- a/backend/FwLite/MiniLcm/SyncHelpers/WritingSystemSync.cs
+++ b/backend/FwLite/MiniLcm/SyncHelpers/WritingSystemSync.cs
@@ -1,7 +1,7 @@
-using MiniLcm;
 using MiniLcm.Models;
-using MiniLcm.SyncHelpers;
 using SystemTextJsonPatch;
+
+namespace MiniLcm.SyncHelpers;
 
 public static class WritingSystemSync
 {
@@ -12,7 +12,7 @@ public static class WritingSystemSync
         return await DiffCollection.Diff(api,
             previousWritingSystems,
             currentWritingSystems,
-            ws => ws.Id,
+            ws => (ws.WsId, ws.Type),
             async (api, currentWs) =>
             {
                 await api.CreateWritingSystem(currentWs.Type, currentWs);
@@ -40,9 +40,11 @@ public static class WritingSystemSync
     public static UpdateObjectInput<WritingSystem>? WritingSystemDiffToUpdate(WritingSystem previousWritingSystem, WritingSystem currentWritingSystem)
     {
         JsonPatchDocument<WritingSystem> patchDocument = new();
-        patchDocument.Operations.AddRange(SimpleStringDiff.GetStringDiff<WritingSystem>(nameof(WritingSystem.WsId),
-            previousWritingSystem.WsId,
-            currentWritingSystem.WsId));
+        if (previousWritingSystem.WsId != currentWritingSystem.WsId)
+        {
+            // TODO: Throw? Or silently ignore?
+            throw new InvalidOperationException($"Tried to change immutable WsId from {previousWritingSystem.WsId} to {currentWritingSystem.WsId}");
+        }
         patchDocument.Operations.AddRange(SimpleStringDiff.GetStringDiff<WritingSystem>(nameof(WritingSystem.Name),
             previousWritingSystem.Name,
             currentWritingSystem.Name));


### PR DESCRIPTION
Fix #1189.

Note that FwDataMiniLcmApi hasn't implemented the UpdateWritingSystem overload with (id, type, update), which the (before, after) method is going to end up calling. So that still needs to happen.