### PR TITLE
Add Update(before, after) API for example sentences

### DIFF
--- a/backend/FwLite/FwLiteProjectSync/DryRunMiniLcmApi.cs
+++ b/backend/FwLite/FwLiteProjectSync/DryRunMiniLcmApi.cs
@@ -182,6 +182,11 @@ public class DryRunMiniLcmApi(IMiniLcmApi api) : IMiniLcmApi
         return Task.CompletedTask;
     }
 
+    public Task<ExampleSentence?> GetExampleSentence(Guid entryId, Guid senseId, Guid id)
+    {
+        return api.GetExampleSentence(entryId, senseId, id);
+    }
+
     public Task<ExampleSentence> CreateExampleSentence(Guid entryId, Guid senseId, ExampleSentence exampleSentence)
     {
         DryRunRecords.Add(new DryRunRecord(nameof(CreateExampleSentence), $"Create example sentence {exampleSentence.Sentence}"));
@@ -195,11 +200,17 @@ public class DryRunMiniLcmApi(IMiniLcmApi api) : IMiniLcmApi
     {
         DryRunRecords.Add(new DryRunRecord(nameof(UpdateExampleSentence),
             $"Update example sentence {exampleSentenceId}, changes: {update.Summarize()}"));
-        var entry = await GetEntry(entryId) ??
-                    throw new NullReferenceException($"unable to find entry with id {entryId}");
-        var sense = entry.Senses.First(s => s.Id == senseId);
-        var exampleSentence = sense.ExampleSentences.First(s => s.Id == exampleSentenceId);
-        return exampleSentence;
+        var exampleSentence = await GetExampleSentence(entryId, senseId, exampleSentenceId);
+        return exampleSentence ?? throw new NullReferenceException($"unable to find example sentence with id {exampleSentenceId}");
+    }
+
+    public Task<ExampleSentence> UpdateExampleSentence(Guid entryId,
+        Guid senseId,
+        ExampleSentence before,
+        ExampleSentence after)
+    {
+        DryRunRecords.Add(new DryRunRecord(nameof(UpdateExampleSentence), $"Update example sentence {after.Id}"));
+        return Task.FromResult(after);
     }
 
     public Task DeleteExampleSentence(Guid entryId, Guid senseId, Guid exampleSentenceId)

--- a/backend/FwLite/LcmCrdt/CrdtMiniLcmApi.cs
+++ b/backend/FwLite/LcmCrdt/CrdtMiniLcmApi.cs
@@ -442,6 +442,14 @@ public class CrdtMiniLcmApi(DataModel dataModel, CurrentProjectService projectSe
         return await dataModel.GetLatest<ExampleSentence>(exampleSentence.Id) ?? throw new NullReferenceException();
     }
 
+    public async Task<ExampleSentence?> GetExampleSentence(Guid entryId, Guid senseId, Guid id)
+    {
+        var exampleSentence = await ExampleSentences.AsTracking(false)
+            .AsQueryable()
+            .SingleOrDefaultAsync(e => e.Id == id);
+        return exampleSentence;
+    }
+
     public async Task<ExampleSentence> UpdateExampleSentence(Guid entryId,
         Guid senseId,
         Guid exampleSentenceId,
@@ -451,6 +459,15 @@ public class CrdtMiniLcmApi(DataModel dataModel, CurrentProjectService projectSe
         var patchChange = new JsonPatchChange<ExampleSentence>(exampleSentenceId, jsonPatch);
         await dataModel.AddChange(ClientId, patchChange);
         return await dataModel.GetLatest<ExampleSentence>(exampleSentenceId) ?? throw new NullReferenceException();
+    }
+
+    public async Task<ExampleSentence> UpdateExampleSentence(Guid entryId,
+        Guid senseId,
+        ExampleSentence before,
+        ExampleSentence after)
+    {
+        await ExampleSentenceSync.Sync(entryId, senseId, after, before, this);
+        return await GetExampleSentence(entryId, senseId, after.Id) ?? throw new NullReferenceException();
     }
 
     public async Task DeleteExampleSentence(Guid entryId, Guid senseId, Guid exampleSentenceId)

--- a/backend/FwLite/MiniLcm/IMiniLcmReadApi.cs
+++ b/backend/FwLite/MiniLcm/IMiniLcmReadApi.cs
@@ -14,6 +14,7 @@ public interface IMiniLcmReadApi
     Task<Entry?> GetEntry(Guid id);
     Task<PartOfSpeech?> GetPartOfSpeech(Guid id);
     Task<SemanticDomain?> GetSemanticDomain(Guid id);
+    Task<ExampleSentence?> GetExampleSentence(Guid entryId, Guid senseId, Guid id);
 }
 
 public record QueryOptions(

--- a/backend/FwLite/MiniLcm/IMiniLcmWriteApi.cs
+++ b/backend/FwLite/MiniLcm/IMiniLcmWriteApi.cs
@@ -53,6 +53,10 @@ public interface IMiniLcmWriteApi
         Guid senseId,
         Guid exampleSentenceId,
         UpdateObjectInput<ExampleSentence> update);
+    Task<ExampleSentence> UpdateExampleSentence(Guid entryId,
+        Guid senseId,
+        ExampleSentence before,
+        ExampleSentence after);
 
     Task DeleteExampleSentence(Guid entryId, Guid senseId, Guid exampleSentenceId);
     #endregion

--- a/backend/FwLite/MiniLcm/SyncHelpers/ExampleSentenceSync.cs
+++ b/backend/FwLite/MiniLcm/SyncHelpers/ExampleSentenceSync.cs
@@ -22,19 +22,26 @@ public static class ExampleSentenceSync
             return 1;
         };
         Func<IMiniLcmApi, ExampleSentence, ExampleSentence, Task<int>> replace =
