### PR TITLE
Fix error creating example project

### DIFF
--- a/backend/FwLite/LcmCrdt.Tests/LcmCrdtTestsKernel.cs
+++ b/backend/FwLite/LcmCrdt.Tests/LcmCrdtTestsKernel.cs
@@ -1,6 +1,7 @@
 ﻿using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Logging;
 
 namespace LcmCrdt.Tests;
 
@@ -9,6 +10,7 @@ public static class LcmCrdtTestsKernel
     public static IServiceCollection AddTestLcmCrdtClient(this IServiceCollection services, CrdtProject? project = null)
     {
         services.TryAddSingleton<IConfiguration>(new ConfigurationRoot([]));
+        services.AddLogging(builder => builder.AddDebug());
         services.AddLcmCrdtClient();
         if (project is not null)
         {

--- a/backend/FwLite/LcmCrdt.Tests/OpenProjectTests.cs
+++ b/backend/FwLite/LcmCrdt.Tests/OpenProjectTests.cs
@@ -7,6 +7,19 @@ namespace LcmCrdt.Tests;
 public class OpenProjectTests
 {
     [Fact]
+    public async Task CanCreateExampleProject()
+    {
+        var sqliteConnectionString = "ExampleProject.sqlite";
+        if (File.Exists(sqliteConnectionString)) File.Delete(sqliteConnectionString);
+        var builder = Host.CreateEmptyApplicationBuilder(null);
+        builder.Services.AddTestLcmCrdtClient();
+        using var host = builder.Build();
+        var services = host.Services;
+        var asyncScope = services.CreateAsyncScope();
+        var crdtProjectsService = asyncScope.ServiceProvider.GetRequiredService<CrdtProjectsService>();
+        await crdtProjectsService.CreateExampleProject("ExampleProject");
+    }
+    [Fact]
     public async Task OpeningAProjectWorks()
     {
         var sqliteConnectionString = "OpeningAProjectWorks.sqlite";

--- a/backend/FwLite/LcmCrdt/CrdtProjectsService.cs
+++ b/backend/FwLite/LcmCrdt/CrdtProjectsService.cs
@@ -179,33 +179,6 @@ public partial class CrdtProjectsService(IServiceProvider provider, ILogger<Crdt
     public static async Task SampleProjectData(IServiceProvider provider, CrdtProject project)
     {
         var lexboxApi = provider.GetRequiredService<IMiniLcmApi>();
-        await lexboxApi.CreateEntry(new()
-        {
-            Id = Guid.NewGuid(),
-            LexemeForm = { Values = { { "en", "Apple" } } },
-            CitationForm = { Values = { { "en", "Apple" } } },
-            LiteralMeaning = { Values = { { "en", "Fruit" } } },
-            Senses =
-            [
-                new()
-                {
-                    Gloss = { Values = { { "en", "Fruit" } } },
-                    Definition =
-                    {
-                        Values =
-                        {
-                            {
-                                "en",
-                                "fruit with red, yellow, or green skin with a sweet or tart crispy white flesh"
-                            }
-                        }
-                    },
-                    SemanticDomains = [],
-                    ExampleSentences = [new() { Sentence = { Values = { { "en", "We ate an apple" } } } }]
-                }
-            ]
-        });
-
         await lexboxApi.CreateWritingSystem(WritingSystemType.Vernacular,
             new()
             {
@@ -252,5 +225,32 @@ public partial class CrdtProjectsService(IServiceProvider provider, ILogger<Crdt
                 Font = "Arial",
                 Exemplars = WritingSystem.LatinExemplars
             });
+
+        await lexboxApi.CreateEntry(new()
+        {
+            Id = Guid.NewGuid(),
+            LexemeForm = { Values = { { "en", "Apple" } } },
+            CitationForm = { Values = { { "en", "Apple" } } },
+            LiteralMeaning = { Values = { { "en", "Fruit" } } },
+            Senses =
+            [
+                new()
+                {
+                    Gloss = { Values = { { "en", "Fruit" } } },
+                    Definition =
+                    {
+                        Values =
+                        {
+                            {
+                                "en",
+                                "fruit with red, yellow, or green skin with a sweet or tart crispy white flesh"
+                            }
+                        }
+                    },
+                    SemanticDomains = [],
+                    ExampleSentences = [new() { Sentence = { Values = { { "en", "We ate an apple" } } } }]
+                }
+            ]
+        });
     }
 }


### PR DESCRIPTION
an error was getting thrown when trying to create an example project. The error was `The process cannot access the file 'C:\dev\LexBox\backend\FwLite\LcmCrdt.Tests\bin\Debug\net9.0\ExampleProject.sqlite' because it is being used by another process.` the stack trace indicated that it was trying to delete the project.

It was trying to delete the project because of this error 
```
System.NullReferenceException
Unable to find a default writing system of type Vernacular
   at LcmCrdt.CrdtMiniLcmApi.GetWritingSystem(WritingSystemId id, WritingSystemType type) in C:\dev\LexBox\backend\FwLite\LcmCrdt\CrdtMiniLcmApi.cs:line 108
   at LcmCrdt.CrdtMiniLcmApi.GetEntry(Guid id) in C:\dev\LexBox\backend\FwLite\LcmCrdt\CrdtMiniLcmApi.cs:line 358
   at LcmCrdt.CrdtMiniLcmApi.CreateEntry(Entry entry) in C:\dev\LexBox\backend\FwLite\LcmCrdt\CrdtMiniLcmApi.cs:line 426
   at LcmCrdt.CrdtProjectsService.SampleProjectData(IServiceProvider provider, CrdtProject project) in 
```
which we were previously ignoring and not logging at all.

In this PR, we're now logging those errors, I've made a more robust project deletion code which will try 10 times with a delay before giving up. Fixed the actual bug which just required creating writing systems first. There's also a test which creates example projects to ensure that doesn't break in the future.