### PR TITLE
fix entry sync with complex forms

### DIFF
--- a/backend/FwLite/FwDataMiniLcmBridge/Api/UpdateProxy/UpdateEntryProxy.cs
+++ b/backend/FwLite/FwDataMiniLcmBridge/Api/UpdateProxy/UpdateEntryProxy.cs
@@ -4,7 +4,7 @@ using SIL.LCModel.Core.KernelInterfaces;
 
 namespace FwDataMiniLcmBridge.Api.UpdateProxy;
 
-public class UpdateEntryProxy : Entry
+public record UpdateEntryProxy : Entry
 {
     private readonly ILexEntry _lcmEntry;
     private readonly FwDataMiniLcmApi _lexboxLcmApi;

--- a/backend/FwLite/FwLiteProjectSync.Tests/EntrySyncTests.cs
+++ b/backend/FwLite/FwLiteProjectSync.Tests/EntrySyncTests.cs
@@ -105,27 +105,4 @@ public class EntrySyncTests : IClassFixture<SyncFixture>
         actual.Should().NotBeNull();
         actual.Should().BeEquivalentTo(after, options => options);
     }
-
-    [Fact]
-    public async Task CanCreateAComplexFormAndItsComponentInOneSync()
-    {
-        //ensure they are synced so a real sync will happen when we want it to
-        await _fixture.SyncService.Sync(_fixture.CrdtApi, _fixture.FwDataApi);
-
-        var complexFormEntry = await _fixture.CrdtApi.CreateEntry(new() { LexemeForm = { { "en", "complexForm" } } });
-        var componentEntry = await _fixture.CrdtApi.CreateEntry(new()
-        {
-            LexemeForm = { { "en", "component" } },
-            ComplexForms =
-            [
-                new ComplexFormComponent()
-                {
-                    ComplexFormEntryId = complexFormEntry.Id, ComponentEntryId = Guid.Empty
-                }
-            ]
-        });
-
-        //one of the entries will be created first, it will try to create the reference to the other but it won't exist yet
-        await _fixture.SyncService.Sync(_fixture.CrdtApi, _fixture.FwDataApi);
-    }
 }

--- a/backend/FwLite/FwLiteProjectSync.Tests/EntrySyncTests.cs
+++ b/backend/FwLite/FwLiteProjectSync.Tests/EntrySyncTests.cs
@@ -105,4 +105,27 @@ public class EntrySyncTests : IClassFixture<SyncFixture>
         actual.Should().NotBeNull();
         actual.Should().BeEquivalentTo(after, options => options);
     }
+
+    [Fact]
+    public async Task CanCreateAComplexFormAndItsComponentInOneSync()
+    {
+        //ensure they are synced so a real sync will happen when we want it to
+        await _fixture.SyncService.Sync(_fixture.CrdtApi, _fixture.FwDataApi);
+
+        var complexFormEntry = await _fixture.CrdtApi.CreateEntry(new() { LexemeForm = { { "en", "complexForm" } } });
+        var componentEntry = await _fixture.CrdtApi.CreateEntry(new()
+        {
+            LexemeForm = { { "en", "component" } },
+            ComplexForms =
+            [
+                new ComplexFormComponent()
+                {
+                    ComplexFormEntryId = complexFormEntry.Id, ComponentEntryId = Guid.Empty
+                }
+            ]
+        });
+
+        //one of the entries will be created first, it will try to create the reference to the other but it won't exist yet
+        await _fixture.SyncService.Sync(_fixture.CrdtApi, _fixture.FwDataApi);
+    }
 }

