### PR TITLE
Add tests for requesting to join project

### DIFF
--- a/.idea/.idea.LexBox/.idea/sqldialects.xml
+++ b/.idea/.idea.LexBox/.idea/sqldialects.xml
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<project version="4">
-  <component name="SqlDialectMappings">
-    <file url="PROJECT" dialect="PostgreSQL" />
-  </component>
-</project>

--- a/frontend/tests/email/e2e-mailbox.ts
+++ b/frontend/tests/email/e2e-mailbox.ts
@@ -12,10 +12,9 @@ export class E2EMailbox extends Mailbox {
     super(email);
   }
 
-  async fetchEmails(subject: EmailSubjects, extraText?: string): Promise<Email[]> {
-    const searchText = subject.toString() + (extraText ?? '');
+  async fetchEmails(subject: EmailSubjects | string): Promise<Email[]> {
     const emails = await this.e2eMailboxApi.fetchEmailList()
-    return emails.filter(email => email.mail_subject.includes(searchText))
+    return emails.filter(email => email.mail_subject.includes(subject))
       .map(email => ({body: email.mail_body}));
   }
 }

--- a/frontend/tests/email/e2e-mailbox.ts
+++ b/frontend/tests/email/e2e-mailbox.ts
@@ -12,9 +12,10 @@ export class E2EMailbox extends Mailbox {
     super(email);
   }
 
-  async fetchEmails(subject: EmailSubjects): Promise<Email[]> {
+  async fetchEmails(subject: EmailSubjects, extraText?: string): Promise<Email[]> {
+    const searchText = subject.toString() + (extraText ?? '');
     const emails = await this.e2eMailboxApi.fetchEmailList()
-    return emails.filter(email => email.mail_subject.includes(subject))
+    return emails.filter(email => email.mail_subject.includes(searchText))
       .map(email => ({body: email.mail_body}));
   }
 }

