### PR TITLE
track author in commit metadata

### DIFF
--- a/backend/FwLite/FwLiteMaui/FwLiteMauiKernel.cs
+++ b/backend/FwLite/FwLiteMaui/FwLiteMauiKernel.cs
@@ -27,8 +27,9 @@ public static class FwLiteMauiKernel
 #endif
         IHostEnvironment env = new HostingEnvironment() { EnvironmentName = environment };
         services.AddSingleton<IHostEnvironment>(env);
-        services.AddFwLiteShared(env);
         services.AddMauiBlazorWebView();
+        //must be added after blazor as it modifies IJSRuntime in order to intercept it's constructor
+        services.AddFwLiteShared(env);
         services.AddSingleton<HostedServiceAdapter>();
         services.AddSingleton<IMauiInitializeService>(sp => sp.GetRequiredService<HostedServiceAdapter>());
         services.Configure<AuthConfig>(config =>

--- a/backend/FwLite/FwLiteShared/Auth/LexboxUser.cs
+++ b/backend/FwLite/FwLiteShared/Auth/LexboxUser.cs
@@ -1,0 +1,3 @@
+﻿namespace FwLiteShared.Auth;
+
+public record LexboxUser(string Name, string Id);

--- a/backend/FwLite/FwLiteShared/Auth/OAuthClient.cs
+++ b/backend/FwLite/FwLiteShared/Auth/OAuthClient.cs
@@ -183,6 +183,12 @@ public class OAuthClient
         return auth?.Account.Username;
     }
 
+    public async Task<LexboxUser?> GetCurrentUser()
+    {
+        var auth = await GetAuth();
+        return auth?.Account.Username is null ? null : new LexboxUser(auth.Account.Username, auth.Account.HomeAccountId.ObjectId);
+    }
+
     public async ValueTask<string?> GetCurrentToken()
     {
         var auth = await GetAuth();

--- a/backend/FwLite/FwLiteShared/Services/FwLiteJson.cs
+++ b/backend/FwLite/FwLiteShared/Services/FwLiteJson.cs
@@ -1,0 +1,27 @@
+﻿using System.Reflection;
+using System.Text.Json;
+using System.Text.Json.Serialization.Metadata;
+using Microsoft.JSInterop;
+using MiniLcm;
+using SIL.Harmony;
+
+namespace FwLiteShared.Services;
+
+public static class FwLiteJson
+{
+    private static readonly PropertyInfo? _jsRuntimeJsonOptionsProperty =
+        typeof(JSRuntime).GetProperty("JsonSerializerOptions", BindingFlags.NonPublic | BindingFlags.Instance);
+
+    public static void ConfigureJsonSerializerOptions(this IJSRuntime jsRuntime, CrdtConfig crdtConfig)
+    {
+        //this is not supported, see: https://github.com/dotnet/aspnetcore/issues/12685
+        //doing it anyway, otherwise our serialization will be broken
+        if (_jsRuntimeJsonOptionsProperty is null)
+            throw new InvalidOperationException("Unable to find JsonSerializerOptions property");
+        var options = (JsonSerializerOptions?)_jsRuntimeJsonOptionsProperty.GetValue(jsRuntime, null);
+        if (options is null) throw new InvalidOperationException("JSRuntime.JsonSerializerOptions returned null");
+        options.TypeInfoResolver = (options.TypeInfoResolver ?? new DefaultJsonTypeInfoResolver())
+            .WithAddedModifier(crdtConfig.MakeJsonTypeModifier())
+            .AddExternalMiniLcmModifiers();
+    }
+}

--- a/backend/FwLite/FwLiteShared/Services/ProjectServicesProvider.cs
+++ b/backend/FwLite/FwLiteShared/Services/ProjectServicesProvider.cs
@@ -52,7 +52,6 @@ public class ProjectServicesProvider(
             _ = jsRuntime.DurableInvokeVoidAsync("notifyEntryUpdated", projectName, entry);
         });
         var miniLcm = ActivatorUtilities.CreateInstance<MiniLcmJsInvokable>(scopedServices, project);
-        var historyService = scopedServices.GetRequiredService<HistoryService>();
         var scope = new ProjectScope(Defer.Async(() =>
         {
             logger.LogInformation("Disposing project scope {ProjectName}", projectName);
@@ -60,7 +59,7 @@ public class ProjectServicesProvider(
             entryUpdatedSubscription.Dispose();
             _projectScopes.Remove(projectName);
             return Task.CompletedTask;
-        }), projectName, miniLcm, new HistoryServiceJsInvokable(historyService));
+        }), projectName, miniLcm, ActivatorUtilities.CreateInstance<HistoryServiceJsInvokable>(scopedServices));
         await TrackScope(scope);
         return scope;
     }

--- a/backend/FwLite/FwLiteShared/Sync/SyncService.cs
+++ b/backend/FwLite/FwLiteShared/Sync/SyncService.cs
@@ -29,7 +29,8 @@ public class SyncService(
             return new SyncResults([], [], false);
         }
 
