### PR TITLE
Get FW projects dir from registry on Windows

### DIFF
--- a/backend/FwLite/FwDataMiniLcmBridge/FwDataBridgeConfig.cs
+++ b/backend/FwLite/FwDataMiniLcmBridge/FwDataBridgeConfig.cs
@@ -1,4 +1,5 @@
 ﻿using System.Runtime.InteropServices;
+using System.Runtime.Versioning;
 using Microsoft.Win32;
 
 namespace FwDataMiniLcmBridge;
@@ -9,6 +10,7 @@ public class FwDataBridgeConfig
         Environment.GetEnvironmentVariable("XDG_DATA_HOME") ??
         Path.Join(Environment.GetEnvironmentVariable("HOME") ?? "", ".local", "share");
 
+    [SupportedOSPlatform("windows")]
     private static string WindowsDataFolder =>
         (string?)Registry.GetValue(@"HKEY_CURRENT_USER\Software\SIL\FieldWorks\9", "ProjectsDir", null)
         ?? @"C:\ProgramData\SIL\FieldWorks";

--- a/backend/FwLite/FwDataMiniLcmBridge/FwDataBridgeConfig.cs
+++ b/backend/FwLite/FwDataMiniLcmBridge/FwDataBridgeConfig.cs
@@ -1,4 +1,5 @@
 ﻿using System.Runtime.InteropServices;
+using Microsoft.Win32;
 
 namespace FwDataMiniLcmBridge;
 
@@ -9,7 +10,7 @@ public class FwDataBridgeConfig
         Path.Join(Environment.GetEnvironmentVariable("HOME") ?? "", ".local", "share");
 
     private static string WindowsDataFolder =>
-        (string?)Microsoft.Win32.Registry.GetValue(@"HKEY_CURRENT_USER\Software\SIL\FieldWorks\9", "ProjectsDir", null)
+        (string?)Registry.GetValue(@"HKEY_CURRENT_USER\Software\SIL\FieldWorks\9", "ProjectsDir", null)
         ?? @"C:\ProgramData\SIL\FieldWorks";
 
     private static readonly string DataFolder =

--- a/backend/FwLite/FwDataMiniLcmBridge/FwDataBridgeConfig.cs
+++ b/backend/FwLite/FwDataMiniLcmBridge/FwDataBridgeConfig.cs
@@ -8,9 +8,13 @@ public class FwDataBridgeConfig
         Environment.GetEnvironmentVariable("XDG_DATA_HOME") ??
         Path.Join(Environment.GetEnvironmentVariable("HOME") ?? "", ".local", "share");
 
+    private static string WindowsDataFolder =>
+        (string?)Microsoft.Win32.Registry.GetValue(@"HKEY_CURRENT_USER\Software\SIL\FieldWorks\9", "ProjectsDir", null)
+        ?? @"C:\ProgramData\SIL\FieldWorks";
+
     private static readonly string DataFolder =
         RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
-            ? @"C:\ProgramData\SIL\FieldWorks"
+            ? WindowsDataFolder
             : Path.Join(UnixDataFolder, "fieldworks");
     public string ProjectsFolder { get; set; } = Path.Join(DataFolder, "Projects");
     public string TemplatesFolder { get; set; } = Path.Join(DataFolder, "Templates");

--- a/backend/FwLite/FwDataMiniLcmBridge/FwDataBridgeConfig.cs
+++ b/backend/FwLite/FwDataMiniLcmBridge/FwDataBridgeConfig.cs
@@ -10,15 +10,30 @@ public class FwDataBridgeConfig
         Environment.GetEnvironmentVariable("XDG_DATA_HOME") ??
         Path.Join(Environment.GetEnvironmentVariable("HOME") ?? "", ".local", "share");
 
+    private static string UnixProgramFolder => UnixDataFolder;
+
     [SupportedOSPlatform("windows")]
     private static string WindowsDataFolder =>
         (string?)Registry.GetValue(@"HKEY_CURRENT_USER\Software\SIL\FieldWorks\9", "ProjectsDir", null)
-        ?? @"C:\ProgramData\SIL\FieldWorks";
+        ?? (string?)Registry.GetValue(@"HKEY_LOCAL_MACHINE\Software\SIL\FieldWorks\9", "ProjectsDir", null)
+        ?? @"C:\ProgramData\SIL\FieldWorks\Projects";
+
+    [SupportedOSPlatform("windows")]
+    private static string WindowsProgramFolder =>
+        (string?)Registry.GetValue(@"HKEY_CURRENT_USER\Software\SIL\FieldWorks\9", "RootCodeDir", null)
+        ?? (string?)Registry.GetValue(@"HKEY_LOCAL_MACHINE\Software\SIL\FieldWorks\9", "RootCodeDir", null)
+        ?? @"C:\Program Files\SIL\FieldWorks 9";
 
     private static readonly string DataFolder =
         RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
             ? WindowsDataFolder
-            : Path.Join(UnixDataFolder, "fieldworks");
-    public string ProjectsFolder { get; set; } = Path.Join(DataFolder, "Projects");
-    public string TemplatesFolder { get; set; } = Path.Join(DataFolder, "Templates");
+            : Path.Join(UnixDataFolder, "fieldworks", "Projects");
+
+    private static readonly string ProgramFolder =
+        RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
+            ? WindowsProgramFolder
+            : Path.Join(UnixProgramFolder, "fieldworks");
+
+    public string ProjectsFolder { get; set; } = DataFolder;
+    public string TemplatesFolder { get; set; } = Path.Join(ProgramFolder, "Templates");
 }


### PR DESCRIPTION
Fixes #1103

We now get the location of FW projects from the Windows registry, falling back to a hardcoded path (which will be correct *most* of the time) if the appropriate registry key is missing.