### PR TITLE
Add merge status API to fw-headless

### DIFF
--- a/backend/FwHeadless/FwHeadlessKernel.cs
+++ b/backend/FwHeadless/FwHeadlessKernel.cs
@@ -17,7 +17,7 @@ public static class FwHeadlessKernel
             .BindConfiguration("FwHeadlessConfig")
             .ValidateDataAnnotations()
             .ValidateOnStart();
-        services.AddSingleton<ProjectSyncStatusService>();
+        services.AddSingleton<SyncJobStatusService>();
         services.AddScoped<SendReceiveService>();
         services.AddScoped<ProjectLookupService>();
         services.AddScoped<LogSanitizerService>();

--- a/backend/FwHeadless/FwHeadlessKernel.cs
+++ b/backend/FwHeadless/FwHeadlessKernel.cs
@@ -17,6 +17,7 @@ public static class FwHeadlessKernel
             .BindConfiguration("FwHeadlessConfig")
             .ValidateDataAnnotations()
             .ValidateOnStart();
+        services.AddSingleton<ProjectSyncStatusService>();
         services.AddScoped<SendReceiveService>();
         services.AddScoped<ProjectLookupService>();
         services.AddScoped<LogSanitizerService>();

--- a/backend/FwHeadless/FwHeadlessKernel.cs
+++ b/backend/FwHeadless/FwHeadlessKernel.cs
@@ -27,6 +27,7 @@ public static class FwHeadlessKernel
             .AddFwDataBridge()
             .AddFwLiteProjectSync();
         services.AddScoped<CrdtSyncService>();
+        services.AddScoped<ProjectContextFromIdService>();
         services.AddTransient<HttpClientAuthHandler>();
         services.AddHttpClient(LexboxHttpClientName,
             (provider, client) =>

--- a/backend/FwHeadless/Program.cs
+++ b/backend/FwHeadless/Program.cs
@@ -149,7 +149,7 @@ static async Task<Results<Ok<ProjectSyncStatus>, NotFound>> GetMergeStatus(
     var commitsOnServer = await lexBoxDb.Set<ServerCommit>().CountAsync(c => c.ProjectId == projectId);
     var lcmCrdtDbContext = services.GetRequiredService<LcmCrdtDbContext>(); // TODO: This *cannot* be right, can it?
     var localCommits = await lcmCrdtDbContext.Set<Commit>().CountAsync();
-    return TypedResults.Ok(ProjectSyncStatus.ReadyToSync(localCommits - commitsOnServer));
+    return TypedResults.Ok(ProjectSyncStatus.ReadyToSync(commitsOnServer - localCommits));
 }
 
 static async Task<FwDataMiniLcmApi> SetupFwData(FwDataProject fwDataProject,

--- a/backend/FwHeadless/Program.cs
+++ b/backend/FwHeadless/Program.cs
@@ -1,4 +1,5 @@
 using FwHeadless;
+using FwHeadless.Services;
 using FwDataMiniLcmBridge;
 using FwDataMiniLcmBridge.Api;
 using FwLiteProjectSync;

--- a/backend/FwHeadless/Program.cs
+++ b/backend/FwHeadless/Program.cs
@@ -11,6 +11,7 @@ using Microsoft.AspNetCore.Http.HttpResults;
 using Microsoft.Extensions.Options;
 using MiniLcm;
 using Scalar.AspNetCore;
+using LexCore.Utils;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -76,7 +77,8 @@ static async Task<Results<Ok<SyncResult>, NotFound, ProblemHttpResult>> ExecuteM
         return TypedResults.Ok(new SyncResult(0, 0));
     }
 
-    using var syncStatusUpdater = new ProjectSyncStatusUpdater(syncStatusService, projectId);
+    syncStatusService.StartSyncing(projectId);
+    using var stopSyncing = Defer.Action(() => syncStatusService.StopSyncing(projectId));
 
     var projectCode = await projectLookupService.GetProjectCode(projectId);
     if (projectCode is null)

--- a/backend/FwHeadless/Program.cs
+++ b/backend/FwHeadless/Program.cs
@@ -38,6 +38,13 @@ app.Use(async (context, next) =>
     await next();
 });
 
