### PR TITLE
Make sync API consistent: always (before, after)

### DIFF
--- a/backend/FwLite/FwDataMiniLcmBridge/Api/FwDataMiniLcmApi.cs
+++ b/backend/FwLite/FwDataMiniLcmBridge/Api/FwDataMiniLcmApi.cs
@@ -220,7 +220,7 @@ public class FwDataMiniLcmApi(Lazy<LcmCache> cacheLazy, bool onCloseSave, ILogge
             "Revert WritingSystem",
             async () =>
             {
-                await WritingSystemSync.Sync(after, before, this);
+                await WritingSystemSync.Sync(before, after, this);
             });
         return await GetWritingSystem(after.WsId, after.Type) ?? throw new NullReferenceException($"unable to find {after.Type} writing system with id {after.WsId}");
     }
@@ -852,7 +852,7 @@ public class FwDataMiniLcmApi(Lazy<LcmCache> cacheLazy, bool onCloseSave, ILogge
             "Revert entry",
             async () =>
             {
-                await EntrySync.Sync(after, before, this);
+                await EntrySync.Sync(before, after, this);
             });
         return await GetEntry(after.Id) ?? throw new NullReferenceException("unable to find entry with id " + after.Id);
     }
@@ -1026,7 +1026,7 @@ public class FwDataMiniLcmApi(Lazy<LcmCache> cacheLazy, bool onCloseSave, ILogge
             "Revert Example Sentence",
             async () =>
             {
-                await ExampleSentenceSync.Sync(entryId, senseId, after, before, this);
+                await ExampleSentenceSync.Sync(entryId, senseId, before, after, this);
             });
         return await GetExampleSentence(entryId, senseId, after.Id) ?? throw new NullReferenceException("unable to find example sentence with id " + after.Id);
     }

