### PR TITLE
Add Update(before, after) API for possibilities

### DIFF
--- a/backend/FwLite/FwDataMiniLcmBridge/Api/FwDataMiniLcmApi.cs
+++ b/backend/FwLite/FwDataMiniLcmBridge/Api/FwDataMiniLcmApi.cs
@@ -235,6 +235,12 @@ public class FwDataMiniLcmApi(Lazy<LcmCache> cacheLazy, bool onCloseSave, ILogge
         return Task.FromResult(FromLcmPartOfSpeech(lcmPartOfSpeech));
     }
 
+    public async Task<PartOfSpeech> UpdatePartOfSpeech(PartOfSpeech before, PartOfSpeech after)
+    {
+        await PartOfSpeechSync.Sync(before, after, this);
+        return await GetPartOfSpeech(after.Id) ?? throw new NullReferenceException($"unable to find part of speech with id {after.Id}");
+    }
+
     public Task DeletePartOfSpeech(Guid id)
     {
         UndoableUnitOfWorkHelper.DoUsingNewOrCurrentUOW("Delete Part of Speech",
@@ -304,6 +310,12 @@ public class FwDataMiniLcmApi(Lazy<LcmCache> cacheLazy, bool onCloseSave, ILogge
                 update.Apply(updateProxy);
             });
         return Task.FromResult(FromLcmSemanticDomain(lcmSemanticDomain));
+    }
+
+    public async Task<SemanticDomain> UpdateSemanticDomain(SemanticDomain before, SemanticDomain after)
+    {
+        await SemanticDomainSync.Sync(before, after, this);
+        return await GetSemanticDomain(after.Id) ?? throw new NullReferenceException($"unable to find semantic domain with id {after.Id}");
     }
 
     public Task DeleteSemanticDomain(Guid id)

--- a/backend/FwLite/FwLiteProjectSync/DryRunMiniLcmApi.cs
+++ b/backend/FwLite/FwLiteProjectSync/DryRunMiniLcmApi.cs
@@ -56,6 +56,12 @@ public class DryRunMiniLcmApi(IMiniLcmApi api) : IMiniLcmApi
         return GetPartOfSpeech(id)!;
     }
 
