### PR TITLE
Apply some user feedback and other small improvements

### DIFF
--- a/frontend/viewer/src/App.svelte
+++ b/frontend/viewer/src/App.svelte
@@ -58,8 +58,9 @@
       },
       Menu: {
         classes: {
+          /* these classes prevent a MultiSelectField from having 2 scrollbars when used with `resize` */
           root: 'flex flex-col',
-          menu: 'overflow-hidden',
+          menu: '[&:has(.actions)]:overflow-hidden',
         }
       }
     },

--- a/frontend/viewer/src/app.postcss
+++ b/frontend/viewer/src/app.postcss
@@ -20,9 +20,10 @@
 /* The search bar dialog is somewhat unique. It should be considered when making global changes here. */
 .dialog {
     /*using 100vh or dvh still caused the action items to get clipped*/
-  height: 100%;
-  width: 767px; /* matches md/max-md */
+  height: min(1200px, 100%);
+  width: min(900px, 100%);
   @apply md:max-h-[calc(100vh-16px)];
+  @apply md:max-w-[calc(100vw-30px)]; /* more than the 16px for height, because of scrollbars */
   @apply flex flex-col;
   @apply max-md:rounded-none;
 

--- a/frontend/viewer/src/app.postcss
+++ b/frontend/viewer/src/app.postcss
@@ -32,6 +32,10 @@
     bottom: 0;
     z-index: 2;
   }
