### PR TITLE
change FwLitePlatform to edition

### DIFF
--- a/backend/LexBoxApi/Config/FwLiteReleaseConfig.cs
+++ b/backend/LexBoxApi/Config/FwLiteReleaseConfig.cs
@@ -9,10 +9,10 @@ namespace LexBoxApi.Config;
 
 public class FwLiteReleaseConfig
 {
-    public Dictionary<FwLiteEdition, FwLitePlatformEdition> Editions { get; set; } = new();
+    public Dictionary<FwLiteEdition, FwLiteEditionConfig> Editions { get; set; } = new();
 }
 
-public class FwLitePlatformEdition
+public class FwLiteEditionConfig
 {
     [Required]
     public required string FileNameRegex { get; init; }

--- a/backend/LexBoxApi/Config/FwLiteReleaseConfig.cs
+++ b/backend/LexBoxApi/Config/FwLiteReleaseConfig.cs
@@ -9,10 +9,10 @@ namespace LexBoxApi.Config;
 
 public class FwLiteReleaseConfig
 {
-    public Dictionary<FwLitePlatform, FwLitePlatformConfig> Platforms { get; set; } = new();
+    public Dictionary<FwLiteEdition, FwLitePlatformEdition> Editions { get; set; } = new();
 }
 
-public class FwLitePlatformConfig
+public class FwLitePlatformEdition
 {
     [Required]
     public required string FileNameRegex { get; init; }

--- a/backend/LexBoxApi/Controllers/FwLiteReleaseController.cs
+++ b/backend/LexBoxApi/Controllers/FwLiteReleaseController.cs
@@ -17,11 +17,11 @@ public class FwLiteReleaseController(FwLiteReleaseService releaseService) : Cont
     [HttpGet("download-latest")]
     [AllowAnonymous]
     [ProducesResponseType(StatusCodes.Status404NotFound)]
-    public async Task<ActionResult> DownloadLatest([FromQuery] FwLitePlatform platform = FwLitePlatform.Windows)
+    public async Task<ActionResult> DownloadLatest([FromQuery] FwLiteEdition edition = FwLiteEdition.Windows)
     {
         using var activity = LexBoxActivitySource.Get().StartActivity();
-        activity?.AddTag(FwLiteReleaseService.FwLitePlatformTag, platform.ToString());
-        var latestRelease = await releaseService.GetLatestRelease(platform);
+        activity?.AddTag(FwLiteReleaseService.FwLiteEditionTag, edition.ToString());
+        var latestRelease = await releaseService.GetLatestRelease(edition);
         if (latestRelease is null)
         {
             activity?.SetStatus(ActivityStatusCode.Error, "Latest release not found");
@@ -36,13 +36,13 @@ public class FwLiteReleaseController(FwLiteReleaseService releaseService) : Cont
     [ProducesResponseType(StatusCodes.Status404NotFound)]
     [ProducesResponseType(StatusCodes.Status200OK)]
     [ProducesDefaultResponseType]
-    public async ValueTask<ActionResult<FwLiteRelease>> LatestRelease([FromQuery] FwLitePlatform platform =
-        FwLitePlatform.Windows, string? appVersion = null)
+    public async ValueTask<ActionResult<FwLiteRelease>> LatestRelease([FromQuery] FwLiteEdition edition =
+        FwLiteEdition.Windows, string? appVersion = null)
     {
         using var activity = LexBoxActivitySource.Get().StartActivity();
         activity?.AddTag(FwLiteReleaseService.FwLiteClientVersionTag, appVersion ?? "unknown");
-        activity?.AddTag(FwLiteReleaseService.FwLitePlatformTag, platform.ToString());
-        var latestRelease = await releaseService.GetLatestRelease(platform);
+        activity?.AddTag(FwLiteReleaseService.FwLiteEditionTag, edition.ToString());
+        var latestRelease = await releaseService.GetLatestRelease(edition);
         activity?.AddTag(FwLiteReleaseService.FwLiteReleaseVersionTag, latestRelease?.Version);
         if (latestRelease is null) return NotFound();
         return latestRelease;
@@ -50,12 +50,12 @@ public class FwLiteReleaseController(FwLiteReleaseService releaseService) : Cont
 
     [HttpGet("should-update")]
     [AllowAnonymous]
-    public async Task<ActionResult<ShouldUpdateResponse>> ShouldUpdate([FromQuery] string appVersion, [FromQuery] FwLitePlatform platform = FwLitePlatform.Windows)
+    public async Task<ActionResult<ShouldUpdateResponse>> ShouldUpdate([FromQuery] string appVersion, [FromQuery] FwLiteEdition edition = FwLiteEdition.Windows)
     {
         using var activity = LexBoxActivitySource.Get().StartActivity();
         activity?.AddTag(FwLiteReleaseService.FwLiteClientVersionTag, appVersion);
-        activity?.AddTag(FwLiteReleaseService.FwLitePlatformTag, platform.ToString());
-        var response = await releaseService.ShouldUpdate(platform, appVersion);
+        activity?.AddTag(FwLiteReleaseService.FwLiteEditionTag, edition.ToString());
+        var response = await releaseService.ShouldUpdate(edition, appVersion);
         activity?.AddTag(FwLiteReleaseService.FwLiteReleaseVersionTag, response.Release?.Version);
         return response;
     }

--- a/backend/LexBoxApi/Services/FwLiteReleases/FwLiteReleaseService.cs
+++ b/backend/LexBoxApi/Services/FwLiteReleases/FwLiteReleaseService.cs
@@ -48,10 +48,10 @@ public class FwLiteReleaseService(IHttpClientFactory factory, HybridCache cache,
 
     private async ValueTask<FwLiteRelease?> FetchLatestReleaseFromGithub(FwLiteEdition edition, CancellationToken token)
     {
-        var platformConfig = config.Value.Editions.GetValueOrDefault(edition);
-        if (platformConfig is null)
+        var editionConfig = config.Value.Editions.GetValueOrDefault(edition);
+        if (editionConfig is null)
         {
-            throw new ArgumentException($"No config for platform {edition}");
+            throw new ArgumentException($"No config for edition {edition}");
         }
         using var activity = LexBoxActivitySource.Get().StartActivity();
         activity?.AddTag(FwLiteEditionTag, edition.ToString());
@@ -87,7 +87,7 @@ public class FwLiteReleaseService(IHttpClientFactory factory, HybridCache cache,
                     continue;
                 }
 
-                var releaseAsset = release.Assets.FirstOrDefault(a => platformConfig.FileName.IsMatch(a.Name));
+                var releaseAsset = release.Assets.FirstOrDefault(a => editionConfig.FileName.IsMatch(a.Name));
                 if (releaseAsset is not null)
                 {
                     activity?.AddTag(FwLiteReleaseVersionTag, release.TagName);

--- a/backend/LexBoxApi/appsettings.json
+++ b/backend/LexBoxApi/appsettings.json
@@ -77,7 +77,7 @@
     }
   },
   "FwLiteRelease": {
-    "Platforms": {
+    "Editions": {
       "Windows": {
         // ends with .msixbundle regex
         "FileNameRegex": "(?i)\\.msixbundle$"

--- a/backend/LexCore/Entities/FwLiteRelease.cs
+++ b/backend/LexCore/Entities/FwLiteRelease.cs
@@ -6,7 +6,7 @@ namespace LexCore.Entities;
 public record FwLiteRelease(string Version, string Url);
 
 [JsonConverter(typeof(JsonStringEnumConverter))]
-public enum FwLitePlatform
+public enum FwLiteEdition
 {
     Windows,
     Linux,

--- a/backend/LexCore/Entities/FwLiteRelease.cs
+++ b/backend/LexCore/Entities/FwLiteRelease.cs
@@ -13,7 +13,9 @@ public enum FwLiteEdition
     Android,
     // ReSharper disable once InconsistentNaming
     iOS,
-    Mac
+    Mac,
+    //not supported for now, see note in FwLiteReleaseController.DownloadLatest
+    WindowsAppInstaller
 }
 
 public record ShouldUpdateResponse(FwLiteRelease? Release)

--- a/backend/Testing/LexCore/Services/FwLiteReleaseServiceTests.cs
+++ b/backend/Testing/LexCore/Services/FwLiteReleaseServiceTests.cs
@@ -21,8 +21,8 @@ public class FwLiteReleaseServiceTests
             .AddHttpClient()
             .AddOptions<FwLiteReleaseConfig>().Configure(config =>
             {
-                config.Platforms.Add(FwLitePlatform.Windows, new FwLitePlatformConfig() { FileNameRegex = "(?i)\\.msixbundle$" });
-                config.Platforms.Add(FwLitePlatform.Linux, new FwLitePlatformConfig() { FileNameRegex = "(?i)linux\\.zip$" });
+                config.Editions.Add(FwLiteEdition.Windows, new FwLitePlatformEdition() { FileNameRegex = "(?i)\\.msixbundle$" });
+                config.Editions.Add(FwLiteEdition.Linux, new FwLitePlatformEdition() { FileNameRegex = "(?i)linux\\.zip$" });
             })
             .Services
             .AddHybridCache()
@@ -32,11 +32,11 @@ public class FwLiteReleaseServiceTests
     }
 
     [Theory]
-    [InlineData(FwLitePlatform.Windows)]
-    [InlineData(FwLitePlatform.Linux)]
-    public async Task CanGetLatestRelease(FwLitePlatform platform)
+    [InlineData(FwLiteEdition.Windows)]
+    [InlineData(FwLiteEdition.Linux)]
+    public async Task CanGetLatestRelease(FwLiteEdition edition)
     {
-        var latestRelease = await _fwLiteReleaseService.GetLatestRelease(platform);
+        var latestRelease = await _fwLiteReleaseService.GetLatestRelease(edition);
         latestRelease.Should().NotBeNull();
         latestRelease.Version.Should().NotBeNullOrEmpty();
         latestRelease.Url.Should().NotBeNullOrEmpty();
@@ -46,7 +46,7 @@ public class FwLiteReleaseServiceTests
     [InlineData("v2024-11-20-d04e9b96")]
     public async Task IsConsideredAnOldVersion(string appVersion)
     {
-        var shouldUpdate = await _fwLiteReleaseService.ShouldUpdate(FwLitePlatform.Windows, appVersion);
+        var shouldUpdate = await _fwLiteReleaseService.ShouldUpdate(FwLiteEdition.Windows, appVersion);
         shouldUpdate.Should().NotBeNull();
         shouldUpdate.Release.Should().NotBeNull();
         shouldUpdate.Update.Should().BeTrue();
@@ -55,9 +55,9 @@ public class FwLiteReleaseServiceTests
     [Fact]
     public async Task ShouldUpdateWithLatestVersionShouldReturnFalse()
     {
-        var latestRelease = await _fwLiteReleaseService.GetLatestRelease(FwLitePlatform.Windows);
+        var latestRelease = await _fwLiteReleaseService.GetLatestRelease(FwLiteEdition.Windows);
         latestRelease.Should().NotBeNull();
-        var shouldUpdate = await _fwLiteReleaseService.ShouldUpdate(FwLitePlatform.Windows, latestRelease.Version);
+        var shouldUpdate = await _fwLiteReleaseService.ShouldUpdate(FwLiteEdition.Windows, latestRelease.Version);
         shouldUpdate.Should().NotBeNull();
         shouldUpdate.Release.Should().BeNull();
         shouldUpdate.Update.Should().BeFalse();

--- a/backend/Testing/LexCore/Services/FwLiteReleaseServiceTests.cs
+++ b/backend/Testing/LexCore/Services/FwLiteReleaseServiceTests.cs
@@ -21,8 +21,8 @@ public class FwLiteReleaseServiceTests
             .AddHttpClient()
             .AddOptions<FwLiteReleaseConfig>().Configure(config =>
             {
-                config.Editions.Add(FwLiteEdition.Windows, new FwLitePlatformEdition() { FileNameRegex = "(?i)\\.msixbundle$" });
-                config.Editions.Add(FwLiteEdition.Linux, new FwLitePlatformEdition() { FileNameRegex = "(?i)linux\\.zip$" });
+                config.Editions.Add(FwLiteEdition.Windows, new FwLiteEditionConfig() { FileNameRegex = "(?i)\\.msixbundle$" });
+                config.Editions.Add(FwLiteEdition.Linux, new FwLiteEditionConfig() { FileNameRegex = "(?i)linux\\.zip$" });
             })
             .Services
             .AddHybridCache()


### PR DESCRIPTION
at some point we may have multiple per OS, for example a portal install of Windows, or a Windows App Installer. The main reason for doing this now is so we can change the query parameter which we won't be able to change later