### PR TITLE
Chore/fix serilization error add entry component change

### DIFF
--- a/backend/FwLite/LcmCrdt.Tests/Changes/ChangeSerializationTests.cs
+++ b/backend/FwLite/LcmCrdt.Tests/Changes/ChangeSerializationTests.cs
@@ -1,82 +1,54 @@
-﻿using System.Text.Json;
+﻿using System.Reflection;
+using System.Text.Json;
 using FluentAssertions.Execution;
 using LcmCrdt.Changes;
 using LcmCrdt.Changes.Entries;
+using MiniLcm.Tests.AutoFakerHelpers;
 using SIL.Harmony.Changes;
+using Soenneker.Utils.AutoBogus;
 using SystemTextJsonPatch;
 
 namespace LcmCrdt.Tests.Changes;
 
 public class ChangeSerializationTests
 {
+    private static readonly AutoFaker Faker = new()
+    {
+        Config =
+        {
+            Overrides = [new WritingSystemIdOverride()]
+        }
+    };
+
     public static IEnumerable<object[]> Changes()
     {
-        yield return
-        [
-            new AddEntryComponentChange(ComplexFormComponent.FromEntries(
-                new Entry() { Id = Guid.NewGuid() },
-                new Entry() { Id = Guid.NewGuid() }))
-        ];
-        yield return
-        [
-            new CreateEntryChange(new Entry() { Id = Guid.NewGuid() })
-        ];
-        yield return [
-            new CreateSenseChange(new Sense() { Id = Guid.NewGuid() }, Guid.NewGuid())
-        ];
-        yield return [
-            new CreateExampleSentenceChange(new ExampleSentence() { Id = Guid.NewGuid() }, Guid.NewGuid())
-        ];
-        yield return
-        [
-            new CreatePartOfSpeechChange(Guid.NewGuid(), new MultiString())
-        ];
-        yield return
-        [
-            new CreateSemanticDomainChange(Guid.NewGuid(), new MultiString(), "1")
-        ];
-        yield return
-        [
-            new CreateWritingSystemChange(new WritingSystem()
+        foreach (var type in LcmCrdtKernel.AllChangeTypes())
+        {
+            //can't generate this type because there's no public constructor, so its specified below
+            if (type == typeof(SetComplexFormComponentChange)) continue;
+
+            object change;
+            if (type.IsGenericType && type.GetGenericTypeDefinition() == typeof(JsonPatchChange<>))
             {
-                Id = Guid.NewGuid(),
-                WsId = "en",
-                Name = "en",
-                Abbreviation = "en",
-                Font = "Arial",
-                Exemplars = ["en"],
-                Type = WritingSystemType.Analysis,
-                Order = 1,
-            }, WritingSystemType.Analysis, Guid.NewGuid(), 1)
-        ];
-        yield return [
-            new SetPartOfSpeechChange(Guid.NewGuid(), Guid.NewGuid())
-        ];
-        yield return [new AddSemanticDomainChange(new SemanticDomain() { Id = Guid.NewGuid() }, Guid.NewGuid())];
-        yield return [new RemoveSemanticDomainChange(Guid.NewGuid(), Guid.NewGuid())];
-        yield return [new ReplaceSemanticDomainChange(Guid.NewGuid(), new SemanticDomain() { Id = Guid.NewGuid() }, Guid.NewGuid())];
-        yield return [new RemoveComplexFormTypeChange(Guid.NewGuid(), Guid.NewGuid())];
-        yield return [new CreateComplexFormType(Guid.NewGuid(), new MultiString())];
-        yield return [new AddComplexFormTypeChange(Guid.NewGuid(), new() { Id = Guid.NewGuid(), Name = new()})];
+                change = PatchMethod.MakeGenericMethod(type.GenericTypeArguments[0]).Invoke(null, null)!;
+            }
+            else
+            {
+                change = Faker.Generate(type);
+            }
+            change.Should().NotBeNull($"change type {type.Name} should have been generated");
+            yield return [change];
+        }
         yield return [SetComplexFormComponentChange.NewComplexForm(Guid.NewGuid(), Guid.NewGuid())];
         yield return [SetComplexFormComponentChange.NewComponent(Guid.NewGuid(), Guid.NewGuid())];
         yield return [SetComplexFormComponentChange.NewComponentSense(Guid.NewGuid(), Guid.NewGuid(), Guid.NewGuid())];
+    }
 
