### PR TITLE
sync on project open

### DIFF
--- a/backend/FwLite/FwLiteShared/Projects/CombinedProjectsService.cs
+++ b/backend/FwLite/FwLiteShared/Projects/CombinedProjectsService.cs
@@ -108,7 +108,7 @@ public class CombinedProjectsService(LexboxProjectService lexboxProjectService,
             server.Authority,
             async (provider, project) =>
             {
-                await provider.GetRequiredService<SyncService>().ExecuteSync();
+                await provider.GetRequiredService<SyncService>().ExecuteSync(true);
             },
             SeedNewProjectData: false,
             AuthenticatedUser: currentUser?.Name,

--- a/backend/FwLite/FwLiteShared/Services/ProjectServicesProvider.cs
+++ b/backend/FwLite/FwLiteShared/Services/ProjectServicesProvider.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Concurrent;
 using FwLiteShared.Projects;
+using FwLiteShared.Sync;
 using LcmCrdt;
 using LexCore.Utils;
 using Microsoft.Extensions.DependencyInjection;
@@ -47,6 +48,7 @@ public class ProjectServicesProvider(
                       throw new InvalidOperationException($"Crdt Project {projectName} not found");
         var currentProjectService = scopedServices.GetRequiredService<CurrentProjectService>();
         var projectData = await currentProjectService.SetupProjectContext(project);
+        await scopedServices.GetRequiredService<SyncService>().ExecuteSync(true);
         await lexboxProjectService.ListenForProjectChanges(projectData, CancellationToken.None);
         var entryUpdatedSubscription = changeEventBus.OnProjectEntryUpdated(project).Subscribe(entry =>
         {

--- a/backend/FwLite/FwLiteShared/Sync/SyncService.cs
+++ b/backend/FwLite/FwLiteShared/Sync/SyncService.cs
@@ -104,7 +104,7 @@ public class SyncService(
         await currentProjectService.SetProjectSyncOrigin(server.Authority, lexboxProjectId);
         try
         {
-            await ExecuteSync();
+            await ExecuteSync(true);
         }
         catch
         {

--- a/backend/FwLite/FwLiteWeb/Hubs/CrdtMiniLcmApiHub.cs
+++ b/backend/FwLite/FwLiteWeb/Hubs/CrdtMiniLcmApiHub.cs
@@ -34,7 +34,7 @@ public class CrdtMiniLcmApiHub(
     public override async Task OnConnectedAsync()
     {
         await Groups.AddToGroupAsync(Context.ConnectionId, ProjectGroup(projectContext.Project.Name));
-        await syncService.ExecuteSync();
+        await syncService.ExecuteSync(true);
         Cleanup =
         [
             changeEventBus.OnProjectEntryUpdated(projectContext.Project).Subscribe(e => OnEntryChangedExternal(e, hubContext, memoryCache, Context.ConnectionId))


### PR DESCRIPTION
this matches the pre blazor functionality. This ensures that we always have the latest version, we could remove this once we have a sync dialog with a button to trigger sync manually, but for now it's the only way to trigger a sync without changing anything