### PR TITLE
specify android version code

### DIFF
--- a/.github/workflows/fw-lite.yaml
+++ b/.github/workflows/fw-lite.yaml
@@ -1,6 +1,11 @@
 ﻿name: FieldWorks Lite
 on:
   workflow_dispatch:
+    inputs:
+      android-version-code:
+        description: 'Android Version Code'
+        required: false
+        default: '1'
   push:
     paths:
       - 'backend/FwLite/**'
@@ -177,7 +182,7 @@ jobs:
         run: |
           dotnet publish -f net9.0-android --artifacts-path ../artifacts \
             -p:ApplicationDisplayVersion=${{ needs.build-and-test.outputs.semver-version }} \
-            -p:ApplicationVersion=${{ needs.build-and-test.outputs.semver-version }} \
+            -p:ApplicationVersion=${{ inputs.android-version-code }} \
             -p:InformationalVersion=${{ needs.build-and-test.outputs.version }} \
             -p:AndroidKeyStore=true \
             -p:AndroidSigningKeyStore=${KEYSTORE_PATH} \

--- a/.github/workflows/fw-lite.yaml
+++ b/.github/workflows/fw-lite.yaml
@@ -1,11 +1,6 @@
 ﻿name: FieldWorks Lite
 on:
   workflow_dispatch:
-    inputs:
-      android-version-code:
-        description: 'Android Version Code'
-        required: false
-        default: '1'
   push:
     paths:
       - 'backend/FwLite/**'
@@ -182,7 +177,7 @@ jobs:
         run: |
           dotnet publish -f net9.0-android --artifacts-path ../artifacts \
             -p:ApplicationDisplayVersion=${{ needs.build-and-test.outputs.semver-version }} \
-            -p:ApplicationVersion=${{ inputs.android-version-code }} \
+            -p:ApplicationVersion=${{ github.run_number }} \
             -p:InformationalVersion=${{ needs.build-and-test.outputs.version }} \
             -p:AndroidKeyStore=true \
             -p:AndroidSigningKeyStore=${KEYSTORE_PATH} \


### PR DESCRIPTION
using the workflow run_number to get a version to stamp android with as it requires a a non decimal number which always goes up.