### PR TITLE
Add close buttons to history & activity views

### DIFF
--- a/frontend/viewer/src/lib/activity/ActivityView.svelte
+++ b/frontend/viewer/src/lib/activity/ActivityView.svelte
@@ -1,5 +1,5 @@
 ﻿<script lang="ts">
-  import {mdiHistory} from '@mdi/js';
+  import {mdiCloseCircle, mdiHistory} from '@mdi/js';
   import {
     cls,
     DurationUnits,
@@ -51,7 +51,10 @@
     </div>
   </Button>
   <Dialog {open} on:close={toggleOff} {loading} persistent={loading} class="w-[700px]">
-    <div slot="title">Activity</div>
+    <div slot="title">
+      Activity
+      <Button on:click={toggleOff} icon={mdiCloseCircle} class="float-end" rounded="full"></Button>
+    </div>
     <div class="m-6 grid gap-x-6 h-[50vh]" style="grid-template-columns: auto 4fr">
       <div class="flex flex-col gap-4 overflow-y-auto">
         <div class="border rounded-md">

--- a/frontend/viewer/src/lib/history/HistoryView.svelte
+++ b/frontend/viewer/src/lib/history/HistoryView.svelte
@@ -1,5 +1,5 @@
 ﻿<script lang="ts">
-  import {mdiHistory} from '@mdi/js';
+  import {mdiCloseCircle, mdiHistory} from '@mdi/js';
   import {Button, cls, Dialog, Duration, DurationUnits, InfiniteScroll, ListItem, Toggle} from 'svelte-ux';
   import EntryEditor from '../entry-editor/object-editors/EntryEditor.svelte';
   import SenseEditor from '../entry-editor/object-editors/SenseEditor.svelte';
@@ -35,7 +35,10 @@
     </div>
   </Button>
   <Dialog {open} on:close={toggleOff} {loading} persistent={loading} class="w-[700px]">
-    <div slot="title">History</div>
+    <div slot="title">
+      History
+      <Button on:click={toggleOff} icon={mdiCloseCircle} class="float-end" rounded="full"></Button>
+    </div>
     <div class="m-6 grid gap-x-6 h-[50vh]" style="grid-template-columns: auto 4fr;">
 
       <div class="flex flex-col gap-4 overflow-y-auto">


### PR DESCRIPTION
Fixes #1330.

Activity and History views now have a close button in the upper right.

![image](https://github.com/user-attachments/assets/1b6d4c19-6dc4-4096-8d3e-da2f87e4bd5a)

![image](https://github.com/user-attachments/assets/1e45b0cd-6ea9-44f2-9d66-5b051044ed40)
