### PR TITLE
Add "Register with Google" button to /register page

### DIFF
--- a/frontend/src/lib/components/RegisterWithGoogleButton.svelte
+++ b/frontend/src/lib/components/RegisterWithGoogleButton.svelte
@@ -1,0 +1,7 @@
+<script lang="ts">
+  import SigninWithGoogleButton from './SigninWithGoogleButton.svelte';
+
+  export let href: string;
+</script>
+
+<SigninWithGoogleButton {href} text="register_with_google" />

--- a/frontend/src/lib/components/SigninWithGoogleButton.svelte
+++ b/frontend/src/lib/components/SigninWithGoogleButton.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   export let href: string;
   import t from '$lib/i18n';
+  export let text: 'sign_in_with_google' | 'register_with_google' = 'sign_in_with_google';
 </script>
 
 <!--
@@ -42,8 +43,8 @@
         <path fill="none" d="M0 0h48v48H0z"></path>
       </svg>
     </div>
-    <span class="gsi-material-button-contents">{$t('login.sign_in_with_google')}</span>
-    <span style="display: none;">{$t('login.sign_in_with_google')}</span>
+    <span class="gsi-material-button-contents">{$t(`login.${text}`)}</span>
+    <span style="display: none;">{$t(`login.${text}`)}</span>
   </div>
 </a>
 

--- a/frontend/src/lib/components/SigninWithGoogleButton.svelte
+++ b/frontend/src/lib/components/SigninWithGoogleButton.svelte
@@ -70,7 +70,9 @@
     cursor: pointer;
     font-family: 'Roboto', arial, sans-serif;
     font-size: 14px;
+    /* EDIT:
     height: 40px;
+    */
     letter-spacing: 0.25px;
     outline: none;
     overflow: hidden;
@@ -84,7 +86,9 @@
     vertical-align: middle;
     white-space: nowrap;
     width: auto;
+    /* EDIT:
     max-width: 400px;
+    */
     min-width: min-content;
   }
 
@@ -104,14 +108,16 @@
     -webkit-flex-wrap: nowrap;
     flex-wrap: nowrap;
     height: 100%;