+// Load project ID from request
+app.Use((context, next) =>
+{
+    var renameThisService = context.RequestServices.GetRequiredService<ProjectContextFromIdService>();
+    return renameThisService.PopulateProjectContext(context, next);
+});
+
 // Configure the HTTP request pipeline.
 if (app.Environment.IsDevelopment())
 {

--- a/backend/FwHeadless/Services/AppVersionService.cs
+++ b/backend/FwHeadless/Services/AppVersionService.cs
@@ -1,6 +1,6 @@
 using System.Reflection;
 
-namespace FwHeadless;
+namespace FwHeadless.Services;
 
 public static class AppVersionService
 {

--- a/backend/FwHeadless/Services/CrdtSyncService.cs
+++ b/backend/FwHeadless/Services/CrdtSyncService.cs
@@ -2,7 +2,7 @@
 using LcmCrdt.RemoteSync;
 using SIL.Harmony;
 
-namespace FwHeadless;
+namespace FwHeadless.Services;
 
 public class CrdtSyncService(
     CrdtHttpSyncService httpSyncService,

--- a/backend/FwHeadless/Services/HttpHelpers.cs
+++ b/backend/FwHeadless/Services/HttpHelpers.cs
@@ -1,0 +1,14 @@
+namespace FwHeadless.Services;
+
+public static class HttpHelpers
+{
+    public static Guid? GetProjectId(this HttpContext? context)
+    {
+        if (context is null) return null;
+        if (context.Request.Query.TryGetValue("projectId", out var projectIds) && projectIds.FirstOrDefault() is string idStr)
+        {
+            if (Guid.TryParse(idStr, out var projectId)) return projectId;
+        }
+        return null;
+    }
+}

--- a/backend/FwHeadless/Services/ProjectContextFromIdService.cs
+++ b/backend/FwHeadless/Services/ProjectContextFromIdService.cs
@@ -1,0 +1,28 @@
+using LcmCrdt;
+using Microsoft.Extensions.Options;
+
+namespace FwHeadless.Services;
+
+// TODO: Pick better name
+public class ProjectContextFromIdService(IOptions<FwHeadlessConfig> config, CrdtProjectsService projectsService, ProjectLookupService projectLookupService)
+{
+    public async Task PopulateProjectContext(HttpContext context, Func<Task> next)
+    {
+        if (context.GetProjectId() is Guid projectId)
+        {
+            var projectCode = await projectLookupService.GetProjectCode(projectId);
+            if (projectCode is not null)
+            {
+                var projectFolder = Path.Join(config.Value.ProjectStorageRoot, $"{projectCode}-{projectId}");
+                var crdtFile = Path.Join(projectFolder, "crdt.sqlite");
+                if (Path.Exists(crdtFile))
+                {
+                    var project = new CrdtProject("crdt", crdtFile);
+                    projectsService.SetProjectScope(project);
+                    await context.RequestServices.GetRequiredService<CurrentProjectService>().PopulateProjectDataCache();
+                }
+            }
+        }
+        await next();
+    }
+}

--- a/backend/FwHeadless/Services/ProjectContextFromIdService.cs
+++ b/backend/FwHeadless/Services/ProjectContextFromIdService.cs
@@ -15,7 +15,7 @@ public class ProjectContextFromIdService(IOptions<FwHeadlessConfig> config, Crdt
             {
                 var projectFolder = Path.Join(config.Value.ProjectStorageRoot, $"{projectCode}-{projectId}");
                 var crdtFile = Path.Join(projectFolder, "crdt.sqlite");
-                if (Path.Exists(crdtFile))
+                if (File.Exists(crdtFile))
                 {
                     var project = new CrdtProject("crdt", crdtFile);
                     projectsService.SetProjectScope(project);

--- a/backend/FwHeadless/Services/ProjectLookupService.cs
+++ b/backend/FwHeadless/Services/ProjectLookupService.cs
@@ -2,7 +2,7 @@ using LexData;
 using Microsoft.EntityFrameworkCore;
 using SIL.Harmony.Core;
 
-namespace FwHeadless;
+namespace FwHeadless.Services;
 
 public class ProjectLookupService(LexBoxDbContext dbContext)
 {

--- a/backend/FwHeadless/Services/ProjectLookupService.cs
+++ b/backend/FwHeadless/Services/ProjectLookupService.cs
@@ -15,6 +15,11 @@ public class ProjectLookupService(LexBoxDbContext dbContext)
         return projectCode;
     }
 
+    public async Task<bool> ProjectExists(Guid projectId)
+    {
+        return await dbContext.Projects.AnyAsync(p => p.Id == projectId);
+    }
+
     public async Task<bool> IsCrdtProject(Guid projectId)
     {
         return await dbContext.Set<ServerCommit>().AnyAsync(c => c.ProjectId == projectId);

--- a/backend/FwHeadless/Services/ProjectSyncStatusService.cs
+++ b/backend/FwHeadless/Services/ProjectSyncStatusService.cs
@@ -22,24 +22,6 @@ public class ProjectSyncStatusService()
     }
 }
 
-public class ProjectSyncStatusUpdater : IDisposable
-{
-    private readonly Guid _projectId;
-    private readonly ProjectSyncStatusService _statusService;
-
-    public ProjectSyncStatusUpdater(ProjectSyncStatusService statusService, Guid projectId)
-    {
-        _projectId = projectId;
-        _statusService = statusService;
-        _statusService.StartSyncing(_projectId);
-    }
-
-    public void Dispose()
-    {
-        _statusService.StopSyncing(_projectId);
-    }
-}
-
 public enum ProjectSyncStatus
 {
     ReadyToSync,

--- a/backend/FwHeadless/Services/ProjectSyncStatusService.cs
+++ b/backend/FwHeadless/Services/ProjectSyncStatusService.cs
@@ -1,0 +1,47 @@
+using System.Collections.Concurrent;
+
+namespace FwHeadless.Services;
+
+public class ProjectSyncStatusService()
+{
+    private ConcurrentDictionary<Guid, ProjectSyncStatus> Status { get; init; } = new();
+
+    public void StartSyncing(Guid projectId)
+    {
+        Status.AddOrUpdate(projectId, (_) => ProjectSyncStatus.Syncing, (_, _) => ProjectSyncStatus.Syncing);
+    }
+
+    public void StopSyncing(Guid projectId)
+    {
+        Status.AddOrUpdate(projectId, (_) => ProjectSyncStatus.ReadyToSync, (_, _) => ProjectSyncStatus.ReadyToSync);
+    }
+
+    public ProjectSyncStatus? SyncStatus(Guid projectId)
+    {
+        return Status.TryGetValue(projectId, out var status) ? status : null;
+    }
+}
+
+public class ProjectSyncStatusUpdater : IDisposable
+{
+    private readonly Guid _projectId;
+    private readonly ProjectSyncStatusService _statusService;
+
+    public ProjectSyncStatusUpdater(ProjectSyncStatusService statusService, Guid projectId)
+    {
+        _projectId = projectId;
+        _statusService = statusService;
+        _statusService.StartSyncing(_projectId);
+    }
+
+    public void Dispose()
+    {
+        _statusService.StopSyncing(_projectId);
+    }
+}
+
+public enum ProjectSyncStatus
+{
+    ReadyToSync,
+    Syncing,
+}

--- a/backend/FwHeadless/Services/ProjectSyncStatusService.cs
+++ b/backend/FwHeadless/Services/ProjectSyncStatusService.cs
@@ -2,13 +2,13 @@ using System.Collections.Concurrent;
 
 namespace FwHeadless.Services;
 
-public class ProjectSyncStatusService()
+public class SyncJobStatusService()
 {
-    private ConcurrentDictionary<Guid, ProjectSyncStatusEnum> Status { get; init; } = new();
+    private ConcurrentDictionary<Guid, SyncJobStatus> Status { get; init; } = new();
 
     public void StartSyncing(Guid projectId)
     {
-        Status.AddOrUpdate(projectId, (_) => ProjectSyncStatusEnum.Syncing, (_, _) => ProjectSyncStatusEnum.Syncing);
+        Status.AddOrUpdate(projectId, (_) => SyncJobStatus.Running, (_, _) => SyncJobStatus.Running);
     }
 
     public void StopSyncing(Guid projectId)
@@ -16,10 +16,16 @@ public class ProjectSyncStatusService()
         Status.Remove(projectId, out var _);
     }
 
-    public ProjectSyncStatusEnum? SyncStatus(Guid projectId)
+    public SyncJobStatus SyncStatus(Guid projectId)
     {
-        return Status.TryGetValue(projectId, out var status) ? status : null;
+        return Status.TryGetValue(projectId, out var status) ? status : SyncJobStatus.NotRunning;
     }
+}
+
+public enum SyncJobStatus
+{
+    NotRunning,
+    Running,
 }
 
 public enum ProjectSyncStatusEnum

--- a/backend/FwHeadless/Services/ProjectSyncStatusService.cs
+++ b/backend/FwHeadless/Services/ProjectSyncStatusService.cs
@@ -38,6 +38,6 @@ public record ProjectSyncStatus(
     public static ProjectSyncStatus Syncing => new(ProjectSyncStatusEnum.Syncing, 0);
     public static ProjectSyncStatus ReadyToSync(int changes)
     {
-        return new(ProjectSyncStatusEnum.Syncing, changes);
+        return new(ProjectSyncStatusEnum.ReadyToSync, changes);
     }
 }

--- a/backend/FwHeadless/Services/ProjectSyncStatusService.cs
+++ b/backend/FwHeadless/Services/ProjectSyncStatusService.cs
@@ -4,26 +4,40 @@ namespace FwHeadless.Services;
 
 public class ProjectSyncStatusService()
 {
-    private ConcurrentDictionary<Guid, ProjectSyncStatus> Status { get; init; } = new();
+    private ConcurrentDictionary<Guid, ProjectSyncStatusEnum> Status { get; init; } = new();
 
     public void StartSyncing(Guid projectId)
     {
-        Status.AddOrUpdate(projectId, (_) => ProjectSyncStatus.Syncing, (_, _) => ProjectSyncStatus.Syncing);
+        Status.AddOrUpdate(projectId, (_) => ProjectSyncStatusEnum.Syncing, (_, _) => ProjectSyncStatusEnum.Syncing);
     }
 
     public void StopSyncing(Guid projectId)
     {
-        Status.AddOrUpdate(projectId, (_) => ProjectSyncStatus.ReadyToSync, (_, _) => ProjectSyncStatus.ReadyToSync);
+        Status.Remove(projectId, out var _);
     }
 
-    public ProjectSyncStatus? SyncStatus(Guid projectId)
+    public ProjectSyncStatusEnum? SyncStatus(Guid projectId)
     {
         return Status.TryGetValue(projectId, out var status) ? status : null;
     }
 }
 
-public enum ProjectSyncStatus
+public enum ProjectSyncStatusEnum
 {
+    NeverSynced,
     ReadyToSync,
     Syncing,
+}
+
+// TODO: Bikeshed this name
+public record ProjectSyncStatus(
+    ProjectSyncStatusEnum status,
+    int ChangesAvailable)
+{
+    public static ProjectSyncStatus NeverSynced => new(ProjectSyncStatusEnum.NeverSynced, 0);
+    public static ProjectSyncStatus Syncing => new(ProjectSyncStatusEnum.Syncing, 0);
+    public static ProjectSyncStatus ReadyToSync(int changes)
+    {
+        return new(ProjectSyncStatusEnum.Syncing, changes);
+    }
 }

--- a/backend/FwHeadless/Services/SendReceiveHelpers.cs
+++ b/backend/FwHeadless/Services/SendReceiveHelpers.cs
@@ -1,7 +1,7 @@
 using FwDataMiniLcmBridge;
 using SIL.Progress;
 
-namespace FwHeadless;
+namespace FwHeadless.Services;
 
 public static class SendReceiveHelpers
 {

--- a/backend/FwHeadless/Services/SendReceiveService.cs
+++ b/backend/FwHeadless/Services/SendReceiveService.cs
@@ -1,8 +1,7 @@
 using FwDataMiniLcmBridge;
-using FwHeadless.Services;
 using Microsoft.Extensions.Options;
 
-namespace FwHeadless;
+namespace FwHeadless.Services;
 
 public class SendReceiveService(IOptions<FwHeadlessConfig> config, SafeLoggingProgress progress)
 {

--- a/backend/LfClassicData/LfClassicMiniLcmApi.cs
+++ b/backend/LfClassicData/LfClassicMiniLcmApi.cs
@@ -20,6 +20,11 @@ public class LfClassicMiniLcmApi(string projectCode, ProjectDbContext dbContext,
         return AsyncEnumerable.Empty<ComplexFormType>();
     }
 
+    public Task<ComplexFormType?> GetComplexFormType(Guid id)
+    {
+        return Task.FromResult<ComplexFormType?>(null);
+    }
+
     public async Task<WritingSystems> GetWritingSystems()
     {
         var inputSystems = await systemDbContext.Projects.AsQueryable()


### PR DESCRIPTION
Fix #1244.

Creates a new GET `/api/crdt-sync-status` endpoint.

Currently this returns 404 if the project ID does not match any project in the lexbox database. For all other projects, this returns ReadyToSync unless a CRDT sync is currently in progress, in which case it returns Syncing.