### PR TITLE
Import and validation fixups

### DIFF
--- a/backend/FwLite/FwDataMiniLcmBridge/Api/FwDataMiniLcmApi.cs
+++ b/backend/FwLite/FwDataMiniLcmBridge/Api/FwDataMiniLcmApi.cs
@@ -480,30 +480,45 @@ public class FwDataMiniLcmApi(Lazy<LcmCache> cacheLazy, bool onCloseSave, ILogge
 
     private Entry FromLexEntry(ILexEntry entry)
     {
-        return new Entry
+        try
         {
-            Id = entry.Guid,
-            Note = FromLcmMultiString(entry.Comment),
-            LexemeForm = FromLcmMultiString(entry.LexemeFormOA.Form),
-            CitationForm = FromLcmMultiString(entry.CitationForm),
-            LiteralMeaning = FromLcmMultiString(entry.LiteralMeaning),
-            Senses = entry.AllSenses.Select(FromLexSense).ToList(),
-            ComplexFormTypes = ToComplexFormTypes(entry),
-            Components = ToComplexFormComponents(entry).ToList(),
-            ComplexForms = [
-                ..entry.ComplexFormEntries.Select(complexEntry => ToEntryReference(entry, complexEntry)),
-                ..entry.AllSenses.SelectMany(sense => sense.ComplexFormEntries.Select(complexEntry => ToSenseReference(sense, complexEntry)))
-            ]
-        };
+            return new Entry
+            {
+                Id = entry.Guid,
+                Note = FromLcmMultiString(entry.Comment),
+                LexemeForm = FromLcmMultiString(entry.LexemeFormOA.Form),
+                CitationForm = FromLcmMultiString(entry.CitationForm),
+                LiteralMeaning = FromLcmMultiString(entry.LiteralMeaning),
+                Senses = entry.AllSenses.Select(FromLexSense).ToList(),
+                ComplexFormTypes = ToComplexFormTypes(entry),
+                Components = ToComplexFormComponents(entry).ToList(),
+                ComplexForms = [
+                    ..entry.ComplexFormEntries.Select(complexEntry => ToEntryReference(entry, complexEntry)),
+                    ..entry.AllSenses.SelectMany(sense => sense.ComplexFormEntries.Select(complexEntry => ToSenseReference(sense, complexEntry)))
+                ]
+            };
+        }
+        catch (Exception e)
+        {
+            var headword = LexEntryHeadword(entry);
+            throw new InvalidOperationException($"Failed to map FW entry to MiniLCM entry '{headword}' ({entry.Guid})", e);
+        }
     }
 
     private string LexEntryHeadword(ILexEntry entry)
     {
-        return new Entry()
+        try
         {
-            LexemeForm = FromLcmMultiString(entry.LexemeFormOA.Form),
-            CitationForm = FromLcmMultiString(entry.CitationForm),
-        }.Headword();
+            return new Entry()
+            {
+                LexemeForm = FromLcmMultiString(entry.LexemeFormOA.Form),
+                CitationForm = FromLcmMultiString(entry.CitationForm),
+            }.Headword();
+        }
+        catch (Exception e)
+        {
+            throw new InvalidOperationException($"Failed to get headword for FW entry {entry.Guid}", e);
+        }
     }
 
     private IList<ComplexFormType> ToComplexFormTypes(ILexEntry entry)

--- a/backend/FwLite/FwDataMiniLcmBridge/Api/FwDataMiniLcmApi.cs
+++ b/backend/FwLite/FwDataMiniLcmBridge/Api/FwDataMiniLcmApi.cs
@@ -304,7 +304,7 @@ public class FwDataMiniLcmApi(Lazy<LcmCache> cacheLazy, bool onCloseSave, ILogge
         {
             Id = semanticDomain.Guid,
             Name = FromLcmMultiString(semanticDomain.Name),
-            Code = semanticDomain.Abbreviation.UiString ?? "",
+            Code = GetSemanticDomainCode(semanticDomain),
             Predefined = CanonicalGuidsSemanticDomain.CanonicalSemDomGuids.Contains(semanticDomain.Guid),
         };
     }
