### PR TITLE
Ensure guest users cannot be org admins

### DIFF
--- a/backend/LexBoxApi/GraphQL/OrgMutations.cs
+++ b/backend/LexBoxApi/GraphQL/OrgMutations.cs
@@ -180,6 +180,8 @@ public class OrgMutations
     [Error<DbError>]
     [Error<NotFoundException>]
     [Error<OrgMemberInvitedByEmail>]
+    [Error<OrgMembersMustBeVerified>]
+    [Error<OrgMembersMustBeVerifiedForRole>]
     [UseMutationConvention]
     [UseFirstOrDefault]
     [UseProjection]
@@ -236,6 +238,8 @@ public class OrgMutations
     /// <param name="role">set to null to remove the member</param>
     [Error<DbError>]
     [Error<NotFoundException>]
+    [Error<OrgMembersMustBeVerified>]
+    [Error<OrgMembersMustBeVerifiedForRole>]
     [UseMutationConvention]
     [UseFirstOrDefault]
     [UseProjection]
@@ -252,6 +256,7 @@ public class OrgMutations
         permissionService.AssertCanEditOrg(org);
         var user = await dbContext.Users.FindAsync(userId);
         NotFoundException.ThrowIfNull(user);
+        if (role is not null) user.AssertHasVerifiedEmailForOrgRole(role.Value);
         await UpdateOrgMemberRole(dbContext, org, role, userId);
         return dbContext.Orgs.Where(o => o.Id == orgId);
     }

--- a/backend/LexCore/Exceptions/OrgMembersMustBeVerified.cs
+++ b/backend/LexCore/Exceptions/OrgMembersMustBeVerified.cs
@@ -1,0 +1,8 @@
+﻿namespace LexCore.Exceptions;
+
+public class OrgMembersMustBeVerified : Exception
+{
+    public OrgMembersMustBeVerified(string message) : base(message)
+    {
+    }
+}

--- a/backend/LexCore/Exceptions/OrgMembersMustBeVerifiedForRole.cs
+++ b/backend/LexCore/Exceptions/OrgMembersMustBeVerifiedForRole.cs
@@ -1,0 +1,11 @@
+﻿using LexCore.Entities;
+
+namespace LexCore.Exceptions;
+
+public class OrgMembersMustBeVerifiedForRole : Exception
+{
+    public OrgMembersMustBeVerifiedForRole(string message, OrgRole role) : base(message)
+    {
+        Data["role"] = role;
+    }
+}

--- a/backend/LexData/Entities/UserEntityConfiguration.cs
+++ b/backend/LexData/Entities/UserEntityConfiguration.cs
@@ -61,4 +61,15 @@ public static class UserEntityExtensions
         // Only project editors (basic role) are allowed not to have verified email addresses
         if (forRole != ProjectRole.Editor) throw new ProjectMembersMustBeVerifiedForRole("Member must verify email before taking on this role", forRole);
     }
+
+    public static void AssertHasVerifiedEmailForOrgRole(this User user, OrgRole forRole = OrgRole.Unknown)
+    {
+        // Users with verified emails are the most common case, so check that first
+        if (user.Email is not null && user.EmailVerified) return;
+        // Users bulk-created by admins might not have email addresses
+        // Users who self-registered must verify email in all cases
+        if (user.CreatedById is null) throw new OrgMembersMustBeVerified("Member must verify email first");
+        // Only basic Org members are allowed not to have verified email addresses
+        if (forRole != OrgRole.User) throw new OrgMembersMustBeVerifiedForRole("Member must verify email before taking on this role", forRole);
+    }
 }

--- a/frontend/schema.graphql
+++ b/frontend/schema.graphql
@@ -353,6 +353,14 @@ type OrgMemberRole {
   role: OrgRole!
 }
 