-        yield return [new JsonPatchChange<Entry>(Guid.NewGuid(), new JsonPatchDocument<Entry>())];
-        yield return [new JsonPatchChange<Sense>(Guid.NewGuid(), new JsonPatchDocument<Sense>())];
-        yield return [new JsonPatchChange<ExampleSentence>(Guid.NewGuid(), new JsonPatchDocument<ExampleSentence>())];
-        yield return [new JsonPatchChange<WritingSystem>(Guid.NewGuid(), new JsonPatchDocument<WritingSystem>())];
-        yield return [new JsonPatchChange<PartOfSpeech>(Guid.NewGuid(), new JsonPatchDocument<PartOfSpeech>())];
-        yield return [new JsonPatchChange<SemanticDomain>(Guid.NewGuid(), new JsonPatchDocument<SemanticDomain>())];
-        yield return [new JsonPatchChange<ComplexFormType>(Guid.NewGuid(), new JsonPatchDocument<ComplexFormType>())];
-        yield return [new DeleteChange<Entry>(Guid.NewGuid())];
-        yield return [new DeleteChange<Sense>(Guid.NewGuid())];
-        yield return [new DeleteChange<ExampleSentence>(Guid.NewGuid())];
-        yield return [new DeleteChange<WritingSystem>(Guid.NewGuid())];
-        yield return [new DeleteChange<PartOfSpeech>(Guid.NewGuid())];
-        yield return [new DeleteChange<SemanticDomain>(Guid.NewGuid())];
-        yield return [new DeleteChange<ComplexFormType>(Guid.NewGuid())];
-        yield return [new DeleteChange<ComplexFormComponent>(Guid.NewGuid())];
+    private static readonly MethodInfo PatchMethod = new Func<IChange>(Patch<Entry>).Method.GetGenericMethodDefinition();
+
+    private static IChange Patch<T>() where T : class
+    {
+        return new JsonPatchChange<T>(Guid.NewGuid(), new JsonPatchDocument<T>());
     }
 
     [Theory]
