### PR TITLE
Bump pgAdmin version to 8.14

### DIFF
--- a/deployment/local-dev/pgadmin-deployment.yaml
+++ b/deployment/local-dev/pgadmin-deployment.yaml
@@ -61,7 +61,7 @@ spec:
           name: pgadmin-config
       containers:
       - name: pgadmin
-        image: dpage/pgadmin4:8.10
+        image: dpage/pgadmin4:8.14
         # pgadmin needs a specific format for its pgpass files
         # Can't just mount k8s secret, so have to run some pre-entrypoint code instead
         command: ["/bin/sh"]


### PR DESCRIPTION
Fixes #1451.

pgAdmin 8.14 came out in November and has several bugfixes over 8.10. None are crucial, but there's no reason not to pull them in since it's a trivial change.