### PR TITLE
never let User.FeatureFlags contain null

### DIFF
--- a/backend/LexCore/Entities/User.cs
+++ b/backend/LexCore/Entities/User.cs
@@ -42,7 +42,13 @@ public class User : EntityBase
 
     public List<ProjectUsers> Projects { get; set; } = new();
     public List<OrgMember> Organizations { get; set; } = [];
-    public List<FeatureFlag> FeatureFlags { get; set; } = [];
+    public List<FeatureFlag> FeatureFlags
+    {
+        get;
+        //even though this may not be null EF still sets it to null based on what's in the db.
+        set => field = value ?? [];
+    } = [];
+
 
     public bool CanLogin()
     {

--- a/backend/LexCore/LexCore.csproj
+++ b/backend/LexCore/LexCore.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
+      <LangVersion>preview</LangVersion>
     </PropertyGroup>
 
     <ItemGroup>


### PR DESCRIPTION
fixes a current bug in develop because the feature flag column is null