### PR TITLE
Make Node GC kick in before available RAM runs out

### DIFF
--- a/frontend/dev.Dockerfile
+++ b/frontend/dev.Dockerfile
@@ -14,4 +14,5 @@ COPY . /app/
 COPY src /app/src
 COPY static /app/static
 ENV DockerDev=true
+ENV NODE_OPTIONS="--max-old-space-size=1024"
 CMD [ "pnpm", "run", "-r", "--include-workspace-root", "lexbox-dev" ]


### PR DESCRIPTION
Fix #1342.

Our ui container, in local dev, is currently allocated a max of 1250 MiB of RAM. Node normally allows its heap to grow up to 2 GiB, resulting in OOM errors in the container. Let's set Node's maximum heap to 1 GiB so that the GC kicks in before Kubernetes kills the container.