### PR TITLE
Chore/improve e2e tests in gha

### DIFF
--- a/.github/workflows/develop-api.yaml
+++ b/.github/workflows/develop-api.yaml
@@ -5,6 +5,7 @@ on:
     paths:
       - 'backend/**'
       - '!backend/FwLite/**'
+      - 'frontend/**'
       - '.github/workflows/lexbox-api.yaml'
       - '.github/workflows/deploy.yaml'
       - 'deployment/lexbox-deployment.yaml'
@@ -14,6 +15,7 @@ on:
     paths:
       - 'backend/**'
       - '!backend/FwLite/**'
+      - 'frontend/**'
       - '.github/workflows/lexbox-api.yaml'
       - '.github/workflows/deploy.yaml'
       - 'deployment/lexbox-deployment.yaml'

--- a/frontend/Taskfile.yml
+++ b/frontend/Taskfile.yml
@@ -21,7 +21,8 @@ tasks:
       - corepack enable || true
       - pnpm install
   playwright-tests:
-    cmd: pnpm test
+    aliases: [ pt ]
+    cmd: pnpm run test {{.CLI_ARGS}}
 
   playwright-generate-tests:
     cmds:

--- a/frontend/tests/logout.test.ts
+++ b/frontend/tests/logout.test.ts
@@ -2,7 +2,8 @@ import {AdminDashboardPage} from './pages/adminDashboardPage';
 import {loginAs} from './utils/authHelpers';
 import {test} from './fixtures';
 
-test('Back button after logout redirects back to login page', async ({page}) => {
+test('Back button after logout redirects back to login page', async ({page, browserName}) => {
+  test.skip(browserName === 'firefox', 'Support for Clear-Site-Data: "cache" was removed and is WIP (https://bugzilla.mozilla.org/show_bug.cgi?id=1838506)');
   await loginAs(page.request, 'admin');
   const adminPage = await new AdminDashboardPage(page).goto();
   const drawer = await adminPage.openDrawer();


### PR DESCRIPTION
As discussed in our team meeting:
- We want Playwright tests to run on frontend changes. This is the easiest way to do that. I could have gotten smart and filtered out viewer changes. But, I wasn't convinced that it was worth it.
- Also as discussed, we'll just disable the test (in Firefox) that uses a header not supported in Firefox. A client-side only fix might be worthwhile in the future.