### PR TITLE
Make SyncFixture users use seperate directories and clean them up

### DIFF
--- a/backend/FwLite/FwLiteProjectSync.Tests/Fixtures/SyncFixture.cs
+++ b/backend/FwLite/FwLiteProjectSync.Tests/Fixtures/SyncFixture.cs
@@ -17,13 +17,17 @@ public class SyncFixture : IAsyncLifetime
         _services.ServiceProvider.GetRequiredService<CrdtFwdataProjectSyncService>();
     public IServiceProvider Services => _services.ServiceProvider;
     private readonly string _projectName;
+    private readonly string _projectFolder;
     private readonly IDisposable _cleanup;
+    private static readonly Lock _preCleanupLock = new();
+    private static readonly Dictionary<string, bool> _preCleanupDone = [];
 
     public static SyncFixture Create([CallerMemberName] string projectName = "", [CallerMemberName] string projectFolder = "") => new(projectName, projectFolder);
 
     private SyncFixture(string projectName, string projectFolder)
     {
         _projectName = projectName;
+        _projectFolder = projectFolder;
         var crdtServices = new ServiceCollection()
             .AddSyncServices(projectFolder);
         var rootServiceProvider = crdtServices.BuildServiceProvider();
@@ -31,15 +35,26 @@ public class SyncFixture : IAsyncLifetime
         _services = rootServiceProvider.CreateAsyncScope();
     }
 
-    public SyncFixture(): this("sena-3_" + Guid.NewGuid().ToString("N"), "FwLiteSyncFixture")
+    public SyncFixture() : this("sena-3_" + Guid.NewGuid().ToString().Split("-")[0], "FwLiteSyncFixture")
     {
     }
 
     public async Task InitializeAsync()
     {
+        using (_preCleanupLock.EnterScope())
+        {
+            if (!_preCleanupDone.ContainsKey(_projectFolder))
+            {
+                _preCleanupDone.Add(_projectFolder, true);
+                if (Path.Exists(_projectFolder))
+                {
+                    Directory.Delete(_projectFolder, true);
+                }
+            }
+        }
+
         var projectsFolder = _services.ServiceProvider.GetRequiredService<IOptions<FwDataBridgeConfig>>().Value
             .ProjectsFolder;
-        if (Path.Exists(projectsFolder)) Directory.Delete(projectsFolder, true);
         Directory.CreateDirectory(projectsFolder);
         _services.ServiceProvider.GetRequiredService<IProjectLoader>()
             .NewProject(new FwDataProject(_projectName, projectsFolder), "en", "en");
@@ -47,7 +62,6 @@ public class SyncFixture : IAsyncLifetime
 
         var crdtProjectsFolder =
             _services.ServiceProvider.GetRequiredService<IOptions<LcmCrdtConfig>>().Value.ProjectPath;
-        if (Path.Exists(crdtProjectsFolder)) Directory.Delete(crdtProjectsFolder, true);
         Directory.CreateDirectory(crdtProjectsFolder);
         var crdtProject = await _services.ServiceProvider.GetRequiredService<CrdtProjectsService>()
             .CreateProject(new(_projectName, FwProjectId: FwDataApi.ProjectId, SeedNewProjectData: false));

--- a/backend/FwLite/FwLiteProjectSync.Tests/Fixtures/SyncFixture.cs
+++ b/backend/FwLite/FwLiteProjectSync.Tests/Fixtures/SyncFixture.cs
@@ -20,7 +20,7 @@ public class SyncFixture : IAsyncLifetime
     private readonly string _projectFolder;
     private readonly IDisposable _cleanup;
     private static readonly Lock _preCleanupLock = new();
-    private static readonly Dictionary<string, bool> _preCleanupDone = [];
+    private static readonly HashSet<string> _preCleanupDone = [];
 
     public static SyncFixture Create([CallerMemberName] string projectName = "", [CallerMemberName] string projectFolder = "") => new(projectName, projectFolder);
 
@@ -41,11 +41,11 @@ public class SyncFixture : IAsyncLifetime
 
     public async Task InitializeAsync()
     {
-        using (_preCleanupLock.EnterScope())
+        lock (_preCleanupLock)
         {
-            if (!_preCleanupDone.ContainsKey(_projectFolder))
+            if (!_preCleanupDone.Contains(_projectFolder))
             {
-                _preCleanupDone.Add(_projectFolder, true);
+                _preCleanupDone.Add(_projectFolder);
                 if (Path.Exists(_projectFolder))
                 {
                     Directory.Delete(_projectFolder, true);


### PR DESCRIPTION
It seemed to me that the `Directory.Delete` calls in `InitializeAsync` were trying to delete files being used by other tests (and causing failures for me). So, I've adapted the Fixture to use a different directory per SyncFixture. That means we don't know how to clean up old test projects on start, so I'm cleaning them up at the end.

It took me a while to figure out how to close pooled open connections. Largely, because there are 3 different `SqliteConnection` classes to choose from and they all have `ClearAllPools()`, but I overlooked the 3rd one and that's the one I actually needed 😆.

It also not clear to me how we'd only clear the connections to just a single db if we wanted to delete it in e.g. prod.

For a while I thought that the db file was still in use after the tests, because `CrdtProjectsService.CreateProject()` has `var db = serviceScope.ServiceProvider.GetRequiredService<LcmCrdtDbContext>();` and doesn't dispose the db afterwards. But disposing it didn't help. And I believe that DbContext will get disposed at the end of the current scope?