### PR TITLE
Make dialog close button usable even when loading

### DIFF
--- a/frontend/viewer/src/lib/activity/ActivityView.svelte
+++ b/frontend/viewer/src/lib/activity/ActivityView.svelte
@@ -51,10 +51,8 @@
     </div>
   </Button>
   <Dialog {open} on:close={toggleOff} {loading} persistent={loading} class="w-[700px]">
-    <div slot="title">
-      Activity
-      <Button on:click={toggleOff} icon={mdiCloseCircle} class="float-end" rounded="full"></Button>
-    </div>
+    <Button on:click={toggleOff} icon={mdiCloseCircle} class="absolute right-2 top-2 z-40" rounded="full"></Button>
+    <div slot="title">Activity</div>
     <div class="m-6 grid gap-x-6 h-[50vh]" style="grid-template-columns: auto 4fr">
       <div class="flex flex-col gap-4 overflow-y-auto">
         <div class="border rounded-md">

--- a/frontend/viewer/src/lib/history/HistoryView.svelte
+++ b/frontend/viewer/src/lib/history/HistoryView.svelte
@@ -35,10 +35,8 @@
     </div>
   </Button>
   <Dialog {open} on:close={toggleOff} {loading} persistent={loading} class="w-[700px]">
-    <div slot="title">
-      History
-      <Button on:click={toggleOff} icon={mdiCloseCircle} class="float-end" rounded="full"></Button>
-    </div>
+    <Button on:click={toggleOff} icon={mdiCloseCircle} class="absolute right-2 top-2 z-40" rounded="full"></Button>
+    <div slot="title">History</div>
     <div class="m-6 grid gap-x-6 h-[50vh]" style="grid-template-columns: auto 4fr;">
 
       <div class="flex flex-col gap-4 overflow-y-auto">


### PR DESCRIPTION
Fixes #1383.

The close button is now at a higher z-index than the "loading" overlay, so it will always be clickable even when the loading indicator is stuck on (such as due to an Internet connection issue).