@@ -314,7 +314,7 @@ public class FwDataMiniLcmApi(Lazy<LcmCache> cacheLazy, bool onCloseSave, ILogge
         return
             SemanticDomainRepository
             .AllInstances()
-            .OrderBy(p => p.Abbreviation.UiString)
+            .OrderBy(GetSemanticDomainCode)
             .ToAsyncEnumerable()
             .Select(FromLcmSemanticDomain);
     }
@@ -323,6 +323,13 @@ public class FwDataMiniLcmApi(Lazy<LcmCache> cacheLazy, bool onCloseSave, ILogge
     {
         var semDom = GetLcmSemanticDomain(id);
         return Task.FromResult(semDom is null ? null : FromLcmSemanticDomain(semDom));
+    }
+
+    private string GetSemanticDomainCode(ICmSemanticDomain semanticDomain)
+    {
+        var abbr = semanticDomain.Abbreviation;
+        // UiString can be null even though there is an abbreviation available
+        return abbr.UiString ?? abbr.BestVernacularAnalysisAlternative.Text;
     }
 
     public async Task<SemanticDomain> CreateSemanticDomain(SemanticDomain semanticDomain)

--- a/backend/FwLite/MiniLcm/Validators/ComplexFormTypeValidator.cs
+++ b/backend/FwLite/MiniLcm/Validators/ComplexFormTypeValidator.cs
@@ -1,5 +1,4 @@
 ﻿using FluentValidation;
-using FluentValidation.Validators;
 using MiniLcm.Models;
 
 namespace MiniLcm.Validators;
@@ -9,6 +8,6 @@ internal class ComplexFormTypeValidator : AbstractValidator<ComplexFormType>
     public ComplexFormTypeValidator()
     {
         RuleFor(c => c.DeletedAt).Null();
-        RuleFor(c => c.Name).Required();
+        RuleFor(c => c.Name).Required(c => c.Id.ToString("D"));
     }
 }

--- a/backend/FwLite/MiniLcm/Validators/EntryValidator.cs
+++ b/backend/FwLite/MiniLcm/Validators/EntryValidator.cs
@@ -8,10 +8,10 @@ public class EntryValidator : AbstractValidator<Entry>
     public EntryValidator()
     {
         RuleFor(e => e.DeletedAt).Null();
-        RuleFor(e => e.LexemeForm).Required();
-        RuleFor(e => e.CitationForm).NoEmptyValues();
-        RuleFor(e => e.LiteralMeaning).NoEmptyValues();
-        RuleFor(e => e.Note).NoEmptyValues();
+        RuleFor(e => e.LexemeForm).Required(GetEntryIdentifier);
+        RuleFor(e => e.CitationForm).NoEmptyValues(GetEntryIdentifier);
+        RuleFor(e => e.LiteralMeaning).NoEmptyValues(GetEntryIdentifier);
+        RuleFor(e => e.Note).NoEmptyValues(GetEntryIdentifier);
         RuleForEach(e => e.Senses).SetValidator(entry => new SenseValidator(entry));
         RuleForEach(e => e.Components).Must(NotBeEmptyComponentReference);
         RuleForEach(e => e.Components).Must(NotBeComponentSelfReference);
@@ -49,5 +49,10 @@ public class EntryValidator : AbstractValidator<Entry>
     {
         // Empty GUID is okay here because it can be guessed from the parent object
         return component.ComponentEntryId == entry.Id || component.ComponentEntryId == Guid.Empty;
+    }
+
+    private string GetEntryIdentifier(Entry entry)
+    {
+        return $"{entry.Headword} - {entry.Id}";
     }
 }

--- a/backend/FwLite/MiniLcm/Validators/ExampleSentenceValidator.cs
+++ b/backend/FwLite/MiniLcm/Validators/ExampleSentenceValidator.cs
@@ -8,13 +8,18 @@ public class ExampleSentenceValidator : AbstractValidator<ExampleSentence>
     public ExampleSentenceValidator()
     {
         RuleFor(es => es.DeletedAt).Null();
-        RuleFor(es => es.Sentence).NoEmptyValues();
-        RuleFor(es => es.Translation).NoEmptyValues();
+        RuleFor(es => es.Sentence).NoEmptyValues(GetExampleSentenceIdentifier);
+        RuleFor(es => es.Translation).NoEmptyValues(GetExampleSentenceIdentifier);
     }
 
     public ExampleSentenceValidator(Sense sense) : this()
     {
         //it's ok if SenseId is an Empty guid
         RuleFor(es => es.SenseId).Equal(sense.Id).When(es => es.SenseId != Guid.Empty).WithMessage(examplesentence => $"ExampleSentence (Id: {examplesentence.Id}) EntryId must match Sense {sense.Id}, but instead was {examplesentence.SenseId}");
+    }
+
+    private string GetExampleSentenceIdentifier(ExampleSentence example)
+    {
+        return example.Id.ToString("D");
     }
 }