-        var httpClient = await oAuthClientFactory.GetClient(project).CreateHttpClient();
+        var oAuthClient = oAuthClientFactory.GetClient(project);
+        var httpClient = await oAuthClient.CreateHttpClient();
         if (httpClient is null)
         {
             logger.LogWarning(
@@ -38,6 +39,8 @@ public class SyncService(
                 project.OriginDomain);
             return new SyncResults([], [], false);
         }
+        var currentUser = await oAuthClient.GetCurrentUser();
+        await currentProjectService.UpdateLastUser(currentUser?.Name, currentUser?.Id);
 
         var remoteModel = await remoteSyncServiceServer.CreateProjectSyncable(project, httpClient);
         var syncResults = await dataModel.SyncWith(remoteModel);

--- a/backend/FwLite/FwLiteShared/TypeGen/ReinforcedFwLiteTypingConfig.cs
+++ b/backend/FwLite/FwLiteShared/TypeGen/ReinforcedFwLiteTypingConfig.cs
@@ -12,6 +12,7 @@ using Reinforced.Typings.Ast.Dependency;
 using Reinforced.Typings.Ast.TypeNames;
 using Reinforced.Typings.Fluent;
 using Reinforced.Typings.Visitors.TypeScript;
+using SIL.Harmony.Core;
 using SIL.Harmony.Db;
 
 namespace FwLiteShared.TypeGen;
@@ -109,6 +110,7 @@ public static class ReinforcedFwLiteTypingConfig
             typeof(FwLiteConfig),
             typeof(HistoryLineItem),
             typeof(ProjectActivity),
+            typeof(CommitMetadata),
             typeof(ObjectSnapshot),
             typeof(ProjectScope)
         ], exportBuilder => exportBuilder.WithPublicProperties());

--- a/backend/FwLite/LcmCrdt.Tests/DataModelSnapshotTests.VerifyDbModel.verified.txt
+++ b/backend/FwLite/LcmCrdt.Tests/DataModelSnapshotTests.VerifyDbModel.verified.txt
@@ -4,6 +4,8 @@
       Id (Guid) Required PK AfterSave:Throw ValueGenerated.OnAdd
       ClientId (Guid) Required
       FwProjectId (Guid?)
+      LastUserId (string)
+      LastUserName (string)
       Name (string) Required
       OriginDomain (string)
     Keys: 

--- a/backend/FwLite/LcmCrdt/AppVersion.cs
+++ b/backend/FwLite/LcmCrdt/AppVersion.cs
@@ -1,0 +1,9 @@
+﻿using System.Reflection;
+
+namespace LcmCrdt;
+
+public class AppVersion
+{
+    public static readonly string Version = (typeof(AppVersion).Assembly)
+        .GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion ?? "dev";
+}

--- a/backend/FwLite/LcmCrdt/CrdtProject.cs
+++ b/backend/FwLite/LcmCrdt/CrdtProject.cs
@@ -16,7 +16,7 @@ public class CrdtProject(string name, string dbPath) : IProjectIdentifier
 /// <param name="OriginDomain">Server to sync with, null if not synced</param>
 /// <param name="ClientId">Unique id for this client machine</param>
 /// <param name="FwProjectId">FieldWorks project id, aka LangProjectId</param>
