### PR TITLE
simplify create new entry dialog

### DIFF
--- a/backend/FwLite/MiniLcm.Tests/Validators/EntryValidatorTests.cs
+++ b/backend/FwLite/MiniLcm.Tests/Validators/EntryValidatorTests.cs
@@ -55,14 +55,14 @@ public class EntryValidatorTests
         _validator.TestValidate(entry).ShouldNotHaveAnyValidationErrors();
     }
 
-    [Fact]
+    [Fact(Skip = "Disabled for now as users can import entries without a lexeme form")]
     public void Fails_WhenLexemeFormIsMissing()
     {
         var entry = new Entry() { Id = Guid.NewGuid() };
         _validator.TestValidate(entry).ShouldHaveValidationErrorFor("LexemeForm");
     }
 
-    [Fact]
+    [Fact(Skip = "Disabled for now as users can import entries without a lexeme form")]
     public void Fails_WhenLexemeFormHasWsWithEmptyContent()
     {
         var entry = new Entry() { Id = Guid.NewGuid(), LexemeForm = new MultiString(){{"en", ""}} };

--- a/backend/FwLite/MiniLcm/Validators/EntryValidator.cs
+++ b/backend/FwLite/MiniLcm/Validators/EntryValidator.cs
@@ -8,7 +8,7 @@ public class EntryValidator : AbstractValidator<Entry>
     public EntryValidator()
     {
         RuleFor(e => e.DeletedAt).Null();
-        RuleFor(e => e.LexemeForm).Required(GetEntryIdentifier);
+        RuleFor(e => e.LexemeForm).NoEmptyValues(GetEntryIdentifier);
         RuleFor(e => e.CitationForm).NoEmptyValues(GetEntryIdentifier);
         RuleFor(e => e.LiteralMeaning).NoEmptyValues(GetEntryIdentifier);
         RuleFor(e => e.Note).NoEmptyValues(GetEntryIdentifier);

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -303,6 +303,9 @@ importers:
       postcss:
         specifier: 'catalog:'
         version: 8.4.47
+      svelte-dnd-action:
+        specifier: ^0.9.57
+        version: 0.9.57(svelte@4.2.19)
       svelte-exmarkdown:
         specifier: ^3.0.5
         version: 3.0.5(svelte@4.2.19)
@@ -5315,6 +5318,11 @@ packages:
       svelte: ^4.0.0 || ^5.0.0-next.0
       typescript: '>=5.0.0'
 
+  svelte-dnd-action@0.9.57:
+    resolution: {integrity: sha512-H1QPlthwAH+xjaISKbp/dQJYeC3Jt1mlTNqJDko0f7XgEyi5ee3PMEuAfF1soJXA0Y5ceb+W8xJXiSZ+2CeMNA==}
+    peerDependencies:
+      svelte: '>=3.23.0 || ^5.0.0-next.0'
+
   svelte-eslint-parser@0.33.1:
     resolution: {integrity: sha512-vo7xPGTlKBGdLH8T5L64FipvTrqv3OQRx9d2z5X05KKZDlF4rQk8KViZO4flKERY+5BiVdOh7zZ7JGJWo5P0uA==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
@@ -8690,7 +8698,7 @@ snapshots:
       sirv: 3.0.0
       tinyglobby: 0.2.9
       tinyrainbow: 1.2.0
-      vitest: 2.1.4(@types/node@20.12.12)(@vitest/ui@2.1.4)(happy-dom@15.7.4)
+      vitest: 2.1.4(@types/node@22.7.3)(@vitest/ui@2.1.4)(happy-dom@15.7.4)
 
   '@vitest/utils@2.1.4':
     dependencies:
@@ -11990,6 +11998,10 @@ snapshots:
       typescript: 5.3.3
     transitivePeerDependencies:
       - picomatch
+
+  svelte-dnd-action@0.9.57(svelte@4.2.19):
+    dependencies:
+      svelte: 4.2.19
 
   svelte-eslint-parser@0.33.1(svelte@4.2.19):
     dependencies:

--- a/frontend/viewer/package.json
+++ b/frontend/viewer/package.json
@@ -57,6 +57,7 @@
     "fast-json-patch": "^3.1.1",
     "just-throttle": "^4.2.0",
     "postcss": "catalog:",
+    "svelte-dnd-action": "^0.9.57",
     "svelte-exmarkdown": "^3.0.5",
     "svelte-preprocess": "catalog:",
     "svelte-routing": "^2.12.0",

--- a/frontend/viewer/src/TestProjectView.svelte
+++ b/frontend/viewer/src/TestProjectView.svelte
@@ -1,19 +1,9 @@
 ﻿<script lang="ts">
 import ProjectView from './ProjectView.svelte';
 import {InMemoryApiService} from '$lib/in-memory-api-service';
-import {DotnetService} from '$lib/dotnet-types';
-import {FwLitePlatform} from '$lib/dotnet-types/generated-types/FwLiteShared/FwLitePlatform';
 import ProjectLoader from './ProjectLoader.svelte';
 
-const inMemoryLexboxApi = new InMemoryApiService();
-window.lexbox.ServiceProvider.setService(DotnetService.MiniLcmApi, inMemoryLexboxApi);
-window.lexbox.ServiceProvider.setService(DotnetService.FwLiteConfig, {
-  appVersion: 'test-project',
-  feedbackUrl: '',
-  os: FwLitePlatform.Web,
-  useDevAssets: true,
-});
-const projectName = inMemoryLexboxApi.projectName;
+const projectName = InMemoryApiService.setup().projectName;
 </script>
 
 <ProjectLoader {projectName} let:onProjectLoaded>

--- a/frontend/viewer/src/app.postcss
+++ b/frontend/viewer/src/app.postcss
@@ -127,3 +127,7 @@
 .AppBar :has(> [slot="actions"]) {
   flex-grow: 0;
 }
+
+html:has(.Dialog) {
+    @apply overflow-hidden;
+}

--- a/frontend/viewer/src/lib/OverrideFields.svelte
+++ b/frontend/viewer/src/lib/OverrideFields.svelte
@@ -1,0 +1,26 @@
+﻿<script lang="ts">
+
+  import {initView, useCurrentView} from '$lib/services/view-service';
+  import type {FieldIds} from '$lib/entry-editor/field-data';
+
+  export let shownFields: FieldIds[] = [];
+  export let respectOrder: boolean = false;
+
+  const currentView = useCurrentView();
+  const overrideView = initView();
+  $:{
+    $overrideView = {
+      ...$currentView,
+      fields: Object.fromEntries(Object.entries($currentView.fields).map(([id, field]) => {
+          return [id, {
+            ...field,
+            show: shownFields.includes(id),
+            order: respectOrder ? shownFields.indexOf(id) : field.order
+          }];
+        })
+      )
+    };
+  }
+</script>
+
+<slot/>

--- a/frontend/viewer/src/lib/entry-editor/NewEntryDialog.svelte
+++ b/frontend/viewer/src/lib/entry-editor/NewEntryDialog.svelte
@@ -68,7 +68,7 @@
   }
 </script>
 
-<Dialog bind:open on:close={onClosing} {loading} persistent={loading} classes={{backdrop: 'overflow-hidden'}}>
+<Dialog bind:open on:close={onClosing} {loading} persistent={loading}>
   <div slot="title">New {fieldName({id: 'entry'}, $currentView.i18nKey)}</div>
   <div class="m-6">
     <OverrideFields shownFields={['lexemeForm', 'citationForm', 'gloss', 'definition']}>

--- a/frontend/viewer/src/lib/entry-editor/NewEntryDialog.svelte
+++ b/frontend/viewer/src/lib/entry-editor/NewEntryDialog.svelte
@@ -6,14 +6,17 @@
   import {Button, Dialog} from 'svelte-ux';
   import type {SaveHandler} from '../services/save-event-service';
   import {useLexboxApi} from '../services/service-provider';
-  import {defaultEntry} from '../utils';
+  import {defaultEntry, defaultSense} from '../utils';
   import EntryEditor from './object-editors/EntryEditor.svelte';
+  import OverrideFields from '$lib/OverrideFields.svelte';
+  import {useWritingSystemService} from '$lib/writing-system-service';
 
   let open = false;
   let loading = false;
   let entry: IEntry = defaultEntry();
 
   const currentView = useCurrentView();
+  const writingSystemService = useWritingSystemService();
   const lexboxApi = useLexboxApi();
   const saveHandler = getContext<SaveHandler>('saveHandler');
   let requester: {
@@ -22,7 +25,9 @@
 
   async function createEntry(e: Event) {
     e.preventDefault();
+    e.stopPropagation();
     if (!requester) throw new Error('No requester');
+    if (!validateEntry()) return;
     loading = true;
     console.debug('Creating entry', entry);
     await saveHandler(() => lexboxApi.createEntry(entry));
@@ -32,6 +37,14 @@
     open = false;
   }
 
+  let errors: string[] = [];
+  function validateEntry(): boolean {
+    errors = [];
+    if (!writingSystemService.headword(entry)) errors.push('Lexeme form is required');
+    if (entry.senses.length > 0 && !writingSystemService.firstDefOrGlossVal(entry.senses[0])) errors.push('Definition or gloss is required');
+    return errors.length === 0;
+  }
+
   export function openWithValue(newEntry: Partial<IEntry>): Promise<IEntry | undefined> {
     return new Promise<IEntry | undefined>((resolve) => {
       if (requester) requester.resolve(undefined);
@@ -39,6 +52,10 @@
       const tmpEntry = defaultEntry();
       open = true;
       entry = {...tmpEntry, ...newEntry, id: tmpEntry.id};
+      if (entry.senses.length === 0) {
+        entry.senses.push(defaultSense(entry.id));
+      }
+      errors = [];
     });
   }
 
@@ -51,12 +68,19 @@
   }
 </script>
 
-<Dialog bind:open on:close={onClosing} {loading} persistent={loading}>
+<Dialog bind:open on:close={onClosing} {loading} persistent={loading} classes={{backdrop: 'overflow-hidden'}}>
   <div slot="title">New {fieldName({id: 'entry'}, $currentView.i18nKey)}</div>
   <div class="m-6">
-    <EntryEditor bind:entry={entry} modalMode/>
+    <OverrideFields shownFields={['lexemeForm', 'citationForm', 'gloss', 'definition']}>
+      <EntryEditor bind:entry={entry} modalMode canAddSense={false} canAddExample={false} />
+    </OverrideFields>
   </div>
   <div class="flex-grow"></div>
+  <div class="self-end m-4">
+    {#each errors as error}
+      <p class="text-danger p-2">{error}</p>
+    {/each}
+  </div>
   <div slot="actions">
     <Button>Cancel</Button>
     <Button variant="fill-light" color="success" on:click={e => createEntry(e)}>Create {fieldName({id: 'entry'}, $currentView.i18nKey)}</Button>

--- a/frontend/viewer/src/lib/entry-editor/field-editors/MultiFieldEditor.svelte
+++ b/frontend/viewer/src/lib/entry-editor/field-editors/MultiFieldEditor.svelte
@@ -26,9 +26,10 @@
   $: writingSystems = writingSystemService.pickWritingSystems(wsType);
   $: empty = !writingSystems.some((ws) => value[ws.wsId] || unsavedChanges[ws.wsId]);
   $: collapse = empty && writingSystems.length > 1;
+  $: hide = !$currentView.fields[id].show;
 </script>
 
-<div class="multi-field field" class:collapse-field={collapse} class:empty class:hidden={!$currentView.fields[id].show} style:grid-area={id}>
+<div class="multi-field field" class:collapse-field={collapse} class:empty class:hidden={hide} style:grid-area={id}>
   <FieldTitle {id} {name} />
   <div class="fields">
     {#each writingSystems as ws, idx (ws.wsId)}

--- a/frontend/viewer/src/lib/entry-editor/object-editors/EntryEditor.svelte
+++ b/frontend/viewer/src/lib/entry-editor/object-editors/EntryEditor.svelte
@@ -99,6 +99,8 @@
   }
   export let modalMode = false;
   export let readonly = false;
+  export let canAddSense = true;
+  export let canAddExample = true;
 
   let editorElem: HTMLDivElement | undefined;
   let highlightedEntity: IExampleSentence | ISense | undefined;
@@ -242,14 +244,14 @@
           {/each}
         </div>
       {/if}
-      {#if !readonly}
+      {#if !readonly && canAddExample}
         <div class="col-span-full flex justify-end mt-4">
           <Button on:click={() => addExample(sense)} icon={mdiPlus} variant="fill-light" color="success" size="sm">Add Example</Button>
         </div>
       {/if}
     </div>
   {/each}
-  {#if !readonly}
+  {#if !readonly && canAddSense}
     <hr class="col-span-full grow border-t-4 my-4">
     <div class="lg-view:hidden flex col-span-full justify-end sticky bottom-3 right-3 z-[2]" class:hidden={modalMode}>
       <!-- sticky isn't working in the new entry dialog. I think that's fine/good. -->

--- a/frontend/viewer/src/lib/in-memory-api-service.ts
+++ b/frontend/viewer/src/lib/in-memory-api-service.ts
@@ -1,22 +1,24 @@
 ﻿/* eslint-disable @typescript-eslint/naming-convention */
 
-import type {
-  IComplexFormComponent,
-  IComplexFormType,
-  IEntry,
-  IExampleSentence,
-  IMiniLcmJsInvokable,
-  IPartOfSpeech,
-  IQueryOptions,
-  ISemanticDomain,
-  ISense,
-  IWritingSystem,
-  IWritingSystems,
-  WritingSystemType
+import {
+  DotnetService,
+  type IComplexFormComponent,
+  type IComplexFormType,
+  type IEntry,
+  type IExampleSentence,
+  type IMiniLcmJsInvokable,
+  type IPartOfSpeech,
+  type IQueryOptions,
+  type ISemanticDomain,
+  type ISense,
+  type IWritingSystem,
+  type IWritingSystems,
+  type WritingSystemType
 } from '$lib/dotnet-types';
 import {entries, partsOfSpeech, projectName, writingSystems} from './entry-data';
 
 import {WritingSystemService} from './writing-system-service';
+import {FwLitePlatform} from '$lib/dotnet-types/generated-types/FwLiteShared/FwLitePlatform';
 
 function pickWs(ws: string, defaultWs: string): string {
   return ws === 'default' ? defaultWs : ws;
@@ -40,6 +42,19 @@ function filterEntries(entries: IEntry[], query: string): IEntry[] {
 const writingSystemService = new WritingSystemService(writingSystems);
 
 export class InMemoryApiService implements IMiniLcmJsInvokable {
+
+  public static setup(): InMemoryApiService {
+    const inMemoryLexboxApi = new InMemoryApiService();
+    window.lexbox.ServiceProvider.setService(DotnetService.MiniLcmApi, inMemoryLexboxApi);
+    window.lexbox.ServiceProvider.setService(DotnetService.FwLiteConfig, {
+      appVersion: 'test-project',
+      feedbackUrl: '',
+      os: FwLitePlatform.Web,
+      useDevAssets: true,
+    });
+    return inMemoryLexboxApi;
+  }
+
   getComplexFormTypes(): Promise<IComplexFormType[]> {
     return Promise.resolve(
       //*
@@ -88,6 +103,9 @@ export class InMemoryApiService implements IMiniLcmJsInvokable {
     return Promise.resolve(this.ApplyQueryOptions(this._Entries(), options));
   }
 
+  getWritingSystemsSync(): IWritingSystems {
+    return writingSystems;
+  }
   getWritingSystems(): Promise<IWritingSystems> {
     return Promise.resolve(writingSystems);
   }

--- a/frontend/viewer/src/lib/sandbox/OptionSandbox.svelte
+++ b/frontend/viewer/src/lib/sandbox/OptionSandbox.svelte
@@ -1,0 +1,63 @@
+﻿<script lang="ts">
+  import {setContext} from 'svelte';
+  import {readable, type Readable} from 'svelte/store';
+  import type {View} from '$lib/entry-editor/view-data';
+  import MultiOptionEditor from '$lib/entry-editor/field-editors/MultiOptionEditor.svelte';
+  import {Button} from 'svelte-ux';
+  import MapBind from '$lib/utils/MapBind.svelte';
+  import {initWritingSystemService} from '$lib/writing-system-service';
+  import {WritingSystemType} from '$lib/dotnet-types';
+
+  initWritingSystemService(readable({
+    analysis: [{
+      id: 'test',
+      wsId: 'test',
+      name: 'test',
+      abbreviation: 'test',
+      font: 'test',
+      exemplars: [],
+      type: WritingSystemType.Analysis,
+      order: 0,
+    }],
+    vernacular: [],
+  }));
+  const fields = {
+    'multi1': {show: true, order: 1},
+    'multi2': {show: true, order: 2},
+    'multi3': {show: true, order: 3},
+  };
+  const fieldGridAreas = Object.keys(fields).map(field => `'${field}'`).join(' ');
+
+  setContext<Readable<View>>('currentView', readable({
+    id: 'sandbox',
+    i18nKey: 'languageForge',
+    label: 'Language Forge',
+    fields,
+  }));
+
+  const options = [
+    {label: 'One', id: '1'},
+    {label: 'Two', id: '2'},
+    {label: 'Three', id: '3'},
+    {label: 'Four', id: '4'},
+  ];
+
+  function findOption(id: string) {
+    return options.find(o => o.id === id)!;
+  }
+
+  let idValue = ['3'];
+  let idObjectValue = [{id: '3'}];
+  let optionValue = [{label: 'Three', id: '3'}];
+</script>
+<MapBind bind:in={idValue} bind:out={idObjectValue} map={(value) => value.map(v => ({id: v}))} unmap={(value => value.map(v => v.id))}/>
+<MapBind bind:in={idObjectValue} bind:out={optionValue} map={(value) => value.map(v => findOption(v.id))} unmap={(value => value)} />
+<div class="grid gap-2" style:grid-template-areas={fieldGridAreas}>
+      <MultiOptionEditor id="multi1" name="String values" bind:value={idValue} valuesAreIds getOptionLabel={(o) => o.label} wsType="analysis" readonly={false} {options} />
+      <MultiOptionEditor id="multi2" name="(id: string) values" bind:value={idObjectValue} getValueById={findOption} getOptionLabel={(o) => o.label} wsType="analysis" readonly={false} {options} />
+      <MultiOptionEditor id="multi3" name="Option values" bind:value={optionValue} getOptionLabel={(o) => o.label} wsType="analysis" readonly={false} {options} />
+    </div>
+    <div class="flex flex-col">
+      <p>selected: {idValue.join('|')}</p>
+      <Button variant="fill" on:click={() => idValue = ['4']}>Select Four only</Button>
+    </div>

--- a/frontend/viewer/src/lib/sandbox/Sandbox.svelte
+++ b/frontend/viewer/src/lib/sandbox/Sandbox.svelte
@@ -1,58 +1,19 @@
 <script lang="ts">
-  import {setContext} from 'svelte';
   import {Button, type MenuOption} from 'svelte-ux';
-  import {readable, type Readable} from 'svelte/store';
-  import MultiOptionEditor from '../entry-editor/field-editors/MultiOptionEditor.svelte';
   import CrdtMultiOptionField from '../entry-editor/inputs/CrdtMultiOptionField.svelte';
-  import {type View} from '../entry-editor/view-data';
-  import MapBind from '../utils/MapBind.svelte';
-  import {initWritingSystemService} from '../writing-system-service';
-  import {DotnetService, WritingSystemType} from '$lib/dotnet-types';
+  import {DotnetService, type ISense} from '$lib/dotnet-types';
   import {useService} from '$lib/services/service-provider';
   import {AppNotification} from '$lib/notifications/notifications';
+  import SenseEditor from '$lib/entry-editor/object-editors/SenseEditor.svelte';
+  import {InMemoryApiService} from '$lib/in-memory-api-service';
+  import OptionSandbox from '$lib/sandbox/OptionSandbox.svelte';
+  import {initWritingSystemService} from '$lib/writing-system-service';
+  import {deriveAsync} from '$lib/utils/time';
+  import {writable} from 'svelte/store';
+  import {initView, initViewSettings} from '$lib/services/view-service';
 
-  initWritingSystemService(readable({
-    analysis: [{
-      id: 'test',
-      wsId: 'test',
-      name: 'test',
-      abbreviation: 'test',
-      font: 'test',
-      exemplars: [],
-      type: WritingSystemType.Analysis,
-      order: 0,
-    }],
-    vernacular: [],
-  }));
 
-  const fields = {
-    'multi1': {show: true, order: 1},
-    'multi2': {show: true, order: 2},
-    'multi3': {show: true, order: 3},
-  };
-  const fieldGridAreas = Object.keys(fields).map(field => `'${field}'`).join(' ');
 
-  setContext<Readable<View>>('currentView', readable({
-    id: 'sandbox',
-    i18nKey: 'languageForge',
-    label: 'Language Forge',
-    fields,
-  }));
-
-  const options = [
-    { label: 'One', id: '1' },
-    { label: 'Two', id: '2' },
-    { label: 'Three', id: '3' },
-    { label: 'Four', id: '4' },
-  ];
-
-  function findOption(id: string) {
-    return options.find(o => o.id === id)!;
-  }
-
-  let idValue = ['3'];
-  let idObjectValue = [{id: '3'}];
-  let optionValue = [{ label: 'Three', id: '3' }];
 
   const crdtOptions: MenuOption[] = [
     {value: 'a', label: 'Alpha'},
@@ -74,22 +35,13 @@
   }
 </script>
 
-<MapBind bind:in={idValue} bind:out={idObjectValue} map={(value) => value.map(v => ({id: v}))} unmap={(value => value.map(v => v.id))} />
-<MapBind bind:in={idObjectValue} bind:out={optionValue} map={(value) => value.map(v => findOption(v.id))} unmap={(value => value)} />
 
 <div class="grid grid-cols-3 gap-6 p-6">
   <div class="flex flex-col gap-2 border p-4 justify-between">
     MultiOptionEditor configurations
-    <div class="grid gap-2" style:grid-template-areas={fieldGridAreas}>
-      <MultiOptionEditor id="multi1" name="String values" bind:value={idValue} valuesAreIds getOptionLabel={(o) => o.label} wsType="analysis" readonly={false} {options} />
-      <MultiOptionEditor id="multi2" name="(id: string) values" bind:value={idObjectValue} getValueById={findOption} getOptionLabel={(o) => o.label} wsType="analysis" readonly={false} {options} />
-      <MultiOptionEditor id="multi3" name="Option values" bind:value={optionValue} getOptionLabel={(o) => o.label} wsType="analysis" readonly={false} {options} />
-    </div>
-    <div class="flex flex-col">
-      <p>selected: {idValue.join('|')}</p>
-      <Button variant="fill" on:click={() => idValue = ['4']}>Select Four only</Button>
-    </div>
+    <OptionSandbox/>
   </div>
+
   <div class="flex flex-col gap-2 border p-4 justify-between">
     <div class="flex flex-col gap-2">
       Lower level editor
@@ -103,6 +55,7 @@
       <Button variant="fill" on:click={() => crdtValue = ['c']}>Select Charlie only</Button>
     </div>
   </div>
+
   <div class="flex flex-col gap-2 border p-4 justify-between">
     <div class="flex flex-col gap-2">
       Notifications

--- a/frontend/viewer/src/lib/sandbox/Sandbox.svelte
+++ b/frontend/viewer/src/lib/sandbox/Sandbox.svelte
@@ -8,11 +8,9 @@
   import {InMemoryApiService} from '$lib/in-memory-api-service';
   import OptionSandbox from '$lib/sandbox/OptionSandbox.svelte';
   import {initWritingSystemService} from '$lib/writing-system-service';
-  import {deriveAsync} from '$lib/utils/time';
   import {writable} from 'svelte/store';
   import {initView, initViewSettings} from '$lib/services/view-service';
-
-
+  import OverrideFields from '$lib/OverrideFields.svelte';
 
 
   const crdtOptions: MenuOption[] = [
@@ -32,6 +30,15 @@
       detail += `This is line ${i + 1} of the detail\n`;
     }
     AppNotification.display('This is a notification with a large detail', 'info', undefined, detail);
+  }
+
+  const inMemoryLexboxApi = InMemoryApiService.setup();
+  initWritingSystemService(writable(inMemoryLexboxApi.getWritingSystemsSync()));
+  initView();
+  initViewSettings();
+
+  function makeSense(s: ISense) {
+    return s;
   }
 </script>
 
@@ -61,12 +68,23 @@
       Notifications
       <Button variant="fill" on:click={() => testingService.throwException()}>Throw Exception</Button>
       <Button variant="fill" on:click={() => testingService.throwExceptionAsync()}>Throw Exception Async</Button>
-      <Button variant="fill" on:click={() => AppNotification.display('This is a simple notification', 'info')}>Simple Notification</Button>
+      <Button variant="fill" on:click={() => AppNotification.display('This is a simple notification', 'info')}>Simple
+        Notification
+      </Button>
       <Button variant="fill" on:click={() => AppNotification.displayAction('This is a notification with an action', 'info', {
         label: 'Action',
         callback: () => alert('Action clicked')
-      })}>Notification with action</Button>
-      <Button variant="fill" on:click={() => triggerNotificationWithLargeDetail()}>Notification with a large detail</Button>
+      })}>Notification with action
+      </Button>
+      <Button variant="fill" on:click={() => triggerNotificationWithLargeDetail()}>Notification with a large detail
+      </Button>
     </div>
+  </div>
+
+  <div class="editor-grid border p-4">
+    <OverrideFields shownFields={['definition', 'gloss']} respectOrder>
+      <SenseEditor
+        sense={makeSense({id: '1', gloss: {'en': 'Hello'}, entryId: 'e1', definition: {}, semanticDomains: [], exampleSentences: []})}/>
+    </OverrideFields>
   </div>
 </div>

--- a/frontend/viewer/src/lib/services/service-provider.ts
+++ b/frontend/viewer/src/lib/services/service-provider.ts
@@ -111,3 +111,7 @@ export function useTroubleshootingService(): ITroubleshootingService | undefined
 export function useService<K extends ServiceKey>(key: K): LexboxServiceRegistry[K] {
   return window.lexbox.ServiceProvider.getService(key);
 }
+
+export function tryUseService<K extends ServiceKey>(key: K): LexboxServiceRegistry[K] | undefined {
+  return window.lexbox.ServiceProvider.tryGetService(key);
+}

--- a/frontend/viewer/src/lib/services/view-service.ts
+++ b/frontend/viewer/src/lib/services/view-service.ts
@@ -9,14 +9,15 @@ export interface ViewSettings {
   showEmptyFields: boolean;
 }
 
-export function initViewSettings(defaultSettings: ViewSettings): Writable<ViewSettings> {
+export function initViewSettings(defaultSettings: ViewSettings = {showEmptyFields: true}): Writable<ViewSettings> {
   //todo load from local storage
   const viewSettingsStore = writable<ViewSettings>(defaultSettings);
   setContext<Writable<ViewSettings>>(viewSettingsContextName, viewSettingsStore);
   return viewSettingsStore;
 }
 
-export function initView(defaultView: View): Writable<View> {
+export function initView(defaultView?: View): Writable<View> {
+  defaultView ??= views[0];
   const localView = localStorage.getItem('currentView');
   const currentViewStore = writable<View>(views.find(v => v.id === localView) ?? defaultView);
   onDestroy(currentViewStore.subscribe(v => localStorage.setItem('currentView', v.id)));
@@ -29,14 +30,18 @@ export function initView(defaultView: View): Writable<View> {
  * and what labels are used.
  */
 export function useCurrentView(): Writable<View> {
-  return getContext<Writable<View>>(currentViewContextName);
+  const currentView = getContext<Writable<View>>(currentViewContextName);
+  if (!currentView) throw new Error('Current view is not initialized. Are you in the context of a project?');
+  return currentView;
 }
 
 /**
  * View settings contains user specified settings, such as hiding empty fields.
  */
 export function useViewSettings(): Writable<ViewSettings> {
-  return getContext<Writable<ViewSettings>>(viewSettingsContextName);
+  const viewSettings = getContext<Writable<ViewSettings>>(viewSettingsContextName);
+  if (!viewSettings) throw new Error('View settings is not initialized. Are you in the context of a project?');
+  return viewSettings;
 }
 
 /**


### PR DESCRIPTION
we now only show citation form, lexeme form, gloss and definition and users aren't allowed to add more senses or example sentences.
I setup the validation to require a headword and a gloss or definition of there's a sense, it can be deleted if they don't want it.

we also disabled validation to allow lexeme form to be empty.

scroll bars should now be hidden when a dialog is open