### PR TITLE
make activity changes textbox readonly

### DIFF
--- a/frontend/viewer/src/app.postcss
+++ b/frontend/viewer/src/app.postcss
@@ -112,3 +112,20 @@
 .AppBar :has(> [slot="actions"]) {
   flex-grow: 0;
 }
+
+/* the input must also be disabled, otherwise it will be editable*/
+.input-readonly {
+    &.TextField, .TextField {
+        opacity: 1;
+
+        input, textarea {
+            /* enable standard text selection */
+            pointer-events: auto;
+            cursor: text;
+        }
+
+        .append {
+            display: none;
+        }
+    }
+}

--- a/frontend/viewer/src/lib/activity/ActivityView.svelte
+++ b/frontend/viewer/src/lib/activity/ActivityView.svelte
@@ -86,8 +86,9 @@
       {#if selectedRow}
         <TextField label="Changes"
                    value={JSON.stringify(selectedRow.changes, null, 4)}
+                   disabled
                    multiline
-                   class="readonly"
+                   class="input-readonly"
                    classes={{input: 'h-80'}}/>
       {/if}
     </div>

--- a/frontend/viewer/src/lib/history/HistoryView.svelte
+++ b/frontend/viewer/src/lib/history/HistoryView.svelte
@@ -70,14 +70,14 @@
       <div>
         {#if record?.entity}
           {#if record.entityName === 'Entry'}
-            <EntryEditor entry={record.entity} modalMode/>
+            <EntryEditor entry={record.entity} modalMode readonly/>
           {:else if record.entityName === 'Sense'}
             <div class="editor-grid">
-              <SenseEditor sense={record.entity}/>
+              <SenseEditor sense={record.entity} readonly/>
             </div>
           {:else if record.entityName === 'ExampleSentence'}
             <div class="editor-grid">
-              <ExampleEditor example={record.entity} readonly={false}/>
+              <ExampleEditor example={record.entity} readonly/>
             </div>
           {/if}
         {/if}


### PR DESCRIPTION
closes #1329 #1331 

Taking a look at the history dialog in readonly mode it looks strange as it feels hard to tell what's data and what's not:
![image](https://github.com/user-attachments/assets/fba045b0-f6d7-470e-84e9-299de6250e86)


I think it looks better with the borders, it's not obvious that it's readonly, but trying to edit will make that obvious.
![image](https://github.com/user-attachments/assets/5ce0cacd-5ed4-4f83-9de0-fd2af0a77261)

@myieye what do you think?

I also noticed a bug that the Complex Forms field is empty in history view so I've made #1369 to track that issue