### PR TITLE
Reproduce duplicate pos

### DIFF
--- a/backend/FwLite/LcmCrdt.Tests/Changes/ChangeSerializationTests.cs
+++ b/backend/FwLite/LcmCrdt.Tests/Changes/ChangeSerializationTests.cs
@@ -93,7 +93,7 @@ public class ChangeSerializationTests
     [Fact]
     public void ChangesIncludesAllValidChangeTypes()
     {
-        var allChangeTypes = LcmCrdtKernel.AllChangeTypes();
+        var allChangeTypes = LcmCrdtKernel.AllChangeTypes().ToArray();
         allChangeTypes.Should().NotBeEmpty();
         var testedTypes = Changes().Select(c => c[0].GetType()).ToArray();
         using (new AssertionScope())

--- a/backend/FwLite/LcmCrdt.Tests/Changes/SenseChangeTests.cs
+++ b/backend/FwLite/LcmCrdt.Tests/Changes/SenseChangeTests.cs
@@ -1,0 +1,28 @@
+﻿using SIL.Harmony.Changes;
+using LcmCrdt.Changes;
+
+namespace LcmCrdt.Tests.Changes;
+
+public class SenseChangeTests(MiniLcmApiFixture fixture) : IClassFixture<MiniLcmApiFixture>
+{
+    [Fact]
+    public async Task AddSenseAndUpdatePartOfSpeechInOneCommit()
+    {
+        // arrange
+        var entry = await fixture.Api.CreateEntry(new() { LexemeForm = { { "en", "test entry" } }, });
+        var partOfSpeech = await fixture.Api.CreatePartOfSpeech(new() { Name = new() { { "en", "test pos" } } });
+        var sense = new Sense() { Id = Guid.NewGuid(), Gloss = new() { { "en", "test sense" } } };
+
+        var createSenseChange = new CreateSenseChange(sense, entry.Id);
+        var setPartOfSpeechChange = new SetPartOfSpeechChange(sense.Id, partOfSpeech.Id);
+        List<IChange> changes = [createSenseChange, setPartOfSpeechChange];
+
+        // act
+        await fixture.DataModel.AddChanges(Guid.NewGuid(), changes);
+
+        // assert
+        var actualSense = await fixture.Api.GetSense(entry.Id, sense.Id);
+        actualSense.Should().NotBeNull();
+        actualSense.PartOfSpeechId.Should().Be(partOfSpeech.Id);
+    }
+}

--- a/backend/FwLite/LcmCrdt.Tests/Changes/UseChangesTests.cs
+++ b/backend/FwLite/LcmCrdt.Tests/Changes/UseChangesTests.cs
@@ -1,0 +1,163 @@
+﻿using System.Diagnostics.CodeAnalysis;
+using System.Text.Json;
+using Bogus;
+using FluentAssertions.Execution;
+using LcmCrdt.Changes;
+using LcmCrdt.Changes.Entries;
+using SIL.Harmony.Changes;
+
+namespace LcmCrdt.Tests.Changes;
+
+public class UseChangesTests(MiniLcmApiFixture fixture) : IClassFixture<MiniLcmApiFixture>
+{
+
+    private static readonly Randomizer random = new();
+    private static readonly Lazy<JsonSerializerOptions> LazyOptions = new(() =>
+    {
+        var config = new CrdtConfig();
+        LcmCrdtKernel.ConfigureCrdt(config);
+        config.JsonSerializerOptions.ReadCommentHandling = JsonCommentHandling.Skip;
+        return config.JsonSerializerOptions;
+    });
+    private static readonly JsonSerializerOptions Options = LazyOptions.Value;
+
+    [Fact]
+    public async Task CanAddAllChangeTypes()
+    {
+        var shuffledChangesWithDependencies = random.Shuffle(GetAllChanges())
+            .ToDictionary(change => change.Change, change => change.Dependencies == null ? null : random.Shuffle(change.Dependencies));
+        var pendingChanges = shuffledChangesWithDependencies.Select(c => c.Key).ToList();
+        var queuedChanges = new List<IChange>();
+
+        while (pendingChanges is not [])
+        {
+            var change = FindFirstSatisfiedChangeRecursive(pendingChanges, shuffledChangesWithDependencies, queuedChanges);
+            if (!pendingChanges.Remove(change)) throw new InvalidOperationException("Change not found in pending changes");
+            queuedChanges.Add(change);
+        }
+
+        try
+        {
+            await fixture.DataModel.AddChanges(Guid.NewGuid(), queuedChanges);
+        }
+        catch (Exception e)
+        {
+            var serializedQueuedChanges = JsonSerializer.Serialize(queuedChanges, Options);
+            throw new Exception($"Failed to add changes: {e.Message}. JSON:\n\n{serializedQueuedChanges}", e);
+        }
+
+    }
+
+    private bool AreSatisfied([NotNullWhen(false)] IEnumerable<IChange>? dependencies, IEnumerable<IChange> queuedChanges)
+    {
+        return dependencies == null || dependencies.All(queuedChanges.Contains);
+    }
+
+    private IChange FindFirstSatisfiedChangeRecursive(IEnumerable<IChange> changes, Dictionary<IChange, IEnumerable<IChange>?> allChangesWithDependencies, IEnumerable<IChange> queuedChanges)
+    {
+        var change = changes.First(d => !queuedChanges.Contains(d));
+        var dependencies = allChangesWithDependencies[change];
+        if (AreSatisfied(dependencies, queuedChanges))
+        {
+            return change;
+        }
+        else
+        {
+            return FindFirstSatisfiedChangeRecursive(dependencies, allChangesWithDependencies, queuedChanges);
+        }
+    }
+
+    [Fact]
+    public void ChangesIncludeAllExpectedChangeTypes()
+    {
+        var allExpectedChangeTypes = LcmCrdtKernel.AllChangeTypes()
+            .Where(type => !type.Name.StartsWith("DeleteChange`") && !type.Name.StartsWith("JsonPatchChange`"));
+        allExpectedChangeTypes.Should().NotBeEmpty();
+
+        var testedTypes = GetAllChanges().Select(c => c.Change.GetType()).ToArray();
+        using (new AssertionScope())
+        {
+            foreach (var allChangeType in allExpectedChangeTypes)
+            {
+                testedTypes.Should().Contain(allChangeType);
+            }
+        }
+    }
+
+    private record ChangeWithDependencies(IChange Change, IEnumerable<IChange>? Dependencies = null);
+
+    private static IEnumerable<ChangeWithDependencies> GetAllChanges()
+    {
+        var entry = new Entry { Id = Guid.NewGuid(), LexemeForm = { { "en", "test entry" } } };
+        var createEntryChange = new CreateEntryChange(entry);
+        yield return new ChangeWithDependencies(createEntryChange);
+
+        var partOfSpeech = new PartOfSpeech { Id = Guid.NewGuid(), Name = { { "en", "test pos" } } };
+        var createPartOfSpeechChange = new CreatePartOfSpeechChange(partOfSpeech.Id, partOfSpeech.Name);
+        yield return new ChangeWithDependencies(createPartOfSpeechChange);
+
+        var sense = new Sense { Id = Guid.NewGuid(), Gloss = { { "en", "test sense" } } };
+        var createSenseChange = new CreateSenseChange(sense, entry.Id);
+        yield return new ChangeWithDependencies(createSenseChange, [createEntryChange]);
+
+        var exampleSentence = new ExampleSentence { Id = Guid.NewGuid(), Sentence = new MultiString { { "en", "test sentence" } } };
+        var createExampleSentenceChange = new CreateExampleSentenceChange(exampleSentence, sense.Id);
+        yield return new ChangeWithDependencies(createExampleSentenceChange, [createSenseChange]);
+
+        var semanticDomain = new SemanticDomain { Id = Guid.NewGuid(), Name = { { "en", "test sd" } } };
+        var createSemanticDomainChange = new CreateSemanticDomainChange(semanticDomain.Id, semanticDomain.Name, "1.1.1");
+        yield return new ChangeWithDependencies(createSemanticDomainChange);
+
+        var writingSystem = new WritingSystem { Id = Guid.NewGuid(), WsId = "de", Name = "test ws", Abbreviation = "tws", Font = "Arial", Type = WritingSystemType.Vernacular };
+        var createWritingSystemChange = new CreateWritingSystemChange(writingSystem, writingSystem.Type, writingSystem.Id, 0);
+        yield return new ChangeWithDependencies(createWritingSystemChange);
+
+        var complexFormTypeName = new MultiString { { "en", "test cft" } };
+        var complexFormType = new ComplexFormType { Id = Guid.NewGuid(), Name = complexFormTypeName };
+        var createComplexFormType = new CreateComplexFormType(complexFormType.Id, complexFormTypeName);
+        yield return new ChangeWithDependencies(createComplexFormType);
+
+        var complexFormEntry = new Entry { Id = Guid.NewGuid(), LexemeForm = { { "en", "test complex form" } } };
+        var createComplexFormEntryChange = new CreateEntryChange(complexFormEntry);
+        yield return new ChangeWithDependencies(createComplexFormEntryChange);
+
+        var complexFormComponent = ComplexFormComponent.FromEntries(complexFormEntry, entry, sense.Id);
+        var createComplexFormComponentChange = new AddEntryComponentChange(complexFormComponent);
+        yield return new ChangeWithDependencies(createComplexFormComponentChange, [createComplexFormEntryChange, createEntryChange, createSenseChange]);
+
+        var setPartOfSpeechChange = new SetPartOfSpeechChange(sense.Id, partOfSpeech.Id);
+        yield return new ChangeWithDependencies(setPartOfSpeechChange, [createSenseChange, createPartOfSpeechChange]);
+
+        var addSemanticDomainChange = new AddSemanticDomainChange(semanticDomain, sense.Id);
+        yield return new ChangeWithDependencies(addSemanticDomainChange, [createSenseChange, createSemanticDomainChange]);
+
+        var semanticDomain2 = new SemanticDomain { Id = Guid.NewGuid(), Name = { { "en", "sd 2" } } };
+        var addSemanticDomain2Change = new CreateSemanticDomainChange(semanticDomain2.Id, semanticDomain2.Name, "1.1.2");
+        yield return new ChangeWithDependencies(addSemanticDomain2Change);
+
+        var replaceSemanticDomainChange = new ReplaceSemanticDomainChange(semanticDomain.Id, semanticDomain2, sense.Id);
+        yield return new ChangeWithDependencies(replaceSemanticDomainChange, [addSemanticDomain2Change, addSemanticDomainChange]);
+
+        var removeSemanticDomainChange = new RemoveSemanticDomainChange(semanticDomain2.Id, sense.Id);
+        yield return new ChangeWithDependencies(removeSemanticDomainChange, [replaceSemanticDomainChange]);
+
+        var addComplexFormTypeChange = new AddComplexFormTypeChange(entry.Id, complexFormType);
+        yield return new ChangeWithDependencies(addComplexFormTypeChange, [createComplexFormType, createEntryChange]);
+
+        var removeComplexFormTypeChange = new RemoveComplexFormTypeChange(entry.Id, complexFormType.Id);
+        yield return new ChangeWithDependencies(removeComplexFormTypeChange, [addComplexFormTypeChange]);
+
+        var componentEntry = new Entry { Id = Guid.NewGuid(), LexemeForm = { { "en", "test component" } } };
+        var createcomponentEntryChange = new CreateEntryChange(componentEntry);
+        yield return new ChangeWithDependencies(createcomponentEntryChange);
+
+        var setComplexFormTypeChange = SetComplexFormComponentChange.NewComponent(complexFormComponent.Id, componentEntry.Id);
+        yield return new ChangeWithDependencies(setComplexFormTypeChange, [createcomponentEntryChange, createComplexFormComponentChange]);
+
+        var setSenseOrderChange = new LcmCrdt.Changes.SetOrderChange<Sense>(sense.Id, 10);
+        yield return new ChangeWithDependencies(setSenseOrderChange, [createSenseChange]);
+
+        var setExampleSentenceOrderChange = new LcmCrdt.Changes.SetOrderChange<ExampleSentence>(exampleSentence.Id, 10);
+        yield return new ChangeWithDependencies(setExampleSentenceOrderChange, [createExampleSentenceChange]);
+    }
+}

--- a/backend/FwLite/LcmCrdt/CrdtMiniLcmApi.cs
+++ b/backend/FwLite/LcmCrdt/CrdtMiniLcmApi.cs
@@ -127,6 +127,7 @@ public class CrdtMiniLcmApi(DataModel dataModel, CurrentProjectService projectSe
 
     public async Task<PartOfSpeech> CreatePartOfSpeech(PartOfSpeech partOfSpeech)
     {
+        if (partOfSpeech.Id == Guid.Empty) partOfSpeech.Id = Guid.NewGuid();
         await validators.ValidateAndThrow(partOfSpeech);
         await AddChange(new CreatePartOfSpeechChange(partOfSpeech.Id, partOfSpeech.Name, partOfSpeech.Predefined));
         return await GetPartOfSpeech(partOfSpeech.Id) ?? throw new NullReferenceException();

--- a/backend/FwLite/LcmCrdt/LcmCrdtKernel.cs
+++ b/backend/FwLite/LcmCrdt/LcmCrdtKernel.cs
@@ -204,15 +204,11 @@ public static class LcmCrdtKernel
             ;
     }
 
-    public static Type[] AllChangeTypes()
+    public static IEnumerable<Type> AllChangeTypes()
     {
         var crdtConfig = new CrdtConfig();
         ConfigureCrdt(crdtConfig);
-
-
-        var list = typeof(ChangeTypeListBuilder).GetProperty("Types", BindingFlags.Instance | BindingFlags.NonPublic)
-            ?.GetValue(crdtConfig.ChangeTypeListBuilder) as List<JsonDerivedType>;
-        return list?.Select(t => t.DerivedType).ToArray() ?? [];
+        return crdtConfig.ChangeTypes;
     }
 
 


### PR DESCRIPTION
Adds a test that reproduces the bug that was patched in 36208e794e3782e36b0ef4d397c1234de7c6d216

The problem is:
- If we use ef-core to Create a new sense and
- That new sense has a PartOfSpeech object on it (which currently could only happen via a `SetPartOfSpeechChange`)
- ef-core will also try to create a new part of speech

This test does not produce exactly the same exception, but it fails for the same reason.
It can be easily adjusted to produce the same exception by clearing the DbContext ChangeTracker after creating the PoS used in the test.

This test results in the exception:
`The instance of entity type 'PartOfSpeech' cannot be tracked because another instance with the key value '{Id: bc52e673-a778-461e-9e97-69a1f13e770b}' is already being tracked.`
Previously we were seeing:
`UNIQUE constraint failed: PartOfSpeech.Id`

This error started showing up in part, because of our recent changes to how we're projecting snapshots.
Previously we were projecting them more incrementally. So, we would have projected the sense without the PoS and then projected it again **with** the PoS, which would have resulted in an UPDATE rather than INSERT, because the sense then already existed.

I believe this is something you always need to be careful of when using an ORM. We could just as easily have had the problem with a single create change type that tries to create an entity with a child.

I don't think there was a good reason that the CreateSenseChange only set the PoS.Id while the SetPartOfSpeechChange set the PoS.Id **and** the PoS object on the sense.

If we run into other scenarios where we need to assign a child entity to a potentially new object, then we can think about projecting more incrementally again. I assume that would be harmless now that we're doing all the projection in a single `SaveChanges()` batch, it's just a bit redundant and currently unnecessary.

Here's a DB that reproduces it in case we want to try other fixes:

[fruit.zip](https://github.com/user-attachments/files/18641237/fruit.zip)

EDIT:
Actually projecting more incrementally would only fix the problem if the create-sense and set-pos changes were in different commits. If they were in the same commit, well, we currently only create a single snapshot anyway.

EDIT: Added another much more generic test that randomly picks up this sort of failure. @hahn-kev I'm curious what you think.
It'd be a bit of maintenance, because it forces you to xplicitly add a legitimate change object for every change type except deletes and JSON patches.

Here's the failure message it (sometimes) produces as a result of the current PoS bug:
```
System.Exception : Failed to add changes: The instance of entity type 'PartOfSpeech' cannot be tracked because another instance with the key value '{Id: 880694bd-df6a-46d3-b01d-7e6528926fdc}' is already being tracked. When attaching existing entities, ensure that only one entity instance with a given key value is attached.. JSON:

[{"$type":"CreatePartOfSpeechChange","Name":{"en":"test pos"},"Predefined":false,"EntityId":"880694bd-df6a-46d3-b01d-7e6528926fdc"},{"$type":"CreateEntryChange","LexemeForm":{"en":"test entry"},"CitationForm":{},"LiteralMeaning":{},"Note":{},"EntityId":"d65508a7-e500-4e2e-9f07-a0ee8dd26e20"},{"$type":"CreateSenseChange","EntryId":"d65508a7-e500-4e2e-9f07-a0ee8dd26e20","Order":0,"Definition":{},"Gloss":{"en":"test sense"},"PartOfSpeechId":null,"SemanticDomains":[],"EntityId":"d32e982e-f1db-4ba4-a3f8-6d626a991028"},{"$type":"SetPartOfSpeechChange","PartOfSpeechId":"880694bd-df6a-46d3-b01d-7e6528926fdc","EntityId":"d32e982e-f1db-4ba4-a3f8-6d626a991028"},{"$type":"CreateEntryChange","LexemeForm":{"en":"test complex form"},"CitationForm":{},"LiteralMeaning":{},"Note":{},"EntityId":"336ac283-447a-45dc-91e6-117c70c18f16"},{"$type":"CreateExampleSentenceChange","SenseId":"d32e982e-f1db-4ba4-a3f8-6d626a991028","Order":0,"Sentence":{"en":"test sentence"},"Translation":{},"Reference":null,"EntityId":"5c586a38-7995-4ea6-8c76-e6bcad8f2d9c"},{"$type":"CreateSemanticDomainChange","Name":{"en":"test sd"},"Predefined":false,"Code":"1.1.1","EntityId":"1aed90a1-1bcd-416d-b3d7-70f790451ca6"},{"$type":"AddSemanticDomainChange","SemanticDomain":{"Id":"1aed90a1-1bcd-416d-b3d7-70f790451ca6","Name":{"en":"test sd"},"Code":"","DeletedAt":null,"Predefined":false},"EntityId":"d32e982e-f1db-4ba4-a3f8-6d626a991028"},{"$type":"CreateComplexFormType","Name":{"en":"test cft"},"EntityId":"cf61bd6d-2a9b-48ff-9486-7543b489a9b7"},{"$type":"CreateWritingSystemChange","WsId":"de","Name":"test ws","Abbreviation":"tws","Font":"Arial","Exemplars":[],"Type":0,"Order":0,"EntityId":"1654804f-c3e9-4197-9b57-ba156e78c49a"},{"$type":"CreateSemanticDomainChange","Name":{"en":"sd 2"},"Predefined":false,"Code":"1.1.2","EntityId":"d6a04758-3a9f-48bc-b878-6ff00a396b18"},{"$type":"ReplaceSemanticDomainChange","OldSemanticDomainId":"1aed90a1-1bcd-416d-b3d7-70f790451ca6","SemanticDomain":{"Id":"d6a04758-3a9f-48bc-b878-6ff00a396b18","Name":{"en":"sd 2"},"Code":"","DeletedAt":null,"Predefined":false},"EntityId":"d32e982e-f1db-4ba4-a3f8-6d626a991028"},{"$type":"RemoveSemanticDomainChange","SemanticDomainId":"d6a04758-3a9f-48bc-b878-6ff00a396b18","EntityId":"d32e982e-f1db-4ba4-a3f8-6d626a991028"},{"$type":"AddEntryComponentChange","ComplexFormEntryId":"336ac283-447a-45dc-91e6-117c70c18f16","ComponentEntryId":"d65508a7-e500-4e2e-9f07-a0ee8dd26e20","ComponentSenseId":"d32e982e-f1db-4ba4-a3f8-6d626a991028","EntityId":"91c275af-a508-4a09-aed7-8fca8616b19c"},{"$type":"AddComplexFormTypeChange","ComplexFormType":{"Id":"cf61bd6d-2a9b-48ff-9486-7543b489a9b7","Name":{"en":"test cft"},"DeletedAt":null},"EntityId":"d65508a7-e500-4e2e-9f07-a0ee8dd26e20"},{"$type":"CreateEntryChange","LexemeForm":{"en":"test component"},"CitationForm":{},"LiteralMeaning":{},"Note":{},"EntityId":"bf738b2f-a29d-41bd-b9ae-1fde8042ff93"},{"$type":"RemoveComplexFormTypeChange","ComplexFormTypeId":"cf61bd6d-2a9b-48ff-9486-7543b489a9b7","EntityId":"d65508a7-e500-4e2e-9f07-a0ee8dd26e20"},{"$type":"SetOrderChange:ExampleSentence","Order":10,"EntityId":"5c586a38-7995-4ea6-8c76-e6bcad8f2d9c"},{"$type":"SetOrderChange:Sense","Order":10,"EntityId":"d32e982e-f1db-4ba4-a3f8-6d626a991028"},{"$type":"SetComplexFormComponentChange","ComplexFormEntryId":null,"ComponentEntryId":"bf738b2f-a29d-41bd-b9ae-1fde8042ff93","ComponentSenseId":null,"EntityId":"91c275af-a508-4a09-aed7-8fca8616b19c"}]
---- System.InvalidOperationException : The instance of entity type 'PartOfSpeech' cannot be tracked because another instance with the key value '{Id: 880694bd-df6a-46d3-b01d-7e6528926fdc}' is already being tracked. When attaching existing entities, ensure that only one entity instance with a given key value is attached.using System.Diagnostics.CodeAnalysis;
```