### PR TITLE
Mark more tests as integration, beacuse they use Postgres

### DIFF
--- a/backend/Testing/Fixtures/Tests/ServicesFixtureTests.cs
+++ b/backend/Testing/Fixtures/Tests/ServicesFixtureTests.cs
@@ -2,6 +2,7 @@
 
 namespace Testing.Fixtures.Tests;
 
+[Trait("Category", "RequiresDb")]
 public class ServicesFixtureTests
 {
     [Fact]

--- a/backend/Testing/LexCore/CrdtServerCommitTests.cs
+++ b/backend/Testing/LexCore/CrdtServerCommitTests.cs
@@ -10,6 +10,7 @@ using Testing.Fixtures;
 namespace Testing.LexCore;
 
 [Collection(nameof(TestingServicesFixture))]
+[Trait("Category", "RequiresDb")]
 public class CrdtServerCommitTests
 {
     private readonly LexBoxDbContext _dbContext;

--- a/backend/Testing/LexCore/Services/ProjectServiceTest.cs
+++ b/backend/Testing/LexCore/Services/ProjectServiceTest.cs
@@ -14,6 +14,7 @@ using Testing.Fixtures;
 namespace Testing.LexCore.Services;
 
 [Collection(nameof(TestingServicesFixture))]
+[Trait("Category", "RequiresDb")]
 public class ProjectServiceTest
 {
     private readonly ProjectService _projectService;

--- a/backend/Testing/LexCore/Services/UserServiceTest.cs
+++ b/backend/Testing/LexCore/Services/UserServiceTest.cs
@@ -12,6 +12,7 @@ using FluentAssertions;
 namespace Testing.LexCore.Services;
 
 [Collection(nameof(TestingServicesFixture))]
+[Trait("Category", "RequiresDb")]
 public class UserServiceTest : IAsyncLifetime
 {
     private readonly UserService _userService;

--- a/backend/Testing/Taskfile.yml
+++ b/backend/Testing/Taskfile.yml
@@ -10,6 +10,13 @@ tasks:
     vars:
       FILTER: '{{default "." .CLI_ARGS}}'
     cmds:
+      - dotnet test --filter="Category!=RequiresDb&Category!=Integration&Category!=FlakyIntegration&{{.FILTER}}"
+
+  unit-with-db:
+    interactive: true
+    vars:
+      FILTER: '{{default "." .CLI_ARGS}}'
+    cmds:
       - dotnet test --filter="Category!=Integration&Category!=FlakyIntegration&{{.FILTER}}"
 
   integration:


### PR DESCRIPTION
These tests fail if Postgres isn't available, so it seems reasonable to me to mark them as integration tests.