--- a/backend/FwLite/MiniLcm/Validators/MultiStringValidator.cs
+++ b/backend/FwLite/MiniLcm/Validators/MultiStringValidator.cs
@@ -5,13 +5,15 @@ namespace MiniLcm.Validators;
 
 internal static class MultiStringValidator
 {
-    public static IRuleBuilderOptions<T, MultiString> Required<T>(this IRuleBuilder<T, MultiString> ruleBuilder)
+    public static IRuleBuilderOptions<T, MultiString> Required<T>(this IRuleBuilder<T, MultiString> ruleBuilder, Func<T, string> getParentId)
     {
-        return ruleBuilder.NotEmpty().NoEmptyValues();
+        return ruleBuilder.NotEmpty()
+            .WithMessage((parent, ms) => $"MultiString must not be empty ({getParentId(parent)})")
+            .NoEmptyValues(getParentId);
     }
-    public static IRuleBuilderOptions<T, MultiString> NoEmptyValues<T>(this IRuleBuilder<T, MultiString> ruleBuilder)
+    public static IRuleBuilderOptions<T, MultiString> NoEmptyValues<T>(this IRuleBuilder<T, MultiString> ruleBuilder, Func<T, string> getParentId)
     {
         return ruleBuilder.Must(ms => ms.Values.All(v => !string.IsNullOrEmpty(v.Value))).WithMessage((parent, ms) =>
-            $"MultiString must not contain empty values, but [{string.Join(", ", ms.Values.Where(v => string.IsNullOrWhiteSpace(v.Value)).Select(v => v.Key))}] was empty");
+            $"MultiString must not contain empty values, but [{string.Join(", ", ms.Values.Where(v => string.IsNullOrWhiteSpace(v.Value)).Select(v => v.Key))}] was empty ({getParentId(parent)})");
     }
 }

--- a/backend/FwLite/MiniLcm/Validators/PartOfSpeechValidator.cs
+++ b/backend/FwLite/MiniLcm/Validators/PartOfSpeechValidator.cs
@@ -9,7 +9,8 @@ public class PartOfSpeechValidator : AbstractValidator<PartOfSpeech>
     {
         RuleFor(pos => pos.Id).Must(BeCanonicalGuid).When(pos => pos.Predefined);
         RuleFor(pos => pos.DeletedAt).Null();
-        RuleFor(pos => pos.Name).Required(pos => pos.Id.ToString("D"));
+        // This seems to block quite a few real projects
+        // RuleFor(pos => pos.Name).Required(pos => pos.Id.ToString("D"));
     }
 
     private bool BeCanonicalGuid(Guid id)

--- a/backend/FwLite/MiniLcm/Validators/PartOfSpeechValidator.cs
+++ b/backend/FwLite/MiniLcm/Validators/PartOfSpeechValidator.cs
@@ -9,7 +9,7 @@ public class PartOfSpeechValidator : AbstractValidator<PartOfSpeech>
     {
         RuleFor(pos => pos.Id).Must(BeCanonicalGuid).When(pos => pos.Predefined);
         RuleFor(pos => pos.DeletedAt).Null();
-        RuleFor(pos => pos.Name).Required();
+        RuleFor(pos => pos.Name).Required(pos => pos.Id.ToString("D"));
     }
 
     private bool BeCanonicalGuid(Guid id)