@@ -85,6 +57,8 @@ public class ChangeSerializationTests
     {
         var config = new CrdtConfig();
         LcmCrdtKernel.ConfigureCrdt(config);
+        //commit id is not serialized
+        change.CommitId = Guid.Empty;
         var type = change.GetType();
         var json = JsonSerializer.Serialize(change, config.JsonSerializerOptions);
         var newChange = JsonSerializer.Deserialize(json, type, config.JsonSerializerOptions);

--- a/backend/FwLite/LcmCrdt.Tests/Changes/ChangeSerializationTests.cs
+++ b/backend/FwLite/LcmCrdt.Tests/Changes/ChangeSerializationTests.cs
@@ -1,0 +1,108 @@
+﻿using System.Text.Json;
+using FluentAssertions.Execution;
+using LcmCrdt.Changes;
+using LcmCrdt.Changes.Entries;
+using SIL.Harmony.Changes;
+using SystemTextJsonPatch;
+
+namespace LcmCrdt.Tests.Changes;
+
+public class ChangeSerializationTests
+{
+    public static IEnumerable<object[]> Changes()
+    {
+        yield return
+        [
+            new AddEntryComponentChange(ComplexFormComponent.FromEntries(
+                new Entry() { Id = Guid.NewGuid() },
+                new Entry() { Id = Guid.NewGuid() }))
+        ];
+        yield return
+        [
+            new CreateEntryChange(new Entry() { Id = Guid.NewGuid() })
+        ];
+        yield return [
+            new CreateSenseChange(new Sense() { Id = Guid.NewGuid() }, Guid.NewGuid())
+        ];
+        yield return [
+            new CreateExampleSentenceChange(new ExampleSentence() { Id = Guid.NewGuid() }, Guid.NewGuid())
+        ];
+        yield return
+        [
+            new CreatePartOfSpeechChange(Guid.NewGuid(), new MultiString())
+        ];
+        yield return
+        [
+            new CreateSemanticDomainChange(Guid.NewGuid(), new MultiString(), "1")
+        ];
+        yield return
+        [
+            new CreateWritingSystemChange(new WritingSystem()
+            {
+                Id = Guid.NewGuid(),
+                WsId = "en",
+                Name = "en",
+                Abbreviation = "en",
+                Font = "Arial",
+                Exemplars = ["en"],
+                Type = WritingSystemType.Analysis,
+                Order = 1,
+            }, WritingSystemType.Analysis, Guid.NewGuid(), 1)
+        ];
+        yield return [
+            new SetPartOfSpeechChange(Guid.NewGuid(), Guid.NewGuid())
+        ];
+        yield return [new AddSemanticDomainChange(new SemanticDomain() { Id = Guid.NewGuid() }, Guid.NewGuid())];
+        yield return [new RemoveSemanticDomainChange(Guid.NewGuid(), Guid.NewGuid())];
+        yield return [new ReplaceSemanticDomainChange(Guid.NewGuid(), new SemanticDomain() { Id = Guid.NewGuid() }, Guid.NewGuid())];
+        yield return [new RemoveComplexFormTypeChange(Guid.NewGuid(), Guid.NewGuid())];
+        yield return [new CreateComplexFormType(Guid.NewGuid(), new MultiString())];
+        yield return [new AddComplexFormTypeChange(Guid.NewGuid(), new() { Id = Guid.NewGuid(), Name = new()})];
+        yield return [SetComplexFormComponentChange.NewComplexForm(Guid.NewGuid(), Guid.NewGuid())];
+        yield return [SetComplexFormComponentChange.NewComponent(Guid.NewGuid(), Guid.NewGuid())];
+        yield return [SetComplexFormComponentChange.NewComponentSense(Guid.NewGuid(), Guid.NewGuid(), Guid.NewGuid())];
+
+        yield return [new JsonPatchChange<Entry>(Guid.NewGuid(), new JsonPatchDocument<Entry>())];
+        yield return [new JsonPatchChange<Sense>(Guid.NewGuid(), new JsonPatchDocument<Sense>())];
+        yield return [new JsonPatchChange<ExampleSentence>(Guid.NewGuid(), new JsonPatchDocument<ExampleSentence>())];
+        yield return [new JsonPatchChange<WritingSystem>(Guid.NewGuid(), new JsonPatchDocument<WritingSystem>())];
+        yield return [new JsonPatchChange<PartOfSpeech>(Guid.NewGuid(), new JsonPatchDocument<PartOfSpeech>())];
+        yield return [new JsonPatchChange<SemanticDomain>(Guid.NewGuid(), new JsonPatchDocument<SemanticDomain>())];
+        yield return [new JsonPatchChange<ComplexFormType>(Guid.NewGuid(), new JsonPatchDocument<ComplexFormType>())];
+        yield return [new DeleteChange<Entry>(Guid.NewGuid())];
+        yield return [new DeleteChange<Sense>(Guid.NewGuid())];
+        yield return [new DeleteChange<ExampleSentence>(Guid.NewGuid())];
+        yield return [new DeleteChange<WritingSystem>(Guid.NewGuid())];
+        yield return [new DeleteChange<PartOfSpeech>(Guid.NewGuid())];
+        yield return [new DeleteChange<SemanticDomain>(Guid.NewGuid())];
+        yield return [new DeleteChange<ComplexFormType>(Guid.NewGuid())];
+        yield return [new DeleteChange<ComplexFormComponent>(Guid.NewGuid())];
+    }
+
+    [Theory]
+    [MemberData(nameof(Changes))]
+    public void CanRoundTripChanges(IChange change)
+    {
+        var config = new CrdtConfig();
+        LcmCrdtKernel.ConfigureCrdt(config);
+        var type = change.GetType();
+        var json = JsonSerializer.Serialize(change, config.JsonSerializerOptions);
+        var newChange = JsonSerializer.Deserialize(json, type, config.JsonSerializerOptions);
+        newChange.Should().BeEquivalentTo(change);
+    }
+
+    [Fact]
+    public void ChangesIncludesAllValidChangeTypes()
+    {
+        var allChangeTypes = LcmCrdtKernel.AllChangeTypes();
+        allChangeTypes.Should().NotBeEmpty();
+        var testedTypes = Changes().Select(c => c[0].GetType()).ToArray();
+        using (new AssertionScope())
+        {
+            foreach (var allChangeType in allChangeTypes)
+            {
+                testedTypes.Should().Contain(allChangeType);
+            }
+        }
+    }
+}

--- a/backend/FwLite/LcmCrdt.Tests/MiniLcmApiFixture.cs
+++ b/backend/FwLite/LcmCrdt.Tests/MiniLcmApiFixture.cs
@@ -5,6 +5,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
 using MiniLcm;
 using MiniLcm.Models;
 using Xunit.Abstractions;
@@ -17,6 +18,7 @@ public class MiniLcmApiFixture : IAsyncLifetime
     private LcmCrdtDbContext? _crdtDbContext;
     public CrdtMiniLcmApi Api => (CrdtMiniLcmApi)_services.ServiceProvider.GetRequiredService<IMiniLcmApi>();
     public DataModel DataModel => _services.ServiceProvider.GetRequiredService<DataModel>();
+    public CrdtConfig CrdtConfig => _services.ServiceProvider.GetRequiredService<IOptions<CrdtConfig>>().Value;
 
     public MiniLcmApiFixture()
     {

--- a/backend/FwLite/LcmCrdt/Changes/AddSemanticDomainChange.cs
+++ b/backend/FwLite/LcmCrdt/Changes/AddSemanticDomainChange.cs
@@ -3,8 +3,8 @@ using SIL.Harmony.Entities;
 
 namespace LcmCrdt.Changes;
 
-public class AddSemanticDomainChange(SemanticDomain semanticDomain, Guid senseId)
-    : EditChange<Sense>(senseId), ISelfNamedType<AddSemanticDomainChange>
+public class AddSemanticDomainChange(SemanticDomain semanticDomain, Guid entityId)
+    : EditChange<Sense>(entityId), ISelfNamedType<AddSemanticDomainChange>
 {
     public SemanticDomain SemanticDomain { get; } = semanticDomain;
 

--- a/backend/FwLite/LcmCrdt/Changes/Entries/AddEntryComponentChange.cs
+++ b/backend/FwLite/LcmCrdt/Changes/Entries/AddEntryComponentChange.cs
@@ -16,9 +16,7 @@ public class AddEntryComponentChange : CreateChange<ComplexFormComponent>, ISelf
     [JsonConstructor]
     public AddEntryComponentChange(Guid entityId,
         Guid complexFormEntryId,
-        string? complexFormHeadword,
         Guid componentEntryId,
-        string? componentHeadword,
         Guid? componentSenseId = null) : base(entityId)
     {
         ComplexFormEntryId = complexFormEntryId;
@@ -28,9 +26,7 @@ public class AddEntryComponentChange : CreateChange<ComplexFormComponent>, ISelf
 
     public AddEntryComponentChange(ComplexFormComponent component) : this(component.Id == default ? Guid.NewGuid() : component.Id,
         component.ComplexFormEntryId,
-        component.ComplexFormHeadword,
         component.ComponentEntryId,
-        component.ComponentHeadword,
         component.ComponentSenseId)
     {
     }

--- a/backend/FwLite/LcmCrdt/Changes/RemoveSemanticDomainChange.cs
+++ b/backend/FwLite/LcmCrdt/Changes/RemoveSemanticDomainChange.cs
@@ -3,8 +3,8 @@ using SIL.Harmony.Entities;
 
 namespace LcmCrdt.Changes;
 
-public class RemoveSemanticDomainChange(Guid semanticDomainId, Guid senseId)
-    : EditChange<Sense>(senseId), ISelfNamedType<RemoveSemanticDomainChange>
+public class RemoveSemanticDomainChange(Guid semanticDomainId, Guid entityId)
+    : EditChange<Sense>(entityId), ISelfNamedType<RemoveSemanticDomainChange>
 {
     public Guid SemanticDomainId { get; } = semanticDomainId;
 

--- a/backend/FwLite/LcmCrdt/Changes/ReplaceSemanticDomainChange.cs
+++ b/backend/FwLite/LcmCrdt/Changes/ReplaceSemanticDomainChange.cs
@@ -3,8 +3,8 @@ using SIL.Harmony.Entities;
 
 namespace LcmCrdt.Changes;
 
-public class ReplaceSemanticDomainChange(Guid oldSemanticDomainId, SemanticDomain semanticDomain, Guid senseId)
-    : EditChange<Sense>(senseId), ISelfNamedType<ReplaceSemanticDomainChange>
+public class ReplaceSemanticDomainChange(Guid oldSemanticDomainId, SemanticDomain semanticDomain, Guid entityId)
+    : EditChange<Sense>(entityId), ISelfNamedType<ReplaceSemanticDomainChange>
 {
     public Guid OldSemanticDomainId { get; } = oldSemanticDomainId;
     public SemanticDomain SemanticDomain { get; } = semanticDomain;

--- a/backend/FwLite/LcmCrdt/LcmCrdtKernel.cs
+++ b/backend/FwLite/LcmCrdt/LcmCrdtKernel.cs
@@ -1,5 +1,7 @@
 ﻿using System.Linq.Expressions;
+using System.Reflection;
 using System.Text.Json;
+using System.Text.Json.Serialization.Metadata;
 using SIL.Harmony;
 using SIL.Harmony.Core;
 using SIL.Harmony.Changes;
@@ -190,6 +192,18 @@ public static class LcmCrdtKernel
             .Add<SetComplexFormComponentChange>()
             .Add<CreateComplexFormType>();
     }
+
+    public static Type[] AllChangeTypes()
+    {
+        var crdtConfig = new CrdtConfig();
+        ConfigureCrdt(crdtConfig);
+
+
+        var list = typeof(ChangeTypeListBuilder).GetProperty("Types", BindingFlags.Instance | BindingFlags.NonPublic)
+            ?.GetValue(crdtConfig.ChangeTypeListBuilder) as List<JsonDerivedType>;
+        return list?.Select(t => t.DerivedType).ToArray() ?? [];
+    }
+
 
     public static Task<IMiniLcmApi> OpenCrdtProject(this IServiceProvider services, CrdtProject project)
     {


### PR DESCRIPTION
fixes a crash like this:
```
---> System.InvalidOperationException: Each parameter in the deserialization constructor on type 'LcmCrdt.Changes.Entries.AddEntryComponentChange' must bind to an object property or field on deserialization. Each parameter name must match with a property or field on the object. Fields are only considered when 'JsonSerializerOptions.IncludeFields' is enabled. The match can be case-insensitive.
   at System.Text.Json.ThrowHelper.ThrowInvalidOperationException_ConstructorParameterIncompleteBinding(Type parentType)
   at System.Text.Json.Serialization.Converters.ObjectWithParameterizedConstructorConverter`1.OnTryRead(Utf8JsonReader& reader, Type typeToConvert, JsonSerializerOptions options, ReadStack& state, T& value)
   at System.Text.Json.Serialization.JsonConverter`1.OnTryReadAsObject(Utf8JsonReader& reader, Type typeToConvert, JsonSerializerOptions options, ReadStack& state, Object& value)
   at System.Text.Json.Serialization.Converters.ObjectDefaultConverter`1.OnTryRead(Utf8JsonReader& reader, Type typeToConvert, JsonSerializerOptions options, ReadStack& state, T& value)
   at System.Text.Json.Serialization.JsonConverter`1.TryRead(Utf8JsonReader& reader, Type typeToConvert, JsonSerializerOptions options, ReadStack& state, T& value, Boolean& isPopulatedValue)
   at System.Text.Json.Serialization.Metadata.JsonPropertyInfo`1.ReadJsonAndSetMember(Object obj, ReadStack& state, Utf8JsonReader& reader)
   at System.Text.Json.Serialization.Converters.ObjectDefaultConverter`1.OnTryRead(Utf8JsonReader& reader, Type typeToConvert, JsonSerializerOptions options, ReadStack& state, T& value)
   at System.Text.Json.Serialization.JsonConverter`1.TryRead(Utf8JsonReader& reader, Type typeToConvert, JsonSerializerOptions options, ReadStack& state, T& value, Boolean& isPopulatedValue)
   at System.Text.Json.Serialization.JsonCollectionConverter`2.OnTryRead(Utf8JsonReader& reader, Type typeToConvert, JsonSerializerOptions options, ReadStack& state, TCollection& value)
   at System.Text.Json.Serialization.JsonConverter`1.TryRead(Utf8JsonReader& reader, Type typeToConvert, JsonSerializerOptions options, ReadStack& state, T& value, Boolean& isPopulatedValue)
   at System.Text.Json.Serialization.Metadata.JsonPropertyInfo`1.ReadJsonAsObject(ReadStack& state, Utf8JsonReader& reader, Object& value)
   at System.Text.Json.Serialization.Converters.ObjectWithParameterizedConstructorConverter`1.ReadConstructorArgumentsWithContinuation(ReadStack& state, Utf8JsonReader& reader, JsonSerializerOptions options)
   at System.Text.Json.Serialization.Converters.ObjectWithParameterizedConstructorConverter`1.OnTryRead(Utf8JsonReader& reader, Type typeToConvert, JsonSerializerOptions options, ReadStack& state, T& value)
   at System.Text.Json.Serialization.JsonConverter`1.TryRead(Utf8JsonReader& reader, Type typeToConvert, JsonSerializerOptions options, ReadStack& state, T& value, Boolean& isPopulatedValue)
   at System.Text.Json.Serialization.JsonCollectionConverter`2.OnTryRead(Utf8JsonReader& reader, Type typeToConvert, JsonSerializerOptions options, ReadStack& state, TCollection& value)
   at System.Text.Json.Serialization.JsonConverter`1.TryRead(Utf8JsonReader& reader, Type typeToConvert, JsonSerializerOptions options, ReadStack& state, T& value, Boolean& isPopulatedValue)
   at System.Text.Json.Serialization.Converters.SmallObjectWithParameterizedConstructorConverter`5.TryRead[TArg](ReadStack& state, Utf8JsonReader& reader, JsonParameterInfo jsonParameterInfo, TArg& arg)
   at System.Text.Json.Serialization.Converters.SmallObjectWithParameterizedConstructorConverter`5.ReadAndCacheConstructorArgument(ReadStack& state, Utf8JsonReader& reader, JsonParameterInfo jsonParameterInfo)
   at System.Text.Json.Serialization.Converters.ObjectWithParameterizedConstructorConverter`1.ReadConstructorArgumentsWithContinuation(ReadStack& state, Utf8JsonReader& reader, JsonSerializerOptions options)
   at System.Text.Json.Serialization.Converters.ObjectWithParameterizedConstructorConverter`1.OnTryRead(Utf8JsonReader& reader, Type typeToConvert, JsonSerializerOptions options, ReadStack& state, T& value)
   at System.Text.Json.Serialization.JsonConverter`1.TryRead(Utf8JsonReader& reader, Type typeToConvert, JsonSerializerOptions options, ReadStack& state, T& value, Boolean& isPopulatedValue)
   at System.Text.Json.Serialization.JsonConverter`1.ReadCore(Utf8JsonReader& reader, T& value, JsonSerializerOptions options, ReadStack& state)
   at System.Text.Json.Serialization.Metadata.JsonTypeInfo`1.ContinueDeserialize(ReadBufferState& bufferState, JsonReaderState& jsonReaderState, ReadStack& readStack, T& value)
   at System.Text.Json.Serialization.Metadata.JsonTypeInfo`1.DeserializeAsync(Stream utf8Json, CancellationToken cancellationToken)
   at System.Net.Http.Json.HttpContentJsonExtensions.ReadFromJsonAsyncCore[T](HttpContent content, JsonSerializerOptions options, CancellationToken cancellationToken)
   at Refit.SystemTextJsonContentSerializer.FromHttpContentAsync[T](HttpContent content, CancellationToken cancellationToken) in c:\temp\releaser\refit\Refit\SystemTextJsonContentSerializer.cs:line 48
   at Refit.RequestBuilderImplementation.DeserializeContentAsync[T](HttpResponseMessage resp, HttpContent content, CancellationToken cancellationToken) in c:\temp\releaser\refit\Refit\RequestBuilderImplementation.cs:line 465
   at Refit.RequestBuilderImplementation.<>c__DisplayClass15_0`2.<<BuildCancellableTaskFuncForMethod>b__0>d.MoveNext() in c:\temp\releaser\refit\Refit\RequestBuilderImplementation.cs:line 390
   --- End of inner exception stack trace ---
   at Refit.RequestBuilderImplementation.<>c__DisplayClass15_0`2.<<BuildCancellableTaskFuncForMethod>b__0>d.MoveNext() in c:\temp\releaser\refit\Refit\RequestBuilderImplementation.cs:line 404
--- End of stack trace from previous location ---
   at Refit.Implementation.Generated.LcmCrdtRemoteSyncISyncHttp.global::LcmCrdt.RemoteSync.ISyncHttp.GetChanges(Guid id, SyncState otherHeads)
   at LcmCrdt.RemoteSync.CrdtProjectSync.SIL.Harmony.ISyncable.GetChanges(SyncState otherHeads)
   at SIL.Harmony.SyncHelper.SyncWith(ISyncable localModel, ISyncable remoteModel, JsonSerializerOptions serializerOptions)
   at SIL.Harmony.DataModel.SyncWith(ISyncable remoteModel)
   at FwLiteShared.Sync.SyncService.ExecuteSync()
   at FwLiteShared.Projects.CombinedProjectsService.<>c.<<DownloadProject>b__6_0>d.MoveNext()
--- End of stack trace from previous location ---
   at LcmCrdt.CrdtProjectsService.CreateProject(CreateProjectRequest request)
   at LcmCrdt.CrdtProjectsService.CreateProject(CreateProjectRequest request)
   at LcmCrdt.CrdtProjectsService.CreateProject(CreateProjectRequest request)
   at FwLiteShared.Projects.CombinedProjectsService.DownloadProject(Guid lexboxProjectId, String projectName, LexboxServer server)
   at LocalWebApp.Routes.ProjectRoutes.<>c.<<MapProjectRoutes>b__0_4>d.MoveNext()
--- End of stack trace from previous location ---
   at Microsoft.AspNetCore.Http.RequestDelegateFactory.ExecuteTaskResult[T](Task`1 task, HttpContext httpContext)
   at Microsoft.AspNetCore.Routing.EndpointMiddleware.<Invoke>g__AwaitRequestTask|7_0(Endpoint endpoint, Task requestTask, ILogger logger)
   at LocalWebApp.LocalWebAppServer.<>c.<<SetupAppServer>b__0_5>d.MoveNext()
--- End of stack trace from previous location ---
   at Microsoft.AspNetCore.Authorization.AuthorizationMiddleware.Invoke(HttpContext context)
   at Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http.HttpProtocol.ProcessRequests[TContext](IHttpApplication`1 application)
```

seen when trying to download a project from lexbox on the latest release. Fixes the issue by removing the properties it can't bind and added tests for all changes, fixed the issues found with other changes