### PR TITLE
Typeahead allows selecting with keyboard

### DIFF
--- a/frontend/src/lib/forms/PlainInput.svelte
+++ b/frontend/src/lib/forms/PlainInput.svelte
@@ -25,7 +25,7 @@
   export let style: string | undefined = undefined;
 
   $: undebouncedValue = value;
-  $: dispatch('input', value);
+  $: if (handlingInputEvent) dispatch('input', value);
 
   export function clear(): void {
     debouncer.clear();
@@ -43,10 +43,15 @@
   $: debouncingStore = debouncer.debouncing;
   $: debouncing = $debouncingStore;
 
+  let handlingInputEvent = false;
+  let handlingInputEventTimeout: ReturnType<typeof setTimeout>;
   function onInput(event: Event): void {
+    clearTimeout(handlingInputEventTimeout);
+    handlingInputEvent = true;
     const currValue = (event.target as HTMLInputElement).value;
     undebouncedValue = currValue;
     debouncer.debounce(currValue);
+    handlingInputEventTimeout = setTimeout(() => handlingInputEvent = false);
   }
 </script>
 

--- a/frontend/src/lib/gql/gql-client.ts
+++ b/frontend/src/lib/gql/gql-client.ts
@@ -62,6 +62,7 @@ function createGqlClient(_gqlEndpoint?: string): Client {
         keys: {
           'Changeset': () => null,
           'UsersCollectionSegment': () => null,
+          'UsersICanSeeCollectionSegment': () => null,
           'FlexProjectMetadata': (metaData) => metaData.projectId as string,
           'ProjectWritingSystems': () => null,
           'FLExWsId': (metaData) => metaData.tag as string,

--- a/frontend/src/routes/(authenticated)/org/[org_id]/AddOrgMemberModal.svelte
+++ b/frontend/src/routes/(authenticated)/org/[org_id]/AddOrgMemberModal.svelte
@@ -106,7 +106,7 @@
       isAdmin={$page.data.user?.isAdmin}
       bind:value={$form.usernameOrEmail}
       error={errors.usernameOrEmail}
-      on:selectedUser={(event) => populateUserProjects(event.detail)}
+      on:selectedUserChange={(event) => populateUserProjects(event.detail)}
       autofocus
       exclude={org.members.map(m => m.user.id)}
       />

--- a/frontend/src/routes/(authenticated)/project/[project_code]/AddProjectMember.svelte
+++ b/frontend/src/routes/(authenticated)/project/[project_code]/AddProjectMember.svelte
@@ -21,7 +21,7 @@
   });
   let formModal: FormModal<typeof schema>;
   $: form = formModal?.form();
-  let selectedUserId: string | null = null;
+  let selectedUserId: string | undefined = undefined;
 
   const { notifySuccess } = useNotifications();
 
@@ -83,8 +83,8 @@
     bind:value={$form.usernameOrEmail}
     error={errors.usernameOrEmail}
     autofocus
-    on:selectedUserId={({ detail }) => {
-        selectedUserId = detail;
+    on:selectedUserChange={({ detail }) => {
+        selectedUserId = detail?.id;
     }}
     exclude={project.users.map(m => m.user.id)}
   />


### PR DESCRIPTION
Fixes #1130.

![image](https://github.com/user-attachments/assets/df86c091-22cf-4106-94d8-a202032aa2ff)

Highlight can be moved with up/down arrow keys, and Enter will select the currently-highlighted entry the same way that clicking on it does.

The one issue is that pressing Enter doesn't close the overlay the way clicking does. Our `use:overlay` action in src/lib/overlay.ts exposes a `closeClickSelector` option, but I couldn't easily find a way to tell the overlay to close programmatically. I believe you wrote the overlay code, @myieye, so if you could let me know how to have the keyboard event handler close the overlay on Enter, that would be helpful.

Other than that, this is working and ready to merge. Certainly it's ready for review.