### PR TITLE
fix login fwlite web

### DIFF
--- a/backend/FwLite/FwLiteShared/Auth/AuthService.cs
+++ b/backend/FwLite/FwLiteShared/Auth/AuthService.cs
@@ -28,6 +28,12 @@ public class AuthService(LexboxProjectService lexboxProjectService, OAuthClientF
         options.Value.AfterLoginWebView?.Invoke();
     }
 
+    [JSInvokable]
+    public bool UseSystemWebView()
+    {
+        return options.Value.SystemWebViewLogin;
+    }
+
     public async Task<string> SignInWebApp(LexboxServer server, string returnUrl)
     {
         var result = await clientFactory.GetClient(server).SignIn(returnUrl);

--- a/backend/FwLite/FwLiteWeb/Components/App.razor
+++ b/backend/FwLite/FwLiteWeb/Components/App.razor
@@ -6,7 +6,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
     <base href="/"/>
     <link rel="icon" type="image/png" href="_content/FwLiteShared/favicon.png"/>
-    <HeadOutlet @rendermode="InteractiveServer"/>
+    <HeadOutlet @rendermode="new InteractiveServerRenderMode(prerender: false)"/>
     <script>
         window.invokeOnWindow = function (methodName, args) {
             if (!(methodName in window)) {
@@ -20,7 +20,7 @@
 </head>
 
 <body>
-<Routes @rendermode="InteractiveServer"/>
+<Routes @rendermode="new InteractiveServerRenderMode(prerender: false)"/>
 <script src="_framework/blazor.web.js"></script>
 </body>
 

--- a/backend/FwLite/FwLiteWeb/Routes/AuthRoutes.cs
+++ b/backend/FwLite/FwLiteWeb/Routes/AuthRoutes.cs
@@ -18,16 +18,12 @@ public static class AuthRoutes
             async (AuthService authService, string authority, IOptions<AuthConfig> options, [FromHeader] string referer) =>
             {
                 var returnUrl = new Uri(referer).PathAndQuery;
-                //todo blazor, once we're using blazor this endpoint will only be used for non webview logins
                 if (options.Value.SystemWebViewLogin)
                 {
-                    await authService.SignInWebView(options.Value.GetServerByAuthority(authority));
-                    return Results.Redirect(returnUrl);
+                    throw new NotSupportedException("System web view login is not supported for this endpoint");
                 }
-                else
-                {
-                    return Results.Redirect(await authService.SignInWebApp(options.Value.GetServerByAuthority(authority), returnUrl));
-                }
+
+                return Results.Redirect(await authService.SignInWebApp(options.Value.GetServerByAuthority(authority), returnUrl));
             });
         group.MapGet("/oauth-callback",
             async (OAuthService oAuthService, HttpContext context) =>

--- a/frontend/viewer/package.json
+++ b/frontend/viewer/package.json
@@ -19,7 +19,7 @@
     "dev": "vite build -m web-component --watch",
     "lexbox-dev": "vite build -m web-component",
     "build": "vite build -m web-component",
-    "build-app": "vite build --emptyOutDir",
+    "build-app": "vite build",
     "preview": "vite preview",
     "test": "vitest run",
     "test:ui": "vitest --ui",

--- a/frontend/viewer/src/lib/auth/LoginButton.svelte
+++ b/frontend/viewer/src/lib/auth/LoginButton.svelte
@@ -1,0 +1,79 @@
+﻿<script context="module" lang="ts">
+    import type {IAuthService} from '$lib/dotnet-types';
+    import {type Readable, writable, type Writable} from 'svelte/store';
+
+    let shouldUseSystemWebViewStore: Writable<boolean> | undefined = undefined;
+
+    function useSystemWebView(authService: IAuthService): Readable<boolean> {
+        if (shouldUseSystemWebViewStore) return shouldUseSystemWebViewStore;
+        shouldUseSystemWebViewStore = writable(true);
+        void authService.useSystemWebView().then(r => shouldUseSystemWebViewStore!.set(r));
+        return shouldUseSystemWebViewStore;
+    }
+</script>
+
+<script lang="ts">
+    import {mdiLogin, mdiLogout} from '@mdi/js';
+    import {Button} from 'svelte-ux';
+    import type {ILexboxServer} from '$lib/dotnet-types';
+    import {useAuthService} from '$lib/services/service-provider';
+    import {createEventDispatcher} from 'svelte';
+
+    const authService = useAuthService();
+    const shouldUseSystemWebView = useSystemWebView(authService);
+    const dispatch = createEventDispatcher<{
+        status: 'logged-in' | 'logged-out'
+    }>();
+    export let isLoggedIn: boolean;
+    export let server: ILexboxServer;
+    let loading = false;
+
+
+    async function login(server: ILexboxServer) {
+        loading = true;
+        try {
+            await authService.signInWebView(server);
+            dispatch('status', 'logged-in');
+        } finally {
+            loading = false;
+        }
+    }
+
+    async function logout(server: ILexboxServer) {
+        loading = true;
+        try {
+            await authService.logout(server);
+            dispatch('status', 'logged-out');
+        } finally {
+            loading = false;
+        }
+    }
+</script>
+
+{#if isLoggedIn}
+    <Button {loading}
+            variant="fill"
+            color="primary"
+            on:click={() => logout(server)}
+            icon={mdiLogout}>
+        Logout
+    </Button>
+{:else}
+    {#if $shouldUseSystemWebView}
+        <Button {loading}
+                variant="fill-light"
+                color="primary"
+                on:click={() => login(server)}
+                icon={mdiLogin}>
+            Login
+        </Button>
+    {:else}
+        <Button {loading}
+                variant="fill-light"
+                color="primary"
+                href="/api/auth/login/{server.id}"
+                icon={mdiLogin}>
+            Login
+        </Button>
+    {/if}
+{/if}

--- a/frontend/viewer/src/lib/dotnet-types/generated-types/FwLiteShared/Auth/IAuthService.ts
+++ b/frontend/viewer/src/lib/dotnet-types/generated-types/FwLiteShared/Auth/IAuthService.ts
@@ -10,6 +10,7 @@ export interface IAuthService
 {
 	servers() : Promise<IServerStatus[]>;
 	signInWebView(server: ILexboxServer) : Promise<void>;
+	useSystemWebView() : Promise<boolean>;
 	signInWebApp(server: ILexboxServer, returnUrl: string) : Promise<string>;
 	logout(server: ILexboxServer) : Promise<void>;
 	getLoggedInName(server: ILexboxServer) : Promise<string>;


### PR DESCRIPTION
login from FwLiteWeb was not working correctly because the frontend code was always trying to use the SystemWebView which it can't do from the web. There's also been a long standing issue of only 1 login attempt being possible at a time and if that login attempt was abandoned then the whole server needed to be restarted. Now that's been fixed and it will cancel abandoned logins after 5 minutes