--- a/backend/FwLite/FwLiteProjectSync.Tests/EntrySyncTests.cs
+++ b/backend/FwLite/FwLiteProjectSync.Tests/EntrySyncTests.cs
@@ -95,8 +95,8 @@ public class EntrySyncTests : IClassFixture<SyncFixture>
     [Fact]
     public async Task CanChangeComplexFormTypeViaSync()
     {
+        var complexFormType = await _fixture.CrdtApi.CreateComplexFormType(new() { Name = new() { { "en", "complexFormType" } } });
         var entry = await _fixture.CrdtApi.CreateEntry(new() { LexemeForm = { { "en", "complexForm1" } } });
-        var complexFormType = await _fixture.CrdtApi.GetComplexFormTypes().FirstAsync();
         var after = (Entry) entry.Copy();
         after.ComplexFormTypes = [complexFormType];
         await EntrySync.Sync(after, entry, _fixture.CrdtApi);

--- a/backend/FwLite/FwLiteProjectSync.Tests/Fixtures/SyncFixture.cs
+++ b/backend/FwLite/FwLiteProjectSync.Tests/Fixtures/SyncFixture.cs
@@ -58,7 +58,7 @@ public class SyncFixture : IAsyncLifetime
         if (Path.Exists(crdtProjectsFolder)) Directory.Delete(crdtProjectsFolder, true);
         Directory.CreateDirectory(crdtProjectsFolder);
         var crdtProject = await _services.ServiceProvider.GetRequiredService<ProjectsService>()
-            .CreateProject(new(_projectName, FwProjectId: FwDataApi.ProjectId, SeedNewProjectData: true));
+            .CreateProject(new(_projectName, FwProjectId: FwDataApi.ProjectId, SeedNewProjectData: false));
         CrdtApi = (CrdtMiniLcmApi) await _services.ServiceProvider.OpenCrdtProject(crdtProject);
     }
 

--- a/backend/FwLite/FwLiteProjectSync.Tests/Fixtures/SyncFixture.cs
+++ b/backend/FwLite/FwLiteProjectSync.Tests/Fixtures/SyncFixture.cs
@@ -69,6 +69,12 @@ public class SyncFixture : IAsyncLifetime
 
     public CrdtMiniLcmApi CrdtApi { get; set; } = null!;
     public FwDataMiniLcmApi FwDataApi { get; set; } = null!;
+
+    public void DeleteSyncSnapshot()
+    {
+        var snapshotPath = CrdtFwdataProjectSyncService.SnapshotPath(FwDataApi.Project);
+        if (File.Exists(snapshotPath)) File.Delete(snapshotPath);
+    }
 }
 
 public class MockProjectContext(CrdtProject? project) : ProjectContext

--- a/backend/FwLite/FwLiteProjectSync.Tests/Fixtures/SyncFixture.cs
+++ b/backend/FwLite/FwLiteProjectSync.Tests/Fixtures/SyncFixture.cs
@@ -50,7 +50,7 @@ public class SyncFixture : IAsyncLifetime
         if (Path.Exists(projectsFolder)) Directory.Delete(projectsFolder, true);
         Directory.CreateDirectory(projectsFolder);
         _services.ServiceProvider.GetRequiredService<IProjectLoader>()
-            .NewProject(new FwDataProject(_projectName, projectsFolder), "en", "fr");
+            .NewProject(new FwDataProject(_projectName, projectsFolder), "en", "en");
         FwDataApi = _services.ServiceProvider.GetRequiredService<FwDataFactory>().GetFwDataMiniLcmApi(_projectName, false);
 
         var crdtProjectsFolder =

--- a/backend/FwLite/FwLiteProjectSync/DryRunMiniLcmApi.cs
+++ b/backend/FwLite/FwLiteProjectSync/DryRunMiniLcmApi.cs
@@ -216,7 +216,7 @@ public class DryRunMiniLcmApi(IMiniLcmApi api) : IMiniLcmApi
 
     public Task DeleteComplexFormComponent(ComplexFormComponent complexFormComponent)
     {
-        DryRunRecords.Add(new DryRunRecord(nameof(DeleteComplexFormComponent), $"Delete complex form component complex entry: {complexFormComponent.ComplexFormHeadword}, component entry: {complexFormComponent.ComponentHeadword}"));
+        DryRunRecords.Add(new DryRunRecord(nameof(DeleteComplexFormComponent), $"Delete complex form component: {complexFormComponent}"));
         return Task.CompletedTask;
     }
 

--- a/backend/FwLite/FwLiteProjectSync/FwLiteProjectSync.csproj
+++ b/backend/FwLite/FwLiteProjectSync/FwLiteProjectSync.csproj
@@ -19,4 +19,8 @@
       <PackageReference Include="System.CommandLine" Version="2.0.0-beta4.22272.1" />
     </ItemGroup>
 
+    <ItemGroup>
+        <InternalsVisibleTo Include="FwLiteProjectSync.Tests"/>
+    </ItemGroup>
+
 </Project>

--- a/backend/FwLite/LcmCrdt.Tests/DataModelSnapshotTests.VerifyDbModel.verified.txt
+++ b/backend/FwLite/LcmCrdt.Tests/DataModelSnapshotTests.VerifyDbModel.verified.txt
@@ -24,6 +24,8 @@
       ComponentEntryId (Guid) Required FK Index
       ComponentHeadword (string)
       ComponentSenseId (Guid?) FK Index
