### PR TITLE
prevent reference cycles in complex forms

### DIFF
--- a/backend/FwLite/LcmCrdt/Changes/Entries/AddEntryComponentChange.cs
+++ b/backend/FwLite/LcmCrdt/Changes/Entries/AddEntryComponentChange.cs
@@ -38,7 +38,10 @@ public class AddEntryComponentChange : CreateChange<ComplexFormComponent>, ISelf
         Sense? componentSense = null;
         if (ComponentSenseId is not null)
             componentSense = await context.GetCurrent<Sense>(ComponentSenseId.Value);
-        return new ComplexFormComponent
+        var shouldBeDeleted = (complexFormEntry?.DeletedAt is not null ||
+                               componentEntry?.DeletedAt is not null ||
+                               (ComponentSenseId.HasValue && componentSense?.DeletedAt is not null));
+        var component = new ComplexFormComponent
         {
             Id = EntityId,
             ComplexFormEntryId = ComplexFormEntryId,
@@ -46,11 +49,34 @@ public class AddEntryComponentChange : CreateChange<ComplexFormComponent>, ISelf
             ComponentEntryId = ComponentEntryId,
             ComponentHeadword = componentEntry?.Headword(),
             ComponentSenseId = ComponentSenseId,
-            DeletedAt = (complexFormEntry?.DeletedAt is not null ||
-                         componentEntry?.DeletedAt is not null ||
-                         (ComponentSenseId.HasValue && componentSense?.DeletedAt is not null))
+            DeletedAt = shouldBeDeleted
                 ? commit.DateTime
                 : (DateTime?)null,
         };
+        if (component.DeletedAt is null && await HasReferenceCycle(component, context)) component.DeletedAt = commit.DateTime;
+        return component;
+    }
+
+    private static async ValueTask<bool> HasReferenceCycle(ComplexFormComponent parent, ChangeContext context)
+    {
+        if (parent.ComplexFormEntryId == parent.ComponentEntryId) return true;
+        //used to avoid checking the same ComplexFormComponent multiple times
+        HashSet<Guid> visited = [parent.Id];
+        Queue<ComplexFormComponent> queue = new Queue<ComplexFormComponent>();
+        queue.Enqueue(parent);
+        while (queue.Count > 0)
+        {
+            var current = queue.Dequeue();
+            if (current.ComplexFormEntryId == parent.ComponentEntryId) return true;
+            await foreach (var o in context.GetObjectsReferencing(current.ComplexFormEntryId))
+            {
+                if (o is not ComplexFormComponent cfc) continue;
+                if (visited.Contains(cfc.Id)) continue;
+                if (cfc.ComplexFormEntryId == parent.ComponentEntryId) return true;
+                queue.Enqueue(cfc);
+                visited.Add(cfc.Id);
+            }
+        }
+        return false;
     }
 }

--- a/backend/FwLite/LcmCrdt/Changes/Entries/AddEntryComponentChange.cs
+++ b/backend/FwLite/LcmCrdt/Changes/Entries/AddEntryComponentChange.cs
@@ -53,7 +53,11 @@ public class AddEntryComponentChange : CreateChange<ComplexFormComponent>, ISelf
                 ? commit.DateTime
                 : (DateTime?)null,
         };
-        if (component.DeletedAt is null && await HasReferenceCycle(component, context)) component.DeletedAt = commit.DateTime;
+        if (component.DeletedAt is null && await HasReferenceCycle(component, context))
+        {
+            component.DeletedAt = commit.DateTime;
+        }
+
         return component;
     }
 
