### PR TITLE
fix auto updating package in use

### DIFF
--- a/.github/workflows/fw-lite.yaml
+++ b/.github/workflows/fw-lite.yaml
@@ -172,16 +172,14 @@ jobs:
       - name: Publish Windows MAUI portable app
         working-directory: backend/FwLite/FwLiteDesktop
         run: |
-          dotnet publish -r win-x64 --artifacts-path ../artifacts -p:WindowsPackageType=None -p:ApplicationDisplayVersion=${{ needs.build-and-test.outputs.semver-version }}
-          dotnet publish -r win-arm64 --artifacts-path ../artifacts -p:WindowsPackageType=None -p:ApplicationDisplayVersion=${{ needs.build-and-test.outputs.semver-version }}
+          dotnet publish -r win-x64 --artifacts-path ../artifacts -p:WindowsPackageType=None -p:ApplicationDisplayVersion=${{ needs.build-and-test.outputs.semver-version }} -p:InformationalVersion=${{ needs.build-and-test.outputs.version }}
           mkdir -p ../artifacts/sign/portable
           cp -r ../artifacts/publish/FwLiteDesktop/* ../artifacts/sign/portable/
 
       - name: Publish Windows MAUI msix app
         working-directory: backend/FwLite/FwLiteDesktop
         run: |
-          dotnet publish -r win-x64 --artifacts-path ../artifacts -p:ApplicationDisplayVersion=${{ needs.build-and-test.outputs.semver-version }}
-          dotnet publish -r win-arm64 --artifacts-path ../artifacts -p:ApplicationDisplayVersion=${{ needs.build-and-test.outputs.semver-version }}
+          dotnet publish -r win-x64 --artifacts-path ../artifacts -p:ApplicationDisplayVersion=${{ needs.build-and-test.outputs.semver-version }} -p:InformationalVersion=${{ needs.build-and-test.outputs.version }}
           mkdir -p ../artifacts/msix
           cp ../artifacts/bin/FwLiteDesktop/*/AppPackages/*/*.msix ../artifacts/msix/
 

--- a/.github/workflows/fw-lite.yaml
+++ b/.github/workflows/fw-lite.yaml
@@ -195,7 +195,7 @@ jobs:
           MakeAppx.exe bundle /v /bv ${{ needs.build-and-test.outputs.semver-version }}.1 /d . /p ../sign/FwLiteDesktop.msixbundle
 
       - name: Sign with Trusted Signing
-#        if: ${{ github.ref_name == 'develop' || github.ref_name == 'main' || github.ref_name == 'chore/auto-update-package-in-use' }}
+        if: ${{ github.ref_name == 'develop' || github.ref_name == 'main' }}
         uses: sillsdev/codesign/trusted-signing-action@v3
         with:
           credentials: ${{ secrets.TRUSTED_SIGNING_CREDENTIALS }}

--- a/.github/workflows/fw-lite.yaml
+++ b/.github/workflows/fw-lite.yaml
@@ -195,7 +195,7 @@ jobs:
           MakeAppx.exe bundle /v /bv ${{ needs.build-and-test.outputs.semver-version }}.1 /d . /p ../sign/FwLiteDesktop.msixbundle
 
       - name: Sign with Trusted Signing
-        if: ${{ github.ref_name == 'develop' || github.ref_name == 'main' || github.ref_name == 'chore/auto-update-package-in-use' }}
+#        if: ${{ github.ref_name == 'develop' || github.ref_name == 'main' || github.ref_name == 'chore/auto-update-package-in-use' }}
         uses: sillsdev/codesign/trusted-signing-action@v3
         with:
           credentials: ${{ secrets.TRUSTED_SIGNING_CREDENTIALS }}

--- a/.github/workflows/fw-lite.yaml
+++ b/.github/workflows/fw-lite.yaml
@@ -195,7 +195,7 @@ jobs:
           MakeAppx.exe bundle /v /bv ${{ needs.build-and-test.outputs.semver-version }}.1 /d . /p ../sign/FwLiteDesktop.msixbundle
 
       - name: Sign with Trusted Signing
-        if: ${{ github.ref_name == 'develop' || github.ref_name == 'main' }}
+        if: ${{ github.ref_name == 'develop' || github.ref_name == 'main' || github.ref_name == 'chore/auto-update-package-in-use' }}
         uses: sillsdev/codesign/trusted-signing-action@v3
         with:
           credentials: ${{ secrets.TRUSTED_SIGNING_CREDENTIALS }}

--- a/backend/FwLite/FwDataMiniLcmBridge/FwDataMiniLcmBridge.csproj
+++ b/backend/FwLite/FwDataMiniLcmBridge/FwDataMiniLcmBridge.csproj
@@ -1,8 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <InformationalVersion>$(ApplicationDisplayVersion)</InformationalVersion>
-        <FileVersion>$(ApplicationDisplayVersion)</FileVersion>
+         <FileVersion>$(ApplicationDisplayVersion)</FileVersion>
     </PropertyGroup>
     <ItemGroup>
         <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="9.0.0" />

--- a/backend/FwLite/FwLiteDesktop/AppVersion.cs
+++ b/backend/FwLite/FwLiteDesktop/AppVersion.cs
@@ -4,6 +4,17 @@ namespace FwLiteDesktop;
 
 public class AppVersion
 {
-    public static readonly string Version = typeof(AppVersion).Assembly
-        .GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion ?? "dev";
+    static AppVersion()
+    {
+        var infoVersion = typeof(AppVersion).Assembly
+            .GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion;
+        //info version may look like v2024-12-12-3073dd1c+3073dd1ce2ff5510f54a9411366f55c958b9ea45. We want to strip off everything after the +, so we can compare versions
+        if (infoVersion is not null && infoVersion.Contains('+'))
+        {
+            infoVersion = infoVersion[..infoVersion.IndexOf('+')];
+        }
+        Version = infoVersion ?? "dev";
+    }
+
+    public static readonly string Version;
 }

--- a/backend/FwLite/FwLiteDesktop/FwLiteDesktop.csproj
+++ b/backend/FwLite/FwLiteDesktop/FwLiteDesktop.csproj
@@ -37,8 +37,8 @@
 		<SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'ios'">11.0</SupportedOSPlatformVersion>
 		<SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'maccatalyst'">13.1</SupportedOSPlatformVersion>
 		<SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'android'">21.0</SupportedOSPlatformVersion>
-		<SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'windows'">10.0.17763.0</SupportedOSPlatformVersion>
-		<TargetPlatformMinVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'windows'">10.0.17763.0</TargetPlatformMinVersion>
+		<SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'windows'">10.0.19041.0</SupportedOSPlatformVersion>
+		<TargetPlatformMinVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'windows'">10.0.19041.0</TargetPlatformMinVersion>
 		<SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'tizen'">6.5</SupportedOSPlatformVersion>
 	</PropertyGroup>
     <PropertyGroup Condition="'$(Configuration)' == 'Debug' ">

--- a/backend/FwLite/FwLiteDesktop/FwLiteDesktop.csproj
+++ b/backend/FwLite/FwLiteDesktop/FwLiteDesktop.csproj
@@ -33,8 +33,6 @@
 		<!-- Versions -->
 		<ApplicationDisplayVersion>1.0</ApplicationDisplayVersion>
 		<ApplicationVersion>1</ApplicationVersion>
-<!--        version used in AppVersion.cs-->
-        <InformationalVersion>$(ApplicationDisplayVersion)</InformationalVersion>
 
 		<SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'ios'">11.0</SupportedOSPlatformVersion>
 		<SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'maccatalyst'">13.1</SupportedOSPlatformVersion>

--- a/backend/FwLite/FwLiteProjectSync/FwLiteProjectSync.csproj
+++ b/backend/FwLite/FwLiteProjectSync/FwLiteProjectSync.csproj
@@ -1,7 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <InformationalVersion>$(ApplicationDisplayVersion)</InformationalVersion>
         <FileVersion>$(ApplicationDisplayVersion)</FileVersion>
     </PropertyGroup>
 

--- a/backend/FwLite/LcmCrdt/LcmCrdt.csproj
+++ b/backend/FwLite/LcmCrdt/LcmCrdt.csproj
@@ -1,7 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <InformationalVersion>$(ApplicationDisplayVersion)</InformationalVersion>
         <FileVersion>$(ApplicationDisplayVersion)</FileVersion>
     </PropertyGroup>
 

--- a/backend/FwLite/LocalWebApp/LocalWebApp.csproj
+++ b/backend/FwLite/LocalWebApp/LocalWebApp.csproj
@@ -5,7 +5,6 @@
         <GenerateEmbeddedFilesManifest>true</GenerateEmbeddedFilesManifest>
         <ServerGarbageCollection>false</ServerGarbageCollection>
         <SelfContained>true</SelfContained>
-        <InformationalVersion>$(ApplicationDisplayVersion)</InformationalVersion>
         <FileVersion>$(ApplicationDisplayVersion)</FileVersion>
     </PropertyGroup>
     <PropertyGroup Condition="'$(Configuration)' == 'Release' ">

--- a/backend/FwLite/MiniLcm/MiniLcm.csproj
+++ b/backend/FwLite/MiniLcm/MiniLcm.csproj
@@ -1,7 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <InformationalVersion>$(ApplicationDisplayVersion)</InformationalVersion>
         <FileVersion>$(ApplicationDisplayVersion)</FileVersion>
     </PropertyGroup>
 


### PR DESCRIPTION
corrects the Information version used for update checks, previously it would look like this: 2024.12.11
+165a44a39dd33871473548694bb81a6b0ef0c2f8
but it should look like this: v2024-12-11-165a44a3 and that was breaking the update check

I also raised the min windows version to have access to an API which allows deferring the update while the app is running. I also removed the ARM builds as they didn't work and we don't have a way of testing them, they were doubling the build time in the meantime.