### PR TITLE
Autofocus lexeme form when new entry dialog opens

### DIFF
--- a/frontend/viewer/src/lib/entry-editor/field-editors/MultiFieldEditor.svelte
+++ b/frontend/viewer/src/lib/entry-editor/field-editors/MultiFieldEditor.svelte
@@ -19,6 +19,7 @@
   export let wsType: WritingSystemSelection;
   export let value: IMultiString;
   export let readonly: boolean = false;
+  export let autofocus: boolean = false;
 
   let unsavedChanges: Record<string, boolean> = {};
   let currentView = useCurrentView();
@@ -31,11 +32,12 @@
 <div class="multi-field field" class:collapse-field={collapse} class:empty class:hidden={!$currentView.fields[id].show} style:grid-area={id}>
   <FieldTitle {id} {name} />
   <div class="fields">
-    {#each writingSystems as ws (ws.wsId)}
+    {#each writingSystems as ws, idx (ws.wsId)}
       <CrdtTextField
         on:change={() => dispatch('change', { value })}
         bind:value={value[ws.wsId]}
         bind:unsavedChanges={unsavedChanges[ws.wsId]}
+        autofocus={autofocus && (idx == 0)}
         label={collapse ? undefined : ws.abbreviation}
         labelPlacement={collapse ? undefined : 'left'}
         placeholder={collapse ? ws.abbreviation : undefined}

--- a/frontend/viewer/src/lib/entry-editor/inputs/CrdtTextField.svelte
+++ b/frontend/viewer/src/lib/entry-editor/inputs/CrdtTextField.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import type { ComponentProps } from 'svelte';
   import CrdtField from './CrdtField.svelte';
-  import { TextField } from 'svelte-ux';
+  import { TextField, autoFocus as autoFocusFunc } from 'svelte-ux';
 
   export let value: string | number | null | undefined;
   export let unsavedChanges = false;
@@ -18,15 +18,18 @@
     if (label && labelElem) labelElem.setAttribute('title', label);
   }
 </script>
-
 <CrdtField on:change bind:value bind:unsavedChanges let:editorValue let:save let:onEditorValueChange viewMergeButtonPortal={append}>
   <TextField
     on:change={(e) => onEditorValueChange(e.detail.inputValue)}
     on:blur={(e) => {if (e.target) save()}}
-    actions={(el) => { addTitleToLabel(el); return []; }}
+    actions={(el) => {
+      addTitleToLabel(el);
+      // autofocus requires a delay otherwise it won't work in a dialog
+      // also we can't use the autofocus attribute because of https://github.com/techniq/svelte-ux/issues/532
+      return autofocus ? [autoFocusFunc(el, {delay: 5})] : [];
+    }}
     value={editorValue}
     disabled={readonly}
-    autofocus={autofocus}
     class="ws-field gap-2 text-right"
     classes={{ root: `${editorValue ? '' : 'empty'} ${readonly ? 'readonly' : ''}`, input: 'field-input', container: 'field-container' }}
     {label}

--- a/frontend/viewer/src/lib/entry-editor/inputs/CrdtTextField.svelte
+++ b/frontend/viewer/src/lib/entry-editor/inputs/CrdtTextField.svelte
@@ -9,6 +9,7 @@
   export let labelPlacement: ComponentProps<TextField>['labelPlacement'] = undefined;
   export let placeholder: string | undefined = undefined;
   export let readonly: boolean | undefined = undefined;
+  export let autofocus: boolean = false;
   let append: HTMLElement;
 
   // Labels don't always fit (beause WS's can be long and ugly), so a title might be important sometimes
@@ -25,6 +26,7 @@
     actions={(el) => { addTitleToLabel(el); return []; }}
     value={editorValue}
     disabled={readonly}
+    autofocus={autofocus}
     class="ws-field gap-2 text-right"
     classes={{ root: `${editorValue ? '' : 'empty'} ${readonly ? 'readonly' : ''}`, input: 'field-input', container: 'field-container' }}
     {label}

--- a/frontend/viewer/src/lib/entry-editor/object-editors/EntryEditor.svelte
+++ b/frontend/viewer/src/lib/entry-editor/object-editors/EntryEditor.svelte
@@ -116,6 +116,7 @@
     <MultiFieldEditor on:change={() => dispatch('change', {entry})}
                       bind:value={entry.lexemeForm}
                       {readonly}
+                      autofocus={modalMode}
                       id="lexemeForm"
                       wsType="vernacular"/>
 


### PR DESCRIPTION
Fixes #1328 

There appears to be a bug with the autofocus attribute in svelte-ux; @hahn-kev worked around the bug and now this is working.