### PR TITLE
Use project-loader component to prevent delayed project loading state

### DIFF
--- a/frontend/viewer/src/CrdtProjectView.svelte
+++ b/frontend/viewer/src/CrdtProjectView.svelte
@@ -1,6 +1,10 @@
 ﻿<script lang="ts">
+  import ProjectLoader from './ProjectLoader.svelte';
   import ProjectView from './ProjectView.svelte';
 
   export let projectName: string;
 </script>
-<ProjectView {projectName} isConnected></ProjectView>
+
+<ProjectLoader {projectName} let:onProjectLoaded>
+  <ProjectView {projectName} isConnected on:loaded={e => onProjectLoaded(e.detail)}></ProjectView>
+</ProjectLoader>

--- a/frontend/viewer/src/DotnetProjectView.svelte
+++ b/frontend/viewer/src/DotnetProjectView.svelte
@@ -8,6 +8,7 @@
   import type {
     IHistoryServiceJsInvokable
   } from '$lib/dotnet-types/generated-types/FwLiteShared/Services/IHistoryServiceJsInvokable';
+  import ProjectLoader from './ProjectLoader.svelte';
 
   const projectServicesProvider = useProjectServicesProvider();
   export let projectName: string;
@@ -36,6 +37,7 @@
     }
   });
 </script>
-{#if serviceLoaded}
-  <ProjectView {projectName} isConnected></ProjectView>
-{/if}
+
+<ProjectLoader readyToLoadProject={serviceLoaded} {projectName} let:onProjectLoaded>
+  <ProjectView {projectName} isConnected on:loaded={e => onProjectLoaded(e.detail)}></ProjectView>
+</ProjectLoader>

--- a/frontend/viewer/src/FwDataProjectView.svelte
+++ b/frontend/viewer/src/FwDataProjectView.svelte
@@ -7,6 +7,7 @@
   import {AppNotification} from './lib/notifications/notifications';
   import {CloseReason} from './lib/generated-signalr-client/TypedSignalR.Client/Lexbox.ClientServer.Hubs';
   import {useEventBus} from './lib/services/event-bus';
+  import ProjectLoader from './ProjectLoader.svelte';
 
   export let projectName: string;
   export let baseUrl: string = '';
@@ -41,4 +42,7 @@
     }
   }));
 </script>
-<ProjectView {projectName} isConnected={$connected}></ProjectView>
+
+<ProjectLoader {projectName} let:onProjectLoaded>
+  <ProjectView {projectName} isConnected={$connected} on:loaded={e => onProjectLoaded(e.detail)}></ProjectView>
+</ProjectLoader>