-    justify-content: space-between;
+    justify-content: center; /* EDIT: space-between */
     position: relative;
     width: 100%;
   }
 
   .gsi-material-button .gsi-material-button-contents {
+    /* EDIT:
     -webkit-flex-grow: 1;
     flex-grow: 1;
+    */
     font-family: 'Roboto', arial, sans-serif;
     font-weight: 500;
     /* EDIT:

--- a/frontend/src/lib/i18n/locales/en.json
+++ b/frontend/src/lib/i18n/locales/en.json
@@ -161,6 +161,7 @@
     "label_password": "Password",
     "missing_user_info": "User info missing",
     "sign_in_with_google": "Sign in with Google",
+    "register_with_google": "Register with Google",
     "title": "Log in",
     "password_missing": "Password missing",
     "link_expired": "The email you clicked has expired. Please request a new one.",

--- a/frontend/src/lib/layout/AppBar.svelte
+++ b/frontend/src/lib/layout/AppBar.svelte
@@ -13,7 +13,7 @@
   });
   let isPlaywright = false;
   let environmentName = env.PUBLIC_ENV_NAME?.toLowerCase();
-  export let user: LexAuthUser | undefined;
+  export let user: LexAuthUser | null;
   $: loggedIn = !!user;
 </script>
 

--- a/frontend/src/lib/layout/Layout.svelte
+++ b/frontend/src/lib/layout/Layout.svelte
@@ -35,7 +35,7 @@
 
 <svelte:window on:keydown={closeOnEscape} />
 
-{#if user}
+{#if user && user.audience == 'LexboxApi'}
   <div class="drawer drawer-end grow">
     <input id="drawer-toggle" type="checkbox" bind:checked={menuToggle} class="drawer-toggle" />
 

--- a/frontend/src/lib/layout/Layout.svelte
+++ b/frontend/src/lib/layout/Layout.svelte
@@ -35,7 +35,7 @@
 
 <svelte:window on:keydown={closeOnEscape} />
 
-{#if user && user.audience == 'LexboxApi'}
+{#if user?.audience === 'LexboxApi'}
   <div class="drawer drawer-end grow">
     <input id="drawer-toggle" type="checkbox" bind:checked={menuToggle} class="drawer-toggle" />
 
@@ -94,7 +94,9 @@
     </div>
   </div>
 {:else}
-  <AppBar user={undefined} />
+  <!-- If the user is authenticated (i.e. not null), but not authorized to use the API, we
+  still want to pass them in here, so we show their name rather than Login and Register buttons. -->
+  <AppBar {user} />
 
   <Content>
     <slot />

--- a/frontend/src/lib/user.test.ts
+++ b/frontend/src/lib/user.test.ts
@@ -1,6 +1,8 @@
 ﻿import {describe, expect, it} from 'vitest';
-import {jwtToUser} from '$lib/user';
+
 import type {AuthUserOrg} from '$lib/gql/generated/graphql';
+import {jwtToUser} from '$lib/user';
+
 describe('jwtToUser', () => {
   it('should convert a jwt token to a LexAuthUser', () => {
     const jwtUser = {
@@ -27,7 +29,7 @@ describe('jwtToUser', () => {
       'exp': 1722673515,
       'iat': 1721377515,
       'iss': 'LexboxApi',
-      'aud': 'LexboxApi'
+      'aud': 'LexboxApi' as const,
     };
     const user = jwtToUser(jwtUser);
     expect(user).toEqual({
@@ -66,7 +68,8 @@ describe('jwtToUser', () => {
       'canCreateProjects': true,
       'createdByAdmin': false,
       'locale': 'en',
-      'emailOrUsername': 'editor@test.com'
+      'emailOrUsername': 'editor@test.com',
+      'audience': 'LexboxApi',
     });
   });
 });

--- a/frontend/src/lib/user.ts
+++ b/frontend/src/lib/user.ts
@@ -36,6 +36,7 @@ type JwtTokenUser = {
   unver?: boolean | undefined,
   mkproj?: boolean | undefined,
   creat?: boolean | undefined,
+  aud: string,
   loc: string,
 }
 
@@ -53,6 +54,7 @@ export type LexAuthUser = {
   emailVerified: boolean
   canCreateProjects: boolean
   createdByAdmin: boolean
+  audience: string
   locale: string
 }
 
@@ -177,7 +179,7 @@ export function getUser(cookies: Cookies): LexAuthUser | null {
 }
 
 export function jwtToUser(user: JwtTokenUser): LexAuthUser {
-  const { sub: id, name, email, user: username, proj: projectsString, role: jwtRole } = user;
+  const { sub: id, aud: audience, name, email, user: username, proj: projectsString, role: jwtRole } = user;
   const role = Object.values(UserRole).find(r => r.toLowerCase() === jwtRole) ?? UserRole.User;
 
   if (user.orgs) {
@@ -199,6 +201,7 @@ export function jwtToUser(user: JwtTokenUser): LexAuthUser {
     canCreateProjects: user.mkproj === true || role === UserRole.Admin,
     createdByAdmin: user.creat ?? false,
     locale: user.loc,
+    audience,
     emailOrUsername: (email ?? username) as string,
   }
 }

--- a/frontend/src/routes/(authenticated)/admin/+page.ts
+++ b/frontend/src/routes/(authenticated)/admin/+page.ts
@@ -260,6 +260,7 @@ export async function _createGuestUserByAdmin(input: CreateGuestUserByAdminInput
                 orgId
                 role
               }
+              audience
             }
             errors {
                 __typename

--- a/frontend/src/routes/(unauthenticated)/register/+page.svelte
+++ b/frontend/src/routes/(unauthenticated)/register/+page.svelte
@@ -4,6 +4,8 @@
   import CreateUser from '$lib/components/Users/CreateUser.svelte';
   import { goto } from '$app/navigation';
   import { register } from '$lib/user';
+  import RegisterWithGoogleButton from '$lib/components/RegisterWithGoogleButton.svelte';
+  import { page } from '$app/stores';
 
   async function onSubmit(): Promise<void> {
     await goto('/home', { invalidateAll: true }); // invalidate so we get the user from the server
@@ -11,5 +13,7 @@
 </script>
 
 <TitlePage title={$t('register.title')}>
+  <RegisterWithGoogleButton href={`/api/login/google?redirectTo=${$page.url.pathname}`}/>
+  <div class="divider lowercase">{$t('common.or')}</div>
   <CreateUser handleSubmit={register} on:submitted={onSubmit} />
 </TitlePage>

--- a/frontend/src/routes/(unauthenticated)/register/+page.svelte
+++ b/frontend/src/routes/(unauthenticated)/register/+page.svelte
@@ -5,7 +5,6 @@
   import { goto } from '$app/navigation';
   import { register } from '$lib/user';
   import RegisterWithGoogleButton from '$lib/components/RegisterWithGoogleButton.svelte';
-  import { page } from '$app/stores';
 
   async function onSubmit(): Promise<void> {
     await goto('/home', { invalidateAll: true }); // invalidate so we get the user from the server
@@ -14,7 +13,7 @@
 
 <TitlePage title={$t('register.title')}>
   <div class="flex flex-col pb-2">
-    <RegisterWithGoogleButton href={`/api/login/google?redirectTo=${$page.url.pathname}`}/>
+    <RegisterWithGoogleButton href={`/api/login/google`}/>
   </div>
   <div class="divider lowercase">{$t('common.or')}</div>
   <CreateUser handleSubmit={register} on:submitted={onSubmit} />

--- a/frontend/src/routes/(unauthenticated)/register/+page.svelte
+++ b/frontend/src/routes/(unauthenticated)/register/+page.svelte
@@ -13,7 +13,9 @@
 </script>
 
 <TitlePage title={$t('register.title')}>
-  <RegisterWithGoogleButton href={`/api/login/google?redirectTo=${$page.url.pathname}`}/>
+  <div class="flex flex-col pb-2">
+    <RegisterWithGoogleButton href={`/api/login/google?redirectTo=${$page.url.pathname}`}/>
+  </div>
   <div class="divider lowercase">{$t('common.or')}</div>
   <CreateUser handleSubmit={register} on:submitted={onSubmit} />
 </TitlePage>


### PR DESCRIPTION
Fixes #1126.

Currently working, but with one issue: when you click on the "Register with Google" button, the user account button in the upper right changes from "Log in" to "Robin Munn" (or whoever) even though you haven't actually completed the registration process yet. That's because the Google OAuth process has produced a JWT that's only valid for registration (it has Audience = LexboxAudience.RegisterAccount), but our layout code wasn't checking the JWT audience before displaying the menu button (it just has an `{#if user}` check in Layout.svelte).

I've now exposed the JWT audience to the JS code, and changed `{#if user}` to `{#if user && user.audience == 'LexboxApi'}` in Layout.svelte. One open question, though: are there any other audiences that should show the user menu? The available JWT audiences are:

* LexboxApi
* RegisterAccount
* ForgotPassword
* SendAndReceive
* SendAndReceiveRefresh

Of those, the only one I'm not sure of is the ForgotPassword JWT audience.  Should we show the user menu on the "Forgot password" screen? My gut says no, but if I'm wrong, it'll be pretty straightforward to change.