### PR TITLE
set the sync date on commits to show in the activity view

### DIFF
--- a/backend/FwLite/FwLiteShared/Services/ProjectServicesProvider.cs
+++ b/backend/FwLite/FwLiteShared/Services/ProjectServicesProvider.cs
@@ -48,7 +48,7 @@ public class ProjectServicesProvider(
                       throw new InvalidOperationException($"Crdt Project {projectName} not found");
         var currentProjectService = scopedServices.GetRequiredService<CurrentProjectService>();
         var projectData = await currentProjectService.SetupProjectContext(project);
-        await scopedServices.GetRequiredService<SyncService>().ExecuteSync(true);
+        await scopedServices.GetRequiredService<SyncService>().SafeExecuteSync(true);
         await lexboxProjectService.ListenForProjectChanges(projectData, CancellationToken.None);
         var entryUpdatedSubscription = changeEventBus.OnProjectEntryUpdated(project).Subscribe(entry =>
         {

--- a/backend/FwLite/FwLiteWeb/Hubs/CrdtMiniLcmApiHub.cs
+++ b/backend/FwLite/FwLiteWeb/Hubs/CrdtMiniLcmApiHub.cs
@@ -34,7 +34,7 @@ public class CrdtMiniLcmApiHub(
     public override async Task OnConnectedAsync()
     {
         await Groups.AddToGroupAsync(Context.ConnectionId, ProjectGroup(projectContext.Project.Name));
-        await syncService.ExecuteSync(true);
+        await syncService.SafeExecuteSync(true);
         Cleanup =
         [
             changeEventBus.OnProjectEntryUpdated(projectContext.Project).Subscribe(e => OnEntryChangedExternal(e, hubContext, memoryCache, Context.ConnectionId))

--- a/backend/FwLite/LcmCrdt/RemoteSync/CrdtHttpSyncService.cs
+++ b/backend/FwLite/LcmCrdt/RemoteSync/CrdtHttpSyncService.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.Extensions.Logging;
+﻿using LcmCrdt.Utils;
+using Microsoft.Extensions.Logging;
 using Refit;
 using SIL.Harmony;
 using SIL.Harmony.Core;
@@ -79,6 +80,11 @@ internal class CrdtProjectSync(ISyncHttp restSyncClient, Guid projectId, Guid cl
     {
         var changes = await restSyncClient.GetChanges(projectId, otherHeads);
         ArgumentNullException.ThrowIfNull(changes);
+        foreach (var commit in changes.MissingFromClient)
+        {
+            //ignore the sync date from the server, we only care about our sync date. Setting this to the correct value is handled in SyncService.UpdateSyncDate
+            commit.SetSyncDate(null);
+        }
         return changes;
     }
 

--- a/backend/FwLite/LcmCrdt/Utils/CommitHelpers.cs
+++ b/backend/FwLite/LcmCrdt/Utils/CommitHelpers.cs
@@ -1,0 +1,24 @@
+﻿using SIL.Harmony.Core;
+
+namespace LcmCrdt.Utils;
+
+public static class CommitHelpers
+{
+    public const string SyncDateProp = "SyncDate";
+    public static DateTimeOffset? SyncDate(this CommitBase commit)
+    {
+        var dateAsString = commit.Metadata[SyncDateProp];
+        if (dateAsString is null) return null;
+        if (DateTimeOffset.TryParse(dateAsString, out var result))
+        {
+            return result;
+        }
+
+        return null;
+    }
+
+    public static void SetSyncDate(this CommitBase commit, DateTimeOffset? syncDate)
+    {
+        commit.Metadata[SyncDateProp] = syncDate?.ToString("u");
+    }
+}

--- a/frontend/viewer/src/lib/activity/ActivityView.svelte
+++ b/frontend/viewer/src/lib/activity/ActivityView.svelte
@@ -120,6 +120,11 @@
           {#if selectedRow.changes.length > 1}
             <span>– ({selectedRow.changes.length} changes)</span>
           {/if}
+          {#if selectedRow.metadata.extraMetadata['SyncDate']}
+            <span class="float-right">
+              Synced <Duration totalUnits={2} minUnits={DurationUnits.Second} start={new Date(selectedRow.metadata.extraMetadata['SyncDate'])}/> ago
+            </span>
+          {/if}
         </div>
         <div class="change-list col-start-2 row-start-2 flex flex-col gap-4 overflow-auto p-1 border rounded h-max max-h-full">
           <InfiniteScroll perPage={100} items={selectedRow.changes} let:visibleItems>


### PR DESCRIPTION
This works by setting the sync date of all commits without one to the date the sync happened. This means any old commits without a date will be changed to show now, but that's fine. Any commits either just sent or received will then be stamped all with the same timestamp.

Shown only in activity view to the right of the author.
![image](https://github.com/user-attachments/assets/f60efa28-fc98-4c3e-88bb-4cbde9e7076b)
