### PR TITLE
configure some chaos testing

### DIFF
--- a/backend/FwLite/FwLiteShared/Auth/OAuthClient.cs
+++ b/backend/FwLite/FwLiteShared/Auth/OAuthClient.cs
@@ -19,7 +19,7 @@ public class OAuthClient
     //all 3 scopes are required to work around this bug https://github.com/AzureAD/microsoft-authentication-library-for-dotnet/issues/5094
     //more can be added in needed but this is the minimum set
     public static IReadOnlyCollection<string> DefaultScopes { get; } = ["profile", "openid", "offline_access" ];
-    public const string AuthHttpClientName = "AuthHttpClient";
+    public const string AuthHttpClientName = "LexboxHttpClient";
     public string? RedirectUrl { get; }
     private readonly IHttpMessageHandlerFactory _httpMessageHandlerFactory;
     private readonly AuthConfig _options;

--- a/backend/FwLite/FwLiteShared/FwLiteShared.csproj
+++ b/backend/FwLite/FwLiteShared/FwLiteShared.csproj
@@ -13,6 +13,7 @@
         <PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="9.0.0"/>
         <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="9.0.0"/>
         <PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.0"/>
+        <PackageReference Include="Microsoft.Extensions.Http.Resilience" Version="9.1.0" />
         <PackageReference Include="Microsoft.Extensions.Options.DataAnnotations" Version="9.0.0"/>
         <PackageReference Include="Microsoft.Identity.Client.Extensions.Msal" Version="4.67.2" />
         <PackageReference Include="Reinforced.Typings" Version="1.6.5" />

--- a/backend/FwLite/FwLiteShared/FwLiteSharedKernel.cs
+++ b/backend/FwLite/FwLiteShared/FwLiteSharedKernel.cs
@@ -55,7 +55,10 @@ public static class FwLiteSharedKernel
         var httpClientBuilder = services.AddHttpClient(OAuthClient.AuthHttpClientName);
         if (environment.IsDevelopment())
         {
-            ConfigureHttpClientChaos(httpClientBuilder);
+            if (!string.IsNullOrEmpty(Environment.GetEnvironmentVariable("FW_LITE_CHAOS")))
+            {
+                ConfigureHttpClientChaos(httpClientBuilder);
+            }
             // Allow self-signed certificates in development
             httpClientBuilder.ConfigurePrimaryHttpMessageHandler(() =>
             {

--- a/backend/FwLite/FwLiteShared/FwLiteSharedKernel.cs
+++ b/backend/FwLite/FwLiteShared/FwLiteSharedKernel.cs
@@ -52,6 +52,7 @@ public static class FwLiteSharedKernel
         var httpClientBuilder = services.AddHttpClient(OAuthClient.AuthHttpClientName);
         if (environment.IsDevelopment())
         {
+            ConfigureHttpClientChaos(httpClientBuilder);
             // Allow self-signed certificates in development
             httpClientBuilder.ConfigurePrimaryHttpMessageHandler(() =>
             {
@@ -62,6 +63,15 @@ public static class FwLiteSharedKernel
                 };
             });
         }
+    }
+
+    private static void ConfigureHttpClientChaos(IHttpClientBuilder builder)
+    {
+        builder.AddResilienceHandler("chaos",
+            pipelineBuilder =>
+            {
+// pipelineBuilder
+            });
     }
 
     private static void DecorateConstructor<TService>(this IServiceCollection services,

--- a/backend/FwLite/FwLiteShared/Projects/LexboxProjectService.cs
+++ b/backend/FwLite/FwLiteShared/Projects/LexboxProjectService.cs
@@ -43,7 +43,7 @@ public class LexboxProjectService(
                 {
                     return await httpClient.GetFromJsonAsync<LexboxProject[]>("api/crdt/listProjects") ?? [];
                 }
-                catch (HttpRequestException e)
+                catch (Exception e)
                 {
                     logger.LogError(e, "Error getting lexbox projects");
                     return [];
@@ -64,7 +64,7 @@ public class LexboxProjectService(
         {
             return (await httpClient.GetFromJsonAsync<Guid?>($"api/crdt/lookupProjectId?code={code}"));
         }
-        catch (HttpRequestException e)
+        catch (Exception e)
         {
             logger.LogError(e, "Error getting lexbox project id");
             return null;

--- a/backend/FwLite/Taskfile.yml
+++ b/backend/FwLite/Taskfile.yml
@@ -13,6 +13,12 @@ tasks:
     label: Run FwLiteWeb with Local LexBox, requires vite dev server to be running, use task fw-lite-web in root
     dir: ./FwLiteWeb
     cmd: dotnet watch --no-hot-reload
+  web-chaos:
+    lable: Run FwLiteWeb with some Chaos injected to http requests to lexbox, requests will have chaos 30% of the time, this includes some latency of 5 seconds
+    dir: ./FwLiteWeb
+    env:
+      FW_LITE_CHAOS: true
+    cmd: dotnet run
 
   tool-restore:
     cmd: dotnet tool restore


### PR DESCRIPTION
only runs on demand when using task web-chaos
there's a 30% chaos rate, which includes some thrown exceptions, 500 responses and 5 second latency. I did find a potential issue but otherwise everything worked fine when I tested it