### PR TITLE
Copy .svelte-kit/tsconfig.json into container

### DIFF
--- a/frontend/.dockerignore
+++ b/frontend/.dockerignore
@@ -3,6 +3,10 @@
 Dockerfile
 playwright.config.js
 .svelte-kit
+!.svelte-kit/tsconfig.json
+!.svelte-kit/ambient.d.ts
+!.svelte-kit/non-ambient.d.ts
+!.svelte-kit/types/**/*
 .vscode
 build
 node_modules


### PR DESCRIPTION
Fixes #1466.

Besides tsconfig.json, we also copy the files that tsconfig.json directly references.