### PR TITLE
Bump PNPM to 9.15.5

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -2,6 +2,8 @@
 # TODO: can't use vanilla alpine version since python is needed for gql-codegen stuff.
 FROM node:20 AS builder-base
 WORKDIR /app
+# Version of corepack distributed with node currently (2025-02-04) has a bug that prevents PNPM installation; latest version has the bugfix
+RUN npm install -g corepack@latest
 RUN corepack enable && corepack prepare pnpm@9.11.0 --activate
 
 FROM builder-base AS builder-viewer

--- a/frontend/dev.Dockerfile
+++ b/frontend/dev.Dockerfile
@@ -2,6 +2,8 @@
 # TODO: can't use vanilla alpine version since python is needed for gql-codegen stuff.
 FROM node:20 AS builder
 
+# Version of corepack distributed with node currently (2025-02-04) has a bug that prevents PNPM installation; latest version has the bugfix
+RUN npm install -g corepack@latest
 RUN corepack enable && corepack prepare pnpm@9.11.0 --activate
 WORKDIR /app
 

--- a/frontend/https-proxy/package.json
+++ b/frontend/https-proxy/package.json
@@ -2,7 +2,7 @@
   "name": "https-proxy",
   "version": "0.0.1",
   "private": true,
-  "packageManager": "pnpm@9.11.0",
+  "packageManager": "pnpm@9.15.5",
   "engines": {
     "node": ">=20",
     "pnpm": ">=9"

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -2,7 +2,7 @@
 	"name": "frontend",
 	"version": "0.0.1",
 	"private": true,
-	"packageManager": "pnpm@9.11.0",
+	"packageManager": "pnpm@9.15.5",
 	"engines": {
 		"node": ">=20",
 		"pnpm": ">=9"

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -10,6 +10,7 @@
 	"scripts": {
 		"dev": "vite dev",
 		"lexbox-dev": "vite dev --port 3000 --host 0.0.0.0",
+		"prepare": "svelte-kit sync",
 		"build": "vite build",
 		"preview": "vite preview",
 		"pretest": "playwright install",

--- a/frontend/viewer/package.json
+++ b/frontend/viewer/package.json
@@ -1,7 +1,7 @@
 {
   "name": "viewer",
   "private": true,
-  "packageManager": "pnpm@9.11.0",
+  "packageManager": "pnpm@9.15.5",
   "engines": {
     "node": ">=20",
     "pnpm": ">=9"


### PR DESCRIPTION
PNPM v9.15.5 brings in several bugfixes, at least one of which (running preprepare scripts from packages on pnpm install, and "preprepare" is not a typo) we'll probably want to have when we upgrade our SvelteKit dependency.

Fixes #1430.
Also fixes #1429.
Also fixes #1446.