### PR TITLE
Allow org admins to create guest users

### DIFF
--- a/backend/LexBoxApi/Controllers/LoginController.cs
+++ b/backend/LexBoxApi/Controllers/LoginController.cs
@@ -170,7 +170,7 @@ public class LoginController(
 
         user.Email = loggedInContext.User.Email;
         user.EmailVerified = true;
-        // Guest ussers are promoted to "regular" users once they verify an email address
+        // Guest users are promoted to "regular" users once they verify an email address
         user.CreatedById = null;
         user.UpdateUpdatedDate();
         await lexBoxDbContext.SaveChangesAsync();

--- a/backend/LexBoxApi/GraphQL/ProjectMutations.cs
+++ b/backend/LexBoxApi/GraphQL/ProjectMutations.cs
@@ -134,9 +134,9 @@ public class ProjectMutations
     [Error<NotFoundException>]
     [Error<InvalidEmailException>]
     [Error<DbError>]
-    [AdminRequired]
     [UseMutationConvention]
     public async Task<BulkAddProjectMembersResult> BulkAddProjectMembers(
+        IPermissionService permissionService,
         LoggedInContext loggedInContext,
         BulkAddProjectMembersInput input,
         LexBoxDbContext dbContext)
@@ -145,6 +145,11 @@ public class ProjectMutations
         {
             var projectExists = await dbContext.Projects.AnyAsync(p => p.Id == input.ProjectId.Value);
             if (!projectExists) throw new NotFoundException("Project not found", "project");
+            await permissionService.AssertCanCreateGuestUserInProject(input.ProjectId.Value);
+        }
+        else
+        {
+            permissionService.AssertCanCreateGuestUserInAnyProject();
         }
         List<UserProjectRole> AddedMembers = [];
         List<UserProjectRole> CreatedMembers = [];

--- a/backend/LexBoxApi/GraphQL/ProjectMutations.cs
+++ b/backend/LexBoxApi/GraphQL/ProjectMutations.cs
@@ -141,16 +141,10 @@ public class ProjectMutations
         BulkAddProjectMembersInput input,
         LexBoxDbContext dbContext)
     {
-        if (input.ProjectId.HasValue)
-        {
-            var projectExists = await dbContext.Projects.AnyAsync(p => p.Id == input.ProjectId.Value);
-            if (!projectExists) throw new NotFoundException("Project not found", "project");
-            await permissionService.AssertCanCreateGuestUserInProject(input.ProjectId.Value);
-        }
-        else
-        {
-            permissionService.AssertCanCreateGuestUserInAnyProject();
-        }
+        await permissionService.AssertCanCreateGuestUserInProject(input.ProjectId);
+        if (input.ProjectId == null) throw new NotFoundException("Project not found", "project");
+        var projectExists = await dbContext.Projects.AnyAsync(p => p.Id == input.ProjectId.Value);
+        if (!projectExists) throw new NotFoundException("Project not found", "project");
         List<UserProjectRole> AddedMembers = [];
         List<UserProjectRole> CreatedMembers = [];
         List<UserProjectRole> ExistingMembers = [];

--- a/backend/LexBoxApi/GraphQL/UserMutations.cs
+++ b/backend/LexBoxApi/GraphQL/UserMutations.cs
@@ -34,7 +34,8 @@ public class UserMutations
         string? Username,
         string Locale,
         string PasswordHash,
-        int PasswordStrength);
+        int PasswordStrength,
+        Guid? ProjectId);
 
     [Error<NotFoundException>]
     [Error<DbError>]