-            async (api, beforeExampleSentence, afterExampleSentence) =>
-            {
-                var updateObjectInput = DiffToUpdate(beforeExampleSentence, afterExampleSentence);
-                if (updateObjectInput is null) return 0;
-                await api.UpdateExampleSentence(entryId, senseId, beforeExampleSentence.Id, updateObjectInput);
-                return 1;
-            };
+            (api, beforeExampleSentence, afterExampleSentence) =>
+                Sync(entryId, senseId, afterExampleSentence, beforeExampleSentence, api);
         return await DiffCollection.Diff(api,
             beforeExampleSentences,
             afterExampleSentences,
             add,
             remove,
             replace);
+    }
+
+    public static async Task<int> Sync(Guid entryId,
+        Guid senseId,
+        ExampleSentence afterExampleSentence,
+        ExampleSentence beforeExampleSentence,
+        IMiniLcmApi api)
+    {
+        var updateObjectInput = DiffToUpdate(beforeExampleSentence, afterExampleSentence);
+        if (updateObjectInput is null) return 0;
+        await api.UpdateExampleSentence(entryId, senseId, beforeExampleSentence.Id, updateObjectInput);
+        return 1;
     }
 
     public static UpdateObjectInput<ExampleSentence>? DiffToUpdate(ExampleSentence beforeExampleSentence,

--- a/backend/LfClassicData/LfClassicMiniLcmApi.cs
+++ b/backend/LfClassicData/LfClassicMiniLcmApi.cs
@@ -314,4 +314,15 @@ public class LfClassicMiniLcmApi(string projectCode, ProjectDbContext dbContext,
         if (entry is null) return null;
         return ToEntry(entry);
     }
+
+    public async Task<ExampleSentence?> GetExampleSentence(Guid entryId, Guid senseId, Guid id)
+    {
+        var entry = await Entries.Find(e => e.Guid == entryId).FirstOrDefaultAsync();
+        if (entry is null) return null;
+        var sense = entry.Senses?.FirstOrDefault(s => s?.Guid == senseId);
+        if (sense is null) return null;
+        var exampleSentence = sense.Examples?.FirstOrDefault(e => e?.Guid == id);
+        if (exampleSentence is null) return null;
+        return ToExampleSentence(sense.Guid, exampleSentence);
+    }
 }


### PR DESCRIPTION
Fix #1187.

Adds a new UpdateExampleSentence(Guid entryId, Guid senseId, ExampleSentence before, ExampleSentence after) method to the IMiniLcmWriteApi interface.

Also adds a GetExampleSentence(Guid entryId, Guid senseId, Guid id) method to the IMiniLcmReadApi interface.