-public record ProjectData(string Name, Guid Id, string? OriginDomain, Guid ClientId, Guid? FwProjectId = null)
+public record ProjectData(string Name, Guid Id, string? OriginDomain, Guid ClientId, Guid? FwProjectId = null, string? LastUserName = null, string? LastUserId = null)
 {
     public static string? GetOriginDomain(Uri? uri)
     {

--- a/backend/FwLite/LcmCrdt/CrdtProjectsService.cs
+++ b/backend/FwLite/LcmCrdt/CrdtProjectsService.cs
@@ -61,7 +61,9 @@ public partial class CrdtProjectsService(IServiceProvider provider, ILogger<Crdt
         Func<IServiceProvider, CrdtProject, Task>? AfterCreate = null,
         bool SeedNewProjectData = false,
         string? Path = null,
-        Guid? FwProjectId = null);
+        Guid? FwProjectId = null,
+        string? AuthenticatedUser = null,
+        string? AuthenticatedUserId = null);
 
     public async Task<CrdtProject> CreateExampleProject(string name)
     {
@@ -85,7 +87,7 @@ public partial class CrdtProjectsService(IServiceProvider provider, ILogger<Crdt
             var projectData = new ProjectData(name,
                 request.Id ?? Guid.NewGuid(),
                 ProjectData.GetOriginDomain(request.Domain),
-                Guid.NewGuid(), request.FwProjectId);
+                Guid.NewGuid(), request.FwProjectId, request.AuthenticatedUser, request.AuthenticatedUserId);
             await InitProjectDb(db, projectData);
             await currentProjectService.RefreshProjectData();
             if (request.SeedNewProjectData)

--- a/backend/FwLite/LcmCrdt/CurrentProjectService.cs
+++ b/backend/FwLite/LcmCrdt/CurrentProjectService.cs
@@ -108,4 +108,16 @@ public class CurrentProjectService(IServiceProvider services, IMemoryCache memor
 
         await RefreshProjectData();
     }
+
+    public async Task UpdateLastUser(string? userName, string? userId)
+    {
+        if (userName is null && userId is null) return;
+        if (userName != ProjectData.LastUserName || userId != ProjectData.LastUserId)
+        {
+            await DbContext.ProjectData.ExecuteUpdateAsync(calls => calls
+                .SetProperty(p => p.LastUserName, userName)
+                .SetProperty(p => p.LastUserId, userId));
+            await RefreshProjectData();
+        }
+    }
 }

--- a/backend/FwLite/LcmCrdt/Migrations/20250120033055_AddProjectDataLastUserInfo.Designer.cs
+++ b/backend/FwLite/LcmCrdt/Migrations/20250120033055_AddProjectDataLastUserInfo.Designer.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using LcmCrdt;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace LcmCrdt.Migrations
 {
     [DbContext(typeof(LcmCrdtDbContext))]
-    partial class LcmCrdtDbContextModelSnapshot : ModelSnapshot
+    [Migration("20250120033055_AddProjectDataLastUserInfo")]
+    partial class AddProjectDataLastUserInfo
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder.HasAnnotation("ProductVersion", "8.0.11");

--- a/backend/FwLite/LcmCrdt/Migrations/20250120033055_AddProjectDataLastUserInfo.cs
+++ b/backend/FwLite/LcmCrdt/Migrations/20250120033055_AddProjectDataLastUserInfo.cs
@@ -1,0 +1,38 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace LcmCrdt.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddProjectDataLastUserInfo : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "LastUserId",
+                table: "ProjectData",
+                type: "TEXT",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "LastUserName",
+                table: "ProjectData",
+                type: "TEXT",
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "LastUserId",
+                table: "ProjectData");
+
+            migrationBuilder.DropColumn(
+                name: "LastUserName",
+                table: "ProjectData");
+        }
+    }
+}

--- a/frontend/viewer/src/lib/dotnet-types/generated-types/LcmCrdt/IHistoryLineItem.ts
+++ b/frontend/viewer/src/lib/dotnet-types/generated-types/LcmCrdt/IHistoryLineItem.ts
@@ -14,5 +14,6 @@ export interface IHistoryLineItem
 	changeName?: string;
 	entity?: IObjectWithId;
 	entityName?: string;
+	authorName?: string;
 }
 /* eslint-enable */

--- a/frontend/viewer/src/lib/dotnet-types/generated-types/LcmCrdt/IProjectActivity.ts
+++ b/frontend/viewer/src/lib/dotnet-types/generated-types/LcmCrdt/IProjectActivity.ts
@@ -3,11 +3,14 @@
 //     Changes to this file may cause incorrect behavior and will be lost if
 //     the code is regenerated.
 
+import type {ICommitMetadata} from '../SIL/Harmony/Core/ICommitMetadata';
+
 export interface IProjectActivity
 {
 	commitId: string;
 	timestamp: string;
 	changes: unknown[];
+	metadata: ICommitMetadata;
 	changeName: string;
 }
 /* eslint-enable */

--- a/frontend/viewer/src/lib/dotnet-types/generated-types/SIL/Harmony/Core/ICommitMetadata.ts
+++ b/frontend/viewer/src/lib/dotnet-types/generated-types/SIL/Harmony/Core/ICommitMetadata.ts
@@ -3,14 +3,12 @@
 //     Changes to this file may cause incorrect behavior and will be lost if
 //     the code is regenerated.
 
-export interface IProjectData
+export interface ICommitMetadata
 {
-	name: string;
-	id: string;
-	originDomain?: string;
-	clientId: string;
-	fwProjectId?: string;
-	lastUserName?: string;
-	lastUserId?: string;
+	authorName?: string;
+	authorId?: string;
+	clientVersion?: string;
+	extraMetadata: { [key:string]: string };
+	item?: string;
 }
 /* eslint-enable */

--- a/frontend/viewer/src/lib/history/HistoryView.svelte
+++ b/frontend/viewer/src/lib/history/HistoryView.svelte
@@ -69,6 +69,7 @@
         </div>
       </div>
       <div>
+        <span>Author: {record?.authorName ?? 'Unknown'}</span>
         {#if record?.entity}
           {#if record.entityName === 'Entry'}
             <EntryEditor entry={record.entity} modalMode readonly/>


### PR DESCRIPTION
closes #1379 

This is implemented by tracking the author in `ProjectData` either on project download or sync. Right now changes can get made without an author, it might make sense on sync if a commit is being sent and it doesn't have an author that we should make the current user the author.

This also ensures that our dotnet interop with js uses our JSON Serialization options defined by CrdtConfig (and the internal mini lcm fields).