@@ -105,7 +106,7 @@ public class UserMutations
     )
     {
         using var createGuestUserActivity = LexBoxActivitySource.Get().StartActivity("CreateGuestUser");
-        permissionService.AssertCanCreateGuestUserInAnyProject();
+        permissionService.AssertCanCreateGuestUserInProject(input.ProjectId);
 
         var hasExistingUser = input.Email is null && input.Username is null
             ? throw new RequiredException("Guest users must have either an email or a username")

--- a/backend/LexBoxApi/GraphQL/UserMutations.cs
+++ b/backend/LexBoxApi/GraphQL/UserMutations.cs
@@ -96,8 +96,8 @@ public class UserMutations
     [Error<DbError>]
     [Error<UniqueValueException>]
     [Error<RequiredException>]
-    [AdminRequired]
     public async Task<LexAuthUser> CreateGuestUserByAdmin(
+        IPermissionService permissionService,
         LoggedInContext loggedInContext,
         CreateGuestUserByAdminInput input,
         LexBoxDbContext dbContext,
@@ -105,6 +105,7 @@ public class UserMutations
     )
     {
         using var createGuestUserActivity = LexBoxActivitySource.Get().StartActivity("CreateGuestUser");
+        permissionService.AssertCanCreateGuestUserInAnyProject();
 
         var hasExistingUser = input.Email is null && input.Username is null
             ? throw new RequiredException("Guest users must have either an email or a username")

--- a/backend/LexBoxApi/Models/Project/ProjectMemberInputs.cs
+++ b/backend/LexBoxApi/Models/Project/ProjectMemberInputs.cs
@@ -4,6 +4,6 @@ namespace LexBoxApi.Models.Project;
 
 public record AddProjectMemberInput(Guid ProjectId, string? UsernameOrEmail, Guid? UserId, ProjectRole Role, bool canInvite);
 
-public record BulkAddProjectMembersInput(Guid? ProjectId, string[] Usernames, ProjectRole Role, string PasswordHash);
+public record BulkAddProjectMembersInput(Guid ProjectId, string[] Usernames, ProjectRole Role, string PasswordHash);
 
 public record ChangeProjectMemberRoleInput(Guid ProjectId, Guid UserId, ProjectRole Role);

--- a/backend/LexBoxApi/Services/PermissionService.cs
+++ b/backend/LexBoxApi/Services/PermissionService.cs
@@ -141,16 +141,14 @@ public class PermissionService(
             throw new UnauthorizedAccessException("Not allowed to change own project role.");
     }
 
-    public async ValueTask<bool> CanCreateGuestUserInProject(Guid? projectId)
+    public async ValueTask<bool> CanCreateGuestUserInProject(Guid projectId)
     {
         if (User is null) return false;
         if (User.Role == UserRole.admin) return true;
-        // Site admins can create guest users even with no project, anyone else (like org admins) must specify a project ID
-        if (projectId is null) return false;
-        return await ManagesOrgThatOwnsProject(projectId.Value);
+        return await ManagesOrgThatOwnsProject(projectId);
     }
 
-    public async ValueTask AssertCanCreateGuestUserInProject(Guid? projectId)
+    public async ValueTask AssertCanCreateGuestUserInProject(Guid projectId)
     {
         if (!await CanCreateGuestUserInProject(projectId)) throw new UnauthorizedAccessException();
     }

--- a/backend/LexBoxApi/Services/PermissionService.cs
+++ b/backend/LexBoxApi/Services/PermissionService.cs
@@ -141,6 +141,30 @@ public class PermissionService(
             throw new UnauthorizedAccessException("Not allowed to change own project role.");
     }
 
+    public async ValueTask<bool> CanCreateGuestUserInProject(Guid projectId)
+    {
+        if (User is null) return false;
+        if (User.Role == UserRole.admin) return true;
+        return await ManagesOrgThatOwnsProject(projectId);
+    }
+
+    public async ValueTask AssertCanCreateGuestUserInProject(Guid projectId)
+    {
+        if (!await CanCreateGuestUserInProject(projectId)) throw new UnauthorizedAccessException();
+    }
+
+    public bool CanCreateGuestUserInAnyProject()
+    {
+        if (User is null) return false;
+        if (User.Role == UserRole.admin) return true;
+        return User.Orgs.Any(o => o.Role == OrgRole.Admin);
+    }
+
+    public void AssertCanCreateGuestUserInAnyProject()
+    {
+        if (!CanCreateGuestUserInAnyProject()) throw new UnauthorizedAccessException();
+    }
+
     public async ValueTask<bool> CanAskToJoinProject(Guid projectId)
     {
         if (User is null) return false;

--- a/backend/LexBoxApi/Services/PermissionService.cs
+++ b/backend/LexBoxApi/Services/PermissionService.cs
@@ -155,6 +155,20 @@ public class PermissionService(
         if (!await CanCreateGuestUserInProject(projectId)) throw new UnauthorizedAccessException();
     }
 
+    public bool CanCreateGuestUserInOrg(Guid? orgId)
+    {
+        if (User is null) return false;
+        if (User.Role == UserRole.admin) return true;
+        // Site admins can create guest users even with no org, anyone else (like org admins) must specify an org ID
+        if (orgId is null) return false;
+        return CanEditOrg(orgId.Value);
+    }
+
+    public void AssertCanCreateGuestUserInOrg(Guid? orgId)
+    {
+        if (!CanCreateGuestUserInOrg(orgId)) throw new UnauthorizedAccessException();
+    }
+
     public async ValueTask<bool> CanAskToJoinProject(Guid projectId)
     {
         if (User is null) return false;

--- a/backend/LexBoxApi/Services/PermissionService.cs
+++ b/backend/LexBoxApi/Services/PermissionService.cs
@@ -141,28 +141,18 @@ public class PermissionService(
             throw new UnauthorizedAccessException("Not allowed to change own project role.");
     }
 
-    public async ValueTask<bool> CanCreateGuestUserInProject(Guid projectId)
+    public async ValueTask<bool> CanCreateGuestUserInProject(Guid? projectId)
     {
         if (User is null) return false;
         if (User.Role == UserRole.admin) return true;
-        return await ManagesOrgThatOwnsProject(projectId);
+        // Site admins can create guest users even with no project, anyone else (like org admins) must specify a project ID
+        if (projectId is null) return false;
+        return await ManagesOrgThatOwnsProject(projectId.Value);
     }
 
-    public async ValueTask AssertCanCreateGuestUserInProject(Guid projectId)
+    public async ValueTask AssertCanCreateGuestUserInProject(Guid? projectId)
     {
         if (!await CanCreateGuestUserInProject(projectId)) throw new UnauthorizedAccessException();
-    }
-
-    public bool CanCreateGuestUserInAnyProject()
-    {
-        if (User is null) return false;
-        if (User.Role == UserRole.admin) return true;
-        return User.Orgs.Any(o => o.Role == OrgRole.Admin);
-    }
-
-    public void AssertCanCreateGuestUserInAnyProject()
-    {
-        if (!CanCreateGuestUserInAnyProject()) throw new UnauthorizedAccessException();
     }
 
     public async ValueTask<bool> CanAskToJoinProject(Guid projectId)

--- a/backend/LexCore/ServiceInterfaces/IPermissionService.cs
+++ b/backend/LexCore/ServiceInterfaces/IPermissionService.cs
@@ -20,8 +20,8 @@ public interface IPermissionService
     ValueTask AssertCanManageProject(Guid projectId);
     ValueTask AssertCanManageProject(string projectCode);
     ValueTask AssertCanManageProjectMemberRole(Guid projectId, Guid userId);
-    ValueTask<bool> CanCreateGuestUserInProject(Guid? projectId);
-    ValueTask AssertCanCreateGuestUserInProject(Guid? projectId);
+    ValueTask<bool> CanCreateGuestUserInProject(Guid projectId);
+    ValueTask AssertCanCreateGuestUserInProject(Guid projectId);
     bool CanCreateGuestUserInOrg(Guid? orgId);
     void AssertCanCreateGuestUserInOrg(Guid? orgId);
     ValueTask<bool> CanAskToJoinProject(Guid projectId);

--- a/backend/LexCore/ServiceInterfaces/IPermissionService.cs
+++ b/backend/LexCore/ServiceInterfaces/IPermissionService.cs
@@ -20,10 +20,8 @@ public interface IPermissionService
     ValueTask AssertCanManageProject(Guid projectId);
     ValueTask AssertCanManageProject(string projectCode);
     ValueTask AssertCanManageProjectMemberRole(Guid projectId, Guid userId);
-    ValueTask<bool> CanCreateGuestUserInProject(Guid projectId);
-    ValueTask AssertCanCreateGuestUserInProject(Guid projectId);
-    bool CanCreateGuestUserInAnyProject();
-    void AssertCanCreateGuestUserInAnyProject();
+    ValueTask<bool> CanCreateGuestUserInProject(Guid? projectId);
+    ValueTask AssertCanCreateGuestUserInProject(Guid? projectId);
     ValueTask<bool> CanAskToJoinProject(Guid projectId);
     ValueTask<bool> CanAskToJoinProject(string projectCode);
     ValueTask AssertCanAskToJoinProject(Guid projectId);

--- a/backend/LexCore/ServiceInterfaces/IPermissionService.cs
+++ b/backend/LexCore/ServiceInterfaces/IPermissionService.cs
@@ -20,6 +20,10 @@ public interface IPermissionService
     ValueTask AssertCanManageProject(Guid projectId);
     ValueTask AssertCanManageProject(string projectCode);
     ValueTask AssertCanManageProjectMemberRole(Guid projectId, Guid userId);
+    ValueTask<bool> CanCreateGuestUserInProject(Guid projectId);
+    ValueTask AssertCanCreateGuestUserInProject(Guid projectId);
+    bool CanCreateGuestUserInAnyProject();
+    void AssertCanCreateGuestUserInAnyProject();
     ValueTask<bool> CanAskToJoinProject(Guid projectId);
     ValueTask<bool> CanAskToJoinProject(string projectCode);
     ValueTask AssertCanAskToJoinProject(Guid projectId);

--- a/backend/LexCore/ServiceInterfaces/IPermissionService.cs
+++ b/backend/LexCore/ServiceInterfaces/IPermissionService.cs
@@ -22,6 +22,8 @@ public interface IPermissionService
     ValueTask AssertCanManageProjectMemberRole(Guid projectId, Guid userId);
     ValueTask<bool> CanCreateGuestUserInProject(Guid? projectId);
     ValueTask AssertCanCreateGuestUserInProject(Guid? projectId);
+    bool CanCreateGuestUserInOrg(Guid? orgId);
+    void AssertCanCreateGuestUserInOrg(Guid? orgId);
     ValueTask<bool> CanAskToJoinProject(Guid projectId);
     ValueTask<bool> CanAskToJoinProject(string projectCode);
     ValueTask AssertCanAskToJoinProject(Guid projectId);

--- a/frontend/schema.graphql
+++ b/frontend/schema.graphql
@@ -727,7 +727,7 @@ input CreateGuestUserByAdminInput {
   locale: String!
   passwordHash: String!
   passwordStrength: Int!
-  projectId: UUID
+  orgId: UUID
 }
 
 input CreateOrganizationInput {

--- a/frontend/schema.graphql
+++ b/frontend/schema.graphql
@@ -673,7 +673,7 @@ input BulkAddOrgMembersInput {
 }
 
 input BulkAddProjectMembersInput {
-  projectId: UUID
+  projectId: UUID!
   usernames: [String!]!
   role: ProjectRole!
   passwordHash: String!

--- a/frontend/schema.graphql
+++ b/frontend/schema.graphql
@@ -254,7 +254,7 @@ type Mutation {
   changeOrgName(input: ChangeOrgNameInput!): ChangeOrgNamePayload! @cost(weight: "10")
   createProject(input: CreateProjectInput!): CreateProjectPayload! @authorize(policy: "VerifiedEmailRequiredPolicy") @cost(weight: "10")
   addProjectMember(input: AddProjectMemberInput!): AddProjectMemberPayload! @cost(weight: "10")
-  bulkAddProjectMembers(input: BulkAddProjectMembersInput!): BulkAddProjectMembersPayload! @authorize(policy: "AdminRequiredPolicy") @cost(weight: "10")
+  bulkAddProjectMembers(input: BulkAddProjectMembersInput!): BulkAddProjectMembersPayload! @cost(weight: "10")
   changeProjectMemberRole(input: ChangeProjectMemberRoleInput!): ChangeProjectMemberRolePayload! @cost(weight: "10")
   askToJoinProject(input: AskToJoinProjectInput!): AskToJoinProjectPayload! @cost(weight: "10")
   changeProjectName(input: ChangeProjectNameInput!): ChangeProjectNamePayload! @cost(weight: "10")
@@ -273,7 +273,7 @@ type Mutation {
   changeUserAccountBySelf(input: ChangeUserAccountBySelfInput!): ChangeUserAccountBySelfPayload! @cost(weight: "10")
   changeUserAccountByAdmin(input: ChangeUserAccountByAdminInput!): ChangeUserAccountByAdminPayload! @authorize(policy: "AdminRequiredPolicy") @cost(weight: "10")
   sendNewVerificationEmailByAdmin(input: SendNewVerificationEmailByAdminInput!): SendNewVerificationEmailByAdminPayload! @authorize(policy: "AdminRequiredPolicy") @cost(weight: "10")
-  createGuestUserByAdmin(input: CreateGuestUserByAdminInput!): CreateGuestUserByAdminPayload! @authorize(policy: "AdminRequiredPolicy") @cost(weight: "10")
+  createGuestUserByAdmin(input: CreateGuestUserByAdminInput!): CreateGuestUserByAdminPayload! @cost(weight: "10")
   deleteUserByAdminOrSelf(input: DeleteUserByAdminOrSelfInput!): DeleteUserByAdminOrSelfPayload! @cost(weight: "10")
   setUserLocked(input: SetUserLockedInput!): SetUserLockedPayload! @authorize(policy: "AdminRequiredPolicy") @cost(weight: "10")
 }
@@ -441,10 +441,8 @@ type Query {
   projectsInMyOrg(input: ProjectsInMyOrgInput! where: ProjectFilterInput @cost(weight: "10") orderBy: [ProjectSortInput!] @cost(weight: "10")): [Project!]! @cost(weight: "10")
   projectById(projectId: UUID!): Project @cost(weight: "10")
   projectByCode(code: String!): Project @cost(weight: "10")
-  draftProjectByCode(code: String!): DraftProject @authorize(policy: "AdminRequiredPolicy") @cost(weight: "10")
   orgs(where: OrganizationFilterInput @cost(weight: "10") orderBy: [OrganizationSortInput!] @cost(weight: "10")): [Organization!]! @cost(weight: "10")
   myOrgs(where: OrganizationFilterInput @cost(weight: "10") orderBy: [OrganizationSortInput!] @cost(weight: "10")): [Organization!]! @cost(weight: "10")
-  usersInMyOrg(skip: Int take: Int where: UserFilterInput @cost(weight: "10") orderBy: [UserSortInput!] @cost(weight: "10")): UsersInMyOrgCollectionSegment @listSize(assumedSize: 1000, slicingArguments: [ "take" ], sizedFields: [ "items" ]) @cost(weight: "10")
   usersICanSee(skip: Int take: Int where: UserFilterInput @cost(weight: "10") orderBy: [UserSortInput!] @cost(weight: "10")): UsersICanSeeCollectionSegment @listSize(assumedSize: 1000, slicingArguments: [ "take" ], sizedFields: [ "items" ]) @cost(weight: "10")
   orgById(orgId: UUID!): OrgById @cost(weight: "10")
   users(skip: Int take: Int where: UserFilterInput @cost(weight: "10") orderBy: [UserSortInput!] @cost(weight: "10")): UsersCollectionSegment @authorize(policy: "AdminRequiredPolicy") @listSize(assumedSize: 1000, slicingArguments: [ "take" ], sizedFields: [ "items" ]) @cost(weight: "10")
@@ -568,15 +566,6 @@ type UsersCollectionSegment {
 
 "A segment of a collection."
 type UsersICanSeeCollectionSegment {
-  "Information to aid in pagination."
-  pageInfo: CollectionSegmentInfo!
-  "A flattened list of the items."
-  items: [User!]
-  totalCount: Int! @cost(weight: "10")
-}
-
-"A segment of a collection."
-type UsersInMyOrgCollectionSegment {
   "Information to aid in pagination."
   pageInfo: CollectionSegmentInfo!
   "A flattened list of the items."
@@ -738,6 +727,7 @@ input CreateGuestUserByAdminInput {
   locale: String!
   passwordHash: String!
   passwordStrength: Int!
+  projectId: UUID
 }
 
 input CreateOrganizationInput {

--- a/frontend/src/lib/gql/gql-client.ts
+++ b/frontend/src/lib/gql/gql-client.ts
@@ -96,9 +96,7 @@ function createGqlClient(_gqlEndpoint?: string): Client {
               cache.invalidate({__typename: 'User', id: args.input.userId});
             },
             bulkAddProjectMembers: (result, args: MutationBulkAddProjectMembersArgs, cache, _info) => {
-              if (args.input.projectId) {
-                cache.invalidate({__typename: 'Project', id: args.input.projectId});
-              }
+              cache.invalidate({__typename: 'Project', id: args.input.projectId});
             },
             createGuestUserByAdmin: (result, args: MutationCreateGuestUserByAdminArgs, cache, _info) => {
               if (args.input.orgId) {

--- a/frontend/src/lib/gql/gql-client.ts
+++ b/frontend/src/lib/gql/gql-client.ts
@@ -37,6 +37,7 @@ import {
   type MutationBulkAddProjectMembersArgs,
   type MutationChangeOrgMemberRoleArgs,
   type MutationChangeUserAccountBySelfArgs,
+  type MutationCreateGuestUserByAdminArgs,
   type MutationCreateOrganizationArgs,
   type MutationCreateProjectArgs,
   type MutationDeleteDraftProjectArgs,
@@ -97,6 +98,11 @@ function createGqlClient(_gqlEndpoint?: string): Client {
             bulkAddProjectMembers: (result, args: MutationBulkAddProjectMembersArgs, cache, _info) => {
               if (args.input.projectId) {
                 cache.invalidate({__typename: 'Project', id: args.input.projectId});
+              }
+            },
+            createGuestUserByAdmin: (result, args: MutationCreateGuestUserByAdminArgs, cache, _info) => {
+              if (args.input.orgId) {
+                cache.invalidate({__typename: 'OrgById', id: args.input.orgId});
               }
             },
             createOrganization: (result: CreateOrgMutation, args: MutationCreateOrganizationArgs, cache, _info) => {

--- a/frontend/src/lib/user.ts
+++ b/frontend/src/lib/user.ts
@@ -120,13 +120,14 @@ export function register(password: string, passwordStrength: number, name: strin
 export function acceptInvitation(password: string, passwordStrength: number, name: string, email: string, locale: string, turnstileToken: string): Promise<RegisterResponse> {
   return createUser('/api/User/acceptInvitation', password, passwordStrength, name, email, locale, turnstileToken);
 }
-export async function createGuestUserByAdmin(password: string, passwordStrength: number, name: string, email: string, locale: string, _turnstileToken: string): Promise<RegisterResponse> {
+export async function createGuestUserByAdmin(password: string, passwordStrength: number, name: string, email: string, locale: string, _turnstileToken: string, orgId?: string): Promise<RegisterResponse> {
   const passwordHash = await hash(password);
   const gqlInput: CreateGuestUserByAdminInput = {
     passwordHash,
     passwordStrength,
     name,
     locale,
+    orgId,
   };
   if (email.includes('@')) {
     gqlInput.email = email;

--- a/frontend/src/routes/(authenticated)/org/[org_id]/+page.svelte
+++ b/frontend/src/routes/(authenticated)/org/[org_id]/+page.svelte
@@ -28,7 +28,7 @@
   import CreateUserModal from '$lib/components/Users/CreateUserModal.svelte';
   import {createGuestUserByAdmin, type LexAuthUser} from '$lib/user';
   import {Duration} from '$lib/util/time';
-  import {browser} from '$app/environment';
+  import IconButton from '$lib/components/IconButton.svelte';
 
   export let data: PageData;
   $: user = data.user;
@@ -66,6 +66,8 @@
   async function openAddOrgMemberModal(): Promise<void> {
     await addOrgMemberModal.openModal();
   }
+
+  let bulkAddMembersModal: BulkAddOrgMembers;
 
   let changeMemberRoleModal: ChangeOrgMemberRoleModal;
   async function openChangeMemberRoleModal(member: OrgUser): Promise<void> {
@@ -132,21 +134,33 @@
       <AddMyProjectsToOrgModal {user} {org} />
     {/if}
     {#if canManage}
-      <Button variant="btn-success"
+    <div class="join gap-x-0.5">
+      <Button variant="btn-success" class="join-item"
         on:click={openAddOrgMemberModal}>
         {$t('org_page.add_user.add_button')}
         <span class="i-mdi-account-plus-outline text-2xl" />
       </Button>
-      <AddOrgMemberModal bind:this={addOrgMemberModal} {org} />
-      <BulkAddOrgMembers orgId={org.id} />
-      <!-- svelte-ignore a11y-no-static-element-interactions -->
-      <svelte:element this={browser ? 'button' : 'div'} class="btn btn-sm btn-success max-xs:btn-square"
-        on:click={() => createUserModal.open()}>
-        <span class="admin-tabs:hidden">
-          {$t('admin_dashboard.create_user_modal.create_user')}
-        </span>
-        <span class="i-mdi-plus text-2xl" />
-      </svelte:element>
+      <Dropdown>
+        <IconButton icon="i-mdi-menu-down" variant="btn-success" join outline={false} />
+        <ul slot="content" class="menu">
+          <li>
+            <button class="whitespace-nowrap text-success" on:click={() => bulkAddMembersModal.open()}>
+              {$t('org_page.bulk_add_members.add_button')}
+              <Icon icon="i-mdi-account-multiple-plus-outline" />
+            </button>
+          </li>
+          <li>
+            <button class="whitespace-nowrap text-success" on:click={() => createUserModal.open()}>
+              {$t('admin_dashboard.create_user_modal.create_user')}
+              <Icon icon="i-mdi-plus" />
+            </button>
+          </li>
+        </ul>
+      </Dropdown>
+    </div>
+    <CreateUserModal handleSubmit={createGuestUserByAdmin} on:submitted={(e) => onUserCreated(e.detail)} bind:this={createUserModal}/>
+    <AddOrgMemberModal bind:this={addOrgMemberModal} {org} />
+    <BulkAddOrgMembers bind:this={bulkAddMembersModal} orgId={org.id} />
     {/if}
   </svelte:fragment>
   <div slot="title" class="max-w-full flex items-baseline flex-wrap">
@@ -240,4 +254,3 @@
 <ConfirmDeleteModal bind:this={deleteOrgModal} i18nScope="delete_org_modal" />
 <ChangeOrgMemberRoleModal orgId={org.id} bind:this={changeMemberRoleModal} />
 <UserModal bind:this={userModal} />
-<CreateUserModal handleSubmit={createGuestUserByAdmin} on:submitted={(e) => onUserCreated(e.detail)} bind:this={createUserModal}/>

--- a/frontend/src/routes/(authenticated)/org/[org_id]/+page.svelte
+++ b/frontend/src/routes/(authenticated)/org/[org_id]/+page.svelte
@@ -120,6 +120,10 @@
     }
   }
 
+  function createGuestUser(password: string, passwordStrength: number, name: string, email: string, locale: string, _turnstileToken: string): ReturnType<typeof createGuestUserByAdmin> {
+    return createGuestUserByAdmin(password, passwordStrength, name, email, locale, _turnstileToken, org.id);
+  }
+
   let createUserModal: CreateUserModal;
   function onUserCreated(user: LexAuthUser): void {
     notifySuccess($t('admin_dashboard.notifications.user_created', { name: user.name }), Duration.Long);
@@ -158,7 +162,7 @@
         </ul>
       </Dropdown>
     </div>
-    <CreateUserModal handleSubmit={createGuestUserByAdmin} on:submitted={(e) => onUserCreated(e.detail)} bind:this={createUserModal}/>
+    <CreateUserModal handleSubmit={createGuestUser} on:submitted={(e) => onUserCreated(e.detail)} bind:this={createUserModal}/>
     <AddOrgMemberModal bind:this={addOrgMemberModal} {org} />
     <BulkAddOrgMembers bind:this={bulkAddMembersModal} orgId={org.id} />
     {/if}

--- a/frontend/src/routes/(authenticated)/org/[org_id]/+page.svelte
+++ b/frontend/src/routes/(authenticated)/org/[org_id]/+page.svelte
@@ -144,13 +144,13 @@
         <IconButton icon="i-mdi-menu-down" variant="btn-success" join outline={false} />
         <ul slot="content" class="menu">
           <li>
-            <button class="whitespace-nowrap text-success" on:click={() => bulkAddMembersModal.open()}>
+            <button class="whitespace-nowrap" on:click={() => bulkAddMembersModal.open()}>
               {$t('org_page.bulk_add_members.add_button')}
               <Icon icon="i-mdi-account-multiple-plus-outline" />
             </button>
           </li>
           <li>
-            <button class="whitespace-nowrap text-success" on:click={() => createUserModal.open()}>
+            <button class="whitespace-nowrap" on:click={() => createUserModal.open()}>
               {$t('admin_dashboard.create_user_modal.create_user')}
               <Icon icon="i-mdi-plus" />
             </button>

--- a/frontend/src/routes/(authenticated)/org/[org_id]/+page.svelte
+++ b/frontend/src/routes/(authenticated)/org/[org_id]/+page.svelte
@@ -25,6 +25,10 @@
   import BulkAddOrgMembers from './BulkAddOrgMembers.svelte';
   import Dropdown from '$lib/components/Dropdown.svelte';
   import AddMyProjectsToOrgModal from './AddMyProjectsToOrgModal.svelte';
+  import CreateUserModal from '$lib/components/Users/CreateUserModal.svelte';
+  import {createGuestUserByAdmin, type LexAuthUser} from '$lib/user';
+  import {Duration} from '$lib/util/time';
+  import {browser} from '$app/environment';
 
   export let data: PageData;
   $: user = data.user;
@@ -113,6 +117,11 @@
       await goto('/');
     }
   }
+
+  let createUserModal: CreateUserModal;
+  function onUserCreated(user: LexAuthUser): void {
+    notifySuccess($t('admin_dashboard.notifications.user_created', { name: user.name }), Duration.Long);
+  }
 </script>
 
 <PageBreadcrumb href="/org/list">{$t('org.table.title')}</PageBreadcrumb>
@@ -130,6 +139,14 @@
       </Button>
       <AddOrgMemberModal bind:this={addOrgMemberModal} {org} />
       <BulkAddOrgMembers orgId={org.id} />
+      <!-- svelte-ignore a11y-no-static-element-interactions -->
+      <svelte:element this={browser ? 'button' : 'div'} class="btn btn-sm btn-success max-xs:btn-square"
+        on:click={() => createUserModal.open()}>
+        <span class="admin-tabs:hidden">
+          {$t('admin_dashboard.create_user_modal.create_user')}
+        </span>
+        <span class="i-mdi-plus text-2xl" />
+      </svelte:element>
     {/if}
   </svelte:fragment>
   <div slot="title" class="max-w-full flex items-baseline flex-wrap">
@@ -223,3 +240,4 @@
 <ConfirmDeleteModal bind:this={deleteOrgModal} i18nScope="delete_org_modal" />
 <ChangeOrgMemberRoleModal orgId={org.id} bind:this={changeMemberRoleModal} />
 <UserModal bind:this={userModal} />
+<CreateUserModal handleSubmit={createGuestUserByAdmin} on:submitted={(e) => onUserCreated(e.detail)} bind:this={createUserModal}/>

--- a/frontend/src/routes/(authenticated)/org/[org_id]/BulkAddOrgMembers.svelte
+++ b/frontend/src/routes/(authenticated)/org/[org_id]/BulkAddOrgMembers.svelte
@@ -1,5 +1,4 @@
 <script lang="ts">
-  import Button from '$lib/forms/Button.svelte';
   import { DialogResponse, FormModal, type FormSubmitReturn } from '$lib/components/modals';
   import { TextArea, isEmail } from '$lib/forms';
   import { OrgRole, type BulkAddOrgMembersResult } from '$lib/gql/types';
@@ -46,7 +45,7 @@
     }
   }
 
-  async function openModal(): Promise<void> {
+  export async function open(): Promise<void> {
     currentStep = BulkAddSteps.Add;
     const { response } = await formModal.open(undefined, async (state) => {
       const usernames = state.usernamesText.currentValue

--- a/frontend/src/routes/(authenticated)/org/[org_id]/BulkAddOrgMembers.svelte
+++ b/frontend/src/routes/(authenticated)/org/[org_id]/BulkAddOrgMembers.svelte
@@ -79,11 +79,6 @@
   }
 </script>
 
-<Button variant="btn-success" on:click={openModal}>
-  {$t('org_page.bulk_add_members.add_button')}
-  <span class="i-mdi-account-multiple-plus-outline text-2xl" />
-</Button>
-
 <FormModal bind:this={formModal} {schema} let:errors>
     <span slot="title">
       {$t('org_page.bulk_add_members.modal_title')}


### PR DESCRIPTION
Fixes #1268.

This adds the same "Create User" button, with the same dialog, to the org page that is on the admin dashboard, if the currently logged-in user has the right to manage the org (i.e., is an org admin).

![image](https://github.com/user-attachments/assets/47274b0c-d2ea-4cd4-a7fd-d745ccdbe012)

It goes to the same "Create User" dialog as the one on the admin page (not screenshotted because this PR makes no changes to it), and has the same effect (if no email provided, creates guest user with "CreatedById" set to the org admin).

One possible improvement, which I have not yet made, would be that if an org admin creates a guest user, that user is automatically added to the currently-viewed org. (With, perhaps, a checkbox to turn that off, in the rare case where an org admin might be wanting to add a guest user NOT associated with any org — but the default should be on).

@myieye - Your thoughts on UI would be welcome. For example, should we change the name of this button when it's on the org page? I feel like having "Add Member", "Bulk Add Members", and "Create User" buttons all one after the other end up being a little much and has the potential for user confusion. But as I'm writing this, it's kind of late in the day and I'm having trouble thinking of what the alternative might be. I'll probably have better ideas tomorrow morning, though.