### PR TITLE
Make sync API consistent: always (before, after)

### DIFF
--- a/backend/FwLite/FwDataMiniLcmBridge/Api/FwDataMiniLcmApi.cs
+++ b/backend/FwLite/FwDataMiniLcmBridge/Api/FwDataMiniLcmApi.cs
@@ -224,7 +224,7 @@ public class FwDataMiniLcmApi(Lazy<LcmCache> cacheLazy, bool onCloseSave, ILogge
             "Revert WritingSystem",
             async () =>
             {
-                await WritingSystemSync.Sync(after, before, this);
+                await WritingSystemSync.Sync(before, after, this);
             });
         return await GetWritingSystem(after.WsId, after.Type) ?? throw new NullReferenceException($"unable to find {after.Type} writing system with id {after.WsId}");
     }
@@ -856,7 +856,7 @@ public class FwDataMiniLcmApi(Lazy<LcmCache> cacheLazy, bool onCloseSave, ILogge
             "Revert entry",
             async () =>
             {
-                await EntrySync.Sync(after, before, this);
+                await EntrySync.Sync(before, after, this);
             });
         return await GetEntry(after.Id) ?? throw new NullReferenceException("unable to find entry with id " + after.Id);
     }
@@ -990,7 +990,7 @@ public class FwDataMiniLcmApi(Lazy<LcmCache> cacheLazy, bool onCloseSave, ILogge
             "Revert Sense",
             async () =>
             {
-                await SenseSync.Sync(entryId, after, before, this);
+                await SenseSync.Sync(entryId, before, after, this);
             });
         return await GetSense(entryId, after.Id) ?? throw new NullReferenceException("unable to find sense with id " + after.Id);
     }
@@ -1106,7 +1106,7 @@ public class FwDataMiniLcmApi(Lazy<LcmCache> cacheLazy, bool onCloseSave, ILogge
             "Revert Example Sentence",
             async () =>
             {
-                await ExampleSentenceSync.Sync(entryId, senseId, after, before, this);
+                await ExampleSentenceSync.Sync(entryId, senseId, before, after, this);
             });
         return await GetExampleSentence(entryId, senseId, after.Id) ?? throw new NullReferenceException("unable to find example sentence with id " + after.Id);
     }

--- a/backend/FwLite/FwLiteProjectSync.Tests/EntrySyncTests.cs
+++ b/backend/FwLite/FwLiteProjectSync.Tests/EntrySyncTests.cs
@@ -33,13 +33,13 @@ public class EntrySyncTests : IClassFixture<SyncFixture>
         var createdEntry = await _fixture.CrdtApi.CreateEntry(await AutoFaker.EntryReadyForCreation(_fixture.CrdtApi));
         var after = await AutoFaker.EntryReadyForCreation(_fixture.CrdtApi, entryId: createdEntry.Id);
 
-        after.Senses = AutoFaker.Faker.Random.Shuffle([
+        after.Senses = [.. AutoFaker.Faker.Random.Shuffle([
                 // copy some senses over, so moves happen
                 ..AutoFaker.Faker.Random.ListItems(createdEntry.Senses),
-                ..(after.Senses)
-            ]).ToList();
+                ..after.Senses
+            ])];
 
