### PR TITLE
Disable hg bundle2 compression

### DIFF
--- a/hgweb/hgweb.hgrc
+++ b/hgweb/hgweb.hgrc
@@ -13,6 +13,8 @@ refreshinterval=5
 bundle1=True
 bundle1.push=True
 bundle1.pull=True
+[experimental]
+bundle2-advertise=false
 
 [paths]
 /a/ = /var/hg/repos/a/*


### PR DESCRIPTION
This forces hg clients to use bundle1 as was the case in hg v3.
It appears that bundle2 results in no compression.