### PR TITLE
Improve error logging

### DIFF
--- a/.github/workflows/fw-lite.yaml
+++ b/.github/workflows/fw-lite.yaml
@@ -295,6 +295,9 @@ jobs:
           zip -r fw-lite-portable.zip fw-lite-portable
           chmod +x fw-lite-web-linux/*/FwLiteWeb
           zip -r fw-lite-web-linux.zip fw-lite-web-linux
+      - name: Rename Installer
+        run: |
+          mv fw-lite-msix/FwLiteMaui.msixbundle fw-lite-msix/FieldWorksLiteInstaller.msixbundle
 
       - name: Create Release
         uses: softprops/action-gh-release@c95fe1489396fe8a9eb87c0abf8aa5b2ef267fda #v2.2.1

--- a/.github/workflows/fw-lite.yaml
+++ b/.github/workflows/fw-lite.yaml
@@ -37,9 +37,14 @@ jobs:
       - uses: actions/setup-dotnet@v4
         with:
           dotnet-version: '9.x'
+      - uses: pnpm/action-setup@fe02b34f77f8bc703788d5817da081398fad5dd2 # v4.0.0
+        with:
+          package_json_file: 'frontend/package.json'
       - uses: actions/setup-node@v4
         with:
           node-version-file: './frontend/package.json'
+          cache: 'pnpm'
+          cache-dependency-path: './frontend/pnpm-lock.yaml'
       - name: Install Task
         uses: arduino/setup-task@b91d5d2c96a56797b48ac1e0e89220bf64044611 #v2
         with:
@@ -60,7 +65,6 @@ jobs:
       - name: Build viewer
         working-directory: frontend/viewer
         run: |
-          corepack enable
           pnpm install
           pnpm run build-app
 

--- a/.github/workflows/lexbox-ui.yaml
+++ b/.github/workflows/lexbox-ui.yaml
@@ -26,14 +26,16 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@fe02b34f77f8bc703788d5817da081398fad5dd2 # v4.0.0
+        with:
+          package_json_file: 'frontend/package.json'
       - uses: actions/setup-node@v4
         with:
           node-version-file: './frontend/package.json'
-      - name: pnpm install
+          cache: 'pnpm'
+          cache-dependency-path: './frontend/pnpm-lock.yaml'
+      - run: pnpm install
         working-directory: ./frontend
-        run: |
-          corepack enable
-          pnpm install
       - name: vitest
         working-directory: ./frontend
         run: |

--- a/backend/FwLite/FwLiteMaui/FwLiteMauiKernel.cs
+++ b/backend/FwLite/FwLiteMaui/FwLiteMauiKernel.cs
@@ -10,6 +10,7 @@ using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Hosting.Internal;
 using Microsoft.Extensions.Logging;
 using NReco.Logging.File;
+using SIL.Harmony;
 
 namespace FwLiteMaui;
 
@@ -105,6 +106,11 @@ public static class FwLiteMauiKernel
         {
             config.CacheFileName = fwLiteMauiConfig.AuthCacheFilePath;
             config.SystemWebViewLogin = true;
+        });
+        services.Configure<CrdtConfig>(config =>
+        {
+            config.FailedSyncOutputPath = Path.Combine(baseDataPath, "failedSyncs");
+            config.LocalResourceCachePath = Path.Combine(baseDataPath, "localResourcesCache");
         });
 
         logging.AddFile(fwLiteMauiConfig.AppLogFilePath);

--- a/backend/FwLite/FwLiteMaui/MauiProgram.cs
+++ b/backend/FwLite/FwLiteMaui/MauiProgram.cs
@@ -77,7 +77,7 @@ public static class MauiProgram
         var app = builder.Build();
         holder.App = app;
         var logger = app.Services.GetRequiredService<ILogger<MauiApp>>();
-        logger.LogInformation("App started");
+        logger.LogInformation("App started, {Version}", AppVersion.Version);
         AppDomain.CurrentDomain.UnhandledException += (sender, e) =>
         {
             if (e.ExceptionObject is Exception exception)

--- a/backend/FwLite/FwLiteMaui/Platforms/Windows/Package.appxmanifest
+++ b/backend/FwLite/FwLiteMaui/Platforms/Windows/Package.appxmanifest
@@ -51,7 +51,7 @@
           <!--Register COM CLSID LocalServer32 registry key-->
           <com:Extension Category="windows.comServer">
               <com:ComServer>
-                  <com:ExeServer Executable="$targetnametoken$.exe" Arguments="-ToastActivated"
+                  <com:ExeServer Executable="FwLiteMaui.exe" Arguments="-ToastActivated"
                                  DisplayName="Toast activator">
                       <com:Class Id="49f2053c-31cc-4eb9-8a65-84491e543d56" DisplayName="Toast activator"/>
                   </com:ExeServer>

--- a/backend/FwLite/FwLiteShared/Projects/CombinedProjectsService.cs
+++ b/backend/FwLite/FwLiteShared/Projects/CombinedProjectsService.cs
@@ -63,8 +63,9 @@ public class CombinedProjectsService(LexboxProjectService lexboxProjectService,
     }
 
     [JSInvokable]
-    public IReadOnlyCollection<ProjectModel> LocalProjects()
+    public async ValueTask<IReadOnlyCollection<ProjectModel>> LocalProjects()
     {
+        await crdtProjectsService.EnsureProjectDataCacheIsLoaded();
         var crdtProjects = crdtProjectsService.ListProjects();
         //todo get project Id and use that to specify the Id in the model. Also pull out server
         var projects = crdtProjects.ToDictionary(p => p.Name,

--- a/backend/FwLite/FwLiteShared/Projects/LexboxProjectService.cs
+++ b/backend/FwLite/FwLiteShared/Projects/LexboxProjectService.cs
@@ -25,6 +25,12 @@ public class LexboxProjectService(
         return options.Value.LexboxServers;
     }
 
+    public LexboxServer? GetServer(ProjectData? projectData)
+    {
+        if (projectData is null) return null;
+        return Servers().FirstOrDefault(s => s.Id == projectData.ServerId);
+    }
+
     public async Task<LexboxProject[]> GetLexboxProjects(LexboxServer server)
     {
         return await cache.GetOrCreateAsync(CacheKey(server),

--- a/backend/FwLite/FwLiteShared/Sync/BackgroundSyncService.cs
+++ b/backend/FwLite/FwLiteShared/Sync/BackgroundSyncService.cs
@@ -68,11 +68,7 @@ public class BackgroundSyncService(
         //need to wait until application is started, otherwise Server urls will be unknown which prevents creating downstream services
         await StartedAsync();
         _running = true;
-        var crdtProjects = crdtProjectsService.ListProjects();
-        foreach (var crdtProject in crdtProjects)
-        {
-            await SyncProject(crdtProject, true, stoppingToken);
-        }
+        await SyncAllProjects(stoppingToken);
 
         try
         {
@@ -86,6 +82,15 @@ public class BackgroundSyncService(
         catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
         {
             // Expected during shutdown
+        }
+    }
+
+    private async Task SyncAllProjects(CancellationToken stoppingToken)
+    {
+        var crdtProjects = crdtProjectsService.ListProjects();
+        foreach (var crdtProject in crdtProjects)
+        {
+            await SyncProject(crdtProject, true, stoppingToken);
         }
     }
 

--- a/backend/FwLite/FwLiteWeb/appsettings.Development.json
+++ b/backend/FwLite/FwLiteWeb/appsettings.Development.json
@@ -3,7 +3,8 @@
   "Logging": {
     "LogLevel": {
       "Default": "Information",
-      "FwLiteWeb.Auth.LoggerAdapter": "Warning"
+      "FwLiteWeb.Auth.LoggerAdapter": "Warning",
+      "Microsoft.AspNetCore.Components.Server.Circuits.RemoteJSRuntime": "Debug"
     }
   },
   "FwLiteWeb": {

--- a/backend/FwLite/LcmCrdt/Changes/SetPartOfSpeechChange.cs
+++ b/backend/FwLite/LcmCrdt/Changes/SetPartOfSpeechChange.cs
@@ -23,6 +23,7 @@ public class SetPartOfSpeechChange(Guid entityId, Guid? partOfSpeechId) : EditCh
             return;
         }
         entity.PartOfSpeechId = partOfSpeech.Id;
-        entity.PartOfSpeech = partOfSpeech;
+        //don't set the part of speech, it may trigger an insert of that part of speech
+        //I wasn't able to figure out how to write a test to cover this sadly, I only saw it live.
     }
 }

--- a/backend/FwLite/LcmCrdt/CrdtProject.cs
+++ b/backend/FwLite/LcmCrdt/CrdtProject.cs
@@ -22,4 +22,6 @@ public record ProjectData(string Name, Guid Id, string? OriginDomain, Guid Clien
     {
         return uri?.GetComponents(UriComponents.SchemeAndServer, UriFormat.Unescaped);
     }
+
+    public string? ServerId => OriginDomain is not null ? new Uri(OriginDomain).Authority : null;
 }

--- a/backend/FwLite/LcmCrdt/LcmCrdtDbContext.cs
+++ b/backend/FwLite/LcmCrdt/LcmCrdtDbContext.cs
@@ -25,7 +25,9 @@ public class LcmCrdtDbContext(DbContextOptions<LcmCrdtDbContext> dbContextOption
     {
         modelBuilder.UseCrdt(options.Value);
 
-        modelBuilder.Entity<ProjectData>().HasKey(p => p.Id);
+        var projectDataModel = modelBuilder.Entity<ProjectData>();
+        projectDataModel.HasKey(p => p.Id);
+        projectDataModel.Ignore(p => p.ServerId);
     }
 
     protected override void ConfigureConventions(ModelConfigurationBuilder builder)

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -2,7 +2,7 @@
 # TODO: can't use vanilla alpine version since python is needed for gql-codegen stuff.
 FROM node:20 AS builder-base
 WORKDIR /app
-RUN corepack enable
+RUN corepack enable && corepack prepare pnpm@9.11.0 --activate
 
 FROM builder-base AS builder-viewer
 COPY pnpm-lock.yaml pnpm-workspace.yaml /app/

--- a/frontend/dev.Dockerfile
+++ b/frontend/dev.Dockerfile
@@ -2,7 +2,7 @@
 # TODO: can't use vanilla alpine version since python is needed for gql-codegen stuff.
 FROM node:20 AS builder
 
-RUN corepack enable
+RUN corepack enable && corepack prepare pnpm@9.11.0 --activate
 WORKDIR /app
 
 COPY package.json pnpm-lock.yaml pnpm-workspace.yaml /app/

--- a/frontend/viewer/src/lib/dotnet-types/generated-types/FwLiteShared/Projects/IProjectModel.ts
+++ b/frontend/viewer/src/lib/dotnet-types/generated-types/FwLiteShared/Projects/IProjectModel.ts
@@ -3,13 +3,15 @@
 //     Changes to this file may cause incorrect behavior and will be lost if
 //     the code is regenerated.
 
+import type {ILexboxServer} from '../Auth/ILexboxServer';
+
 export interface IProjectModel
 {
 	name: string;
 	crdt: boolean;
 	fwdata: boolean;
 	lexbox: boolean;
-	serverAuthority?: string;
+	server?: ILexboxServer;
 	id?: string;
 }
 /* eslint-enable */