--- a/frontend/tests/email/email-page.ts
+++ b/frontend/tests/email/email-page.ts
@@ -7,6 +7,7 @@ export enum EmailSubjects {
   ForgotPassword = 'Forgot your password?',
   PasswordChanged = 'Your password was changed',
   ProjectInvitation = 'Project invitation:',
+  ProjectJoinRequest = 'Project join request',
 }
 
 export class EmailPage extends BasePage {
@@ -20,6 +21,10 @@ export class EmailPage extends BasePage {
 
   clickVerifyEmail(): Promise<void> {
     return this.bodyLocator.getByRole('link', {name: 'Verify e-mail'}).click();
+  }
+
+  clickApproveRequest(): Promise<void> {
+    return this.bodyLocator.getByRole('link', {name: 'Approve request'}).click();
   }
 
   clickResetPassword(): Promise<void> {

--- a/frontend/tests/email/mailbox.ts
+++ b/frontend/tests/email/mailbox.ts
@@ -9,13 +9,13 @@ export interface Email {
 export abstract class Mailbox {
   constructor(readonly email: string) { }
 
-  abstract fetchEmails(subject: EmailSubjects | string, extraText?: string): Promise<Email[]>;
+  abstract fetchEmails(subject: EmailSubjects | string): Promise<Email[]>;
 
-  async openEmail(page: Page, subject: EmailSubjects | string, extraText?: string, index: number = 0): Promise<EmailPage> {
+  async openEmail(page: Page, subject: EmailSubjects | string, index: number = 0): Promise<EmailPage> {
     let email: Email | undefined = undefined;
 
     await expect.poll(async () => {
-      const emails = await this.fetchEmails(subject, extraText);
+      const emails = await this.fetchEmails(subject);
       email = emails[index];
       return email;
     }, {

--- a/frontend/tests/email/mailbox.ts
+++ b/frontend/tests/email/mailbox.ts
@@ -9,13 +9,13 @@ export interface Email {
 export abstract class Mailbox {
   constructor(readonly email: string) { }
 
-  abstract fetchEmails(subject: EmailSubjects): Promise<Email[]>;
+  abstract fetchEmails(subject: EmailSubjects, extraText?: string): Promise<Email[]>;
 
-  async openEmail(page: Page, subject: EmailSubjects, index: number = 0): Promise<EmailPage> {
+  async openEmail(page: Page, subject: EmailSubjects, extraText?: string, index: number = 0): Promise<EmailPage> {
     let email: Email | undefined = undefined;
 
     await expect.poll(async () => {
-      const emails = await this.fetchEmails(subject);
+      const emails = await this.fetchEmails(subject, extraText);
       email = emails[index];
       return email;
     }, {

--- a/frontend/tests/email/mailbox.ts
+++ b/frontend/tests/email/mailbox.ts
@@ -9,9 +9,9 @@ export interface Email {
 export abstract class Mailbox {
   constructor(readonly email: string) { }
 
-  abstract fetchEmails(subject: EmailSubjects, extraText?: string): Promise<Email[]>;
+  abstract fetchEmails(subject: EmailSubjects | string, extraText?: string): Promise<Email[]>;
 
-  async openEmail(page: Page, subject: EmailSubjects, extraText?: string, index: number = 0): Promise<EmailPage> {
+  async openEmail(page: Page, subject: EmailSubjects | string, extraText?: string, index: number = 0): Promise<EmailPage> {
     let email: Email | undefined = undefined;
 
     await expect.poll(async () => {

--- a/frontend/tests/email/maildev-mailbox.ts
+++ b/frontend/tests/email/maildev-mailbox.ts
@@ -14,10 +14,9 @@ export class MaildevMailbox extends Mailbox {
     super(email);
   }
 
-  async fetchEmails(subject: EmailSubjects, extraText?: string): Promise<Email[]> {
-    const searchText = subject.toString() + (extraText ?? '');
+  async fetchEmails(subject: EmailSubjects | string): Promise<Email[]> {
     const emails = await this.fetchMyEmails();
-    return emails.filter(email => email.subject.includes(searchText))
+    return emails.filter(email => email.subject.includes(subject))
       .map(email => ({body: email.html}));
   }
 

--- a/frontend/tests/email/maildev-mailbox.ts
+++ b/frontend/tests/email/maildev-mailbox.ts
@@ -14,9 +14,10 @@ export class MaildevMailbox extends Mailbox {
     super(email);
   }
 
-  async fetchEmails(subject: EmailSubjects): Promise<Email[]> {
+  async fetchEmails(subject: EmailSubjects, extraText?: string): Promise<Email[]> {
+    const searchText = subject.toString() + (extraText ?? '');
     const emails = await this.fetchMyEmails();
-    return emails.filter(email => email.subject.includes(subject))
+    return emails.filter(email => email.subject.includes(searchText))
       .map(email => ({body: email.html}));
   }
 

--- a/frontend/tests/emailWorkflow.test.ts
+++ b/frontend/tests/emailWorkflow.test.ts
@@ -12,7 +12,6 @@ import {randomUUID} from 'crypto';
 import {test} from './fixtures';
 import {ProjectPage} from './pages/projectPage';
 import {OrgPage} from './pages/orgPage';
-import {ProjectRole} from '$lib/gql/types';
 
 const userIdsToDelete: string[] = [];
 
@@ -169,7 +168,7 @@ test('ask to join project via new-project page', async ({ page, tempUser, tempUs
 
     // Add manager to Elawa project
     await loginAs(newPage.request, 'admin');
-    await addUserToProject(newPage.request, manager.id, elawaProjectId, ProjectRole.Manager);
+    await addUserToProject(newPage.request, manager.id, elawaProjectId, 'MANAGER');
 
     const { name, email, password } = tempUserInTestOrg;
 
@@ -221,7 +220,7 @@ test('ask to join project via project page', async ({ page, tempUser, tempUserIn
 
     // Add manager to Elawa project
     await loginAs(newPage.request, 'admin');
-    await addUserToProject(newPage.request, manager.id, elawaProjectId, ProjectRole.Manager);
+    await addUserToProject(newPage.request, manager.id, elawaProjectId, 'MANAGER');
 
     const { name, email, password } = tempUserInTestOrg;
 

--- a/frontend/tests/emailWorkflow.test.ts
+++ b/frontend/tests/emailWorkflow.test.ts
@@ -195,7 +195,7 @@ test('ask to join project via new-project page', async ({ page, tempUserInTestOr
     await dashboardPage.openProject('Sena 3', 'sena-3');
 });
 
-test.only('ask to join project via project page', async ({ page, tempUserInTestOrg }) => {
+test('ask to join project via project page', async ({ page, tempUserInTestOrg }) => {
     test.setTimeout(TEST_TIMEOUT_2X);
 
     const { name, email, password } = tempUserInTestOrg;

--- a/frontend/tests/emailWorkflow.test.ts
+++ b/frontend/tests/emailWorkflow.test.ts
@@ -168,12 +168,12 @@ test('ask to join project via new-project page', async ({ page, tempUserInTestOr
     let newPage = await verifyTempUserEmail(page, tempUserInTestOrg);
     dashboardPage = await new UserDashboardPage(newPage).goto();
 
-    // Create project with similar name to Sena-3
+    // Create project with similar name to Elawa
     const newProjectPage = await dashboardPage.clickCreateProject();
-    await newProjectPage.fillForm({name: 'Sena', code: 'xyz', purpose: 'Testing', organization: 'Test Org'});
+    await newProjectPage.fillForm({name: 'Elaw', code: 'xyz', purpose: 'Testing', organization: 'Test Org'});
     await expect(newProjectPage.extraProjectsDiv).toBeVisible();
     await expect(newProjectPage.askToJoinBtn).toBeDisabled();
-    await newProjectPage.extraProjectsDiv.locator('#extra-projects-sena-3').check();
+    await newProjectPage.extraProjectsDiv.locator('#extra-projects-elawa-dev-flex').check();
     await expect(newProjectPage.askToJoinBtn).toBeEnabled();
     await newProjectPage.askToJoinBtn.click();
     await expect(newProjectPage.toast('has been sent to the project manager(s)')).toBeVisible();
@@ -185,14 +185,14 @@ test('ask to join project via new-project page', async ({ page, tempUserInTestOr
     const pagePromise = emailPage.page.context().waitForEvent('page');
     await emailPage.clickApproveRequest();
     newPage = await pagePromise;
-    const sena3ProjectPage = await new ProjectPage(newPage, 'Sena 3', 'sena-3').waitFor();
-    await sena3ProjectPage.modal.getByRole('button', {name: 'Add Member'}).click();
-    await sena3ProjectPage.goto();
+    const elawaProjectPage = await new ProjectPage(newPage, 'Elawa', 'elawa-dev-flex').waitFor();
+    await elawaProjectPage.modal.getByRole('button', {name: 'Add Member'}).click();
+    await elawaProjectPage.goto();
 
-    // Log in as temp user, should see Sena-3 project
+    // Log in as temp user, should see Elawa project
     await loginAs(page.request, email, password);
     dashboardPage = await new UserDashboardPage(page).goto();
-    await dashboardPage.openProject('Sena 3', 'sena-3');
+    await dashboardPage.openProject('Elawa', 'elawa-dev-flex');
 });
 
 test('ask to join project via project page', async ({ page, tempUserInTestOrg }) => {
@@ -211,11 +211,11 @@ test('ask to join project via project page', async ({ page, tempUserInTestOrg })
     let newPage = await pagePromise;
     dashboardPage = await new UserDashboardPage(newPage).goto();
 
-    // Get to Sena-3 project page via org page, then ask to join
+    // Get to Elawa project page via org page, then ask to join
     const testOrgPage = await new OrgPage(page, 'Test Org', testOrgId).goto();
     await testOrgPage.membersTab.click();
     await testOrgPage.projectsTab.click();
-    const projectPage = await testOrgPage.openProject('Sena 3', 'sena-3');
+    const projectPage = await testOrgPage.openProject('Elawa', 'elawa-dev-flex');
     await projectPage.askToJoinButton.click();
 
     // Log in as manager, approve join request.
@@ -225,12 +225,12 @@ test('ask to join project via project page', async ({ page, tempUserInTestOrg })
     pagePromise = emailPage.page.context().waitForEvent('page');
     await emailPage.clickApproveRequest();
     newPage = await pagePromise;
-    let sena3ProjectPage = await new ProjectPage(newPage, 'Sena 3', 'sena-3').waitFor();
-    await sena3ProjectPage.modal.getByRole('button', {name: 'Add Member'}).click();
-    await sena3ProjectPage.goto();
+    const elawaProjectPage = await new ProjectPage(newPage, 'Elawa', 'elawa-dev-flex').waitFor();
+    await elawaProjectPage.modal.getByRole('button', {name: 'Add Member'}).click();
+    await elawaProjectPage.goto();
 
-    // Log in as temp user, should see Sena-3 project
+    // Log in as temp user, should see Elawa project
     await loginAs(page.request, email, password);
     dashboardPage = await new UserDashboardPage(page).goto();
-    await dashboardPage.openProject('Sena 3', 'sena-3');
+    await dashboardPage.openProject('Elawa', 'elawa-dev-flex');
 });

--- a/frontend/tests/emailWorkflow.test.ts
+++ b/frontend/tests/emailWorkflow.test.ts
@@ -229,7 +229,6 @@ test('ask to join project via project page', async ({ page, tempUser, tempUserIn
 
     // Get to Elawa project page via org page, then ask to join
     const testOrgPage = await new OrgPage(newPage, 'Test Org', testOrgId).goto();
-    await testOrgPage.membersTab.click();
     await testOrgPage.projectsTab.click();
     const projectPage = await testOrgPage.openProject('Elawa', 'elawa-dev-flex');
     await projectPage.askToJoinButton.click();

--- a/frontend/tests/emailWorkflow.test.ts
+++ b/frontend/tests/emailWorkflow.test.ts
@@ -10,7 +10,6 @@ import {UserDashboardPage} from './pages/userDashboardPage';
 import {expect} from '@playwright/test';
 import {randomUUID} from 'crypto';
 import {test} from './fixtures';
-import {MaildevMailbox} from './email/maildev-mailbox';
 import {ProjectPage} from './pages/projectPage';
 import {OrgPage} from './pages/orgPage';
 import {ProjectRole} from '$lib/gql/types';
@@ -166,11 +165,11 @@ test('ask to join project via new-project page', async ({ page, tempUser, tempUs
 
     // Must verify email before being made manager of a project
     await dashboardPage.emailVerificationAlert.assertPleaseVerify();
-    let newPage = await verifyTempUserEmail(page, tempUserInTestOrg);
+    let newPage = await verifyTempUserEmail(page, manager);
 
     // Add manager to Elawa project
     await loginAs(newPage.request, 'admin');
-    await addUserToProject(page.request, manager.id, elawaProjectId, ProjectRole.Manager);
+    await addUserToProject(newPage.request, manager.id, elawaProjectId, ProjectRole.Manager);
 
     const { name, email, password } = tempUserInTestOrg;
 
@@ -193,8 +192,8 @@ test('ask to join project via new-project page', async ({ page, tempUser, tempUs
     await expect(newProjectPage.toast('has been sent to the project manager(s)')).toBeVisible();
 
     // Log in as manager, approve join request.
-    await loginAs(page.request, 'manager');
-    const emailPage = await manager.mailbox.openEmail(page, EmailSubjects.ProjectJoinRequest, `: ${name}`);
+    await loginAs(page.request, manager.email, manager.password);
+    const emailPage = await manager.mailbox.openEmail(page, `${EmailSubjects.ProjectJoinRequest}: ${name}`);
     const pagePromise = emailPage.page.context().waitForEvent('page');
     await emailPage.clickApproveRequest();
     newPage = await pagePromise;
@@ -218,11 +217,11 @@ test('ask to join project via project page', async ({ page, tempUser, tempUserIn
 
     // Must verify email before being made manager of a project
     await dashboardPage.emailVerificationAlert.assertPleaseVerify();
-    let newPage = await verifyTempUserEmail(page, tempUserInTestOrg);
+    let newPage = await verifyTempUserEmail(page, manager);
 
     // Add manager to Elawa project
     await loginAs(newPage.request, 'admin');
-    await addUserToProject(page.request, manager.id, elawaProjectId, ProjectRole.Manager);
+    await addUserToProject(newPage.request, manager.id, elawaProjectId, ProjectRole.Manager);
 
     const { name, email, password } = tempUserInTestOrg;
 
@@ -245,8 +244,8 @@ test('ask to join project via project page', async ({ page, tempUser, tempUserIn
     await projectPage.askToJoinButton.click();
 
     // Log in as manager, approve join request.
-    await loginAs(page.request, 'manager');
-    emailPage = await manager.mailbox.openEmail(page, EmailSubjects.ProjectJoinRequest, `: ${name}`);
+    await loginAs(page.request, manager.email, manager.password);
+    emailPage = await manager.mailbox.openEmail(page, `${EmailSubjects.ProjectJoinRequest}: ${name}`);
     pagePromise = emailPage.page.context().waitForEvent('page');
     await emailPage.clickApproveRequest();
     newPage = await pagePromise;

--- a/frontend/tests/envVars.ts
+++ b/frontend/tests/envVars.ts
@@ -4,6 +4,7 @@ export const httpScheme = isDev ? 'http://' : 'https://';
 export const serverBaseUrl = `${httpScheme}${serverHostname}`;
 export const defaultPassword = process.env.TEST_DEFAULT_PASSWORD ?? 'pass';
 export const testOrgId = process.env.TEST_ORG_ID ?? '292c80e6-a815-4cd1-9ea2-34bd01274de6';
+export const elawaProjectId = process.env.ELAWA_PROJECT_ID ?? '9e972940-8a8e-4b29-a609-bdc2f93b3507';
 
 export const authCookieName = '.LexBoxAuth';
 export const invalidJwt = 'eyJhbGciOiJIUzI1NiJ9.eyJSb2xlIjoiQWRtaW4iLCJJc3N1ZXIiOiJJc3N1ZXIiLCJVc2VybmFtZSI6IkphdmFJblVzZSIsImV4cCI6MTY5OTM0ODY2NywiaWF0IjoxNjk5MzQ4NjY3fQ.f8N63gcD_iv-E_x0ERhJwARaBKnZnORaZGe0N2J0VGM';

--- a/frontend/tests/envVars.ts
+++ b/frontend/tests/envVars.ts
@@ -3,6 +3,8 @@ export const isDev = process.env.NODE_ENV === 'development' || serverHostname.st
 export const httpScheme = isDev ? 'http://' : 'https://';
 export const serverBaseUrl = `${httpScheme}${serverHostname}`;
 export const defaultPassword = process.env.TEST_DEFAULT_PASSWORD ?? 'pass';
+export const testOrgId = process.env.TEST_ORG_ID ?? '292c80e6-a815-4cd1-9ea2-34bd01274de6';
+
 export const authCookieName = '.LexBoxAuth';
 export const invalidJwt = 'eyJhbGciOiJIUzI1NiJ9.eyJSb2xlIjoiQWRtaW4iLCJJc3N1ZXIiOiJJc3N1ZXIiLCJVc2VybmFtZSI6IkphdmFJblVzZSIsImV4cCI6MTY5OTM0ODY2NywiaWF0IjoxNjk5MzQ4NjY3fQ.f8N63gcD_iv-E_x0ERhJwARaBKnZnORaZGe0N2J0VGM';
 

--- a/frontend/tests/fixtures.ts
+++ b/frontend/tests/fixtures.ts
@@ -1,7 +1,7 @@
 import {test as base, expect, type BrowserContext, type BrowserContextOptions} from '@playwright/test';
 import * as testEnv from './envVars';
 import {type UUID, randomUUID} from 'crypto';
-import {deleteUser, loginAs, registerUser} from './utils/authHelpers';
+import {addUserToOrg, deleteUser, loginAs, registerUser} from './utils/authHelpers';
 import {executeGql, type GqlResult} from './utils/gqlHelpers';
 import {mkdtemp, rm} from 'fs/promises';
 import {join} from 'path';
@@ -11,6 +11,7 @@ import {isDev} from './envVars';
 import {E2EMailboxApi} from './email/e2e-mailbox-module-patched';
 import {MaildevMailbox} from './email/maildev-mailbox';
 import {E2EMailbox} from './email/e2e-mailbox';
+import {OrgRole} from '$lib/gql/types';
 
 export interface TempUser {
   id: UUID
@@ -32,6 +33,7 @@ type Fixtures = {
   contextFactory: (options: BrowserContextOptions) => Promise<BrowserContext>,
   uniqueTestId: string,
   tempUser: Readonly<TempUser>,
+  tempUserInTestOrg: Readonly<TempUser>,
   tempProject: TempProject,
   tempDir: string,
   mailboxFactory: () => Promise<Mailbox>,
@@ -96,9 +98,32 @@ export const test = base.extend<Fixtures>({
   tempUser: async ({browser, page, mailboxFactory}, use, testInfo) => {
     const mailbox = await mailboxFactory();
     const email = mailbox.email;
-    const name = `Test: ${testInfo.title} - ${email}`;
+    const name = `Test: ${testInfo.title} - ${email.replaceAll('@', "(at)")}`;
     const password = email;
     const tempUserId = await registerUser(page, name, email, password);
+    const tempUser = Object.freeze({
+      id: tempUserId,
+      name,
+      email,
+      password,
+      mailbox,
+    });
+    await use(tempUser);
+    const context = await browser.newContext();
+    await loginAs(context.request, 'admin');
+    await deleteUser(context.request, tempUser.id);
+    await context.close();
+  },
+  tempUserInTestOrg: async ({browser, page, mailboxFactory}, use, testInfo) => {
+    const mailbox = await mailboxFactory();
+    const email = mailbox.email;
+    const name = `Test: ${testInfo.title} - ${email.replaceAll('@', "(at)")}`;
+    console.log(name);
+    const password = email;
+    const tempUserId = await registerUser(page, name, email, password);
+    await loginAs(page.request, 'admin');
+    await addUserToOrg(page.request, tempUserId, testEnv.testOrgId, OrgRole.User);
+    await loginAs(page.request, email, password);
     const tempUser = Object.freeze({
       id: tempUserId,
       name,

--- a/frontend/tests/fixtures.ts
+++ b/frontend/tests/fixtures.ts
@@ -118,7 +118,6 @@ export const test = base.extend<Fixtures>({
     const mailbox = await mailboxFactory();
     const email = mailbox.email;
     const name = `Test: ${testInfo.title} - ${email.replaceAll('@', "(at)")}`;
-    console.log(name);
     const password = email;
     const tempUserId = await registerUser(page, name, email, password);
     await loginAs(page.request, 'admin');

--- a/frontend/tests/fixtures.ts
+++ b/frontend/tests/fixtures.ts
@@ -98,7 +98,7 @@ export const test = base.extend<Fixtures>({
   tempUser: async ({browser, page, mailboxFactory}, use, testInfo) => {
     const mailbox = await mailboxFactory();
     const email = mailbox.email;
-    const name = `Test: ${testInfo.title} - ${email.replaceAll('@', "(at)")}`;
+    const name = `Test: ${testInfo.title} - ${email.replaceAll('@', '(at)')}`;
     const password = email;
     const tempUserId = await registerUser(page, name, email, password);
     const tempUser = Object.freeze({
@@ -117,7 +117,7 @@ export const test = base.extend<Fixtures>({
   tempUserInTestOrg: async ({browser, page, mailboxFactory}, use, testInfo) => {
     const mailbox = await mailboxFactory();
     const email = mailbox.email;
-    const name = `Test: ${testInfo.title} - ${email.replaceAll('@', "(at)")}`;
+    const name = `Test: ${testInfo.title} - ${email.replaceAll('@', '(at)')}`;
     const password = email;
     const tempUserId = await registerUser(page, name, email, password);
     await loginAs(page.request, 'admin');

--- a/frontend/tests/fixtures.ts
+++ b/frontend/tests/fixtures.ts
@@ -11,7 +11,6 @@ import {isDev} from './envVars';
 import {E2EMailboxApi} from './email/e2e-mailbox-module-patched';
 import {MaildevMailbox} from './email/maildev-mailbox';
 import {E2EMailbox} from './email/e2e-mailbox';
-import {OrgRole} from '../src/lib/gql/types';
 
 export interface TempUser {
   id: UUID
@@ -121,7 +120,7 @@ export const test = base.extend<Fixtures>({
     const password = email;
     const tempUserId = await registerUser(page, name, email, password);
     await loginAs(page.request, 'admin');
-    await addUserToOrg(page.request, tempUserId, testEnv.testOrgId, OrgRole.User);
+    await addUserToOrg(page.request, tempUserId, testEnv.testOrgId, 'USER');
     await loginAs(page.request, email, password);
     const tempUser = Object.freeze({
       id: tempUserId,

--- a/frontend/tests/fixtures.ts
+++ b/frontend/tests/fixtures.ts
@@ -11,7 +11,7 @@ import {isDev} from './envVars';
 import {E2EMailboxApi} from './email/e2e-mailbox-module-patched';
 import {MaildevMailbox} from './email/maildev-mailbox';
 import {E2EMailbox} from './email/e2e-mailbox';
-import {OrgRole} from '$lib/gql/types';
+import {OrgRole} from '../src/lib/gql/types';
 
 export interface TempUser {
   id: UUID

--- a/frontend/tests/pages/basePage.ts
+++ b/frontend/tests/pages/basePage.ts
@@ -13,6 +13,11 @@ export class BasePage {
     return undefined;
   }
 
+  get toastDiv(): Locator { return this.page.locator('.toast'); }
+  toast(text: string|RegExp, options?: {exact: boolean}): Locator {
+    return this.toastDiv.getByText(text, options);
+  }
+
   get urlPattern(): RegExp | undefined {
     if (!this.url) return undefined;
     return new RegExp(regexEscape(this.url) + '($|\\?|#)');

--- a/frontend/tests/pages/createProjectPage.ts
+++ b/frontend/tests/pages/createProjectPage.ts
@@ -1,10 +1,11 @@
 import {BasePage} from './basePage';
-import type {Page} from '@playwright/test';
+import type {Locator, Page} from '@playwright/test';
 
 type ProjectConfig = {
   code: string;
   customCode: boolean;
   name: string;
+  organization: string;
   type: string;
   purpose: 'Software Developer' | 'Testing' | 'Training' | 'Language Project';
   description: string;
@@ -14,12 +15,15 @@ export class CreateProjectPage extends BasePage {
   constructor(page: Page) {
     super(page, page.getByRole('heading', { name: /(Create|Request) Project/ }), `/project/create`);
   }
+  get extraProjectsDiv(): Locator { return this.page.locator('#group-extra-projects'); }
+  get askToJoinBtn(): Locator { return this.page.getByRole('button', {name: 'Ask to join', exact: true}); }
 
   async fillForm(values: Pick<ProjectConfig, 'code'> & Partial<ProjectConfig>): Promise<ProjectConfig> {
     let code = values.code;
-    const { customCode = false, name = code, type = 'FLEx', purpose = 'Software Developer', description = name } = values;
+    const { customCode = false, name = code, type = 'FLEx', purpose = 'Software Developer', description = name, organization = '' } = values;
     await this.page.getByLabel('Name').fill(name);
     await this.page.getByLabel('Description').fill(description ?? name);
+    if (organization) await this.page.getByLabel('Organization').selectOption({ label: organization })
     await this.page.getByLabel('Project type').selectOption({ label: type });
     await this.page.getByLabel('Purpose').selectOption({ label: purpose });
     await this.page.getByLabel('Language Code').fill(code);
@@ -29,7 +33,7 @@ export class CreateProjectPage extends BasePage {
     } else {
       code = await this.page.getByLabel('Code', {exact: true}).inputValue();
     }
-    return { code, name, type, purpose, description, customCode };
+    return { code, name, organization, type, purpose, description, customCode };
   }
 
   async submit(): Promise<void> {

--- a/frontend/tests/pages/createProjectPage.ts
+++ b/frontend/tests/pages/createProjectPage.ts
@@ -36,6 +36,10 @@ export class CreateProjectPage extends BasePage {
     return { code, name, organization, type, purpose, description, customCode };
   }
 
+  async selectExtraProject(projectCode: string): Promise<void> {
+    await this.extraProjectsDiv.locator(`#extra-projects-${projectCode}`).check();
+  }
+
   async submit(): Promise<void> {
     await this.page.getByRole('button', {name: /(Create|Request) Project/}).click();
   }

--- a/frontend/tests/pages/orgPage.ts
+++ b/frontend/tests/pages/orgPage.ts
@@ -1,0 +1,30 @@
+import type {Locator, Page} from '@playwright/test';
+
+import {BasePage} from './basePage';
+import {ProjectPage} from './projectPage';
+
+export class OrgPage extends BasePage {
+  get moreSettingsDiv(): Locator { return this.page.locator('.collapse').filter({ hasText: 'More settings' }); }
+  get deleteProjectButton(): Locator { return this.moreSettingsDiv.getByRole('button', {name: 'Delete project'}); }
+
+  get projectsTab(): Locator { return this.page.getByRole('tab', { name: 'Projects' }); }
+  get membersTab(): Locator { return this.page.getByRole('tab', { name: 'Members' }); }
+  get settingsTab(): Locator { return this.page.getByRole('tab', { name: 'Settings' }); }
+  get historyTab(): Locator { return this.page.getByRole('tab', { name: 'History' }); }
+
+  projectLink(projectName: string): Locator { return this.page.getByRole('link', {name: projectName, exact: true}); }
+
+  constructor(page: Page, private name: string, private orgId: string) {
+    super(page, page.getByRole('heading', {name: `Organization: ${name}`}), `/org/${orgId}`);
+  }
+
+  async clickProject(projectName: string): Promise<void> {
+    await this.projectsTab.click();
+    return this.projectLink(projectName).click();
+  }
+
+  async openProject(projectName: string, projectCode: string): Promise<ProjectPage> {
+    await this.clickProject(projectName);
+    return await new ProjectPage(this.page, projectName, projectCode).waitFor();
+  }
+}

--- a/frontend/tests/pages/projectPage.ts
+++ b/frontend/tests/pages/projectPage.ts
@@ -13,6 +13,7 @@ export class ProjectPage extends BasePage {
   get verifyRepoButton(): Locator { return this.moreSettingsDiv.getByRole('button', {name: 'Verify repository'}); }
   get addMemberButton(): Locator { return this.page.getByRole('button', {name: 'Add/Invite Member'}); }
   get browseButton(): Locator { return this.page.getByRole('link', {name: 'Browse'}); }
+  get modal(): Locator { return this.page.locator('.modal-box'); }
 
   constructor(page: Page, private name: string, private code: string) {
     super(page, page.getByRole('heading', {name: `Project: ${name}`}), `/project/${code}`);

--- a/frontend/tests/pages/projectPage.ts
+++ b/frontend/tests/pages/projectPage.ts
@@ -12,6 +12,7 @@ export class ProjectPage extends BasePage {
   get resetProjectButton(): Locator { return this.moreSettingsDiv.getByRole('button', {name: 'Reset project'}); }
   get verifyRepoButton(): Locator { return this.moreSettingsDiv.getByRole('button', {name: 'Verify repository'}); }
   get addMemberButton(): Locator { return this.page.getByRole('button', {name: 'Add/Invite Member'}); }
+  get askToJoinButton(): Locator { return this.page.getByRole('button', {name: 'Ask to join'}); }
   get browseButton(): Locator { return this.page.getByRole('link', {name: 'Browse'}); }
   get modal(): Locator { return this.page.locator('.modal-box'); }
 

--- a/frontend/tests/utils/authHelpers.ts
+++ b/frontend/tests/utils/authHelpers.ts
@@ -1,5 +1,5 @@
 import {expect, type APIRequestContext, type Page} from '@playwright/test';
-import {defaultPassword, testOrgId, serverBaseUrl} from '../envVars';
+import {defaultPassword, serverBaseUrl} from '../envVars';
 import {RegisterPage} from '../pages/registerPage';
 import {UserDashboardPage} from '../pages/userDashboardPage';
 import type {UUID} from 'crypto';

--- a/frontend/tests/utils/authHelpers.ts
+++ b/frontend/tests/utils/authHelpers.ts
@@ -48,7 +48,7 @@ export async function verifyTempUserEmail(page: Page, tempUser: TempUser): Promi
   return pagePromise;
 }
 
-export async function addUserToOrg(api: APIRequestContext, userId: string, orgId: string, role: string): Promise<unknown> {
+export async function addUserToOrg(api: APIRequestContext, userId: string, orgId: string, role: 'ADMIN' | 'USER' | 'UNKNOWN'): Promise<unknown> {
   return executeGql(api, `
     mutation {
         changeOrgMemberRole(input: { userId: "${userId}", orgId: "${orgId}", role: ${role} }) {
@@ -65,7 +65,7 @@ export async function addUserToOrg(api: APIRequestContext, userId: string, orgId
   `);
 }
 
-export async function addUserToProject(api: APIRequestContext, userId: string, projectId: string, role: string): Promise<unknown> {
+export async function addUserToProject(api: APIRequestContext, userId: string, projectId: string, role: 'EDITOR' | 'MANAGER' | 'UNKNOWN'): Promise<unknown> {
   return executeGql(api, `
     mutation {
         addProjectMember(input: { userId: "${userId}", projectId: "${projectId}", role: ${role}, canInvite: false }) {

--- a/frontend/tests/utils/authHelpers.ts
+++ b/frontend/tests/utils/authHelpers.ts
@@ -5,7 +5,7 @@ import {UserDashboardPage} from '../pages/userDashboardPage';
 import type {UUID} from 'crypto';
 import {executeGql} from './gqlHelpers';
 import {LoginPage} from '../pages/loginPage';
-import type {OrgRole} from '$lib/gql/types';
+import type {OrgRole, ProjectRole} from '$lib/gql/types';
 import type {TempUser} from '../fixtures';
 import {EmailSubjects} from '../email/email-page';
 
@@ -56,6 +56,20 @@ export async function addUserToOrg(api: APIRequestContext, userId: string, orgId
             organization {
                 id
             }
+            errors {
+                ... on Error {
+                    message
+                }
+            }
+        }
+    }
+  `);
+}
+
+export async function addUserToProject(api: APIRequestContext, userId: string, projectId: string, role: ProjectRole): Promise<unknown> {
+  return executeGql(api, `
+    mutation {
+        addProjectMember(input: { userId: "${userId}", projectId: "${projectId}", role: ${role} }) {
             errors {
                 ... on Error {
                     message

--- a/frontend/tests/utils/authHelpers.ts
+++ b/frontend/tests/utils/authHelpers.ts
@@ -69,7 +69,10 @@ export async function addUserToOrg(api: APIRequestContext, userId: string, orgId
 export async function addUserToProject(api: APIRequestContext, userId: string, projectId: string, role: ProjectRole): Promise<unknown> {
   return executeGql(api, `
     mutation {
-        addProjectMember(input: { userId: "${userId}", projectId: "${projectId}", role: ${role} }) {
+        addProjectMember(input: { userId: "${userId}", projectId: "${projectId}", role: ${role}, canInvite: false }) {
+            project {
+                id
+            }
             errors {
                 ... on Error {
                     message

--- a/frontend/tests/utils/authHelpers.ts
+++ b/frontend/tests/utils/authHelpers.ts
@@ -6,6 +6,8 @@ import type {UUID} from 'crypto';
 import {executeGql} from './gqlHelpers';
 import {LoginPage} from '../pages/loginPage';
 import type {OrgRole} from '$lib/gql/types';
+import type {TempUser} from '../fixtures';
+import {EmailSubjects} from '../email/email-page';
 
 export async function loginAs(api: APIRequestContext, emailOrUsername: string, password: string = defaultPassword): Promise<void> {
   const loginData = {
@@ -36,6 +38,15 @@ export async function registerUser(page: Page, name: string, email: string, pass
   await new UserDashboardPage(page).waitFor();
   const userId = await getCurrentUserId(page.request);
   return userId;
+}
+
+// Verify email address; returns a Page promise that should be used to load a UserDashboardPage or AdminDashboardPage
+// Does not call loginAs(page.request, tempUser.email, tempUser.password); calling code should be doing that
+export async function verifyTempUserEmail(page: Page, tempUser: TempUser): Promise<Page> {
+  const emailPage = await tempUser.mailbox.openEmail(page, EmailSubjects.VerifyEmail);
+  const pagePromise = emailPage.page.context().waitForEvent('page');
+  await emailPage.clickVerifyEmail();
+  return pagePromise;
 }
 
 export async function addUserToOrg(api: APIRequestContext, userId: string, orgId: string, role: OrgRole): Promise<UUID> {

--- a/frontend/tests/utils/authHelpers.ts
+++ b/frontend/tests/utils/authHelpers.ts
@@ -49,7 +49,7 @@ export async function verifyTempUserEmail(page: Page, tempUser: TempUser): Promi
   return pagePromise;
 }
 
-export async function addUserToOrg(api: APIRequestContext, userId: string, orgId: string, role: OrgRole): Promise<UUID> {
+export async function addUserToOrg(api: APIRequestContext, userId: string, orgId: string, role: OrgRole): Promise<unknown> {
   return executeGql(api, `
     mutation {
         changeOrgMemberRole(input: { userId: "${userId}", orgId: "${orgId}", role: ${role} }) {

--- a/frontend/tests/utils/authHelpers.ts
+++ b/frontend/tests/utils/authHelpers.ts
@@ -5,7 +5,6 @@ import {UserDashboardPage} from '../pages/userDashboardPage';
 import type {UUID} from 'crypto';
 import {executeGql} from './gqlHelpers';
 import {LoginPage} from '../pages/loginPage';
-import type {OrgRole, ProjectRole} from '$lib/gql/types';
 import type {TempUser} from '../fixtures';
 import {EmailSubjects} from '../email/email-page';
 
@@ -49,7 +48,7 @@ export async function verifyTempUserEmail(page: Page, tempUser: TempUser): Promi
   return pagePromise;
 }
 
-export async function addUserToOrg(api: APIRequestContext, userId: string, orgId: string, role: OrgRole): Promise<unknown> {
+export async function addUserToOrg(api: APIRequestContext, userId: string, orgId: string, role: string): Promise<unknown> {
   return executeGql(api, `
     mutation {
         changeOrgMemberRole(input: { userId: "${userId}", orgId: "${orgId}", role: ${role} }) {
@@ -66,7 +65,7 @@ export async function addUserToOrg(api: APIRequestContext, userId: string, orgId
   `);
 }
 
-export async function addUserToProject(api: APIRequestContext, userId: string, projectId: string, role: ProjectRole): Promise<unknown> {
+export async function addUserToProject(api: APIRequestContext, userId: string, projectId: string, role: string): Promise<unknown> {
   return executeGql(api, `
     mutation {
         addProjectMember(input: { userId: "${userId}", projectId: "${projectId}", role: ${role}, canInvite: false }) {


### PR DESCRIPTION
Fixes #1014

This adds two tests: one that exercises the create-project page workflow, and one that exercises the workflow that goes through the project page's "Ask to Join" button visible to org members.