+    public Task<PartOfSpeech> UpdatePartOfSpeech(PartOfSpeech before, PartOfSpeech after)
+    {
+        DryRunRecords.Add(new DryRunRecord(nameof(UpdatePartOfSpeech), $"Update part of speech {after.Id}"));
+        return Task.FromResult(after);
+    }
+
     public Task DeletePartOfSpeech(Guid id)
     {
         DryRunRecords.Add(new DryRunRecord(nameof(DeletePartOfSpeech), $"Delete part of speech {id}"));
@@ -81,13 +87,19 @@ public class DryRunMiniLcmApi(IMiniLcmApi api) : IMiniLcmApi
 
     public Task<SemanticDomain> UpdateSemanticDomain(Guid id, UpdateObjectInput<SemanticDomain> update)
     {
-        DryRunRecords.Add(new DryRunRecord(nameof(UpdateSemanticDomain), $"Update part of speech {id}"));
+        DryRunRecords.Add(new DryRunRecord(nameof(UpdateSemanticDomain), $"Update semantic domain {id}"));
         return GetSemanticDomain(id)!;
+    }
+
+    public Task<SemanticDomain> UpdateSemanticDomain(SemanticDomain before, SemanticDomain after)
+    {
+        DryRunRecords.Add(new DryRunRecord(nameof(UpdateSemanticDomain), $"Update semantic domain {after.Id}"));
+        return Task.FromResult(after);
     }
 
     public Task DeleteSemanticDomain(Guid id)
     {
-        DryRunRecords.Add(new DryRunRecord(nameof(DeleteSemanticDomain), $"Delete part of speech {id}"));
+        DryRunRecords.Add(new DryRunRecord(nameof(DeleteSemanticDomain), $"Delete semantic domain {id}"));
         return Task.CompletedTask;
     }
 

--- a/backend/FwLite/LcmCrdt/CrdtMiniLcmApi.cs
+++ b/backend/FwLite/LcmCrdt/CrdtMiniLcmApi.cs
@@ -97,6 +97,12 @@ public class CrdtMiniLcmApi(DataModel dataModel, CurrentProjectService projectSe
         return await GetPartOfSpeech(id) ?? throw new NullReferenceException();
     }
 
+    public async Task<PartOfSpeech> UpdatePartOfSpeech(PartOfSpeech before, PartOfSpeech after)
+    {
+        await PartOfSpeechSync.Sync(before, after, this);
+        return await GetPartOfSpeech(after.Id) ?? throw new NullReferenceException($"unable to find part of speech with id {after.Id}");
+    }
+
     public async Task DeletePartOfSpeech(Guid id)
     {
         await dataModel.AddChange(ClientId, new DeleteChange<PartOfSpeech>(id));
@@ -125,6 +131,12 @@ public class CrdtMiniLcmApi(DataModel dataModel, CurrentProjectService projectSe
 
         await dataModel.AddChanges(ClientId, [..semDom.ToChanges(update.Patch)]);
         return await GetSemanticDomain(id) ?? throw new NullReferenceException();
+    }
+
+    public async Task<SemanticDomain> UpdateSemanticDomain(SemanticDomain before, SemanticDomain after)
+    {
+        await SemanticDomainSync.Sync(before, after, this);
+        return await GetSemanticDomain(after.Id) ?? throw new NullReferenceException($"unable to find semantic domain with id {after.Id}");
     }
 
     public async Task DeleteSemanticDomain(Guid id)

--- a/backend/FwLite/MiniLcm/IMiniLcmWriteApi.cs
+++ b/backend/FwLite/MiniLcm/IMiniLcmWriteApi.cs
@@ -16,12 +16,14 @@ public interface IMiniLcmWriteApi
     #region PartOfSpeech
     Task<PartOfSpeech> CreatePartOfSpeech(PartOfSpeech partOfSpeech);
     Task<PartOfSpeech> UpdatePartOfSpeech(Guid id, UpdateObjectInput<PartOfSpeech> update);
+    Task<PartOfSpeech> UpdatePartOfSpeech(PartOfSpeech before, PartOfSpeech after);
     Task DeletePartOfSpeech(Guid id);
     #endregion
 
     #region SemanticDomain
     Task<SemanticDomain> CreateSemanticDomain(SemanticDomain semanticDomain);
     Task<SemanticDomain> UpdateSemanticDomain(Guid id, UpdateObjectInput<SemanticDomain> update);
+    Task<SemanticDomain> UpdateSemanticDomain(SemanticDomain before, SemanticDomain after);
     Task DeleteSemanticDomain(Guid id);
     #endregion
 

--- a/backend/FwLite/MiniLcm/SyncHelpers/PartOfSpeechSync.cs
+++ b/backend/FwLite/MiniLcm/SyncHelpers/PartOfSpeechSync.cs
@@ -23,12 +23,16 @@ public static class PartOfSpeechSync
                 await api.DeletePartOfSpeech(previousPos.Id);
                 return 1;
             },
-            async (api, previousPos, currentPos) =>
-            {
-                var updateObjectInput = PartOfSpeechDiffToUpdate(previousPos, currentPos);
-                if (updateObjectInput is not null) await api.UpdatePartOfSpeech(currentPos.Id, updateObjectInput);
-                return updateObjectInput is null ? 0 : 1;
-            });
+            (api, previousPos, currentPos) => Sync(previousPos, currentPos, api));
+    }
+
+    public static async Task<int> Sync(PartOfSpeech before,
+        PartOfSpeech after,
+        IMiniLcmApi api)
+    {
+        var updateObjectInput = PartOfSpeechDiffToUpdate(before, after);
+        if (updateObjectInput is not null) await api.UpdatePartOfSpeech(after.Id, updateObjectInput);
+        return updateObjectInput is null ? 0 : 1;
     }
 
     public static UpdateObjectInput<PartOfSpeech>? PartOfSpeechDiffToUpdate(PartOfSpeech previousPartOfSpeech, PartOfSpeech currentPartOfSpeech)

--- a/backend/FwLite/MiniLcm/SyncHelpers/SemanticDomainSync.cs
+++ b/backend/FwLite/MiniLcm/SyncHelpers/SemanticDomainSync.cs
@@ -23,12 +23,16 @@ public static class SemanticDomainSync
                 await api.DeleteSemanticDomain(previousPos.Id);
                 return 1;
             },
-            async (api, previousPos, currentPos) =>
-            {
-                var updateObjectInput = SemanticDomainDiffToUpdate(previousPos, currentPos);
-                if (updateObjectInput is not null) await api.UpdateSemanticDomain(currentPos.Id, updateObjectInput);
-                return updateObjectInput is null ? 0 : 1;
-            });
+            (api, previousSemdom, currentSemdom) => Sync(previousSemdom, currentSemdom, api));
+    }
+
+    public static async Task<int> Sync(SemanticDomain before,
+        SemanticDomain after,
+        IMiniLcmApi api)
+    {
+        var updateObjectInput = SemanticDomainDiffToUpdate(before, after);
+        if (updateObjectInput is not null) await api.UpdateSemanticDomain(after.Id, updateObjectInput);
+        return updateObjectInput is null ? 0 : 1;
     }
 
     public static UpdateObjectInput<SemanticDomain>? SemanticDomainDiffToUpdate(SemanticDomain previousSemanticDomain, SemanticDomain currentSemanticDomain)


### PR DESCRIPTION
Fix #1188.

* Parts of speech:

Adds a new UpdatePartOfSpeech(PartOfSpeech before, PartOfSpeech after) method to the IMiniLcmWriteApi interface.

No need to add a GetPartOfSpeech(Guid id) method to the IMiniLcmReadApi interface, as it was already there.

* Semantic domains:

Adds a new UpdateSemanticDomain(SemanticDomain before, SemanticDomain after) method to the IMiniLcmWriteApi interface.

No need to add a GetSemanticDomain(Guid id) method to the IMiniLcmReadApi interface, as it was already there.
