### PR TITLE
introduce configuration to define fw lite platform releases and how release assets are matched per platform, add a platform as a parameter to the http api

### DIFF
--- a/backend/LexBoxApi/Config/FwLiteReleaseConfig.cs
+++ b/backend/LexBoxApi/Config/FwLiteReleaseConfig.cs
@@ -1,0 +1,22 @@
+﻿using System.ComponentModel.DataAnnotations;
+using System.Diagnostics.CodeAnalysis;
+using System.Text.Json.Serialization;
+using System.Text.RegularExpressions;
+using LexBoxApi.Controllers;
+using LexCore.Entities;
+
+namespace LexBoxApi.Config;
+
+public class FwLiteReleaseConfig
+{
+    public Dictionary<FwLitePlatform, FwLitePlatformConfig> Platforms { get; set; } = new();
+}
+
+public class FwLitePlatformConfig
+{
+    [Required]
+    public required string FileNameRegex { get; init; }
+
+    [field: AllowNull]
+    public Regex FileName => field ??= new Regex(FileNameRegex);
+}

--- a/backend/LexBoxApi/Controllers/FwLiteReleaseController.cs
+++ b/backend/LexBoxApi/Controllers/FwLiteReleaseController.cs
@@ -1,12 +1,10 @@
 ﻿using System.Diagnostics;
-using System.Text.Json;
-using System.Text.Json.Serialization;
+using LexBoxApi.Config;
 using LexBoxApi.Otel;
 using LexBoxApi.Services.FwLiteReleases;
 using LexCore.Entities;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
-using Microsoft.Extensions.Caching.Hybrid;
 
 namespace LexBoxApi.Controllers;
 
@@ -19,10 +17,11 @@ public class FwLiteReleaseController(FwLiteReleaseService releaseService) : Cont
     [HttpGet("download-latest")]
     [AllowAnonymous]
     [ProducesResponseType(StatusCodes.Status404NotFound)]
