### PR TITLE
Fix random failure on msbuild --getProperty:OutputPath

### DIFF
--- a/backend/Testing/Taskfile.yml
+++ b/backend/Testing/Taskfile.yml
@@ -1,9 +1,5 @@
 ﻿version: 3
 
-vars:
-  OUTPUT_PATH:
-    sh: dotnet msbuild --getProperty:OutputPath
-
 tasks:
   unit:
     interactive: true
@@ -75,8 +71,14 @@ tasks:
     cmd: task playwright -- {{.CLI_ARGS}}
 
   traces:
+    env:
+      OUTPUT_PATH:
+        sh: dotnet msbuild --getProperty:OutputPath
     cmd: explorer "{{.OUTPUT_PATH}}playwright-traces"
     ignore_error: true
 
   playwright-install:
+    env:
+      OUTPUT_PATH:
+        sh: dotnet msbuild --getProperty:OutputPath
     cmd: pwsh '{{.OUTPUT_PATH}}playwright.ps1 install'


### PR DESCRIPTION
On some computers, `dotnet msbuild --getProperty:OutputPath` has been randomly freezing or failing to run. Let's switch to running it only in the commands that actually need it.

Fixes #1349.