+        Annotations: 
+          Relational:ColumnName: ComponentSenseId
       DeletedAt (DateTimeOffset?)
       SnapshotId (no field, Guid?) Shadow FK Index
     Keys: 
@@ -34,10 +36,15 @@
       ComplexFormComponent {'ComponentSenseId'} -> Sense {'Id'} Cascade
       ComplexFormComponent {'SnapshotId'} -> ObjectSnapshot {'Id'} Unique SetNull
     Indexes: 
-      ComplexFormEntryId
       ComponentEntryId
       ComponentSenseId
       SnapshotId Unique
+      ComplexFormEntryId, ComponentEntryId Unique
+        Annotations: 
+          Relational:Filter: ComponentSenseId IS NULL
+      ComplexFormEntryId, ComponentEntryId, ComponentSenseId Unique
+        Annotations: 
+          Relational:Filter: ComponentSenseId IS NOT NULL
     Annotations: 
       DiscriminatorProperty: 
       Relational:FunctionName: 

--- a/backend/FwLite/LcmCrdt.Tests/JsonPatchEntryRewriteTests.cs
+++ b/backend/FwLite/LcmCrdt.Tests/JsonPatchEntryRewriteTests.cs
@@ -20,7 +20,6 @@ public class JsonPatchEntryRewriteTests
             changes.Should().ContainSingle().Which.Should().BeOfType<AddEntryComponentChange>().Subject;
         addEntryComponentChange.ComplexFormEntryId.Should().Be(_entry.Id);
         addEntryComponentChange.ComponentEntryId.Should().Be(componentEntry.Id);
-        addEntryComponentChange.ComponentHeadword.Should().Be(componentEntry.Headword());
     }
 
     [Fact]
@@ -84,7 +83,6 @@ public class JsonPatchEntryRewriteTests
             changes.Should().ContainSingle().Which.Should().BeOfType<AddEntryComponentChange>().Subject;
         addEntryComponentChange.ComplexFormEntryId.Should().Be(_entry.Id);
         addEntryComponentChange.ComponentEntryId.Should().Be(componentEntry.Id);
-        addEntryComponentChange.ComponentHeadword.Should().Be(componentEntry.Headword());
     }
 
     [Fact]