-        await EntrySync.Sync(after, createdEntry, _fixture.CrdtApi);
+        await EntrySync.Sync(createdEntry, after, _fixture.CrdtApi);
         var actual = await _fixture.CrdtApi.GetEntry(after.Id);
         actual.Should().NotBeNull();
         actual.Should().BeEquivalentTo(after, options => options
@@ -71,7 +71,7 @@ public class EntrySyncTests : IClassFixture<SyncFixture>
         after.Components[0].ComponentEntryId = component2.Id;
         after.Components[0].ComponentHeadword = component2.Headword();
 
-        await EntrySync.Sync(after, complexForm, _fixture.CrdtApi);
+        await EntrySync.Sync(complexForm, after, _fixture.CrdtApi);
 
         var actual = await _fixture.CrdtApi.GetEntry(after.Id);
         actual.Should().NotBeNull();
@@ -103,7 +103,7 @@ public class EntrySyncTests : IClassFixture<SyncFixture>
         after.ComplexForms[0].ComplexFormEntryId = complexForm2.Id;
         after.ComplexForms[0].ComplexFormHeadword = complexForm2.Headword();
 
-        await EntrySync.Sync(after, component, _fixture.CrdtApi);
+        await EntrySync.Sync(component, after, _fixture.CrdtApi);
 
         var actual = await _fixture.CrdtApi.GetEntry(after.Id);
         actual.Should().NotBeNull();
@@ -117,7 +117,7 @@ public class EntrySyncTests : IClassFixture<SyncFixture>
         var entry = await _fixture.CrdtApi.CreateEntry(new() { LexemeForm = { { "en", "complexForm1" } } });
         var after = (Entry) entry.Copy();
         after.ComplexFormTypes = [complexFormType];
-        await EntrySync.Sync(after, entry, _fixture.CrdtApi);
+        await EntrySync.Sync(entry, after, _fixture.CrdtApi);
 
         var actual = await _fixture.CrdtApi.GetEntry(after.Id);
         actual.Should().NotBeNull();

--- a/backend/FwLite/FwLiteProjectSync.Tests/UpdateDiffTests.cs
+++ b/backend/FwLite/FwLiteProjectSync.Tests/UpdateDiffTests.cs
@@ -27,7 +27,7 @@ public class UpdateDiffTests
         var entryDiffToUpdate = EntrySync.EntryDiffToUpdate(before, after);
         ArgumentNullException.ThrowIfNull(entryDiffToUpdate);
         entryDiffToUpdate.Apply(before);
-         before.Should().BeEquivalentTo(after, options => options.Excluding(x => x.Id)
+        before.Should().BeEquivalentTo(after, options => options.Excluding(x => x.Id)
             .Excluding(x => x.DeletedAt).Excluding(x => x.Senses)
             .Excluding(x => x.Components)
             .Excluding(x => x.ComplexForms)
@@ -35,11 +35,11 @@ public class UpdateDiffTests
     }
 
     [Fact]
-    public async Task SenseDiffShouldUpdateAllFields()
+    public void SenseDiffShouldUpdateAllFields()
     {
         var before = new Sense();
         var after = AutoFaker.Generate<Sense>();
-        var senseDiffToUpdate = await SenseSync.SenseDiffToUpdate(before, after);
+        var senseDiffToUpdate = SenseSync.SenseDiffToUpdate(before, after);
         ArgumentNullException.ThrowIfNull(senseDiffToUpdate);
         senseDiffToUpdate.Apply(before);
         before.Should().BeEquivalentTo(after, options => options.Excluding(x => x.Id).Excluding(x => x.EntryId).Excluding(x => x.DeletedAt).Excluding(x => x.ExampleSentences).Excluding(x => x.SemanticDomains));

--- a/backend/FwLite/FwLiteProjectSync/CrdtFwdataProjectSyncService.cs
+++ b/backend/FwLite/FwLiteProjectSync/CrdtFwdataProjectSyncService.cs
@@ -65,26 +65,26 @@ public class CrdtFwdataProjectSyncService(MiniLcmImport miniLcmImport, ILogger<C
         }
 
         var currentFwDataWritingSystems = await fwdataApi.GetWritingSystems();
-        var crdtChanges = await WritingSystemSync.Sync(currentFwDataWritingSystems, projectSnapshot.WritingSystems, crdtApi);
-        var fwdataChanges = await WritingSystemSync.Sync(await crdtApi.GetWritingSystems(), currentFwDataWritingSystems, fwdataApi);
+        var crdtChanges = await WritingSystemSync.Sync(projectSnapshot.WritingSystems, currentFwDataWritingSystems, crdtApi);
+        var fwdataChanges = await WritingSystemSync.Sync(currentFwDataWritingSystems, await crdtApi.GetWritingSystems(), fwdataApi);
 
         var currentFwDataPartsOfSpeech = await fwdataApi.GetPartsOfSpeech().ToArrayAsync();
-        crdtChanges += await PartOfSpeechSync.Sync(currentFwDataPartsOfSpeech, projectSnapshot.PartsOfSpeech, crdtApi);
-        fwdataChanges += await PartOfSpeechSync.Sync(await crdtApi.GetPartsOfSpeech().ToArrayAsync(), currentFwDataPartsOfSpeech, fwdataApi);
+        crdtChanges += await PartOfSpeechSync.Sync(projectSnapshot.PartsOfSpeech, currentFwDataPartsOfSpeech, crdtApi);
+        fwdataChanges += await PartOfSpeechSync.Sync(currentFwDataPartsOfSpeech, await crdtApi.GetPartsOfSpeech().ToArrayAsync(), fwdataApi);
 
         var currentFwDataSemanticDomains = await fwdataApi.GetSemanticDomains().ToArrayAsync();
-        crdtChanges += await SemanticDomainSync.Sync(currentFwDataSemanticDomains, projectSnapshot.SemanticDomains, crdtApi);
-        fwdataChanges += await SemanticDomainSync.Sync(await crdtApi.GetSemanticDomains().ToArrayAsync(), currentFwDataSemanticDomains, fwdataApi);
+        crdtChanges += await SemanticDomainSync.Sync(projectSnapshot.SemanticDomains, currentFwDataSemanticDomains, crdtApi);
+        fwdataChanges += await SemanticDomainSync.Sync(currentFwDataSemanticDomains, await crdtApi.GetSemanticDomains().ToArrayAsync(), fwdataApi);
 
         var currentFwDataComplexFormTypes = await fwdataApi.GetComplexFormTypes().ToArrayAsync();
-        crdtChanges += await ComplexFormTypeSync.Sync(currentFwDataComplexFormTypes, projectSnapshot.ComplexFormTypes, crdtApi);
-        fwdataChanges += await ComplexFormTypeSync.Sync(await crdtApi.GetComplexFormTypes().ToArrayAsync(), currentFwDataComplexFormTypes, fwdataApi);
+        crdtChanges += await ComplexFormTypeSync.Sync(projectSnapshot.ComplexFormTypes, currentFwDataComplexFormTypes, crdtApi);
+        fwdataChanges += await ComplexFormTypeSync.Sync(currentFwDataComplexFormTypes, await crdtApi.GetComplexFormTypes().ToArrayAsync(), fwdataApi);
 
         var currentFwDataEntries = await fwdataApi.GetAllEntries().ToArrayAsync();
-        crdtChanges += await EntrySync.Sync(currentFwDataEntries, projectSnapshot.Entries, crdtApi);
+        crdtChanges += await EntrySync.Sync(projectSnapshot.Entries, currentFwDataEntries, crdtApi);
         LogDryRun(crdtApi, "crdt");
 
-        fwdataChanges += await EntrySync.Sync(await crdtApi.GetAllEntries().ToArrayAsync(), currentFwDataEntries, fwdataApi);
+        fwdataChanges += await EntrySync.Sync(currentFwDataEntries, await crdtApi.GetAllEntries().ToArrayAsync(), fwdataApi);
         LogDryRun(fwdataApi, "fwdata");
 
         //todo push crdt changes to lexbox

--- a/backend/FwLite/LcmCrdt/CrdtMiniLcmApi.cs
+++ b/backend/FwLite/LcmCrdt/CrdtMiniLcmApi.cs
@@ -69,7 +69,7 @@ public class CrdtMiniLcmApi(DataModel dataModel, CurrentProjectService projectSe
 
     public async Task<WritingSystem> UpdateWritingSystem(WritingSystem before, WritingSystem after)
     {
-        await WritingSystemSync.Sync(after, before, this);
+        await WritingSystemSync.Sync(before, after, this);
         return await GetWritingSystem(after.WsId, after.Type) ?? throw new NullReferenceException("unable to find writing system with id " + after.WsId);
     }
 
@@ -448,7 +448,7 @@ public class CrdtMiniLcmApi(DataModel dataModel, CurrentProjectService projectSe
 
     public async Task<Entry> UpdateEntry(Entry before, Entry after)
     {
-        await EntrySync.Sync(after, before, this);
+        await EntrySync.Sync(before, after, this);
         return await GetEntry(after.Id) ?? throw new NullReferenceException("unable to find entry with id " + after.Id);
     }
 
@@ -509,7 +509,7 @@ public class CrdtMiniLcmApi(DataModel dataModel, CurrentProjectService projectSe
 
     public async Task<Sense> UpdateSense(Guid entryId, Sense before, Sense after)
     {
-        await SenseSync.Sync(entryId, after, before, this);
+        await SenseSync.Sync(entryId, before, after, this);
         return await GetSense(entryId, after.Id) ?? throw new NullReferenceException("unable to find sense with id " + after.Id);
     }
 
@@ -566,7 +566,7 @@ public class CrdtMiniLcmApi(DataModel dataModel, CurrentProjectService projectSe
         ExampleSentence before,
         ExampleSentence after)
     {
-        await ExampleSentenceSync.Sync(entryId, senseId, after, before, this);
+        await ExampleSentenceSync.Sync(entryId, senseId, before, after, this);
         return await GetExampleSentence(entryId, senseId, after.Id) ?? throw new NullReferenceException();
     }
 

--- a/backend/FwLite/MiniLcm/SyncHelpers/ComplexFormTypeSync.cs
+++ b/backend/FwLite/MiniLcm/SyncHelpers/ComplexFormTypeSync.cs
@@ -5,8 +5,8 @@ namespace MiniLcm.SyncHelpers;
 
 public static class ComplexFormTypeSync
 {
-    public static async Task<int> Sync(ComplexFormType[] afterComplexFormTypes,
-        ComplexFormType[] beforeComplexFormTypes,
+    public static async Task<int> Sync(ComplexFormType[] beforeComplexFormTypes,
+        ComplexFormType[] afterComplexFormTypes,
         IMiniLcmApi api)
     {
         return await DiffCollection.Diff(

--- a/backend/FwLite/MiniLcm/SyncHelpers/ExampleSentenceSync.cs
+++ b/backend/FwLite/MiniLcm/SyncHelpers/ExampleSentenceSync.cs
@@ -7,8 +7,8 @@ public static class ExampleSentenceSync
 {
     public static async Task<int> Sync(Guid entryId,
         Guid senseId,
-        IList<ExampleSentence> afterExampleSentences,
         IList<ExampleSentence> beforeExampleSentences,
+        IList<ExampleSentence> afterExampleSentences,
         IMiniLcmApi api)
     {
         return await DiffCollection.Diff(
@@ -19,8 +19,8 @@ public static class ExampleSentenceSync
 
     public static async Task<int> Sync(Guid entryId,
         Guid senseId,
-        ExampleSentence afterExampleSentence,
         ExampleSentence beforeExampleSentence,
+        ExampleSentence afterExampleSentence,
         IMiniLcmApi api)
     {
         var updateObjectInput = DiffToUpdate(beforeExampleSentence, afterExampleSentence);
@@ -66,7 +66,7 @@ public static class ExampleSentenceSync
 
         public override Task<int> Replace(ExampleSentence beforeExampleSentence, ExampleSentence afterExampleSentence)
         {
-            return Sync(entryId, senseId, afterExampleSentence, beforeExampleSentence, api);
+            return Sync(entryId, senseId, beforeExampleSentence, afterExampleSentence, api);
         }
     }
 }

--- a/backend/FwLite/MiniLcm/SyncHelpers/PartOfSpeechSync.cs
+++ b/backend/FwLite/MiniLcm/SyncHelpers/PartOfSpeechSync.cs
@@ -5,13 +5,13 @@ namespace MiniLcm.SyncHelpers;
 
 public static class PartOfSpeechSync
 {
-    public static async Task<int> Sync(PartOfSpeech[] previousPartsOfSpeech,
-        PartOfSpeech[] currentPartsOfSpeech,
+    public static async Task<int> Sync(PartOfSpeech[] beforePartsOfSpeech,
+        PartOfSpeech[] afterPartsOfSpeech,
         IMiniLcmApi api)
     {
         return await DiffCollection.Diff(
-            previousPartsOfSpeech,
-            currentPartsOfSpeech,
+            beforePartsOfSpeech,
+            afterPartsOfSpeech,
             new PartsOfSpeechDiffApi(api));
     }
 
@@ -24,16 +24,16 @@ public static class PartOfSpeechSync
         return updateObjectInput is null ? 0 : 1;
     }
 
-    public static UpdateObjectInput<PartOfSpeech>? PartOfSpeechDiffToUpdate(PartOfSpeech previousPartOfSpeech, PartOfSpeech currentPartOfSpeech)
+    public static UpdateObjectInput<PartOfSpeech>? PartOfSpeechDiffToUpdate(PartOfSpeech beforePartOfSpeech, PartOfSpeech afterPartOfSpeech)
     {
         JsonPatchDocument<PartOfSpeech> patchDocument = new();
         patchDocument.Operations.AddRange(MultiStringDiff.GetMultiStringDiff<PartOfSpeech>(nameof(PartOfSpeech.Name),
-            previousPartOfSpeech.Name,
-            currentPartOfSpeech.Name));
+            beforePartOfSpeech.Name,
+            afterPartOfSpeech.Name));
         // TODO: Once we add abbreviations to MiniLcm's PartOfSpeech objects, then:
         // patchDocument.Operations.AddRange(GetMultiStringDiff<PartOfSpeech>(nameof(PartOfSpeech.Abbreviation),
-        //     previousPartOfSpeech.Abbreviation,
-        //     currentPartOfSpeech.Abbreviation));
+        //     beforePartOfSpeech.Abbreviation,
+        //     afterPartOfSpeech.Abbreviation));
         if (patchDocument.Operations.Count == 0) return null;
         return new UpdateObjectInput<PartOfSpeech>(patchDocument);
     }
@@ -46,15 +46,15 @@ public static class PartOfSpeechSync
             return 1;
         }
 
-        public override async Task<int> Remove(PartOfSpeech previousPos)
+        public override async Task<int> Remove(PartOfSpeech beforePos)
         {
-            await api.DeletePartOfSpeech(previousPos.Id);
+            await api.DeletePartOfSpeech(beforePos.Id);
             return 1;
         }
 
-        public override Task<int> Replace(PartOfSpeech previousPos, PartOfSpeech currentPos)
+        public override Task<int> Replace(PartOfSpeech beforePos, PartOfSpeech afterPos)
         {
-            return Sync(previousPos, currentPos, api);
+            return Sync(beforePos, afterPos, api);
         }
     }
 }

--- a/backend/FwLite/MiniLcm/SyncHelpers/PartOfSpeechSync.cs
+++ b/backend/FwLite/MiniLcm/SyncHelpers/PartOfSpeechSync.cs
@@ -5,8 +5,8 @@ namespace MiniLcm.SyncHelpers;
 
 public static class PartOfSpeechSync
 {
-    public static async Task<int> Sync(PartOfSpeech[] currentPartsOfSpeech,
-        PartOfSpeech[] previousPartsOfSpeech,
+    public static async Task<int> Sync(PartOfSpeech[] previousPartsOfSpeech,
+        PartOfSpeech[] currentPartsOfSpeech,
         IMiniLcmApi api)
     {
         return await DiffCollection.Diff(

--- a/backend/FwLite/MiniLcm/SyncHelpers/SemanticDomainSync.cs
+++ b/backend/FwLite/MiniLcm/SyncHelpers/SemanticDomainSync.cs
@@ -5,8 +5,8 @@ namespace MiniLcm.SyncHelpers;
 
 public static class SemanticDomainSync
 {
-    public static async Task<int> Sync(SemanticDomain[] currentSemanticDomains,
-        SemanticDomain[] previousSemanticDomains,
+    public static async Task<int> Sync(SemanticDomain[] previousSemanticDomains,
+        SemanticDomain[] currentSemanticDomains,
         IMiniLcmApi api)
     {
         return await DiffCollection.Diff(

--- a/backend/FwLite/MiniLcm/SyncHelpers/SemanticDomainSync.cs
+++ b/backend/FwLite/MiniLcm/SyncHelpers/SemanticDomainSync.cs
@@ -5,13 +5,13 @@ namespace MiniLcm.SyncHelpers;
 
 public static class SemanticDomainSync
 {
-    public static async Task<int> Sync(SemanticDomain[] previousSemanticDomains,
-        SemanticDomain[] currentSemanticDomains,
+    public static async Task<int> Sync(SemanticDomain[] beforeSemanticDomains,
+        SemanticDomain[] afterSemanticDomains,
         IMiniLcmApi api)
     {
         return await DiffCollection.Diff(
-            previousSemanticDomains,
-            currentSemanticDomains,
+            beforeSemanticDomains,
+            afterSemanticDomains,
             new SemanticDomainsDiffApi(api));
     }
 
@@ -24,16 +24,16 @@ public static class SemanticDomainSync
         return updateObjectInput is null ? 0 : 1;
     }
 
-    public static UpdateObjectInput<SemanticDomain>? SemanticDomainDiffToUpdate(SemanticDomain previousSemanticDomain, SemanticDomain currentSemanticDomain)
+    public static UpdateObjectInput<SemanticDomain>? SemanticDomainDiffToUpdate(SemanticDomain beforeSemanticDomain, SemanticDomain afterSemanticDomain)
     {
         JsonPatchDocument<SemanticDomain> patchDocument = new();
         patchDocument.Operations.AddRange(MultiStringDiff.GetMultiStringDiff<SemanticDomain>(nameof(SemanticDomain.Name),
-            previousSemanticDomain.Name,
-            currentSemanticDomain.Name));
+            beforeSemanticDomain.Name,
+            afterSemanticDomain.Name));
         // TODO: Once we add abbreviations to MiniLcm's SemanticDomain objects, then:
         // patchDocument.Operations.AddRange(GetMultiStringDiff<SemanticDomain>(nameof(SemanticDomain.Abbreviation),
-        //     previousSemanticDomain.Abbreviation,
-        //     currentSemanticDomain.Abbreviation));
+        //     beforeSemanticDomain.Abbreviation,
+        //     afterSemanticDomain.Abbreviation));
         if (patchDocument.Operations.Count == 0) return null;
         return new UpdateObjectInput<SemanticDomain>(patchDocument);
     }
@@ -46,15 +46,15 @@ public static class SemanticDomainSync
             return 1;
         }
 
-        public override async Task<int> Remove(SemanticDomain previousSemDom)
+        public override async Task<int> Remove(SemanticDomain beforeSemDom)
         {
-            await api.DeleteSemanticDomain(previousSemDom.Id);
+            await api.DeleteSemanticDomain(beforeSemDom.Id);
             return 1;
         }
 
-        public override Task<int> Replace(SemanticDomain previousSemDom, SemanticDomain currentSemDom)
+        public override Task<int> Replace(SemanticDomain beforeSemDom, SemanticDomain afterSemDom)
         {
-            return Sync(previousSemDom, currentSemDom, api);
+            return Sync(beforeSemDom, afterSemDom, api);
         }
     }
 }

--- a/backend/FwLite/MiniLcm/SyncHelpers/SenseSync.cs
+++ b/backend/FwLite/MiniLcm/SyncHelpers/SenseSync.cs
@@ -6,16 +6,16 @@ namespace MiniLcm.SyncHelpers;
 public static class SenseSync
 {
     public static async Task<int> Sync(Guid entryId,
-        Sense afterSense,
         Sense beforeSense,
+        Sense afterSense,
         IMiniLcmApi api)
     {
-        var updateObjectInput = await SenseDiffToUpdate(beforeSense, afterSense);
+        var updateObjectInput = SenseDiffToUpdate(beforeSense, afterSense);
         if (updateObjectInput is not null) await api.UpdateSense(entryId, beforeSense.Id, updateObjectInput);
         var changes = await ExampleSentenceSync.Sync(entryId,
             beforeSense.Id,
-            afterSense.ExampleSentences,
             beforeSense.ExampleSentences,
+            afterSense.ExampleSentences,
             api);
         changes += await DiffCollection.Diff(
             beforeSense.SemanticDomains,
@@ -24,7 +24,7 @@ public static class SenseSync
         return changes + (updateObjectInput is null ? 0 : 1);
     }
 
-    public static async Task<UpdateObjectInput<Sense>?> SenseDiffToUpdate(Sense beforeSense, Sense afterSense)
+    public static UpdateObjectInput<Sense>? SenseDiffToUpdate(Sense beforeSense, Sense afterSense)
     {
         JsonPatchDocument<Sense> patchDocument = new();
         patchDocument.Operations.AddRange(

--- a/backend/FwLite/MiniLcm/SyncHelpers/WritingSystemSync.cs
+++ b/backend/FwLite/MiniLcm/SyncHelpers/WritingSystemSync.cs
@@ -5,15 +5,15 @@ namespace MiniLcm.SyncHelpers;
 
 public static class WritingSystemSync
 {
-    public static async Task<int> Sync(WritingSystems currentWritingSystems,
-        WritingSystems previousWritingSystems,
+    public static async Task<int> Sync(WritingSystems previousWritingSystems,
+        WritingSystems currentWritingSystems,
         IMiniLcmApi api)
     {
-        return await Sync(currentWritingSystems.Vernacular, previousWritingSystems.Vernacular, api) +
-               await Sync(currentWritingSystems.Analysis, previousWritingSystems.Analysis, api);
+        return await Sync(previousWritingSystems.Vernacular, currentWritingSystems.Vernacular, api) +
+               await Sync(previousWritingSystems.Analysis, currentWritingSystems.Analysis, api);
     }
-    public static async Task<int> Sync(WritingSystem[] currentWritingSystems,
-        WritingSystem[] previousWritingSystems,
+    public static async Task<int> Sync(WritingSystem[] previousWritingSystems,
+        WritingSystem[] currentWritingSystems,
         IMiniLcmApi api)
     {
         return await DiffCollection.Diff(
@@ -22,7 +22,7 @@ public static class WritingSystemSync
             new WritingSystemsDiffApi(api));
     }
 
-    public static async Task<int> Sync(WritingSystem afterWs, WritingSystem beforeWs, IMiniLcmApi api)
+    public static async Task<int> Sync(WritingSystem beforeWs, WritingSystem afterWs, IMiniLcmApi api)
     {
         var updateObjectInput = WritingSystemDiffToUpdate(beforeWs, afterWs);
         if (updateObjectInput is not null) await api.UpdateWritingSystem(afterWs.WsId, afterWs.Type, updateObjectInput);
@@ -73,7 +73,7 @@ public static class WritingSystemSync
 
         public override Task<int> Replace(WritingSystem previousWs, WritingSystem currentWs)
         {
-            return Sync(currentWs, previousWs, api);
+            return Sync(previousWs, currentWs, api);
         }
     }
 }


### PR DESCRIPTION
Also update all call sites so that code behavior remains the same.

Fixes #1293.

This is #1301 rebased on top of #1267 now that #1267 is the only open PR that touches the update API.