### PR TITLE
fix errors in viewer caused by WsValidation and new Update Api

### DIFF
--- a/backend/FwLite/MiniLcm/Models/WritingSystemId.cs
+++ b/backend/FwLite/MiniLcm/Models/WritingSystemId.cs
@@ -33,7 +33,8 @@ public readonly record struct WritingSystemId: ISpanFormattable, ISpanParsable<W
 
     public WritingSystemId(string code)
     {
-        if (code == "default" || IetfLanguageTag.IsValid(code))
+        //__key is used by the LfClassicMiniLcmApi to smuggle non guid ids with possibilitie lists
+        if (code == "default" || code == "__key" || IetfLanguageTag.IsValid(code))
         {
             Code = code;
         }

--- a/frontend/viewer/src/lib/Editor.svelte
+++ b/frontend/viewer/src/lib/Editor.svelte
@@ -26,12 +26,14 @@
   const viewSettings = useViewSettings();
 
   async function onChange(e: { entry: IEntry, sense?: ISense, example?: IExampleSentence }) {
+    if (readonly) return;
     await updateEntry(e.entry);
     dispatch('change', {entry: e.entry});
     updateInitialEntry();
   }
 
   async function onDelete(e: { entry: IEntry, sense?: ISense, example?: IExampleSentence }) {
+    if (readonly) return;
     if (e.example !== undefined && e.sense !== undefined) {
       await saveHandler(() => lexboxApi.DeleteExampleSentence(e.entry.id, e.sense!.id, e.example!.id));
     } else if (e.sense !== undefined) {


### PR DESCRIPTION
WsId validation broke the LfClassic api as it was using the wsId '__key' to passing some ids across. 

Additionally now that we're using the new update api we are just always calling `api.UpdateEntry` instead of only calling it when changes are detected via json patch, this meant that the Viewer was calling update even when it's not implemented which was throwing an error