@@ -71,7 +75,9 @@ public class AddEntryComponentChange : CreateChange<ComplexFormComponent>, ISelf
             await foreach (var o in context.GetObjectsReferencing(current.ComplexFormEntryId))
             {
                 if (o is not ComplexFormComponent cfc) continue;
+                if (cfc.DeletedAt is not null) continue;
                 if (visited.Contains(cfc.Id)) continue;
+
                 if (cfc.ComplexFormEntryId == parent.ComponentEntryId) return true;
                 queue.Enqueue(cfc);
                 visited.Add(cfc.Id);

--- a/backend/FwLite/MiniLcm.Tests/ComplexFormComponentTestsBase.cs
+++ b/backend/FwLite/MiniLcm.Tests/ComplexFormComponentTestsBase.cs
@@ -92,6 +92,34 @@ public abstract class ComplexFormComponentTestsBase : MiniLcmTestBase
     }
 
     [Fact]
+    public async Task CreateComplexFormComponent_ThrowsWhenMakingASimpleReferenceCycle()
+    {
+        var act = async () => await Api.CreateComplexFormComponent(ComplexFormComponent.FromEntries(_componentEntry, _componentEntry));
+        await act.Should().ThrowAsync<Exception>();
+    }
+
+    [Fact]
+    public async Task CreateComplexFormComponent_ThrowsWhenMakingA2LayerReferenceCycle()
+    {
+        await Api.CreateComplexFormComponent(ComplexFormComponent.FromEntries(_complexFormEntry, _componentEntry));
+        var act = async () => await Api.CreateComplexFormComponent(ComplexFormComponent.FromEntries(_componentEntry, _complexFormEntry));
+        await act.Should().ThrowAsync<Exception>();
+    }
+
+    [Fact]
+    public async Task CreateComplexFormComponent_ThrowsWhenMakingA3LayerReferenceCycle()
+    {
+        var entry3 = await Api.CreateEntry(new()
+        {
+            Id = Guid.NewGuid(), LexemeForm = { { "en", "entry3" } }
+        });
+        await Api.CreateComplexFormComponent(ComplexFormComponent.FromEntries(_complexFormEntry, entry3));
+        await Api.CreateComplexFormComponent(ComplexFormComponent.FromEntries(entry3, _componentEntry));
+        var act = async () => await Api.CreateComplexFormComponent(ComplexFormComponent.FromEntries(_componentEntry, _complexFormEntry));
+        await act.Should().ThrowAsync<Exception>();
+    }
+
+    [Fact]
     public async Task CreateComplexFormType_Works()
     {
         var complexFormType = new ComplexFormType() { Id = Guid.NewGuid(), Name = new() { { "en", "test" } } };

--- a/backend/FwLite/MiniLcm.Tests/ComplexFormComponentTestsBase.cs
+++ b/backend/FwLite/MiniLcm.Tests/ComplexFormComponentTestsBase.cs
@@ -120,6 +120,20 @@ public abstract class ComplexFormComponentTestsBase : MiniLcmTestBase
     }
 
     [Fact]
+    public async Task CreateComplexFormComponent_WorksWhenAComponentWasDeletedWhichWouldCauseACycle()
+    {
+        var entry3 = await Api.CreateEntry(new()
+        {
+            Id = Guid.NewGuid(), LexemeForm = { { "en", "entry3" } }
+        });
+        await Api.CreateComplexFormComponent(ComplexFormComponent.FromEntries(_complexFormEntry, entry3));
+        var complexFormComponent = await Api.CreateComplexFormComponent(ComplexFormComponent.FromEntries(entry3, _componentEntry));
+        await Api.DeleteComplexFormComponent(complexFormComponent);
+        var act = async () => await Api.CreateComplexFormComponent(ComplexFormComponent.FromEntries(_componentEntry, _complexFormEntry));
+        await act.Should().NotThrowAsync("a component was deleted which was part of the cycle");
+    }
+
+    [Fact]
     public async Task CreateComplexFormType_Works()
     {
         var complexFormType = new ComplexFormType() { Id = Guid.NewGuid(), Name = new() { { "en", "test" } } };


### PR DESCRIPTION
this will avoid issues syncing with Fw where lcm will throw if you attempt to make a reference cycle