### PR TITLE
Do not throw exceptions for empty model number

### DIFF
--- a/backend/LexBoxApi/Services/HgService.cs
+++ b/backend/LexBoxApi/Services/HgService.cs
@@ -275,8 +275,8 @@ public partial class HgService : IHgService, IHostedService
         try
         {
             var json = JsonDocument.Parse(text);
-            if (json.RootElement.GetProperty("modelversion").TryGetInt32(out int version)) return version;
-            _logger.LogError("Invalid model version in GetModelVersionOfFlexProject, should be a number but got {modelversion}", json.RootElement.GetProperty("modelversion").ToString());
+            if (json.RootElement.TryGetProperty("modelversion", out var modelversion) && modelversion.TryGetInt32(out int version)) return version;
+            _logger.LogError("Invalid JSON {text} in GetModelVersionOfFlexProject, should have one property \"modelversion\" that's a number", text);
             return null;
         }
         catch (JsonException e)

--- a/backend/LexBoxApi/Services/HgService.cs
+++ b/backend/LexBoxApi/Services/HgService.cs
@@ -271,7 +271,7 @@ public partial class HgService : IHgService, IHostedService
     {
         var result = await ExecuteHgCommandServerCommand(code, "flexmodelversion", token);
         var text = await result.ReadAsStringAsync(token);
-        if (string.IsNullOrEmpty(text)) return null;
+        if (string.IsNullOrWhiteSpace(text)) return null;
         try
         {
             var json = JsonDocument.Parse(text);

--- a/backend/LexBoxApi/Services/HgService.cs
+++ b/backend/LexBoxApi/Services/HgService.cs
@@ -271,8 +271,17 @@ public partial class HgService : IHgService, IHostedService
     {
         var result = await ExecuteHgCommandServerCommand(code, "flexmodelversion", token);
         var text = await result.ReadAsStringAsync(token);
-        var json = JsonDocument.Parse(text);
-        return json.RootElement.GetProperty("modelversion").GetInt32();
+        if (string.IsNullOrEmpty(text)) return null;
+        try
+        {
+            var json = JsonDocument.Parse(text);
+            return json.RootElement.GetProperty("modelversion").GetInt32();
+        }
+        catch (JsonException e)
+        {
+            _logger.LogError("Malformed JSON {text} in GetModelVersionOfFlexProject: {error}", text, e.ToString());
+            return null;
+        }
     }
 
     public Task RevertRepo(ProjectCode code, string revHash)

--- a/backend/LexBoxApi/Services/HgService.cs
+++ b/backend/LexBoxApi/Services/HgService.cs
@@ -275,7 +275,9 @@ public partial class HgService : IHgService, IHostedService
         try
         {
             var json = JsonDocument.Parse(text);
-            return json.RootElement.GetProperty("modelversion").GetInt32();
+            if (json.RootElement.GetProperty("modelversion").TryGetInt32(out int version)) return version;
+            _logger.LogError("Invalid model version in GetModelVersionOfFlexProject, should be a number but got {modelversion}", json.RootElement.GetProperty("modelversion").ToString());
+            return null;
         }
         catch (JsonException e)
         {


### PR DESCRIPTION
Fix #1242.

If a project is empty, the FLEx model version command returns an empty string. HgService.GetModelVersionOfFlexProject should not throw an exception in such cases, but simply return null meaning "can't find the FLEx model".