--- a/backend/FwLite/MiniLcm/Validators/SemanticDomainValidator.cs
+++ b/backend/FwLite/MiniLcm/Validators/SemanticDomainValidator.cs
@@ -7,10 +7,12 @@ public class SemanticDomainValidator : AbstractValidator<SemanticDomain>
 {
     public SemanticDomainValidator()
     {
-        RuleFor(s => s.Code).NotNull().NotEmpty();
+        RuleFor(s => s.Code)
+            .NotNull().WithMessage((s) => $"Code is required ({s.Name} - {s.Id})")
+            .NotEmpty().WithMessage((s) => $"Code is required ({s.Name} - {s.Id})");
         RuleFor(s => s.DeletedAt).Null();
         RuleFor(s => s.Id).Must(BeCanonicalGuid).When(s => s.Predefined);
-        RuleFor(s => s.Name).Required();
+        RuleFor(s => s.Name).Required(s => s.Id.ToString("D"));
     }
 
     private bool BeCanonicalGuid(Guid id)

--- a/backend/FwLite/MiniLcm/Validators/SenseValidator.cs
+++ b/backend/FwLite/MiniLcm/Validators/SenseValidator.cs
@@ -8,8 +8,8 @@ public class SenseValidator : AbstractValidator<Sense>
     public SenseValidator()
     {
         RuleFor(s => s.DeletedAt).Null();
-        RuleFor(s => s.Definition).NoEmptyValues();
-        RuleFor(s => s.Gloss).NoEmptyValues();
+        RuleFor(s => s.Definition).NoEmptyValues(GetSenseIdentifier);
+        RuleFor(s => s.Gloss).NoEmptyValues(GetSenseIdentifier);
         RuleFor(s => s.PartOfSpeech!).SetValidator(new PartOfSpeechValidator()).When(s => s.PartOfSpeech is not null);
         RuleFor(s => s.PartOfSpeechId).Equal(s => s.PartOfSpeech!.Id).When(s => s.PartOfSpeech is not null && s.PartOfSpeechId is not null);
         RuleForEach(s => s.SemanticDomains).SetValidator(new SemanticDomainValidator());
@@ -20,5 +20,15 @@ public class SenseValidator : AbstractValidator<Sense>
     {
         //it's ok if senses EntryId is an Empty guid
         RuleFor(s => s.EntryId).Equal(entry.Id).When(s => s.EntryId != Guid.Empty).WithMessage(sense => $"Sense (Id: {sense.Id}) EntryId must match Entry {entry.Id}, but instead was {sense.EntryId}");
+    }
+
+    private string GetSenseIdentifier(Sense sense)
+    {
+        var firstGloss = sense.Gloss?.Values?.Values.FirstOrDefault();
+        if (string.IsNullOrWhiteSpace(firstGloss))
+        {
+            return sense.Id.ToString("D");
+        }
+        return $"{sense.Gloss} - {sense.Id}";
     }
 }

--- a/backend/FwLite/MiniLcm/Validators/WritingSystemValidator.cs
+++ b/backend/FwLite/MiniLcm/Validators/WritingSystemValidator.cs
@@ -8,10 +8,10 @@ public class WritingSystemValidator : AbstractValidator<WritingSystem>
 {
     public WritingSystemValidator()
     {
-        RuleFor(ws => ws.Abbreviation).NotNull().NotEmpty();
+        RuleFor(ws => ws.Abbreviation).NotNull().NotEmpty().WithMessage((s) => $"Abbreviation is required ({s.WsId} - {s.Name} - {s.Id})");
         RuleFor(ws => ws.DeletedAt).Null();
-        RuleFor(ws => ws.Name).NotNull().NotEmpty();
-        RuleFor(ws => ws.WsId).Must(BeValidWsId);
+        RuleFor(ws => ws.Name).NotNull().NotEmpty().WithMessage((s) => $"Name is required ({s.WsId} - {s.Id})");
+        RuleFor(ws => ws.WsId).Must(BeValidWsId).WithMessage(ws => $"Invalid writing system id: {ws.WsId}");
     }
 
     private bool BeValidWsId(WritingSystemId wsId)


### PR DESCRIPTION
I was playing with importing and updating various projects and found these changes to be valuable.

- Turning off the Pos.Name validation is something @hahn-kev suggested a while ago
- I see the catch in `FromLexEntry(ILexEntry entry)` trigger when `entry.ComplexFormEntryRefs.SingleOrDefault()` finds multiple items. We haven't decided what to do about that, but it's nice to at least see which entry is causing the problem. By doing so, I could modify the fwdata file to make the import happy. Deleting the entry refs in the UI didn't really help 🙃.
- The try catch in `LexEntryHeadword(entry)` is maybe excessive. It just felt good, beacuse I'm calling it from a catch block.
- I ran into other validation errors that didn't provide enough context for me to troubleshoot. Especially when we're complaining that something is null or empty, well....what is it?! 😆