### PR TITLE
Bug/1259 project page will forever spam gql requests when projectchangesets returns a 404

### DIFF
--- a/frontend/src/lib/gql/gql-client.ts
+++ b/frontend/src/lib/gql/gql-client.ts
@@ -62,6 +62,8 @@ function createGqlClient(_gqlEndpoint?: string): Client {
           'Changeset': () => null,
           'UsersCollectionSegment': () => null,
           'FlexProjectMetadata': (metaData) => metaData.projectId as string,
+          'ProjectWritingSystems': () => null,
+          'FLExWsId': (metaData) => metaData.tag as string,
         },
         updates: {
           Mutation: {

--- a/frontend/src/lib/gql/gql-client.ts
+++ b/frontend/src/lib/gql/gql-client.ts
@@ -64,14 +64,6 @@ function createGqlClient(_gqlEndpoint?: string): Client {
           'FlexProjectMetadata': (metaData) => metaData.projectId as string,
         },
         updates: {
-          Query: {
-            'projectByCode': (result, args, cache) => {
-              if (result.projectByCode === null) {
-                // Don't cache null project results
-                cache.invalidate('Query', 'projectByCode', args);
-              }
-            },
-          },
           Mutation: {
             createProject: (result: CreateProjectMutation, args: MutationCreateProjectArgs, cache, _info) => {
               if (args.input.orgId) {
@@ -83,6 +75,10 @@ function createGqlClient(_gqlEndpoint?: string): Client {
               cache.inspectFields('Query')
                 .filter(field => field.fieldName === dashboardQuery || field.fieldName === adminDashboardQuery)
                 .forEach(field => cache.invalidate('Query', field.fieldKey));
+              // Invalidate the project code in case there's a deleted project with the same code in the cache
+              // in a perfect world, we might update the cache with a result from the create mutation response,
+              // but then we'd probably still need to refetch it, because fields would be missing
+              cache.invalidate('Query', 'projectByCode', {code: args.input.code});
             },
             softDeleteProject: (result, args: MutationSoftDeleteProjectArgs, cache, _info) => {
               cache.invalidate({__typename: 'Project', id: args.input.projectId});


### PR DESCRIPTION
Resolves #1259 (hopefully?)

@hahn-kev I couldn't reproduce this either 😕. But it seems likely that this is the change we need 🤷.
The delete and recreate test still passes for me locally 😄 