+type OrgMembersMustBeVerified implements Error {
+  message: String!
+}
+
+type OrgMembersMustBeVerifiedForRole implements Error {
+  message: String!
+}
+
 type OrgProjects {
   org: Organization!
   project: Project!
@@ -589,7 +597,7 @@ union BulkAddOrgMembersError = NotFoundError | DbError | UnauthorizedAccessError
 
 union BulkAddProjectMembersError = NotFoundError | InvalidEmailError | DbError
 
-union ChangeOrgMemberRoleError = DbError | NotFoundError
+union ChangeOrgMemberRoleError = DbError | NotFoundError | OrgMembersMustBeVerified | OrgMembersMustBeVerifiedForRole
 
 union ChangeOrgNameError = NotFoundError | DbError | RequiredError
 
@@ -623,7 +631,7 @@ union RemoveProjectFromOrgError = DbError | NotFoundError
 
 union SendNewVerificationEmailByAdminError = NotFoundError | DbError | InvalidOperationError
 
-union SetOrgMemberRoleError = DbError | NotFoundError | OrgMemberInvitedByEmail
+union SetOrgMemberRoleError = DbError | NotFoundError | OrgMemberInvitedByEmail | OrgMembersMustBeVerified | OrgMembersMustBeVerifiedForRole
 
 union SetProjectConfidentialityError = NotFoundError | DbError
 

--- a/frontend/src/routes/(authenticated)/org/[org_id]/AddOrgMemberModal.svelte
+++ b/frontend/src/routes/(authenticated)/org/[org_id]/AddOrgMemberModal.svelte
@@ -74,6 +74,12 @@
         userInvited = true;
         return undefined; // Close modal as if success
       }
+      if (error?.byType('OrgMembersMustBeVerified')) {
+        return { usernameOrEmail: [$t('org_page.add_user.user_must_be_verified')] };
+      }
+      if (error?.byType('OrgMembersMustBeVerifiedForRole')) {
+        return { role: [$t('org_page.add_user.admin_must_be_verified')] };
+      }
 
       return error?.message;
     });

--- a/frontend/src/routes/(authenticated)/org/[org_id]/ChangeOrgMemberRoleModal.svelte
+++ b/frontend/src/routes/(authenticated)/org/[org_id]/ChangeOrgMemberRoleModal.svelte
@@ -25,6 +25,12 @@
         member.userId,
         $form.role,
       );
+      if (result.error?.byType('OrgMembersMustBeVerified')) {
+        return { role: [$t('org_page.add_user.user_must_be_verified')] };
+      }
+      if (result.error?.byType('OrgMembersMustBeVerifiedForRole')) {
+        return { role: [$t('org_page.add_user.admin_must_be_verified')] };
+      }
       return result.error?.message;
     });
   }

--- a/frontend/tests/emailWorkflow.test.ts
+++ b/frontend/tests/emailWorkflow.test.ts
@@ -174,10 +174,6 @@ test('ask to join project via new-project page', async ({ page, tempUser, tempUs
     await loginAs(page.request, email, password);
     dashboardPage = await new UserDashboardPage(page).goto();
 
-    // Must verify email before being allowed to request project creation
-    newPage = await verifyTempUserEmail(page, tempUserInTestOrg);
-    dashboardPage = await new UserDashboardPage(newPage).goto();
-
     // Create project with similar name to Elawa
     const newProjectPage = await dashboardPage.clickCreateProject();
     await newProjectPage.fillForm({name: 'Elaw', code: 'xyz', purpose: 'Testing', organization: 'Test Org'});
@@ -222,13 +218,9 @@ test('ask to join project via project page', async ({ page, tempUser, tempUserIn
     const { name, email, password } = tempUserInTestOrg;
 
     await loginAs(page.request, email, password);
-    dashboardPage = await new UserDashboardPage(page).goto();
-
-    // Must verify email before being allowed to request project creation
-    newPage = await verifyTempUserEmail(page, tempUserInTestOrg);
 
     // Get to Elawa project page via org page, then ask to join
-    const testOrgPage = await new OrgPage(newPage, 'Test Org', testOrgId).goto();
+    const testOrgPage = await new OrgPage(page, 'Test Org', testOrgId).goto();
     await testOrgPage.projectsTab.click();
     const projectPage = await testOrgPage.openProject('Elawa', 'elawa-dev-flex');
     await projectPage.askToJoinButton.click();


### PR DESCRIPTION
Fixes #1449.

Now when you try to make a guest user into an org admin, you can't:

![image](https://github.com/user-attachments/assets/cbaf0986-b16c-4241-bdc8-b64446921d39)

I also went ahead and implemented a rule that org admins must have verified email addresses, because we hadn't been doing that check either.