--- a/backend/FwLite/LcmCrdt/CrdtMiniLcmApi.cs
+++ b/backend/FwLite/LcmCrdt/CrdtMiniLcmApi.cs
@@ -18,14 +18,15 @@ public class CrdtMiniLcmApi(DataModel dataModel, CurrentProjectService projectSe
     private Guid ClientId { get; } = projectService.ProjectData.ClientId;
     public ProjectData ProjectData => projectService.ProjectData;
 
-    private IQueryable<Entry> Entries => dataModel.QueryLatest<Entry>();
-    private IQueryable<ComplexFormComponent> ComplexFormComponents => dataModel.QueryLatest<ComplexFormComponent>();
-    private IQueryable<ComplexFormType> ComplexFormTypes => dataModel.QueryLatest<ComplexFormType>();
-    private IQueryable<Sense> Senses => dataModel.QueryLatest<Sense>();
-    private IQueryable<ExampleSentence> ExampleSentences => dataModel.QueryLatest<ExampleSentence>();
-    private IQueryable<WritingSystem> WritingSystems => dataModel.QueryLatest<WritingSystem>();
-    private IQueryable<SemanticDomain> SemanticDomains => dataModel.QueryLatest<SemanticDomain>();
-    private IQueryable<PartOfSpeech> PartsOfSpeech => dataModel.QueryLatest<PartOfSpeech>();
+    private IQueryable<Entry> Entries => dataModel.QueryLatest<Entry>().AsTracking(false);
+    private IQueryable<ComplexFormComponent> ComplexFormComponents => dataModel.QueryLatest<ComplexFormComponent>()
+        .AsTracking(false);
+    private IQueryable<ComplexFormType> ComplexFormTypes => dataModel.QueryLatest<ComplexFormType>().AsTracking(false);
+    private IQueryable<Sense> Senses => dataModel.QueryLatest<Sense>().AsTracking(false);
+    private IQueryable<ExampleSentence> ExampleSentences => dataModel.QueryLatest<ExampleSentence>().AsTracking(false);
+    private IQueryable<WritingSystem> WritingSystems => dataModel.QueryLatest<WritingSystem>().AsTracking(false);
+    private IQueryable<SemanticDomain> SemanticDomains => dataModel.QueryLatest<SemanticDomain>().AsTracking(false);
+    private IQueryable<PartOfSpeech> PartsOfSpeech => dataModel.QueryLatest<PartOfSpeech>().AsTracking(false);
 
     public async Task<WritingSystems> GetWritingSystems()
     {

--- a/backend/FwLite/LcmCrdt/CrdtMiniLcmApi.cs
+++ b/backend/FwLite/LcmCrdt/CrdtMiniLcmApi.cs
@@ -151,6 +151,11 @@ public class CrdtMiniLcmApi(DataModel dataModel, CurrentProjectService projectSe
 
     public async Task<ComplexFormComponent> CreateComplexFormComponent(ComplexFormComponent complexFormComponent)
     {
+        var existing = await ComplexFormComponents.SingleOrDefaultAsync(c =>
+            c.ComplexFormEntryId == complexFormComponent.ComplexFormEntryId
+            && c.ComponentEntryId == complexFormComponent.ComponentEntryId
+            && c.ComponentSenseId == complexFormComponent.ComponentSenseId);
+        if (existing is not null) return existing;
         var addEntryComponentChange = new AddEntryComponentChange(complexFormComponent);
         await dataModel.AddChange(ClientId, addEntryComponentChange);
         return (await ComplexFormComponents.SingleOrDefaultAsync(c => c.Id == addEntryComponentChange.EntityId)) ?? throw NotFoundException.ForType<ComplexFormComponent>();

--- a/backend/FwLite/LcmCrdt/LcmCrdtKernel.cs
+++ b/backend/FwLite/LcmCrdt/LcmCrdtKernel.cs
@@ -134,7 +134,22 @@ public static class LcmCrdtKernel
             .Add<ComplexFormType>()
             .Add<ComplexFormComponent>(builder =>
             {
+                const string componentSenseId = "ComponentSenseId";
                 builder.ToTable("ComplexFormComponents");
+                builder.Property(c => c.ComponentSenseId).HasColumnName(componentSenseId);
+                //these indexes are used to ensure that we don't create duplicate complex form components
+                //we need the filter otherwise 2 components which are the same and have a null sense id can be created because 2 rows with the same null are not considered duplicates
+                builder.HasIndex(component => new
+                {
+                    component.ComplexFormEntryId,
+                    component.ComponentEntryId,
+                    component.ComponentSenseId
+                }).IsUnique().HasFilter($"{componentSenseId} IS NOT NULL");
+                builder.HasIndex(component => new
+                {
+                    component.ComplexFormEntryId,
+                    component.ComponentEntryId
+                }).IsUnique().HasFilter($"{componentSenseId} IS NULL");
             });
 
         config.ChangeTypeListBuilder.Add<JsonPatchChange<Entry>>()

--- a/backend/FwLite/MiniLcm.Tests/ComplexFormComponentTestsBase.cs
+++ b/backend/FwLite/MiniLcm.Tests/ComplexFormComponentTestsBase.cs
@@ -51,6 +51,22 @@ public abstract class ComplexFormComponentTestsBase : MiniLcmTestBase
     }
 
     [Fact]
+    public async Task CreateComplexFormComponent_UsingTheSameComponentWithNullSenseDoesNothing()
+    {
+        var component1 = await Api.CreateComplexFormComponent(ComplexFormComponent.FromEntries(_complexFormEntry, _componentEntry));
+        var component2 = await Api.CreateComplexFormComponent(ComplexFormComponent.FromEntries(_complexFormEntry, _componentEntry));
+        component2.Should().BeEquivalentTo(component1);
+    }
+
+    [Fact]
+    public async Task CreateComplexFormComponent_UsingTheSameComponentWithSenseDoesNothing()
+    {
+        var component1 = await Api.CreateComplexFormComponent(ComplexFormComponent.FromEntries(_complexFormEntry, _componentEntry, _componentSenseId1));
+        var component2 = await Api.CreateComplexFormComponent(ComplexFormComponent.FromEntries(_complexFormEntry, _componentEntry, _componentSenseId1));
+        component2.Should().BeEquivalentTo(component1);
+    }
+
+    [Fact]
     public async Task CreateComplexFormComponent_WorksWithSense()
     {
         var component = await Api.CreateComplexFormComponent(ComplexFormComponent.FromEntries(_complexFormEntry, _componentEntry, _componentSenseId1));

--- a/backend/FwLite/MiniLcm/Exceptions/CreateObjectException.cs
+++ b/backend/FwLite/MiniLcm/Exceptions/CreateObjectException.cs
@@ -1,0 +1,12 @@
+﻿namespace MiniLcm.Exceptions;
+
+public class CreateObjectException: Exception
+{
+    public CreateObjectException(string? message) : base(message)
+    {
+    }
+
+    public CreateObjectException(string? message, Exception? innerException) : base(message, innerException)
+    {
+    }
+}

--- a/backend/FwLite/MiniLcm/Exceptions/SyncObjectException.cs
+++ b/backend/FwLite/MiniLcm/Exceptions/SyncObjectException.cs
@@ -1,0 +1,12 @@
+﻿namespace MiniLcm.Exceptions;
+
+public class SyncObjectException: Exception
+{
+    public SyncObjectException(string? message) : base(message)
+    {
+    }
+
+    public SyncObjectException(string? message, Exception? innerException) : base(message, innerException)
+    {
+    }
+}

--- a/backend/FwLite/MiniLcm/Models/Entry.cs
+++ b/backend/FwLite/MiniLcm/Models/Entry.cs
@@ -1,6 +1,6 @@
 ﻿namespace MiniLcm.Models;
 
-public class Entry : IObjectWithId<Entry>
+public record Entry : IObjectWithId<Entry>
 {
     public Guid Id { get; set; }
     public DateTimeOffset? DeletedAt { get; set; }
@@ -67,6 +67,11 @@ public class Entry : IObjectWithId<Entry>
 
     public void RemoveReference(Guid id, DateTimeOffset time)
     {
+    }
+
+    public Entry WithoutEntryRefs()
+    {
+        return this with { Components = [], ComplexForms = [] };
     }
 }
 

--- a/backend/FwLite/MiniLcm/SyncHelpers/DiffCollection.cs
+++ b/backend/FwLite/MiniLcm/SyncHelpers/DiffCollection.cs
@@ -4,6 +4,73 @@ namespace MiniLcm.SyncHelpers;
 
 public static class DiffCollection
 {
+    /// <summary>
+    /// Diffs a list, for new items calls add, it will then call update for the item returned from the add, using that as the before item for the replace call
+    /// </summary>
+    /// <param name="api"></param>
+    /// <param name="before"></param>
+    /// <param name="after"></param>
+    /// <param name="identity"></param>
+    /// <param name="add">api, value, return value to be used as the before item for the replace call</param>
+    /// <param name="remove"></param>
+    /// <param name="replace">api, before, after is the parameter order</param>
+    /// <typeparam name="T"></typeparam>
+    /// <typeparam name="TId"></typeparam>
+    /// <returns></returns>
+    public static async Task<int> DiffAddThenUpdate<T, TId>(
+        IMiniLcmApi api,
+        IList<T> before,
+        IList<T> after,
+        Func<T, TId> identity,
+        Func<IMiniLcmApi, T, Task<T>> add,
+        Func<IMiniLcmApi, T, Task<int>> remove,
+        Func<IMiniLcmApi, T, T, Task<int>> replace) where TId : notnull
+    {
+        var changes = 0;
+        var afterEntriesDict = after.ToDictionary(identity);
+
+        foreach (var beforeEntry in before)
+        {
+            if (afterEntriesDict.TryGetValue(identity(beforeEntry), out var afterEntry))
+            {
+                changes += await replace(api, beforeEntry, afterEntry);
+            }
+            else
+            {
+                changes += await remove(api, beforeEntry);
+            }
+
+            afterEntriesDict.Remove(identity(beforeEntry));
+        }
+
+        var postAddUpdates = new List<(T created, T after)>(afterEntriesDict.Values.Count);
+        foreach (var value in afterEntriesDict.Values)
+        {
+            changes++;
+            postAddUpdates.Add((await add(api, value), value));
+        }
+        foreach ((T createdItem, T afterItem) in postAddUpdates)
+        {
+            //todo this may do a lot more work than it needs to, eg sense will be created during add, but they will be checked again here when we know they didn't change
+            await replace(api, createdItem, afterItem);
+        }
+
+        return changes;
+    }
+
+    /// <summary>
+    ///
+    /// </summary>
+    /// <param name="api"></param>
+    /// <param name="before"></param>
+    /// <param name="after"></param>
+    /// <param name="identity"></param>
+    /// <param name="add"></param>
+    /// <param name="remove"></param>
+    /// <param name="replace">api, before, after is the parameter order</param>
+    /// <typeparam name="T"></typeparam>
+    /// <typeparam name="TId"></typeparam>
+    /// <returns></returns>
     public static async Task<int> Diff<T, TId>(
         IMiniLcmApi api,
         IList<T> before,
@@ -36,6 +103,7 @@ public static class DiffCollection
 
         return changes;
     }
+
     public static async Task<int> Diff<T>(
         IMiniLcmApi api,
         IList<T> before,

--- a/backend/FwLite/MiniLcm/SyncHelpers/EntrySync.cs
+++ b/backend/FwLite/MiniLcm/SyncHelpers/EntrySync.cs
@@ -10,10 +10,13 @@ public static class EntrySync
         Entry[] beforeEntries,
         IMiniLcmApi api)
     {
-        Func<IMiniLcmApi, Entry, Task<int>> add = static async (api, afterEntry) =>
+        Func<IMiniLcmApi, Entry, Task<Entry>> add = static async (api, afterEntry) =>
         {
-            await api.CreateEntry(afterEntry);
-            return 1;
+            //create each entry without components.
+            //After each entry is created, then replace will be called to create those components
+            var entryWithoutEntryRefs = afterEntry.WithoutEntryRefs();
+            await api.CreateEntry(entryWithoutEntryRefs);
+            return entryWithoutEntryRefs;
         };
         Func<IMiniLcmApi, Entry, Task<int>> remove = static async (api, beforeEntry) =>
         {
@@ -21,7 +24,7 @@ public static class EntrySync
             return 1;
         };
         Func<IMiniLcmApi, Entry, Entry, Task<int>> replace = static async (api, beforeEntry, afterEntry) => await Sync(afterEntry, beforeEntry, api);
-        return await DiffCollection.Diff(api, beforeEntries, afterEntries, add, remove, replace);
+        return await DiffCollection.DiffAddThenUpdate(api, beforeEntries, afterEntries, entry => entry.Id, add, remove, replace);
     }
 
     public static async Task<int> Sync(Entry afterEntry, Entry beforeEntry, IMiniLcmApi api)

--- a/backend/FwLite/MiniLcm/SyncHelpers/EntrySync.cs
+++ b/backend/FwLite/MiniLcm/SyncHelpers/EntrySync.cs
@@ -29,14 +29,21 @@ public static class EntrySync
 
     public static async Task<int> Sync(Entry afterEntry, Entry beforeEntry, IMiniLcmApi api)
     {
-        var updateObjectInput = EntryDiffToUpdate(beforeEntry, afterEntry);
-        if (updateObjectInput is not null) await api.UpdateEntry(afterEntry.Id, updateObjectInput);
-        var changes = await SensesSync(afterEntry.Id, afterEntry.Senses, beforeEntry.Senses, api);
+        try
+        {
+            var updateObjectInput = EntryDiffToUpdate(beforeEntry, afterEntry);
+            if (updateObjectInput is not null) await api.UpdateEntry(afterEntry.Id, updateObjectInput);
+            var changes = await SensesSync(afterEntry.Id, afterEntry.Senses, beforeEntry.Senses, api);
 
-        changes += await Sync(afterEntry.Components, beforeEntry.Components, api);
-        changes += await Sync(afterEntry.ComplexForms, beforeEntry.ComplexForms, api);
-        changes += await Sync(afterEntry.Id, afterEntry.ComplexFormTypes, beforeEntry.ComplexFormTypes, api);
-        return changes + (updateObjectInput is null ? 0 : 1);
+            changes += await Sync(afterEntry.Components, beforeEntry.Components, api);
+            changes += await Sync(afterEntry.ComplexForms, beforeEntry.ComplexForms, api);
+            changes += await Sync(afterEntry.Id, afterEntry.ComplexFormTypes, beforeEntry.ComplexFormTypes, api);
+            return changes + (updateObjectInput is null ? 0 : 1);
+        }
+        catch (Exception e)
+        {
+            throw new SyncObjectException($"Failed to sync entry {afterEntry}", e);
+        }
     }
 
     private static async Task<int> Sync(Guid entryId,


### PR DESCRIPTION
should close #1251

the issue (as shown in the test) is that creating 2 entries in one sync where they reference eachother means that the first one will try to create a ref to an object that doesn't yet exist