--- a/frontend/viewer/src/lib/dotnet-types/generated-types/LcmCrdt/IProjectData.ts
+++ b/frontend/viewer/src/lib/dotnet-types/generated-types/LcmCrdt/IProjectData.ts
@@ -12,5 +12,6 @@ export interface IProjectData
 	fwProjectId?: string;
 	lastUserName?: string;
 	lastUserId?: string;
+	serverId?: string;
 }
 /* eslint-enable */

--- a/frontend/viewer/src/lib/services/projects-service.ts
+++ b/frontend/viewer/src/lib/services/projects-service.ts
@@ -1,5 +1,6 @@
-﻿import {AppNotification} from '../notifications/notifications';
-import type {IServerStatus, ICombinedProjectsService, IProjectModel, ILexboxServer, IServerProjects} from '$lib/dotnet-types';
+﻿import type {ICombinedProjectsService, ILexboxServer, IProjectModel, IServerProjects, IServerStatus} from '$lib/dotnet-types';
+
+import {AppNotification} from '../notifications/notifications';
 
 export type Project = IProjectModel;
 export type ServerStatus = IServerStatus;
@@ -44,7 +45,7 @@ export class ProjectService implements ICombinedProjectsService {
   }
 
   async downloadCrdtProject(project: Project) {
-    const r = await fetch(`/api/download/crdt/${project.serverAuthority}/${project.id}?projectName=${project.name}`, {method: 'POST'});
+    const r = await fetch(`/api/download/crdt/${project.server!.authority}/${project.id}?projectName=${project.name}`, {method: 'POST'});
     if (!r.ok) {
       AppNotification.display(`Failed to download project ${project.name}: ${r.statusText} (${r.status})`, 'error', 'long');
       console.error(`Failed to download project ${project.name}: ${r.statusText} (${r.status})`, r, await r.text())
@@ -64,7 +65,7 @@ export class ProjectService implements ICombinedProjectsService {
   async getProjectServer(projectName: string): Promise<string|null> {
     const projects = await this.localProjects();
     //todo project server is always null from local projects`
-    return projects.find(p => p.name === projectName)?.serverAuthority ?? null;
+    return projects.find(p => p.name === projectName)?.server?.authority ?? null;
   }
 
   async localProjects(): Promise<Project[]> {

--- a/frontend/viewer/src/lib/troubleshoot/TroubleshootDialog.svelte
+++ b/frontend/viewer/src/lib/troubleshoot/TroubleshootDialog.svelte
@@ -1,10 +1,11 @@
 ﻿<script lang="ts">
   import {Button, Dialog, Field} from 'svelte-ux';
-  import {useTroubleshootingService} from '$lib/services/service-provider';
+  import {useFwLiteConfig, useTroubleshootingService} from '$lib/services/service-provider';
   import {AppNotification} from '$lib/notifications/notifications';
   import {mdiFileExport, mdiFileEye, mdiFolderSearch} from '@mdi/js';
 
   const service = useTroubleshootingService();
+  const config = useFwLiteConfig();
   export let open = false;
 
   async function tryOpenDataDirectory() {
@@ -16,6 +17,8 @@
 <Dialog bind:open={open} style="height: auto">
   <div slot="title">Troubleshoot</div>
   <div class="flex flex-col gap-4 items-start p-4">
+    <p>Application version: <span class="font-mono text-surface-content/50 border-b">{config.appVersion}</span></p>
+
     {#await service?.getDataDirectory() then value}
       <Field label="Data Directory" {value} class="self-stretch">
           <span slot="append">


### PR DESCRIPTION
- log app version during startup
- set a path for failed syncs to write to
- fix a com server configuration issue preventing notifications from showing
- simplify home view in an attempt to avoid weird cases where a project doesn't show as syncing when it is
- enable logging of errors in js runtimes, this only works in FwLiteWeb, there doesn't seem to be a way to log errors at that layer in Maui