--- a/backend/FwLite/FwLiteProjectSync.Tests/EntrySyncTests.cs
+++ b/backend/FwLite/FwLiteProjectSync.Tests/EntrySyncTests.cs
@@ -22,7 +22,7 @@ public class EntrySyncTests : IClassFixture<SyncFixture>
     {
         var createdEntry = await _fixture.CrdtApi.CreateEntry(await AutoFaker.EntryReadyForCreation(_fixture.CrdtApi));
         var after = await AutoFaker.EntryReadyForCreation(_fixture.CrdtApi, entryId: createdEntry.Id);
-        await EntrySync.Sync(after, createdEntry, _fixture.CrdtApi);
+        await EntrySync.Sync(createdEntry, after, _fixture.CrdtApi);
         var actual = await _fixture.CrdtApi.GetEntry(after.Id);
         actual.Should().NotBeNull();
         actual.Should().BeEquivalentTo(after, options => options);
@@ -53,7 +53,7 @@ public class EntrySyncTests : IClassFixture<SyncFixture>
         after.Components[0].ComponentEntryId = component2.Id;
         after.Components[0].ComponentHeadword = component2.Headword();
 
-        await EntrySync.Sync(after, complexForm, _fixture.CrdtApi);
+        await EntrySync.Sync(complexForm, after, _fixture.CrdtApi);
 
         var actual = await _fixture.CrdtApi.GetEntry(after.Id);
         actual.Should().NotBeNull();
@@ -85,7 +85,7 @@ public class EntrySyncTests : IClassFixture<SyncFixture>
         after.ComplexForms[0].ComplexFormEntryId = complexForm2.Id;
         after.ComplexForms[0].ComplexFormHeadword = complexForm2.Headword();
 
-        await EntrySync.Sync(after, component, _fixture.CrdtApi);
+        await EntrySync.Sync(component, after, _fixture.CrdtApi);
 
         var actual = await _fixture.CrdtApi.GetEntry(after.Id);
         actual.Should().NotBeNull();
@@ -99,7 +99,7 @@ public class EntrySyncTests : IClassFixture<SyncFixture>
         var entry = await _fixture.CrdtApi.CreateEntry(new() { LexemeForm = { { "en", "complexForm1" } } });
         var after = (Entry) entry.Copy();
         after.ComplexFormTypes = [complexFormType];
-        await EntrySync.Sync(after, entry, _fixture.CrdtApi);
+        await EntrySync.Sync(entry, after, _fixture.CrdtApi);
 
         var actual = await _fixture.CrdtApi.GetEntry(after.Id);
         actual.Should().NotBeNull();

--- a/backend/FwLite/FwLiteProjectSync/CrdtFwdataProjectSyncService.cs
+++ b/backend/FwLite/FwLiteProjectSync/CrdtFwdataProjectSyncService.cs
@@ -65,26 +65,26 @@ public class CrdtFwdataProjectSyncService(MiniLcmImport miniLcmImport, ILogger<C
         }
 
         var currentFwDataWritingSystems = await fwdataApi.GetWritingSystems();
-        var crdtChanges = await WritingSystemSync.Sync(currentFwDataWritingSystems, projectSnapshot.WritingSystems, crdtApi);
-        var fwdataChanges = await WritingSystemSync.Sync(await crdtApi.GetWritingSystems(), currentFwDataWritingSystems, fwdataApi);
+        var crdtChanges = await WritingSystemSync.Sync(projectSnapshot.WritingSystems, currentFwDataWritingSystems, crdtApi);
+        var fwdataChanges = await WritingSystemSync.Sync(currentFwDataWritingSystems, await crdtApi.GetWritingSystems(), fwdataApi);
 
         var currentFwDataPartsOfSpeech = await fwdataApi.GetPartsOfSpeech().ToArrayAsync();
-        crdtChanges += await PartOfSpeechSync.Sync(currentFwDataPartsOfSpeech, projectSnapshot.PartsOfSpeech, crdtApi);
-        fwdataChanges += await PartOfSpeechSync.Sync(await crdtApi.GetPartsOfSpeech().ToArrayAsync(), currentFwDataPartsOfSpeech, fwdataApi);
+        crdtChanges += await PartOfSpeechSync.Sync(projectSnapshot.PartsOfSpeech, currentFwDataPartsOfSpeech, crdtApi);
+        fwdataChanges += await PartOfSpeechSync.Sync(currentFwDataPartsOfSpeech, await crdtApi.GetPartsOfSpeech().ToArrayAsync(), fwdataApi);
 
         var currentFwDataSemanticDomains = await fwdataApi.GetSemanticDomains().ToArrayAsync();
-        crdtChanges += await SemanticDomainSync.Sync(currentFwDataSemanticDomains, projectSnapshot.SemanticDomains, crdtApi);
-        fwdataChanges += await SemanticDomainSync.Sync(await crdtApi.GetSemanticDomains().ToArrayAsync(), currentFwDataSemanticDomains, fwdataApi);
+        crdtChanges += await SemanticDomainSync.Sync(projectSnapshot.SemanticDomains, currentFwDataSemanticDomains, crdtApi);
+        fwdataChanges += await SemanticDomainSync.Sync(currentFwDataSemanticDomains, await crdtApi.GetSemanticDomains().ToArrayAsync(), fwdataApi);
 
         var currentFwDataComplexFormTypes = await fwdataApi.GetComplexFormTypes().ToArrayAsync();
-        crdtChanges += await ComplexFormTypeSync.Sync(currentFwDataComplexFormTypes, projectSnapshot.ComplexFormTypes, crdtApi);
-        fwdataChanges += await ComplexFormTypeSync.Sync(await crdtApi.GetComplexFormTypes().ToArrayAsync(), currentFwDataComplexFormTypes, fwdataApi);
+        crdtChanges += await ComplexFormTypeSync.Sync(projectSnapshot.ComplexFormTypes, currentFwDataComplexFormTypes, crdtApi);
+        fwdataChanges += await ComplexFormTypeSync.Sync(currentFwDataComplexFormTypes, await crdtApi.GetComplexFormTypes().ToArrayAsync(), fwdataApi);
 
         var currentFwDataEntries = await fwdataApi.GetAllEntries().ToArrayAsync();
-        crdtChanges += await EntrySync.Sync(currentFwDataEntries, projectSnapshot.Entries, crdtApi);
+        crdtChanges += await EntrySync.Sync(projectSnapshot.Entries, currentFwDataEntries, crdtApi);
         LogDryRun(crdtApi, "crdt");
 
-        fwdataChanges += await EntrySync.Sync(await crdtApi.GetAllEntries().ToArrayAsync(), currentFwDataEntries, fwdataApi);
+        fwdataChanges += await EntrySync.Sync(currentFwDataEntries, await crdtApi.GetAllEntries().ToArrayAsync(), fwdataApi);
         LogDryRun(fwdataApi, "fwdata");
 
         //todo push crdt changes to lexbox

--- a/backend/FwLite/LcmCrdt/CrdtMiniLcmApi.cs
+++ b/backend/FwLite/LcmCrdt/CrdtMiniLcmApi.cs
@@ -61,7 +61,7 @@ public class CrdtMiniLcmApi(DataModel dataModel, CurrentProjectService projectSe
 
     public async Task<WritingSystem> UpdateWritingSystem(WritingSystem before, WritingSystem after)
     {
-        await WritingSystemSync.Sync(after, before, this);
+        await WritingSystemSync.Sync(before, after, this);
         return await GetWritingSystem(after.WsId, after.Type) ?? throw new NullReferenceException("unable to find writing system with id " + after.WsId);
     }
 
@@ -427,7 +427,7 @@ public class CrdtMiniLcmApi(DataModel dataModel, CurrentProjectService projectSe
 
     public async Task<Entry> UpdateEntry(Entry before, Entry after)
     {
-        await EntrySync.Sync(after, before, this);
+        await EntrySync.Sync(before, after, this);
         return await GetEntry(after.Id) ?? throw new NullReferenceException("unable to find entry with id " + after.Id);
     }
 
@@ -519,7 +519,7 @@ public class CrdtMiniLcmApi(DataModel dataModel, CurrentProjectService projectSe
         ExampleSentence before,
         ExampleSentence after)
     {
-        await ExampleSentenceSync.Sync(entryId, senseId, after, before, this);
+        await ExampleSentenceSync.Sync(entryId, senseId, before, after, this);
         return await GetExampleSentence(entryId, senseId, after.Id) ?? throw new NullReferenceException();
     }
 

--- a/backend/FwLite/MiniLcm/SyncHelpers/ComplexFormTypeSync.cs
+++ b/backend/FwLite/MiniLcm/SyncHelpers/ComplexFormTypeSync.cs
@@ -5,8 +5,8 @@ namespace MiniLcm.SyncHelpers;
 
 public static class ComplexFormTypeSync
 {
-    public static async Task<int> Sync(ComplexFormType[] afterComplexFormTypes,
-        ComplexFormType[] beforeComplexFormTypes,
+    public static async Task<int> Sync(ComplexFormType[] beforeComplexFormTypes,
+        ComplexFormType[] afterComplexFormTypes,
         IMiniLcmApi api)
     {
         return await DiffCollection.Diff(api,

--- a/backend/FwLite/MiniLcm/SyncHelpers/ExampleSentenceSync.cs
+++ b/backend/FwLite/MiniLcm/SyncHelpers/ExampleSentenceSync.cs
@@ -7,8 +7,8 @@ public static class ExampleSentenceSync
 {
     public static async Task<int> Sync(Guid entryId,
         Guid senseId,
-        IList<ExampleSentence> afterExampleSentences,
         IList<ExampleSentence> beforeExampleSentences,
+        IList<ExampleSentence> afterExampleSentences,
         IMiniLcmApi api)
     {
         Func<IMiniLcmApi, ExampleSentence, Task<int>> add = async (api, afterExampleSentence) =>
@@ -23,7 +23,7 @@ public static class ExampleSentenceSync
         };
         Func<IMiniLcmApi, ExampleSentence, ExampleSentence, Task<int>> replace =
             (api, beforeExampleSentence, afterExampleSentence) =>
-                Sync(entryId, senseId, afterExampleSentence, beforeExampleSentence, api);
+                Sync(entryId, senseId, beforeExampleSentence, afterExampleSentence, api);
         return await DiffCollection.Diff(api,
             beforeExampleSentences,
             afterExampleSentences,
@@ -34,8 +34,8 @@ public static class ExampleSentenceSync
 
     public static async Task<int> Sync(Guid entryId,
         Guid senseId,
-        ExampleSentence afterExampleSentence,
         ExampleSentence beforeExampleSentence,
+        ExampleSentence afterExampleSentence,
         IMiniLcmApi api)
     {
         var updateObjectInput = DiffToUpdate(beforeExampleSentence, afterExampleSentence);

--- a/backend/FwLite/MiniLcm/SyncHelpers/PartOfSpeechSync.cs
+++ b/backend/FwLite/MiniLcm/SyncHelpers/PartOfSpeechSync.cs
@@ -5,8 +5,8 @@ namespace MiniLcm.SyncHelpers;
 
 public static class PartOfSpeechSync
 {
-    public static async Task<int> Sync(PartOfSpeech[] currentPartsOfSpeech,
-        PartOfSpeech[] previousPartsOfSpeech,
+    public static async Task<int> Sync(PartOfSpeech[] previousPartsOfSpeech,
+        PartOfSpeech[] currentPartsOfSpeech,
         IMiniLcmApi api)
     {
         return await DiffCollection.Diff(api,

--- a/backend/FwLite/MiniLcm/SyncHelpers/PartOfSpeechSync.cs
+++ b/backend/FwLite/MiniLcm/SyncHelpers/PartOfSpeechSync.cs
@@ -5,25 +5,25 @@ namespace MiniLcm.SyncHelpers;
 
 public static class PartOfSpeechSync
 {
-    public static async Task<int> Sync(PartOfSpeech[] previousPartsOfSpeech,
-        PartOfSpeech[] currentPartsOfSpeech,
+    public static async Task<int> Sync(PartOfSpeech[] beforePartsOfSpeech,
+        PartOfSpeech[] afterPartsOfSpeech,
         IMiniLcmApi api)
     {
         return await DiffCollection.Diff(api,
-            previousPartsOfSpeech,
-            currentPartsOfSpeech,
+            beforePartsOfSpeech,
+            afterPartsOfSpeech,
             pos => pos.Id,
-            async (api, currentPos) =>
+            async (api, afterPos) =>
             {
-                await api.CreatePartOfSpeech(currentPos);
+                await api.CreatePartOfSpeech(afterPos);
                 return 1;
             },
-            async (api, previousPos) =>
+            async (api, beforePos) =>
             {
-                await api.DeletePartOfSpeech(previousPos.Id);
+                await api.DeletePartOfSpeech(beforePos.Id);
                 return 1;
             },
-            (api, previousPos, currentPos) => Sync(previousPos, currentPos, api));
+            (api, beforePos, afterPos) => Sync(beforePos, afterPos, api));
     }
 
     public static async Task<int> Sync(PartOfSpeech before,
@@ -35,12 +35,12 @@ public static class PartOfSpeechSync
         return updateObjectInput is null ? 0 : 1;
     }
 
-    public static UpdateObjectInput<PartOfSpeech>? PartOfSpeechDiffToUpdate(PartOfSpeech previousPartOfSpeech, PartOfSpeech currentPartOfSpeech)
+    public static UpdateObjectInput<PartOfSpeech>? PartOfSpeechDiffToUpdate(PartOfSpeech beforePartOfSpeech, PartOfSpeech afterPartOfSpeech)
     {
         JsonPatchDocument<PartOfSpeech> patchDocument = new();
         patchDocument.Operations.AddRange(MultiStringDiff.GetMultiStringDiff<PartOfSpeech>(nameof(PartOfSpeech.Name),
-            previousPartOfSpeech.Name,
-            currentPartOfSpeech.Name));
+            beforePartOfSpeech.Name,
+            afterPartOfSpeech.Name));
         // TODO: Once we add abbreviations to MiniLcm's PartOfSpeech objects, then:
         // patchDocument.Operations.AddRange(GetMultiStringDiff<PartOfSpeech>(nameof(PartOfSpeech.Abbreviation),
         //     previousPartOfSpeech.Abbreviation,

--- a/backend/FwLite/MiniLcm/SyncHelpers/SemanticDomainSync.cs
+++ b/backend/FwLite/MiniLcm/SyncHelpers/SemanticDomainSync.cs
@@ -5,25 +5,25 @@ namespace MiniLcm.SyncHelpers;
 
 public static class SemanticDomainSync
 {
-    public static async Task<int> Sync(SemanticDomain[] previousSemanticDomains,
-        SemanticDomain[] currentSemanticDomains,
+    public static async Task<int> Sync(SemanticDomain[] beforeSemanticDomains,
+        SemanticDomain[] afterSemanticDomains,
         IMiniLcmApi api)
     {
         return await DiffCollection.Diff(api,
-            previousSemanticDomains,
-            currentSemanticDomains,
+            beforeSemanticDomains,
+            afterSemanticDomains,
             pos => pos.Id,
-            async (api, currentPos) =>
+            async (api, afterPos) =>
             {
-                await api.CreateSemanticDomain(currentPos);
+                await api.CreateSemanticDomain(afterPos);
                 return 1;
             },
-            async (api, previousPos) =>
+            async (api, beforePos) =>
             {
-                await api.DeleteSemanticDomain(previousPos.Id);
+                await api.DeleteSemanticDomain(beforePos.Id);
                 return 1;
             },
-            (api, previousSemdom, currentSemdom) => Sync(previousSemdom, currentSemdom, api));
+            (api, beforeSemdom, afterSemdom) => Sync(beforeSemdom, afterSemdom, api));
     }
 
     public static async Task<int> Sync(SemanticDomain before,
@@ -35,12 +35,12 @@ public static class SemanticDomainSync
         return updateObjectInput is null ? 0 : 1;
     }
 
-    public static UpdateObjectInput<SemanticDomain>? SemanticDomainDiffToUpdate(SemanticDomain previousSemanticDomain, SemanticDomain currentSemanticDomain)
+    public static UpdateObjectInput<SemanticDomain>? SemanticDomainDiffToUpdate(SemanticDomain beforeSemanticDomain, SemanticDomain afterSemanticDomain)
     {
         JsonPatchDocument<SemanticDomain> patchDocument = new();
         patchDocument.Operations.AddRange(MultiStringDiff.GetMultiStringDiff<SemanticDomain>(nameof(SemanticDomain.Name),
-            previousSemanticDomain.Name,
-            currentSemanticDomain.Name));
+            beforeSemanticDomain.Name,
+            afterSemanticDomain.Name));
         // TODO: Once we add abbreviations to MiniLcm's SemanticDomain objects, then:
         // patchDocument.Operations.AddRange(GetMultiStringDiff<SemanticDomain>(nameof(SemanticDomain.Abbreviation),
         //     previousSemanticDomain.Abbreviation,

--- a/backend/FwLite/MiniLcm/SyncHelpers/SemanticDomainSync.cs
+++ b/backend/FwLite/MiniLcm/SyncHelpers/SemanticDomainSync.cs
@@ -5,8 +5,8 @@ namespace MiniLcm.SyncHelpers;
 
 public static class SemanticDomainSync
 {
-    public static async Task<int> Sync(SemanticDomain[] currentSemanticDomains,
-        SemanticDomain[] previousSemanticDomains,
+    public static async Task<int> Sync(SemanticDomain[] previousSemanticDomains,
+        SemanticDomain[] currentSemanticDomains,
         IMiniLcmApi api)
     {
         return await DiffCollection.Diff(api,

--- a/backend/FwLite/MiniLcm/SyncHelpers/SenseSync.cs
+++ b/backend/FwLite/MiniLcm/SyncHelpers/SenseSync.cs
@@ -6,16 +6,16 @@ namespace MiniLcm.SyncHelpers;
 public static class SenseSync
 {
     public static async Task<int> Sync(Guid entryId,
-        Sense afterSense,
         Sense beforeSense,
+        Sense afterSense,
         IMiniLcmApi api)
     {
         var updateObjectInput = await SenseDiffToUpdate(beforeSense, afterSense);
         if (updateObjectInput is not null) await api.UpdateSense(entryId, beforeSense.Id, updateObjectInput);
         var changes = await ExampleSentenceSync.Sync(entryId,
             beforeSense.Id,
-            afterSense.ExampleSentences,
             beforeSense.ExampleSentences,
+            afterSense.ExampleSentences,
             api);
         return changes + (updateObjectInput is null ? 0 : 1);
     }

--- a/backend/FwLite/MiniLcm/SyncHelpers/WritingSystemSync.cs
+++ b/backend/FwLite/MiniLcm/SyncHelpers/WritingSystemSync.cs
@@ -5,35 +5,35 @@ namespace MiniLcm.SyncHelpers;
 
 public static class WritingSystemSync
 {
-    public static async Task<int> Sync(WritingSystems previousWritingSystems,
-        WritingSystems currentWritingSystems,
+    public static async Task<int> Sync(WritingSystems beforeWritingSystems,
+        WritingSystems afterWritingSystems,
         IMiniLcmApi api)
     {
-        return await Sync(previousWritingSystems.Vernacular, currentWritingSystems.Vernacular, api) +
-               await Sync(previousWritingSystems.Analysis, currentWritingSystems.Analysis, api);
+        return await Sync(beforeWritingSystems.Vernacular, afterWritingSystems.Vernacular, api) +
+               await Sync(beforeWritingSystems.Analysis, afterWritingSystems.Analysis, api);
     }
-    public static async Task<int> Sync(WritingSystem[] previousWritingSystems,
-        WritingSystem[] currentWritingSystems,
+    public static async Task<int> Sync(WritingSystem[] beforeWritingSystems,
+        WritingSystem[] afterWritingSystems,
         IMiniLcmApi api)
     {
         return await DiffCollection.Diff(api,
-            previousWritingSystems,
-            currentWritingSystems,
+            beforeWritingSystems,
+            afterWritingSystems,
             ws => (ws.WsId, ws.Type),
-            async (api, currentWs) =>
+            async (api, afterWs) =>
             {
-                await api.CreateWritingSystem(currentWs.Type, currentWs);
+                await api.CreateWritingSystem(afterWs.Type, afterWs);
                 return 1;
             },
-            async (api, previousWs) =>
+            async (api, beforeWs) =>
             {
-                // await api.DeleteWritingSystem(previousWs.Id); // Deleting writing systems is dangerous as it causes cascading data deletion. Needs careful thought.
+                // await api.DeleteWritingSystem(beforeWs.Id); // Deleting writing systems is dangerous as it causes cascading data deletion. Needs careful thought.
                 // TODO: should we throw an exception?
                 return 0;
             },
-            async (api, previousWs, currentWs) =>
+            async (api, beforeWs, afterWs) =>
             {
-                return await Sync(previousWs, currentWs, api);
+                return await Sync(beforeWs, afterWs, api);
             });
     }
 
@@ -44,23 +44,23 @@ public static class WritingSystemSync
         return updateObjectInput is null ? 0 : 1;
     }
 
-    public static UpdateObjectInput<WritingSystem>? WritingSystemDiffToUpdate(WritingSystem previousWritingSystem, WritingSystem currentWritingSystem)
+    public static UpdateObjectInput<WritingSystem>? WritingSystemDiffToUpdate(WritingSystem beforeWritingSystem, WritingSystem afterWritingSystem)
     {
         JsonPatchDocument<WritingSystem> patchDocument = new();
-        if (previousWritingSystem.WsId != currentWritingSystem.WsId)
+        if (beforeWritingSystem.WsId != afterWritingSystem.WsId)
         {
             // TODO: Throw? Or silently ignore?
-            throw new InvalidOperationException($"Tried to change immutable WsId from {previousWritingSystem.WsId} to {currentWritingSystem.WsId}");
+            throw new InvalidOperationException($"Tried to change immutable WsId from {beforeWritingSystem.WsId} to {afterWritingSystem.WsId}");
         }
         patchDocument.Operations.AddRange(SimpleStringDiff.GetStringDiff<WritingSystem>(nameof(WritingSystem.Name),
-            previousWritingSystem.Name,
-            currentWritingSystem.Name));
+            beforeWritingSystem.Name,
+            afterWritingSystem.Name));
         patchDocument.Operations.AddRange(SimpleStringDiff.GetStringDiff<WritingSystem>(nameof(WritingSystem.Abbreviation),
-            previousWritingSystem.Abbreviation,
-            currentWritingSystem.Abbreviation));
+            beforeWritingSystem.Abbreviation,
+            afterWritingSystem.Abbreviation));
         patchDocument.Operations.AddRange(SimpleStringDiff.GetStringDiff<WritingSystem>(nameof(WritingSystem.Font),
-            previousWritingSystem.Font,
-            currentWritingSystem.Font));
+            beforeWritingSystem.Font,
+            afterWritingSystem.Font));
         // TODO: Exemplars, Order, and do we need DeletedAt?
         if (patchDocument.Operations.Count == 0) return null;
         return new UpdateObjectInput<WritingSystem>(patchDocument);

--- a/backend/FwLite/MiniLcm/SyncHelpers/WritingSystemSync.cs
+++ b/backend/FwLite/MiniLcm/SyncHelpers/WritingSystemSync.cs
@@ -5,15 +5,15 @@ namespace MiniLcm.SyncHelpers;
 
 public static class WritingSystemSync
 {
-    public static async Task<int> Sync(WritingSystems currentWritingSystems,
-        WritingSystems previousWritingSystems,
+    public static async Task<int> Sync(WritingSystems previousWritingSystems,
+        WritingSystems currentWritingSystems,
         IMiniLcmApi api)
     {
-        return await Sync(currentWritingSystems.Vernacular, previousWritingSystems.Vernacular, api) +
-               await Sync(currentWritingSystems.Analysis, previousWritingSystems.Analysis, api);
+        return await Sync(previousWritingSystems.Vernacular, currentWritingSystems.Vernacular, api) +
+               await Sync(previousWritingSystems.Analysis, currentWritingSystems.Analysis, api);
     }
-    public static async Task<int> Sync(WritingSystem[] currentWritingSystems,
-        WritingSystem[] previousWritingSystems,
+    public static async Task<int> Sync(WritingSystem[] previousWritingSystems,
+        WritingSystem[] currentWritingSystems,
         IMiniLcmApi api)
     {
         return await DiffCollection.Diff(api,
@@ -33,11 +33,11 @@ public static class WritingSystemSync
             },
             async (api, previousWs, currentWs) =>
             {
-                return await Sync(currentWs, previousWs, api);
+                return await Sync(previousWs, currentWs, api);
             });
     }
 
-    public static async Task<int> Sync(WritingSystem afterWs, WritingSystem beforeWs, IMiniLcmApi api)
+    public static async Task<int> Sync(WritingSystem beforeWs, WritingSystem afterWs, IMiniLcmApi api)
     {
         var updateObjectInput = WritingSystemDiffToUpdate(beforeWs, afterWs);
         if (updateObjectInput is not null) await api.UpdateWritingSystem(afterWs.WsId, afterWs.Type, updateObjectInput);


### PR DESCRIPTION
Also update all call sites so that code behavior remains the same.

Fix #1293.