--- a/frontend/viewer/src/ProjectLoader.svelte
+++ b/frontend/viewer/src/ProjectLoader.svelte
@@ -1,0 +1,25 @@
+<script lang="ts">
+  import {ProgressCircle} from 'svelte-ux';
+  import {writable} from 'svelte/store';
+  import {fade} from 'svelte/transition';
+
+  export let readyToLoadProject = true;
+  export let projectName: string;
+
+  let projectLoaded = writable(false);
+  $: loading = !readyToLoadProject || !$projectLoaded;
+</script>
+
+{#if loading}
+  <div class="absolute w-full h-full z-10 bg-surface-100 flex grow items-center justify-center" out:fade={{duration: 800}}>
+    <div class="inline-flex flex-col items-center text-4xl gap-4 opacity-75">
+      <span>Loading <span class="text-primary-500">{projectName}</span>...</span><ProgressCircle class="text-surface-content" />
+    </div>
+  </div>
+{/if}
+
+{#if readyToLoadProject}
+  <div class:hidden={!$projectLoaded} class:contents={$projectLoaded}>
+    <slot onProjectLoaded={projectLoaded.set} />
+  </div>
+{/if}

--- a/frontend/viewer/src/ProjectView.svelte
+++ b/frontend/viewer/src/ProjectView.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import {AppBar, Button, ProgressCircle} from 'svelte-ux';
+  import {AppBar, Button} from 'svelte-ux';
   import {
     mdiArrowCollapseRight,
     mdiArrowExpandLeft,
@@ -13,14 +13,13 @@
   import {headword} from './lib/utils';
   import {useFwLiteConfig, useLexboxApi} from './lib/services/service-provider';
   import type {IEntry} from './lib/dotnet-types';
-  import {onDestroy, onMount, setContext} from 'svelte';
+  import {createEventDispatcher, onDestroy, onMount, setContext} from 'svelte';
   import {derived, type Readable, writable} from 'svelte/store';
   import {deriveAsync} from './lib/utils/time';
   import {type LexboxFeatures, type LexboxPermissions} from './lib/config-types';
   import ViewOptionsDrawer from './lib/layout/ViewOptionsDrawer.svelte';
   import EntryList from './lib/layout/EntryList.svelte';
   import Toc from './lib/layout/Toc.svelte';
-  import {fade} from 'svelte/transition';
   import DictionaryEntryViewer from './lib/layout/DictionaryEntryViewer.svelte';
   import NewEntryDialog from './lib/entry-editor/NewEntryDialog.svelte';
   import SearchBar from './lib/search-bar/SearchBar.svelte';
@@ -43,7 +42,10 @@
   import {initDialogService} from '$lib/entry-editor/dialog-service';
   import OpenInFieldWorksButton from '$lib/OpenInFieldWorksButton.svelte';
 
-  export let loading = false;
+  const dispatch = createEventDispatcher<{
+    loaded: boolean;
+  }>();
+
   export let about: string | undefined = undefined;
 
   const changeEventBus = useEventBus();
@@ -212,7 +214,8 @@
     navigateToEntryId = null;
   }
 
-  $: _loading = !$entries || !$writingSystems || loading;
+  $: projectLoaded = !!($entries && $writingSystems);
+  $: dispatch('loaded', projectLoaded);
 
   function onEntryCreated(entry: IEntry, options?: NewEntryDialogOptions) {
     $entries?.push(entry);//need to add it before refresh, otherwise it won't get selected because it's not in the list
@@ -298,13 +301,7 @@
 </svelte:head>
 
 
-{#if _loading || !$entries}
-<div class="absolute w-full h-full z-10 bg-surface-100 flex grow items-center justify-center" out:fade={{duration: 800}}>
-  <div class="inline-flex flex-col items-center text-4xl gap-4 opacity-75">
-    <span>Loading <span class="text-primary-500">{projectName}</span>...</span><ProgressCircle class="text-surface-content" />
-  </div>
-</div>
-{:else}
+{#if projectLoaded}
 <div class="project-view !flex flex-col PortalTarget" style={spaceForEditorStyle}>
   <AppBar class="bg-secondary min-h-12 shadow-md" head={false}>
     <div slot="title" class="prose whitespace-nowrap">

--- a/frontend/viewer/src/TestProjectView.svelte
+++ b/frontend/viewer/src/TestProjectView.svelte
@@ -3,6 +3,7 @@ import ProjectView from './ProjectView.svelte';
 import {InMemoryApiService} from '$lib/in-memory-api-service';
 import {DotnetService} from '$lib/dotnet-types';
 import {FwLitePlatform} from '$lib/dotnet-types/generated-types/FwLiteShared/FwLitePlatform';
+import ProjectLoader from './ProjectLoader.svelte';
 
 const inMemoryLexboxApi = new InMemoryApiService();
 window.lexbox.ServiceProvider.setService(DotnetService.MiniLcmApi, inMemoryLexboxApi);
@@ -12,5 +13,9 @@ window.lexbox.ServiceProvider.setService(DotnetService.FwLiteConfig, {
   os: FwLitePlatform.Web,
   useDevAssets: true,
 });
+const projectName = inMemoryLexboxApi.projectName;
 </script>
-<ProjectView projectName={inMemoryLexboxApi.projectName} isConnected />
+
+<ProjectLoader {projectName} let:onProjectLoaded>
+  <ProjectView {projectName} isConnected on:loaded={e => onProjectLoaded(e.detail)}></ProjectView>
+</ProjectLoader>

--- a/frontend/viewer/src/WebComponent.svelte
+++ b/frontend/viewer/src/WebComponent.svelte
@@ -5,6 +5,7 @@
   import css from './app.postcss?inline';
   import {DotnetService} from '$lib/dotnet-types';
   import {FwLitePlatform} from '$lib/dotnet-types/generated-types/FwLiteShared/FwLitePlatform';
+  import ProjectLoader from './ProjectLoader.svelte';
 
   let loading = true;
 
@@ -51,5 +52,7 @@
 </svelte:element>
 
 <div class="app contents" class:dark={$currentTheme.dark}>
-  <ProjectView {projectName} isConnected {loading} showHomeButton={false} {about} />
+  <ProjectLoader readyToLoadProject={!loading} {projectName} let:onProjectLoaded>
+    <ProjectView {projectName} isConnected showHomeButton={false} {about}  on:loaded={e => onProjectLoaded(e.detail)} />
+  </ProjectLoader>
 </div>


### PR DESCRIPTION
This PR pulls the project loading state out into a seperate component, so that we can show the loading state sooner:

[project-loader.webm](https://github.com/user-attachments/assets/ccd949bd-9b1c-47db-85fb-41673c0f29cb)

I tested:
- Crdt project
- FieldWorks project
- Lexbox viewer project
- Testing project