-    public async Task<ActionResult> DownloadLatest()
+    public async Task<ActionResult> DownloadLatest([FromQuery] FwLitePlatform platform = FwLitePlatform.Windows)
     {
         using var activity = LexBoxActivitySource.Get().StartActivity();
-        var latestRelease = await releaseService.GetLatestRelease();
+        activity?.AddTag(FwLiteReleaseService.FwLitePlatformTag, platform.ToString());
+        var latestRelease = await releaseService.GetLatestRelease(platform);
         if (latestRelease is null)
         {
             activity?.SetStatus(ActivityStatusCode.Error, "Latest release not found");
@@ -37,11 +36,13 @@ public class FwLiteReleaseController(FwLiteReleaseService releaseService) : Cont
     [ProducesResponseType(StatusCodes.Status404NotFound)]
     [ProducesResponseType(StatusCodes.Status200OK)]
     [ProducesDefaultResponseType]
-    public async ValueTask<ActionResult<FwLiteRelease>> LatestRelease(string? appVersion = null)
+    public async ValueTask<ActionResult<FwLiteRelease>> LatestRelease([FromQuery] FwLitePlatform platform =
+        FwLitePlatform.Windows, string? appVersion = null)
     {
         using var activity = LexBoxActivitySource.Get().StartActivity();
         activity?.AddTag(FwLiteReleaseService.FwLiteClientVersionTag, appVersion ?? "unknown");
-        var latestRelease = await releaseService.GetLatestRelease();
+        activity?.AddTag(FwLiteReleaseService.FwLitePlatformTag, platform.ToString());
+        var latestRelease = await releaseService.GetLatestRelease(platform);
         activity?.AddTag(FwLiteReleaseService.FwLiteReleaseVersionTag, latestRelease?.Version);
         if (latestRelease is null) return NotFound();
         return latestRelease;
@@ -49,11 +50,12 @@ public class FwLiteReleaseController(FwLiteReleaseService releaseService) : Cont
 
     [HttpGet("should-update")]
     [AllowAnonymous]
-    public async Task<ActionResult<ShouldUpdateResponse>> ShouldUpdate([FromQuery] string appVersion)
+    public async Task<ActionResult<ShouldUpdateResponse>> ShouldUpdate([FromQuery] string appVersion, [FromQuery] FwLitePlatform platform = FwLitePlatform.Windows)
     {
         using var activity = LexBoxActivitySource.Get().StartActivity();
         activity?.AddTag(FwLiteReleaseService.FwLiteClientVersionTag, appVersion);
-        var response = await releaseService.ShouldUpdate(appVersion);
+        activity?.AddTag(FwLiteReleaseService.FwLitePlatformTag, platform.ToString());
+        var response = await releaseService.ShouldUpdate(platform, appVersion);
         activity?.AddTag(FwLiteReleaseService.FwLiteReleaseVersionTag, response.Release?.Version);
         return response;
     }

--- a/backend/LexBoxApi/LexBoxApi.csproj
+++ b/backend/LexBoxApi/LexBoxApi.csproj
@@ -5,6 +5,7 @@
         <IncludeOpenAPIAnalyzers>true</IncludeOpenAPIAnalyzers>
         <UserSecretsId>7392cddf-9b3b-441c-9316-203bb5c4a6bc</UserSecretsId>
         <GarbageCollectionAdaptationMode>1</GarbageCollectionAdaptationMode>
+        <LangVersion>preview</LangVersion>
     </PropertyGroup>
 
     <ItemGroup>

--- a/backend/LexBoxApi/LexBoxKernel.cs
+++ b/backend/LexBoxApi/LexBoxKernel.cs
@@ -49,6 +49,10 @@ public static class LexBoxKernel
             .BindConfiguration("HealthChecks")
             .ValidateDataAnnotations()
             .ValidateOnStart();
+        services.AddOptions<FwLiteReleaseConfig>()
+            .BindConfiguration("FwLiteRelease")
+            .ValidateDataAnnotations()
+            .ValidateOnStart();
         services.AddHttpClient();
         services.AddServiceDiscovery();
         services.AddHttpClient<FwHeadlessClient>(client => client.BaseAddress = new ("http://fwHeadless"))

--- a/backend/LexBoxApi/Services/FwLiteReleases/FwLiteReleaseService.cs
+++ b/backend/LexBoxApi/Services/FwLiteReleases/FwLiteReleaseService.cs
@@ -1,28 +1,31 @@
 ﻿using System.Diagnostics;
-using LexBoxApi.Controllers;
+using LexBoxApi.Config;
 using LexBoxApi.Otel;
 using LexCore.Entities;
 using Microsoft.Extensions.Caching.Hybrid;
+using Microsoft.Extensions.Options;
 
 namespace LexBoxApi.Services.FwLiteReleases;
 
-public class FwLiteReleaseService(IHttpClientFactory factory, HybridCache cache)
+public class FwLiteReleaseService(IHttpClientFactory factory, HybridCache cache, IOptions<FwLiteReleaseConfig> config)
 {
     private const string GithubLatestRelease = "GithubLatestRelease";
     public const string FwLiteClientVersionTag = "app.fw-lite.client.version";
+    public const string FwLitePlatformTag = "app.fw-lite.platform";
     public const string FwLiteReleaseVersionTag = "app.fw-lite.release.version";
 
-    public async ValueTask<FwLiteRelease?> GetLatestRelease(CancellationToken token = default)
+    public async ValueTask<FwLiteRelease?> GetLatestRelease(FwLitePlatform platform, CancellationToken token = default)
     {
-        return await cache.GetOrCreateAsync(GithubLatestRelease,
+        return await cache.GetOrCreateAsync($"{GithubLatestRelease}|{platform}",
+            platform,
             FetchLatestReleaseFromGithub,
             new HybridCacheEntryOptions() { Expiration = TimeSpan.FromDays(1) },
-            cancellationToken: token);
+            cancellationToken: token, tags: [GithubLatestRelease]);
     }
 
-    public async ValueTask<ShouldUpdateResponse> ShouldUpdate(string appVersion)
+    public async ValueTask<ShouldUpdateResponse> ShouldUpdate(FwLitePlatform platform, string appVersion)
     {
-        var latestRelease = await GetLatestRelease();
+        var latestRelease = await GetLatestRelease(platform);
         if (latestRelease is null) return new ShouldUpdateResponse(null);
 
         var shouldUpdateToRelease = ShouldUpdateToRelease(appVersion, latestRelease.Version);
@@ -36,12 +39,18 @@ public class FwLiteReleaseService(IHttpClientFactory factory, HybridCache cache)
 
     public async ValueTask InvalidateReleaseCache()
     {
-        await cache.RemoveAsync(GithubLatestRelease);
+        await cache.RemoveByTagAsync(GithubLatestRelease);
     }
 
-    private async ValueTask<FwLiteRelease?> FetchLatestReleaseFromGithub(CancellationToken token)
+    private async ValueTask<FwLiteRelease?> FetchLatestReleaseFromGithub(FwLitePlatform platform, CancellationToken token)
     {
+        var platformConfig = config.Value.Platforms.GetValueOrDefault(platform);
+        if (platformConfig is null)
+        {
+            throw new ArgumentException($"No config for platform {platform}");
+        }
         using var activity = LexBoxActivitySource.Get().StartActivity();
+        activity?.AddTag(FwLitePlatformTag, platform.ToString());
         var response = await factory.CreateClient("Github")
             .SendAsync(new HttpRequestMessage(HttpMethod.Get,
                     "https://api.github.com/repos/sillsdev/languageforge-lexbox/releases")
@@ -74,12 +83,11 @@ public class FwLiteReleaseService(IHttpClientFactory factory, HybridCache cache)
                     continue;
                 }
 
-                var msixBundle = release.Assets.FirstOrDefault(a =>
-                    a.Name.EndsWith(".msixbundle", StringComparison.InvariantCultureIgnoreCase));
-                if (msixBundle is not null)
+                var releaseAsset = release.Assets.FirstOrDefault(a => platformConfig.FileName.IsMatch(a.Name));
+                if (releaseAsset is not null)
                 {
                     activity?.AddTag(FwLiteReleaseVersionTag, release.TagName);
-                    return new FwLiteRelease(release.TagName, msixBundle.BrowserDownloadUrl);
+                    return new FwLiteRelease(release.TagName, releaseAsset.BrowserDownloadUrl);
                 }
             }
         }

--- a/backend/LexBoxApi/appsettings.json
+++ b/backend/LexBoxApi/appsettings.json
@@ -75,5 +75,17 @@
     "fwHeadless": {
       "http": ["fw-headless"]
     }
+  },
+  "FwLiteRelease": {
+    "Platforms": {
+      "Windows": {
+        // ends with .msixbundle regex
+        "FileNameRegex": "(?i)\\.msixbundle$"
+      },
+      "Linux": {
+        // ends with linux.zip regex
+        "FileNameRegex": "(?i)linux\\.zip$"
+      }
+    }
   }
 }

--- a/backend/LexCore/Entities/FwLiteRelease.cs
+++ b/backend/LexCore/Entities/FwLiteRelease.cs
@@ -10,6 +10,10 @@ public enum FwLitePlatform
 {
     Windows,
     Linux,
+    Android,
+    // ReSharper disable once InconsistentNaming
+    iOS,
+    Mac
 }
 
 public record ShouldUpdateResponse(FwLiteRelease? Release)

--- a/backend/LexCore/Entities/FwLiteRelease.cs
+++ b/backend/LexCore/Entities/FwLiteRelease.cs
@@ -1,8 +1,16 @@
 ﻿using System.Diagnostics.CodeAnalysis;
+using System.Text.Json.Serialization;
 
 namespace LexCore.Entities;
 
 public record FwLiteRelease(string Version, string Url);
+
+[JsonConverter(typeof(JsonStringEnumConverter))]
+public enum FwLitePlatform
+{
+    Windows,
+    Linux,
+}
 
 public record ShouldUpdateResponse(FwLiteRelease? Release)
 {


### PR DESCRIPTION
this will let us link to the latest linux release. Ideally the configuration should always be checked in and only defined in appsettings.json, however this will let us change the config without redeploying via an environment variable in k8s