### PR TITLE
Project managers invited by email can create projects

### DIFF
--- a/backend/LexBoxApi/Controllers/UserController.cs
+++ b/backend/LexBoxApi/Controllers/UserController.cs
@@ -184,7 +184,7 @@ public class UserController : ControllerBase
             EmailVerified = jwtUser?.Email == input.Email,
             CreatedById = creatorId,
             Locked = false,
-            CanCreateProjects = false
+            CanCreateProjects = jwtUser?.Email == input.Email && jwtUser.CanCreateProjects == true,
         };
         UpdateUserMemberships(jwtUser, userEntity);
         return userEntity;

--- a/backend/LexBoxApi/Services/EmailService.cs
+++ b/backend/LexBoxApi/Services/EmailService.cs
@@ -103,7 +103,7 @@ public class EmailService(
         string? language = null)
     {
         language ??= User.DefaultLocalizationCode;
-        var authUser = CreateUserForInvite(emailAddress, language);
+        var authUser = CreateUserForInvite(emailAddress, language, canCreateProjects: orgRole == OrgRole.Admin);
         authUser.Orgs = [new AuthUserOrg(orgRole, orgId)];
         await SendInvitationEmail(authUser, emailAddress, managerName, orgName, language, isProjectInvitation: false);
 
@@ -124,12 +124,12 @@ public class EmailService(
         string? language = null)
     {
         language ??= User.DefaultLocalizationCode;
-        var authUser = CreateUserForInvite(emailAddress, language);
+        var authUser = CreateUserForInvite(emailAddress, language, canCreateProjects: role == ProjectRole.Manager);
         authUser.Projects = [new AuthUserProject(role, projectId)];
         await SendInvitationEmail(authUser, emailAddress, managerName, projectName, language, isProjectInvitation: true);
 
     }
-    private LexAuthUser CreateUserForInvite(string emailAddress, string? language)
+    private LexAuthUser CreateUserForInvite(string emailAddress, string? language, bool canCreateProjects = false)
     {
         language ??= User.DefaultLocalizationCode;
         return new LexAuthUser
@@ -141,7 +141,7 @@ public class EmailService(
             EmailVerificationRequired = null,
             Role = UserRole.user,
             UpdatedDate = DateTimeOffset.Now.ToUnixTimeSeconds(),
-            CanCreateProjects = null,
+            CanCreateProjects = canCreateProjects ? true : null,
             Locale = language,
             Locked = null,
             Projects = [],


### PR DESCRIPTION
If someone is promoted to manager by other means, they can create projects without needing a draft project approved by an admin. Sending an email invitation to a new user and giving them the project-manager role right off the bat should have the same effect.

We also apply the same logic to org admins: if someone is invited as an org admin, we trust them enough to let them create new projects.

Fixes #1297.