+
+  * {
+    overscroll-behavior: contain;
+  }
 }
 
 .Checkbox *, label:has(.Switch) {

--- a/frontend/viewer/src/lib/DictionaryEntry.svelte
+++ b/frontend/viewer/src/lib/DictionaryEntry.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import type { IEntry } from '$lib/dotnet-types';
+  import type { IEntry, ISense } from '$lib/dotnet-types';
   import {useWritingSystemService} from './writing-system-service';
   import { usePartsOfSpeech } from './parts-of-speech';
 
@@ -11,62 +11,88 @@
   const wsService = useWritingSystemService();
 
   $: headwords = wsService.vernacular
-    .map(ws => ({ws: ws.wsId, value: wsService.headword(entry)}))
+    .map(ws => ({
+      wsId: ws.wsId,
+      value: wsService.headword(entry, ws.wsId),
+      color: wsService.wsColor(ws.wsId, 'vernacular'),
+    }))
     .filter(({value}) => !!value);
+
+  $: senses = entry.senses.map(getRenderedContent);
+
+  /**
+   * Returns the rendered content for a sense.
+   * Primary purpose is to filter out list items that won't be rendered,
+   * so we can easily/reliably determine if an item is the last that will be rendered.
+   * @param sense
+   */
+  function getRenderedContent(sense: ISense) {
+    return {
+      id: sense.id,
+      partOfSpeech: $partsOfSpeech.find(pos => pos.id === sense.partOfSpeechId)?.label,
+      glossesAndDefs: wsService.analysis
+        .map(ws => ({
+          wsId: ws.wsId,
+          wsAbbr: ws.abbreviation,
+          gloss: sense.gloss[ws.wsId],
+          definition: sense.definition[ws.wsId],
+          color: wsService.wsColor(ws.wsId, 'analysis'),
+        }))
+        .filter(({gloss, definition}) => gloss || definition),
+      exampleSentences: sense.exampleSentences.map(example => ({
+        id: example.id,
+        sentences: [
+          ...wsService.vernacular.map(ws => ({
+            text: example.sentence[ws.wsId],
+            color: wsService.wsColor(ws.wsId, 'vernacular'),
+          })),
+          ...wsService.analysis.map(ws => ({
+            text: example.translation[ws.wsId],
+            color: wsService.wsColor(ws.wsId, 'analysis'),
+          })),
+        ].filter(({text}) => !!text),
+      })),
+    }
+  }
 
   const partsOfSpeech = usePartsOfSpeech();
 </script>
 
 <div>
-  <strong class="inline-flex gap-1">
-    {#each headwords as {ws, value}, i}
-      {#if value}
-        {#if i > 0}/{/if}
-        <span class={wsService.wsColor(ws, 'vernacular')}>{value}</span>
-      {/if}
+  <strong class="inline-flex gap-1 mr-1">
+    {#each headwords as headword, i (headword.wsId)}
+      {#if i > 0}/{/if}
+      <span class={headword.color}>{headword.value}</span>
     {/each}
   </strong>
-  {#each entry.senses as sense, i (sense.id)}
-    {#if entry.senses.length > 1}
+  {#each senses as sense, i (sense.id)}
+    {#if senses.length > 1}
       <br />
       <strong class="ml-2">{i + 1} · </strong>
     {/if}
-    {@const partOfSpeech = $partsOfSpeech.find(pos => pos.id === sense.partOfSpeechId)?.label}
-    {#if partOfSpeech}
-      <i>{partOfSpeech}</i>
+    {#if sense.partOfSpeech}
+      <i>{sense.partOfSpeech}</i>
     {/if}
     <span>
-      {#each wsService.analysis as ws}
-        {#if sense.gloss[ws.wsId] || sense.definition[ws.wsId]}
-          <span class="ml-0.5">
-            <sub class="-mr-0.5">{ws.abbreviation}</sub>
-            {#if sense.gloss[ws.wsId]}
-              <span class={wsService.wsColor(ws.wsId, 'analysis')}>{sense.gloss[ws.wsId]}</span>;
-            {/if}
-            {#if sense.definition[ws.wsId]}
-              <span class={wsService.wsColor(ws.wsId, 'analysis')}>{sense.definition[ws.wsId]}</span>
-            {/if}
-          </span>
-        {/if}
+      {#each sense.glossesAndDefs as glossAndDef (glossAndDef.wsId)}
+        <span class="ml-0.5">
+          <sub class="-mr-0.5">{glossAndDef.wsAbbr}</sub>
+          {#if glossAndDef.gloss}
+            <span class={glossAndDef.color}>{glossAndDef.gloss}</span>{#if glossAndDef.definition};{/if}
+          {/if}
+          {#if glossAndDef.definition}
+            <span class={glossAndDef.color}>{glossAndDef.definition}</span>
+          {/if}
+        </span>
       {/each}
     </span>
     {#each sense.exampleSentences as example (example.id)}
-      {@const usedVernacular = wsService.vernacular.filter(ws => !!example.sentence[ws.wsId])}
-      {@const usedAnalysis = wsService.analysis.filter(ws => !!example.translation[ws.wsId])}
-      {#if usedVernacular.length || usedAnalysis.length}
-        <span class="-mr-0.5">[</span>
-          {#each usedVernacular as ws}
-            <span class={wsService.wsColor(ws.wsId, 'vernacular')}>{example.sentence[ws.wsId]}</span>
-            <span></span><!-- standardizes whitespace between texts -->
-          {/each}
-          <span></span>
-          {#each usedAnalysis as ws}
-            <span class={wsService.wsColor(ws.wsId, 'analysis')}>{example.translation[ws.wsId]}</span>
-            <span></span><!-- standardizes whitespace between texts -->
-          {/each}
-        <span class="-ml-0.5">]</span>
-        <span></span><!-- standardizes whitespace between texts -->
-      {/if}
+      {#each example.sentences as sentence, j}
+        {@const first = j === 0}
+        {@const last = j === example.sentences.length - 1}
+        {#if j > 0};{/if}
+        {#if first}[{/if}<span class={sentence.color}>{sentence.text}</span>{#if last}]{/if}
+      {/each}
     {/each}
   {/each}
 </div>

--- a/frontend/viewer/src/lib/activity/ActivityView.svelte
+++ b/frontend/viewer/src/lib/activity/ActivityView.svelte
@@ -82,7 +82,7 @@
         {#if !activity || activity.length === 0}
           <div class="p-4 text-center opacity-75">No activity found</div>
         {:else}
-          <InfiniteScroll perPage={10} items={activity} let:visibleItems>
+          <InfiniteScroll perPage={50} items={activity} let:visibleItems>
             {#each visibleItems as row (row.timestamp)}
               <ListItem
                 title={row.changeName}

--- a/frontend/viewer/src/lib/entry-editor/EntryOrSensePicker.svelte
+++ b/frontend/viewer/src/lib/entry-editor/EntryOrSensePicker.svelte
@@ -19,6 +19,7 @@
   import type { SaveHandler } from '../services/save-event-service';
   import {SortField} from '$lib/dotnet-types';
   import {useWritingSystemService} from '$lib/writing-system-service';
+  import NewEntryButton from './NewEntryButton.svelte';
 
   const dispatch = createEventDispatcher<{
     pick: EntrySenseSelection;
@@ -87,8 +88,8 @@
   }
 
 
-  async function onClickCreateNewEntry(search: string): Promise<void> {
-    const entry = await projectCommands.createNewEntry(search, { dontSelect: true });
+  async function onClickCreateNewEntry(): Promise<void> {
+    const entry = await projectCommands.createNewEntry($search, { dontSelect: true });
     selectedEntry = entry;
     selectedEntryId = entry?.id;
     if (entry) {
@@ -208,23 +209,25 @@
       </div>
     {/each}
     {#if $displayedEntries.length === 0 && addedEntries.length === 0}
-      <div class="p-4 text-center opacity-75">
+      <div class="p-4 text-center opacity-75 flex justify-center items-center gap-2">
         {#if $result.search}
           No entries found <Icon data={mdiMagnifyRemoveOutline} />
+          <NewEntryButton on:click={onClickCreateNewEntry} />
         {:else if $loading}
           <ProgressCircle size={30} />
         {:else}
-            Search for an entry {onlyEntries ? '' : 'or sense'} <Icon data={mdiBookSearchOutline} />
+            Search for an entry {onlyEntries ? '' : 'or sense'} <Icon data={mdiBookSearchOutline} /> or
+            <NewEntryButton on:click={onClickCreateNewEntry} />
         {/if}
       </div>
     {/if}
-    {#if $result.search}
+    {#if $displayedEntries.length}
       <ListItem
         title="Create new Entry..."
         icon={mdiBookPlusOutline}
         classes={{root: 'text-success py-4 border-none rounded m-0.5 hover:bg-success-900/25'}}
         noShadow
-        on:click={() => onClickCreateNewEntry($result.search ?? '')}
+        on:click={onClickCreateNewEntry}
       />
     {/if}
     {#if $result.entries.length > $displayedEntries.length}

--- a/frontend/viewer/src/lib/entry-editor/NewEntryButton.svelte
+++ b/frontend/viewer/src/lib/entry-editor/NewEntryButton.svelte
@@ -10,6 +10,6 @@
 
 <Button on:click icon={mdiBookPlusOutline} variant="fill-outline" color="success" size="sm">
   <div class="hidden sm:contents">
-    New {fieldName({id: 'entry'}, $currentView.i18nKey)}
+    Create {fieldName({id: 'entry'}, $currentView.i18nKey)}
   </div>
 </Button>

--- a/frontend/viewer/src/lib/entry-editor/object-editors/EntryEditor.svelte
+++ b/frontend/viewer/src/lib/entry-editor/object-editors/EntryEditor.svelte
@@ -159,22 +159,26 @@
                       id="citationForm"
                       wsType="vernacular"/>
 
-    <ComplexForms on:change={() => dispatch('change', {entry})}
-                  bind:value={entry.complexForms}
-                  {readonly}
-                  {entry}
-                  id="complexForms" />
+    {#if !modalMode}
 
-    <ComplexFormTypes on:change={() => dispatch('change', {entry})}
-                  bind:value={entry.complexFormTypes}
-                  {readonly}
-                  id="complexFormTypes" />
+      <ComplexForms on:change={() => dispatch('change', {entry})}
+                    bind:value={entry.complexForms}
+                    {readonly}
+                    {entry}
+                    id="complexForms" />
 
-    <ComplexFormComponents  on:change={() => dispatch('change', {entry})}
-                            bind:value={entry.components}
-                            {readonly}
-                            {entry}
-                            id="components" />
+      <ComplexFormTypes on:change={() => dispatch('change', {entry})}
+                    bind:value={entry.complexFormTypes}
+                    {readonly}
+                    id="complexFormTypes" />
+
+      <ComplexFormComponents  on:change={() => dispatch('change', {entry})}
+                              bind:value={entry.components}
+                              {readonly}
+                              {entry}
+                              id="components" />
+
+    {/if}
 
     <MultiFieldEditor on:change={() => dispatch('change', {entry})}
                       bind:value={entry.literalMeaning}

--- a/frontend/viewer/src/lib/history/HistoryView.svelte
+++ b/frontend/viewer/src/lib/history/HistoryView.svelte
@@ -23,9 +23,13 @@
 
   async function load() {
     loading = true;
-    history = await historyService.load(id);
-    record = history[0];
-    loading = false;
+    try {
+      history = [];
+      history = await historyService.load(id);
+      record = history[0];
+    } finally {
+      loading = false;
+    }
   }
 
   async function showEntry(row: HistoryItem) {
@@ -35,12 +39,18 @@
       record = row;
     }
   }
+
+  function reset() {
+    record = undefined;
+    history = [];
+  }
 </script>
 
-<Dialog bind:open {loading} persistent={loading}>
+<Dialog bind:open {loading} persistent={loading} on:close={reset}>
   <Button on:click={() => open = false} icon={mdiClose} class="absolute right-2 top-2 z-40" rounded="full"></Button>
   <div slot="title">History</div>
-  <div class="m-4 mt-0 grid gap-x-6 gap-y-1 overflow-hidden" style="grid-template-rows: auto minmax(0,100%)">
+  {#if !loading}
+  <div class="m-4 mt-0 grid gap-x-6 gap-y-1 overflow-hidden" style="grid-template-rows: auto minmax(0,100%); grid-template-columns: minmax(min-content, 1fr) minmax(min-content, 2fr);">
     <div class="flex flex-col gap-4 overflow-hidden row-start-2">
       <div class="border rounded-md overflow-y-auto">
         {#if !history || history.length === 0}
@@ -70,33 +80,36 @@
         {/if}
       </div>
     </div>
-    {#if record?.entity && record?.entityName}
-      <div class="col-start-2 row-start-1 text-sm flex justify-between items-center px-2 pb-0.5">
-        <span>Author:
-          {#if record.authorName}
-            <span class="font-semibold">{record.authorName}</span>
-          {:else}
-            <span class="opacity-75 italic">Unknown</span>
-          {/if}
-        </span>
-        <div class="hidden sm:contents">
-          <ShowEmptyFieldsSwitch bind:value={showEmptyFields} />
+    <div class="grid grid-cols-subgrid grid-rows-subgrid col-start-2 row-span-2">
+      {#if record?.entity && record?.entityName}
+        <div class="col-start-2 row-start-1 text-sm flex justify-between items-center px-2 pb-0.5">
+          <span>Author:
+            {#if record.authorName}
+              <span class="font-semibold">{record.authorName}</span>
+            {:else}
+              <span class="opacity-75 italic">Unknown</span>
+            {/if}
+          </span>
+          <div class="hidden sm:contents">
+            <ShowEmptyFieldsSwitch bind:value={showEmptyFields} />
+          </div>
         </div>
-      </div>
-      <div class="col-start-2 row-start-2 overflow-auto p-3 pt-2 border rounded h-max max-h-full" class:hide-empty={!showEmptyFields}>
-        {#if record.entityName === 'Entry'}
-          <EntryEditor entry={record.entity} modalMode readonly/>
-        {:else if record.entityName === 'Sense'}
-          <div class="editor-grid">
-            <SenseEditor sense={record.entity} readonly/>
-          </div>
-        {:else if record.entityName === 'ExampleSentence'}
-          <div class="editor-grid">
-            <ExampleEditor example={record.entity} readonly/>
-          </div>
-        {/if}
-      </div>
-    {/if}
+        <div class="col-start-2 row-start-2 overflow-auto p-3 pt-2 border rounded h-max max-h-full" class:hide-empty={!showEmptyFields}>
+          {#if record.entityName === 'Entry'}
+            <EntryEditor entry={record.entity} modalMode readonly/>
+          {:else if record.entityName === 'Sense'}
+            <div class="editor-grid">
+              <SenseEditor sense={record.entity} readonly/>
+            </div>
+          {:else if record.entityName === 'ExampleSentence'}
+            <div class="editor-grid">
+              <ExampleEditor example={record.entity} readonly/>
+            </div>
+          {/if}
+        </div>
+      {/if}
+    </div>
   </div>
+  {/if}
   <div class="flex-grow"></div>
 </Dialog>

--- a/frontend/viewer/src/lib/history/HistoryView.svelte
+++ b/frontend/viewer/src/lib/history/HistoryView.svelte
@@ -56,7 +56,7 @@
         {#if !history || history.length === 0}
           <div class="p-4 text-center opacity-75">No history found</div>
         {:else}
-          <InfiniteScroll perPage={10} items={history} let:visibleItems>
+          <InfiniteScroll perPage={50} items={history} let:visibleItems>
             {#each visibleItems as row (`${row.commitId}_${row.changeIndex}`)}
               <ListItem
                 title={row.changeName ?? 'No change name'}

--- a/frontend/viewer/src/lib/notifications/NotificationOutlet.svelte
+++ b/frontend/viewer/src/lib/notifications/NotificationOutlet.svelte
@@ -1,10 +1,11 @@
-<script lang="ts">
+﻿<script lang="ts">
   import {AppNotification} from './notifications';
   import {Notification, Icon, Button} from 'svelte-ux';
   import {
     mdiAlert,
     mdiAlertCircleOutline,
     mdiCheckCircleOutline,
+    mdiClose,
     mdiInformationOutline
   } from '@mdi/js';
 
@@ -35,5 +36,10 @@
       </Notification>
     </div>
   {/each}
+  {#if $notifications.length > 1}
+    <Button class="w-[min(400px,100%)] shadow-lg" variant="fill-outline" on:click={() => AppNotification.clear()} icon={mdiClose}>
+      Close all
+    </Button>
+  {/if}
 </div>
 {/if}

--- a/frontend/viewer/src/lib/notifications/NotificationOutlet.svelte
+++ b/frontend/viewer/src/lib/notifications/NotificationOutlet.svelte
@@ -1,4 +1,4 @@
-﻿<script lang="ts">
+<script lang="ts">
   import {AppNotification} from './notifications';
   import {Notification, Icon, Button} from 'svelte-ux';
   import {
@@ -11,9 +11,9 @@
   const notifications = AppNotification.notifications;
 </script>
 {#if $notifications.length}
-<div class="fixed bottom-0 z-50 flex flex-col gap-2 p-4 w-full overflow-y-auto">
+<div class="fixed bottom-0 left-1/2 -translate-x-1/2 z-50 flex flex-col items-center gap-2 p-4 min-w-[min(400px,100%)] overflow-y-auto overflow-x-hidden">
   {#each $notifications as notification (notification)}
-    <div class="max-w-full min-w-[min(400px, 100%)] mx-auto">
+    <div class="max-w-full min-w-[min(400px,100%)]">
       <Notification open on:close={() => AppNotification.remove(notification)} closeIcon actionsPlacement="inline" classes={{title: 'max-h-[30vh] overflow-y-auto px-2 whitespace-break-spaces'}}>
         <div slot="icon">
           {#if notification.type === 'success'}

--- a/frontend/viewer/src/lib/notifications/notifications.ts
+++ b/frontend/viewer/src/lib/notifications/notifications.ts
@@ -32,6 +32,10 @@ export class AppNotification {
     this._notifications.update(notifications => notifications.filter(n => n !== notification));
   }
 
+  public static clear(): void {
+    this._notifications.set([]);
+  }
+
   private constructor(public message: string, public type: 'success' | 'error' | 'info' | 'warning', public action?: NotificationAction) {
   }
 }

--- a/frontend/viewer/src/lib/search-bar/SearchBar.svelte
+++ b/frontend/viewer/src/lib/search-bar/SearchBar.svelte
@@ -50,8 +50,9 @@
   const lexboxApi = useLexboxApi();
   const fetchCount = 105;
   const { value: result, loading } = deriveAsync(search, async (s) => {
+    s = s?.trim();
     if (!s) return Promise.resolve({ entries: [], search: undefined });
-    const entries = await lexboxApi.searchEntries(s ?? '', {
+    const entries = await lexboxApi.searchEntries(s, {
       offset: 0,
       count: fetchCount,
       order: {field: SortField.Headword, writingSystem: 'default', ascending: true},


### PR DESCRIPTION
- Hid the complex-form/component stuff in the new-entry dialog, so we avoid the issue of Add component/complex form from trying to reuse the new-entry dialog.
![image](https://github.com/user-attachments/assets/b08da168-b876-40fe-8d5b-8f8d36b04aae)

- Trimmed the quick-search query, so white-space doesn't confuse anyone

- Added a "Close all" notification button if there are multiple notifications:
![image](https://github.com/user-attachments/assets/0400c7fa-f6ca-4f5b-b690-be9641ee07da)

- Improved change UI names a bit:
![image](https://github.com/user-attachments/assets/920846bd-4f4d-449c-be9b-a0a913ac9bff)

Various other bugs:
- When a notification was shown it blocked clicks on the whole width of the screen
- My WritingSystemService change broke headwords in the dictionary-preview: it always used the default ws for every ws.

Applied some feedback from Sara's document:
- Removed extra semi-colons from the dictionary-entry-preview
![image](https://github.com/user-attachments/assets/3accc227-d14c-4861-a6a1-f23a366a5f60)

- Made it possible to create entries from the Add component/complex-form dialogs without having to search first
![image](https://github.com/user-attachments/assets/d5fbe910-aad3-41ec-8b83-623806b6b0c5)
![image](https://github.com/user-attachments/assets/07057b3f-214f-4d81-8366-c86318e8168e)

