### PR TITLE
Add Update(before, after) API for senses

### DIFF
--- a/backend/FwLite/FwLiteProjectSync.Tests/UpdateDiffTests.cs
+++ b/backend/FwLite/FwLiteProjectSync.Tests/UpdateDiffTests.cs
@@ -37,7 +37,7 @@ public class UpdateDiffTests
         var senseDiffToUpdate = await SenseSync.SenseDiffToUpdate(before, after);
         ArgumentNullException.ThrowIfNull(senseDiffToUpdate);
         senseDiffToUpdate.Apply(before);
-        before.Should().BeEquivalentTo(after, options => options.Excluding(x => x.Id).Excluding(x => x.EntryId).Excluding(x => x.DeletedAt).Excluding(x => x.ExampleSentences));
+        before.Should().BeEquivalentTo(after, options => options.Excluding(x => x.Id).Excluding(x => x.EntryId).Excluding(x => x.DeletedAt).Excluding(x => x.ExampleSentences).Excluding(x => x.SemanticDomains));
     }
 
     [Fact]

--- a/backend/FwLite/FwLiteProjectSync/DryRunMiniLcmApi.cs
+++ b/backend/FwLite/FwLiteProjectSync/DryRunMiniLcmApi.cs
@@ -190,6 +190,11 @@ public class DryRunMiniLcmApi(IMiniLcmApi api) : IMiniLcmApi
         await Task.CompletedTask;
     }
 
+    public Task<Sense?> GetSense(Guid entryId, Guid id)
+    {
+        return api.GetSense(entryId, id);
+    }
+
     public Task<Sense> CreateSense(Guid entryId, Sense sense)
     {
         DryRunRecords.Add(new DryRunRecord(nameof(CreateSense), $"Create sense {sense.Gloss}"));
@@ -204,6 +209,13 @@ public class DryRunMiniLcmApi(IMiniLcmApi api) : IMiniLcmApi
                     throw new NullReferenceException($"unable to find entry with id {entryId}");
         var sense = entry.Senses.First(s => s.Id == senseId);
         return sense;
+    }
+
+    public async Task<Sense> UpdateSense(Guid entryId, Sense before, Sense after)
+    {
+        DryRunRecords.Add(new DryRunRecord(nameof(UpdateSense),
+            $"Update sense {after.Id}"));
+        return await GetSense(entryId, after.Id) ?? throw new NullReferenceException($"unable to find sense with id {after.Id}");
     }
 
     public Task DeleteSense(Guid entryId, Guid senseId)

--- a/backend/FwLite/MiniLcm/IMiniLcmReadApi.cs
+++ b/backend/FwLite/MiniLcm/IMiniLcmReadApi.cs
@@ -13,6 +13,7 @@ public interface IMiniLcmReadApi
     IAsyncEnumerable<Entry> GetEntries(QueryOptions? options = null);
     IAsyncEnumerable<Entry> SearchEntries(string query, QueryOptions? options = null);
     Task<Entry?> GetEntry(Guid id);
+    Task<Sense?> GetSense(Guid entryId, Guid id);
     Task<PartOfSpeech?> GetPartOfSpeech(Guid id);
     Task<SemanticDomain?> GetSemanticDomain(Guid id);
     Task<ExampleSentence?> GetExampleSentence(Guid entryId, Guid senseId, Guid id);

--- a/backend/FwLite/MiniLcm/IMiniLcmWriteApi.cs
+++ b/backend/FwLite/MiniLcm/IMiniLcmWriteApi.cs
@@ -48,6 +48,7 @@ public interface IMiniLcmWriteApi
     #region Sense
     Task<Sense> CreateSense(Guid entryId, Sense sense);
     Task<Sense> UpdateSense(Guid entryId, Guid senseId, UpdateObjectInput<Sense> update);
+    Task<Sense> UpdateSense(Guid entryId, Sense before, Sense after);
     Task DeleteSense(Guid entryId, Guid senseId);
     Task AddSemanticDomainToSense(Guid senseId, SemanticDomain semanticDomain);
     Task RemoveSemanticDomainFromSense(Guid senseId, Guid semanticDomainId);

--- a/backend/LfClassicData/LfClassicMiniLcmApi.cs
+++ b/backend/LfClassicData/LfClassicMiniLcmApi.cs
@@ -20,6 +20,11 @@ public class LfClassicMiniLcmApi(string projectCode, ProjectDbContext dbContext,
         return AsyncEnumerable.Empty<ComplexFormType>();
     }
 
+    public Task<ComplexFormType?> GetComplexFormType(Guid id)
+    {
+        return Task.FromResult<ComplexFormType?>(null);
+    }
+
     public async Task<WritingSystems> GetWritingSystems()
     {
         var inputSystems = await systemDbContext.Projects.AsQueryable()

--- a/backend/LfClassicData/LfClassicMiniLcmApi.cs
+++ b/backend/LfClassicData/LfClassicMiniLcmApi.cs
@@ -315,6 +315,15 @@ public class LfClassicMiniLcmApi(string projectCode, ProjectDbContext dbContext,
         return ToEntry(entry);
     }
 
+    public async Task<Sense?> GetSense(Guid entryId, Guid id)
+    {
+        var entry = await Entries.Find(e => e.Guid == entryId).FirstOrDefaultAsync();
+        if (entry is null) return null;
+        var sense = entry.Senses?.FirstOrDefault(s => s?.Guid == id);
+        if (sense is null) return null;
+        return ToSense(entryId, sense);
+    }
+
     public async Task<ExampleSentence?> GetExampleSentence(Guid entryId, Guid senseId, Guid id)
     {
         var entry = await Entries.Find(e => e.Guid == entryId).FirstOrDefaultAsync();


### PR DESCRIPTION
Fix #1186.

Adds a new UpdateSense(Guid entryId, Sense before, Sense after) method to the IMiniLcmWriteApi interface.

Also adds a GetSense(Guid entryId, Guid id) method to the IMiniLcmReadApi interface.