### PR TITLE
Bug/1418 generate oauth token from db

### DIFF
--- a/.github/workflows/integration-test-gha.yaml
+++ b/.github/workflows/integration-test-gha.yaml
@@ -97,6 +97,7 @@ jobs:
 
       ##playwright tests
       - name: Setup and run playwright tests
+        if: ${{ !cancelled() }}
         uses: ./.github/actions/playwright-tests
         with:
           lexbox-hostname: 'localhost:6579'

--- a/backend/FwLite/FwLiteShared/Auth/HttpClientRefreshDelegate.cs
+++ b/backend/FwLite/FwLiteShared/Auth/HttpClientRefreshDelegate.cs
@@ -1,0 +1,40 @@
+﻿using LexCore.Auth;
+using Microsoft.Extensions.Logging;
+
+namespace FwLiteShared.Auth;
+
+public class HttpClientRefreshDelegate(OAuthClientFactory clientFactory, ILogger<HttpClientRefreshDelegate> logger) : DelegatingHandler
+{
+    protected override HttpResponseMessage Send(HttpRequestMessage request, CancellationToken cancellationToken)
+    {
+        var response = base.Send(request, cancellationToken);
+        HandleResponse(response);
+        return response;
+    }
+
+    protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+    {
+        var response = await base.SendAsync(request, cancellationToken);
+        HandleResponse(response);
+        return response;
+    }
+
+    private void HandleResponse(HttpResponseMessage response)
+    {
+        var authority = response.RequestMessage?.RequestUri?.Authority;
+        if (string.IsNullOrEmpty(authority))
+        {
+            logger.LogWarning("Unable to get authority from response");
+            return;
+        }
+
+        if (!response.Headers.TryGetValues(LexAuthConstants.JwtUpdatedHeader, out var values))
+        {
+            return;
+        }
+        if (!values.Any()) return;
+
+        _ = Task.Run(() => clientFactory.GetClient(authority).RefreshToken());
+
+    }
+}

--- a/backend/FwLite/FwLiteShared/Auth/OAuthClientFactory.cs
+++ b/backend/FwLite/FwLiteShared/Auth/OAuthClientFactory.cs
@@ -45,4 +45,9 @@ public class OAuthClientFactory(IServiceProvider provider,
         if (string.IsNullOrEmpty(originDomain)) throw new InvalidOperationException("No origin domain in project data");
         return GetClient(options.Value.GetServer(project));
     }
+
+    public OAuthClient GetClient(string authority)
+    {
+        return GetClient(options.Value.GetServerByAuthority(authority));
+    }
 }

--- a/backend/FwLite/FwLiteShared/FwLiteSharedKernel.cs
+++ b/backend/FwLite/FwLiteShared/FwLiteSharedKernel.cs
@@ -56,7 +56,7 @@ public static class FwLiteSharedKernel
         services.AddSingleton<IHostedService>(sp => sp.GetRequiredService<OAuthService>());
         services.AddOptionsWithValidateOnStart<AuthConfig>().BindConfiguration("Auth").ValidateDataAnnotations();
         services.AddSingleton<LoggerAdapter>();
-        services.AddSingleton<HttpClientRefreshDelegate>();
+        services.AddTransient<HttpClientRefreshDelegate>();
         var httpClientBuilder = services.AddHttpClient(OAuthClient.AuthHttpClientName);
         httpClientBuilder.AddHttpMessageHandler<HttpClientRefreshDelegate>();
         if (environment.IsDevelopment())

--- a/backend/FwLite/FwLiteShared/FwLiteSharedKernel.cs
+++ b/backend/FwLite/FwLiteShared/FwLiteSharedKernel.cs
@@ -56,7 +56,9 @@ public static class FwLiteSharedKernel
         services.AddSingleton<IHostedService>(sp => sp.GetRequiredService<OAuthService>());
         services.AddOptionsWithValidateOnStart<AuthConfig>().BindConfiguration("Auth").ValidateDataAnnotations();
         services.AddSingleton<LoggerAdapter>();
+        services.AddSingleton<HttpClientRefreshDelegate>();
         var httpClientBuilder = services.AddHttpClient(OAuthClient.AuthHttpClientName);
+        httpClientBuilder.AddHttpMessageHandler<HttpClientRefreshDelegate>();
         if (environment.IsDevelopment())
         {
             if (!string.IsNullOrEmpty(Environment.GetEnvironmentVariable("FW_LITE_CHAOS")))

--- a/backend/LexBoxApi/Auth/AuthKernel.cs
+++ b/backend/LexBoxApi/Auth/AuthKernel.cs
@@ -27,6 +27,7 @@ public static class AuthKernel
     public const string DefaultScheme = "JwtOrCookie";
     public const string JwtOverBasicAuthUsername = "bearer";
     public const string AuthCookieName = LexAuthConstants.AuthCookieName;
+    public const string OAuthAuthenticationType = "OAuth";
 
     public static void AddLexBoxAuth(IServiceCollection services,
         IConfigurationRoot configuration,
@@ -248,7 +249,11 @@ public static class AuthKernel
                 options.SetTokenEndpointUris("api/oauth/token");
                 options.SetIntrospectionEndpointUris("api/oauth/introspect");
                 options.SetUserinfoEndpointUris("api/oauth/userinfo");
-                options.Configure(serverOptions => serverOptions.Handlers.Add(ScopeRequestFixer.Descriptor));
+                options.Configure(serverOptions =>
+                {
+                    serverOptions.TokenValidationParameters.AuthenticationType = OAuthAuthenticationType;
+                    serverOptions.Handlers.Add(ScopeRequestFixer.Descriptor);
+                });
 
                 options.SetAccessTokenLifetime(TimeSpan.FromHours(1));
                 options.SetRefreshTokenLifetime(TimeSpan.FromDays(14));

--- a/backend/LexBoxApi/Auth/AuthKernel.cs
+++ b/backend/LexBoxApi/Auth/AuthKernel.cs
@@ -295,6 +295,8 @@ public static class AuthKernel
             })
             .AddValidation(options =>
             {
+                options.Configure(validationOptions =>
+                    validationOptions.TokenValidationParameters.AuthenticationType = OAuthAuthenticationType);
                 options.UseLocalServer();
                 options.UseAspNetCore();
                 options.AddAudiences(Enum.GetValues<LexboxAudience>().Where(a => a != LexboxAudience.Unknown).Select(a => a.ToString()).ToArray());

--- a/backend/LexBoxApi/Auth/LexAuthService.cs
+++ b/backend/LexBoxApi/Auth/LexAuthService.cs
@@ -96,7 +96,8 @@ public class LexAuthService
         {
             // calling sign in will return a token in a cookie, that's not how oauth works so don't do that here, just notify the client with a header
             context.Response.Headers[JwtUpdatedHeader] = updatedValue;
-            return null;
+            activity?.AddTag("app.user.refresh", "notified");
+            return _loggedInContext.User;
         }
 
         var dbUser = await _lexBoxDbContext.Users

--- a/backend/LexBoxApi/Auth/LexAuthService.cs
+++ b/backend/LexBoxApi/Auth/LexAuthService.cs
@@ -127,6 +127,11 @@ public class LexAuthService
         return await GetUser(u => u.GoogleId == googleId);
     }
 
+    public async Task<(LexAuthUser? lexAuthUser, User? user)> GetUserById(Guid id)
+    {
+        return await GetUser(u => u.Id == id);
+    }
+
     private async Task<(LexAuthUser? lexAuthUser, User? user)> GetUser(Expression<Func<User, bool>> predicate)
     {
         var user = await _lexBoxDbContext.Users

--- a/backend/LexBoxApi/Auth/LexAuthService.cs
+++ b/backend/LexBoxApi/Auth/LexAuthService.cs
@@ -19,7 +19,7 @@ namespace LexBoxApi.Auth;
 
 public class LexAuthService
 {
-    public const string JwtUpdatedHeader = "lexbox-jwt-updated";
+    public const string JwtUpdatedHeader = LexAuthConstants.JwtUpdatedHeader;
     private readonly IOptions<JwtOptions> _userOptions;
     private readonly LexBoxDbContext _lexBoxDbContext;
     private readonly IHttpContextAccessor _httpContextAccessor;

--- a/backend/LexBoxApi/Controllers/AuthTestingController.cs
+++ b/backend/LexBoxApi/Controllers/AuthTestingController.cs
@@ -9,7 +9,7 @@ namespace LexBoxApi.Controllers;
 
 [ApiController]
 [Route("/api/[controller]")]
-public class AuthTestingController : ControllerBase
+public class AuthTestingController(LoggedInContext loggedInContext) : ControllerBase
 {
     [HttpGet("requires-auth")]
     public OkObjectResult RequiresAuth()
@@ -43,5 +43,11 @@ public class AuthTestingController : ControllerBase
     public ActionResult RequiresFwBetaFeatureFlag()
     {
         return Ok();
+    }
+
+    [HttpGet("token-project-count")]
+    public ActionResult<int> TokenProjectCount()
+    {
+        return loggedInContext.User.Projects.Length;
     }
 }

--- a/backend/LexBoxApi/Controllers/LoginController.cs
+++ b/backend/LexBoxApi/Controllers/LoginController.cs
@@ -208,7 +208,7 @@ public class LoginController(
     [ProducesResponseType(StatusCodes.Status401Unauthorized)]
     public async Task<ActionResult<LexAuthUser>> RefreshJwt()
     {
-        var user = await lexAuthService.RefreshUser(loggedInContext.User.Id);
+        var user = await lexAuthService.RefreshUser();
         if (user == null) return Unauthorized();
         return user;
     }

--- a/backend/LexBoxApi/Controllers/OauthController.cs
+++ b/backend/LexBoxApi/Controllers/OauthController.cs
@@ -265,10 +265,18 @@ public class OauthController(
                         "User account is not found."
                 }));
         }
+
+        var lexAuthClaims = lexAuthUser.GetClaims();
+        IEnumerable<Claim> allClaims = [
+            .. lexAuthClaims,
+            // include claims the oauth client sent / is expecting that we don't already have
+            .. user.Claims.Where(claim => !lexAuthClaims.Any(c => c.Type == claim.Type))
+        ];
+
         // Create the claims-based identity that will be used by OpenIddict to generate tokens.
         var identity = new ClaimsIdentity(
             authenticationType: AuthKernel.OAuthAuthenticationType,
-            claims: lexAuthUser.GetClaims(),
+            claims: allClaims,
             nameType: OpenIddictConstants.Claims.Name,
             roleType: OpenIddictConstants.Claims.Role);
 

--- a/backend/LexBoxApi/Controllers/OauthController.cs
+++ b/backend/LexBoxApi/Controllers/OauthController.cs
@@ -254,10 +254,21 @@ public class OauthController(
     {
         AssertOAuthSetup();
         var userId = GetUserId(user);
+        var (lexAuthUser, _) = await lexAuthService.GetUserById(userId);
+        if (lexAuthUser is null)
+        {
+            return Forbid(authenticationSchemes: OpenIddictServerAspNetCoreDefaults.AuthenticationScheme,
+                properties: new AuthenticationProperties(new Dictionary<string, string?>
+                {
+                    [OpenIddictServerAspNetCoreConstants.Properties.Error] = OpenIddictConstants.Errors.AccessDenied,
+                    [OpenIddictServerAspNetCoreConstants.Properties.ErrorDescription] =
+                        "User account is not found."
+                }));
+        }
         // Create the claims-based identity that will be used by OpenIddict to generate tokens.
         var identity = new ClaimsIdentity(
             authenticationType: TokenValidationParameters.DefaultAuthenticationType,
-            claims: user.Claims,
+            claims: lexAuthUser.GetClaims(),
             nameType: OpenIddictConstants.Claims.Name,
             roleType: OpenIddictConstants.Claims.Role);
 

--- a/backend/LexBoxApi/Controllers/OauthController.cs
+++ b/backend/LexBoxApi/Controllers/OauthController.cs
@@ -267,7 +267,7 @@ public class OauthController(
         }
         // Create the claims-based identity that will be used by OpenIddict to generate tokens.
         var identity = new ClaimsIdentity(
-            authenticationType: TokenValidationParameters.DefaultAuthenticationType,
+            authenticationType: AuthKernel.OAuthAuthenticationType,
             claims: lexAuthUser.GetClaims(),
             nameType: OpenIddictConstants.Claims.Name,
             roleType: OpenIddictConstants.Claims.Role);

--- a/backend/LexBoxApi/Controllers/TestingController.cs
+++ b/backend/LexBoxApi/Controllers/TestingController.cs
@@ -1,3 +1,4 @@
+using System.Collections.Immutable;
 using LexBoxApi.Auth;
 using LexBoxApi.Auth.Attributes;
 using LexBoxApi.Services;
@@ -10,6 +11,7 @@ using LexData.Entities;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
+using OpenIddict.Abstractions;
 
 namespace LexBoxApi.Controllers;
 
@@ -21,7 +23,8 @@ public class TestingController(
     IHgService hgService,
     SeedingData seedingData,
     ProjectService projectService,
-    LoggedInContext loggedInContext)
+    LoggedInContext loggedInContext,
+    IOpenIddictAuthorizationManager? authorizationManager = null)
     : ControllerBase
 {
 #if DEBUG
@@ -113,5 +116,18 @@ public class TestingController(
     public async Task<string[]> TestCleanupResetBackups(bool dryRun = true)
     {
         return await hgService.CleanupResetBackups(dryRun);
+    }
+
+    [HttpPost("pre-approve-oauth-app")]
+    public async Task<ActionResult> PreApproveOauthApp(string clientId, string scopes)
+    {
+        if (authorizationManager is null) throw new InvalidOperationException("authorizationManager is null");
+        await authorizationManager.CreateAsync(
+            principal: User,
+            subject: loggedInContext.User.Id.ToString(),
+            client: clientId,
+            type: OpenIddictConstants.AuthorizationTypes.Permanent,
+            scopes: [..scopes.Split(' ')]);
+        return Ok();
     }
 }

--- a/backend/LexBoxApi/GraphQL/CustomTypes/RefreshJwtAttribute.cs
+++ b/backend/LexBoxApi/GraphQL/CustomTypes/RefreshJwtAttribute.cs
@@ -29,7 +29,7 @@ public class RefreshJwtAttribute: ObjectFieldDescriptorAttribute
                 return;
             }
 
-            await authService.RefreshUser(loggedInContext.User.Id);
+            await authService.RefreshUser();
         }
     }
 }

--- a/backend/LexBoxApi/GraphQL/LexAuthUserOutOfSyncExtensions.cs
+++ b/backend/LexBoxApi/GraphQL/LexAuthUserOutOfSyncExtensions.cs
@@ -5,11 +5,18 @@ namespace LexBoxApi.GraphQL;
 
 public static class LexAuthUserOutOfSyncExtensions
 {
-    public static bool IsOutOfSyncWithMyProjects(this LexAuthUser user, List<Project> myProjects)
+    public static bool IsOutOfSyncWithMyProjects(this LexAuthUser user, IReadOnlyCollection<Project> myProjects)
     {
         if (user.IsAdmin) return false; // admins don't have projects in their token
         if (user.Projects.Length != myProjects.Count) return true; // different number of projects
         return myProjects.Any(proj => user.IsOutOfSyncWithProject(proj, isMyProject: true));
+    }
+
+    public static bool IsOutOfSyncWithMyProjects(this LexAuthUser user, ICollection<Guid> projectIds)
+    {
+        if (user.IsAdmin) return false; // admins don't have projects in their token
+        if (user.Projects.Length != projectIds.Count) return true; // different number of projects
+        return user.Projects.Select(p => p.ProjectId).Intersect(projectIds).Count() != projectIds.Count;
     }
 
     public static bool IsOutOfSyncWithMyOrgs(this LexAuthUser user, List<Organization> myOrgs)

--- a/backend/LexBoxApi/GraphQL/LexQueries.cs
+++ b/backend/LexBoxApi/GraphQL/LexQueries.cs
@@ -29,7 +29,7 @@ public class LexQueries
 
         if (loggedInContext.User.IsOutOfSyncWithMyProjects(myProjects))
         {
-            await lexAuthService.RefreshUser(userId, LexAuthConstants.ProjectsClaimType);
+            await lexAuthService.RefreshUser(LexAuthConstants.ProjectsClaimType);
         }
 
         return myProjects.AsQueryable();
@@ -134,7 +134,7 @@ public class LexQueries
         if (project is null) return project;
 
         var updatedUser = loggedInContext.User.IsOutOfSyncWithProject(project)
-            ? await lexAuthService.RefreshUser(loggedInContext.User.Id, LexAuthConstants.ProjectsClaimType)
+            ? await lexAuthService.RefreshUser(LexAuthConstants.ProjectsClaimType)
             : null;
 
         await permissionService.AssertCanViewProject(code, updatedUser);
@@ -164,7 +164,7 @@ public class LexQueries
 
         if (loggedInContext.User.IsOutOfSyncWithMyOrgs(myOrgs))
         {
-            await lexAuthService.RefreshUser(userId, LexAuthConstants.OrgsClaimType);
+            await lexAuthService.RefreshUser(LexAuthConstants.OrgsClaimType);
         }
         return myOrgs.AsQueryable();
     }
@@ -206,7 +206,7 @@ public class LexQueries
         if (org is null) return org;
 
         var updatedUser = loggedInContext.User.IsOutOfSyncWithOrg(org)
-            ? await lexAuthService.RefreshUser(loggedInContext.User.Id, LexAuthConstants.OrgsClaimType)
+            ? await lexAuthService.RefreshUser(LexAuthConstants.OrgsClaimType)
             : null;
 
         // Site admins and org admins can see everything

--- a/backend/LexCore/Auth/LexAuthConstants.cs
+++ b/backend/LexCore/Auth/LexAuthConstants.cs
@@ -18,6 +18,7 @@ public static class LexAuthConstants
     public const string CreatedByAdminClaimType = "creat";
     public const string UpdatedDateClaimType = "date";
     public const string LocaleClaimType = "loc";
+    public const string JwtUpdatedHeader = "lexbox-jwt-updated";
 }
 
 /// <summary>

--- a/backend/Testing/GraphQL/LexAuthUserOutOfSyncExtensionsTests.cs
+++ b/backend/Testing/GraphQL/LexAuthUserOutOfSyncExtensionsTests.cs
@@ -93,7 +93,7 @@ public class LexAuthUserOutOfSyncExtensionsTests
 
         var editorUser = user with { Projects = [new AuthUserProject(ProjectRole.Editor, project.Id)] };
         editorUser.IsOutOfSyncWithProject(project).Should().BeFalse(); // might be out of sync, but we can't tell
-        editorUser.IsOutOfSyncWithMyProjects([]).Should().BeTrue();
+        editorUser.IsOutOfSyncWithMyProjects(Array.Empty<Project>()).Should().BeTrue();
     }
 
     [Fact]

--- a/backend/Testing/LexCore/LexAuthUserTests.cs
+++ b/backend/Testing/LexCore/LexAuthUserTests.cs
@@ -29,6 +29,7 @@ public class LexAuthUserTests
     private readonly LexAuthService _lexAuthService = new LexAuthService(
         new OptionsWrapper<JwtOptions>(JwtOptions.TestingOptions),
         null!,
+        null!,
         null!);
 
     private readonly LexAuthUser _user = new()

--- a/frontend/tests/oauth.test.ts
+++ b/frontend/tests/oauth.test.ts
@@ -23,12 +23,14 @@ test.describe('oauth tests', () => {
     const name = `can login with oauth, ${flow.approved ? 'pre-approved' : 'not approved'}, ${flow.loggedIn ? 'logged in' : 'not logged in'}`;
     test(name, async ({page, tempUser}) => {
 
-      if (flow.approved || flow.loggedIn) await loginAs(page.request, tempUser);
-      if (flow.approved) {
-        await preApproveOauthApp(page.request, OidcDebuggerPage.clientId, OidcDebuggerPage.scopes);
-      }
-      if (!flow.loggedIn) {
-        await logout(page);
+      if (flow.approved || flow.loggedIn){
+        await loginAs(page.request, tempUser);
+        if (flow.approved) {
+          await preApproveOauthApp(page.request, OidcDebuggerPage.clientId, OidcDebuggerPage.scopes);
+        }
+        if (!flow.loggedIn) {
+          await logout(page);
+        }
       }
 
       const oauthTestPage = await new OidcDebuggerPage(page).goto();
@@ -51,8 +53,8 @@ test.describe('oauth tests', () => {
         await approvalPage.clickAuthorize();
       }
 
-      await oauthTestPage.waitForDebuggerPage();
-      const result = await oauthTestPage.getDebuggerIdToken();
+      const successPage = await oauthTestPage.waitForSuccessPage();
+      const result = await successPage.getDebuggerIdToken();
       expect(result).not.toBeFalsy();
     });
   }
@@ -83,9 +85,9 @@ test.describe('oauth tests', () => {
     const oauthTestPage = await new OidcDebuggerPage(page).goto();
     await oauthTestPage.fillForm(serverBaseUrl);
     await oauthTestPage.submit();
-    await oauthTestPage.waitForDebuggerPage();
+    const successPage = await oauthTestPage.waitForSuccessPage();
 
-    const token = await oauthTestPage.getDebuggerAccessToken();
+    const token = await successPage.getDebuggerAccessToken();
     const userProjectCountAfter = await userProjectCount(token);
     expect(userProjectCountAfter).toBe(userProjectCountBefore + 1);
   });
@@ -98,9 +100,9 @@ test.describe('oauth tests', () => {
     const oauthTestPage = await new OidcDebuggerPage(page).goto();
     await oauthTestPage.fillForm(serverBaseUrl);
     await oauthTestPage.submit();
-    await oauthTestPage.waitForDebuggerPage();
+    const successPage = await oauthTestPage.waitForSuccessPage();
 
-    const token = await oauthTestPage.getDebuggerAccessToken();
+    const token = await successPage.getDebuggerAccessToken();
 
     const response = await fetch(`${serverBaseUrl}/api/login/refresh`, {
       method: 'POST',

--- a/frontend/tests/oauth.test.ts
+++ b/frontend/tests/oauth.test.ts
@@ -5,6 +5,7 @@ import {OidcDebuggerPage} from './pages/oidcDebuggerPage';
 import {addUserToProject, loginAs, logout, preApproveOauthApp} from './utils/authHelpers';
 import {OauthApprovalPage} from './pages/oauthApprovalPage';
 import {elawaProjectId, serverBaseUrl} from './envVars';
+import {jwtDecode, type JwtPayload} from 'jwt-decode';
 
 // we've got a matrix of flows to test
 // pre approved, not approved yet,
@@ -54,8 +55,12 @@ test.describe('oauth tests', () => {
       }
 
       const successPage = await oauthTestPage.waitForSuccessPage();
-      const result = await successPage.getDebuggerIdToken();
-      expect(result).not.toBeFalsy();
+      const idToken = await successPage.getDebuggerIdToken();
+      expect(idToken).not.toBeFalsy();
+      const idTokenUser = jwtDecode<JwtPayload & {name: string}>(idToken);
+      expect(idTokenUser).toBeTruthy();
+      expect(idTokenUser.sub).toBe(tempUser.id);
+      expect(idTokenUser.name).toBe(tempUser.name);
     });
   }
 

--- a/frontend/tests/oauth.test.ts
+++ b/frontend/tests/oauth.test.ts
@@ -24,14 +24,15 @@ test.describe('oauth tests', () => {
     const name = `can login with oauth, ${flow.approved ? 'pre-approved' : 'not approved'}, ${flow.loggedIn ? 'logged in' : 'not logged in'}`;
     test(name, async ({page, tempUser}) => {
 
-      if (flow.approved || flow.loggedIn){
+      if (flow.approved || flow.loggedIn) {
         await loginAs(page.request, tempUser);
         if (flow.approved) {
           await preApproveOauthApp(page.request, OidcDebuggerPage.clientId, OidcDebuggerPage.scopes);
         }
-        if (!flow.loggedIn) {
-          await logout(page);
-        }
+      }
+      // tempUsers are currently always automatically logged in 😔
+      if (!flow.loggedIn) {
+        await logout(page);
       }
 
       const oauthTestPage = await new OidcDebuggerPage(page).goto();

--- a/frontend/tests/oauth.test.ts
+++ b/frontend/tests/oauth.test.ts
@@ -1,0 +1,52 @@
+﻿import {expect} from '@playwright/test';
+import {test} from './fixtures';
+import {LoginPage} from './pages/loginPage';
+import {defaultPassword} from './envVars';
+import {OidcDebuggerPage} from './pages/oidcDebuggerPage';
+import {loginAs, logout} from './utils/authHelpers';
+import {OauthApprovalPage} from './pages/oauthApprovalPage';
+
+// we've got a matrix of flows to test
+// pre approved, not approved yet,
+// logged in already, not logged in
+
+//use https://oidcdebugger.com/ to test oauth
+const flows = [{approved: true, loggedIn: false}, {approved: false, loggedIn: false}, {approved: true, loggedIn: true}, {approved: false, loggedIn: true}];
+test.describe('oauth tests', () => {
+  for (const flow of flows) {
+    const name = `can login with oauth, ${flow.approved ? 'pre-approved' : 'not approved'}, ${flow.loggedIn ? 'logged in' : 'not logged in'}`;
+    test(name, async ({page, baseURL, tempUser}) => {
+      if (!baseURL) throw new Error('baseURL is not set');
+      if (flow.loggedIn) {
+        await loginAs(page.request, tempUser);
+      } else {
+        await logout(page);
+      }
+
+      const oauthTestPage = await new OidcDebuggerPage(page).goto();
+      await oauthTestPage.fillForm(baseURL);
+      await oauthTestPage.submit();
+      const approvalPage = new OauthApprovalPage(page);
+
+      if (!flow.loggedIn) {
+        await expect(page).not.toHaveURL(OidcDebuggerPage.redirectUrl);
+        await approvalPage.expectNotOnPage();
+
+        const loginPage = await new LoginPage(page).waitFor();
+        await loginPage.fillForm('admin', defaultPassword);
+        await loginPage.submit();
+      }
+      if (!flow.approved) {
+        await expect(page).not.toHaveURL(OidcDebuggerPage.redirectUrl);
+
+        await approvalPage.waitFor();
+        await approvalPage.clickAuthorize();
+      }
+
+      await oauthTestPage.waitForDebuggerPage();
+      const result = await oauthTestPage.getDebuggerIdToken();
+      console.log('result', result);
+      expect(result).toContain('id_token=');
+    });
+  }
+});

--- a/frontend/tests/pages/oauthApprovalPage.ts
+++ b/frontend/tests/pages/oauthApprovalPage.ts
@@ -1,0 +1,12 @@
+﻿import {BasePage} from './basePage';
+import type {Page} from '@playwright/test';
+
+export class OauthApprovalPage extends BasePage {
+  constructor(page: Page) {
+    super(page, page.locator('.i-mdi-approval'), '/authorize');
+  }
+
+  async clickAuthorize(): Promise<void> {
+    await this.page.getByRole('button', {name: 'Authorize'}).click();
+  }
+}

--- a/frontend/tests/pages/oidcDebuggerPage.ts
+++ b/frontend/tests/pages/oidcDebuggerPage.ts
@@ -1,0 +1,33 @@
+﻿import {BasePage} from './basePage';
+import type {Page} from '@playwright/test';
+
+export class OidcDebuggerPage extends BasePage {
+static readonly redirectUrl = 'https://oidcdebugger.com/debug';
+  debuggerPage: BasePage = new BasePage(this.page, this.page.getByText('Success!'), OidcDebuggerPage.redirectUrl);
+  constructor(page: Page) {
+    super(page, page.getByText('OpenID Connect Debugger'), 'https://oidcdebugger.com');
+  }
+
+  async fillForm(baseURL: string) {
+    await this.page.locator('#authorizeUri').fill(`${baseURL}/api/oauth/open-id-auth`);
+    await this.page.locator('#redirectUri').fill(OidcDebuggerPage.redirectUrl);
+    await this.page.locator('#clientId').fill(`oidc-debugger`);
+    await this.page.locator('#scopes').fill(`openid profile`);
+    await this.page.locator('#responseType-code').check();
+    await this.page.locator('#use-pkce').check();
+    await this.page.locator('#tokenUri').fill(`${baseURL}/api/oauth/token`);
+    await this.page.locator('#responseMode-formPost').check();
+  }
+
+  async submit(): Promise<void> {
+    await this.page.getByRole('link', {name: 'Send Request'}).click();
+  }
+
+  async waitForDebuggerPage() {
+    await this.debuggerPage.waitFor();
+  }
+
+  async getDebuggerIdToken(): Promise<string> {
+    return await this.debuggerPage.page.getByTitle('PKCE result').innerText();
+  }
+}

--- a/frontend/tests/pages/oidcDebuggerPage.ts
+++ b/frontend/tests/pages/oidcDebuggerPage.ts
@@ -1,12 +1,12 @@
 ﻿import {BasePage} from './basePage';
-import {expect, type Page} from '@playwright/test';
+import {expect, type Locator, type Page} from '@playwright/test';
 
 export class OidcDebuggerPage extends BasePage {
   static readonly redirectUrl = 'https://oidcdebugger.com/debug';
   static readonly clientId = `oidc-debugger`;
   static readonly scopes = `openid profile`;
 
-  debuggerPage: BasePage = new BasePage(this.page, this.page.getByText('Success!'), OidcDebuggerPage.redirectUrl);
+  successPage: OidcDebuggerSuccessPage = new OidcDebuggerSuccessPage(this.page);
   constructor(page: Page) {
     super(page, page.getByText('OpenID Connect Debugger'), 'https://oidcdebugger.com');
   }
@@ -26,12 +26,19 @@ export class OidcDebuggerPage extends BasePage {
     await this.page.getByRole('link', {name: 'Send Request'}).click();
   }
 
-  async waitForDebuggerPage() {
-    await this.debuggerPage.waitFor();
+  async waitForSuccessPage() {
+    return await this.successPage.waitFor();
+  }
+}
+
+export class OidcDebuggerSuccessPage extends BasePage {
+
+  constructor(page: Page) {
+    super(page, page.getByText('Success!'), OidcDebuggerPage.redirectUrl);
   }
 
   async getPkceResult(): Promise<Record<string, string>> {
-    const str = await this.debuggerPage.page.getByTitle('PKCE result').innerText();
+    const str = await this.page.getByTitle('PKCE result').innerText();
     return Object.fromEntries<string>(str.split('\n').map(s => s.split('=', 2) as [string, string]));
   }
 

--- a/frontend/tests/pages/oidcDebuggerPage.ts
+++ b/frontend/tests/pages/oidcDebuggerPage.ts
@@ -2,7 +2,10 @@
 import type {Page} from '@playwright/test';
 
 export class OidcDebuggerPage extends BasePage {
-static readonly redirectUrl = 'https://oidcdebugger.com/debug';
+  static readonly redirectUrl = 'https://oidcdebugger.com/debug';
+  static readonly clientId = `oidc-debugger`;
+  static readonly scopes = `openid profile`;
+
   debuggerPage: BasePage = new BasePage(this.page, this.page.getByText('Success!'), OidcDebuggerPage.redirectUrl);
   constructor(page: Page) {
     super(page, page.getByText('OpenID Connect Debugger'), 'https://oidcdebugger.com');
@@ -11,8 +14,8 @@ static readonly redirectUrl = 'https://oidcdebugger.com/debug';
   async fillForm(baseURL: string) {
     await this.page.locator('#authorizeUri').fill(`${baseURL}/api/oauth/open-id-auth`);
     await this.page.locator('#redirectUri').fill(OidcDebuggerPage.redirectUrl);
-    await this.page.locator('#clientId').fill(`oidc-debugger`);
-    await this.page.locator('#scopes').fill(`openid profile`);
+    await this.page.locator('#clientId').fill(OidcDebuggerPage.clientId);
+    await this.page.locator('#scopes').fill(OidcDebuggerPage.scopes);
     await this.page.locator('#responseType-code').check();
     await this.page.locator('#use-pkce').check();
     await this.page.locator('#tokenUri').fill(`${baseURL}/api/oauth/token`);

--- a/frontend/tests/pages/oidcDebuggerPage.ts
+++ b/frontend/tests/pages/oidcDebuggerPage.ts
@@ -1,12 +1,12 @@
 ﻿import {BasePage} from './basePage';
-import {expect, type Locator, type Page} from '@playwright/test';
+import {expect, type Page} from '@playwright/test';
 
 export class OidcDebuggerPage extends BasePage {
   static readonly redirectUrl = 'https://oidcdebugger.com/debug';
   static readonly clientId = `oidc-debugger`;
   static readonly scopes = `openid profile`;
 
-  successPage: OidcDebuggerSuccessPage = new OidcDebuggerSuccessPage(this.page);
+  readonly successPage = new OidcDebuggerSuccessPage(this.page);
   constructor(page: Page) {
     super(page, page.getByText('OpenID Connect Debugger'), 'https://oidcdebugger.com');
   }
@@ -26,7 +26,7 @@ export class OidcDebuggerPage extends BasePage {
     await this.page.getByRole('link', {name: 'Send Request'}).click();
   }
 
-  async waitForSuccessPage() {
+  async waitForSuccessPage(): Promise<OidcDebuggerSuccessPage> {
     return await this.successPage.waitFor();
   }
 }

--- a/frontend/tests/pages/oidcDebuggerPage.ts
+++ b/frontend/tests/pages/oidcDebuggerPage.ts
@@ -1,5 +1,5 @@
 ﻿import {BasePage} from './basePage';
-import type {Page} from '@playwright/test';
+import {expect, type Page} from '@playwright/test';
 
 export class OidcDebuggerPage extends BasePage {
   static readonly redirectUrl = 'https://oidcdebugger.com/debug';
@@ -30,7 +30,20 @@ export class OidcDebuggerPage extends BasePage {
     await this.debuggerPage.waitFor();
   }
 
+  async getPkceResult(): Promise<Record<string, string>> {
+    const str = await this.debuggerPage.page.getByTitle('PKCE result').innerText();
+    return Object.fromEntries<string>(str.split('\n').map(s => s.split('=', 2) as [string, string]));
+  }
+
+  async getDebuggerAccessToken(): Promise<string> {
+    const result = await this.getPkceResult();
+    expect(result.access_token).not.toBeFalsy();
+    return result.access_token;
+  }
+
   async getDebuggerIdToken(): Promise<string> {
-    return await this.debuggerPage.page.getByTitle('PKCE result').innerText();
+    const result = await this.getPkceResult();
+    expect(result.id_token).not.toBeFalsy();
+    return result.id_token;
   }
 }

--- a/frontend/tests/utils/authHelpers.ts
+++ b/frontend/tests/utils/authHelpers.ts
@@ -101,3 +101,8 @@ export async function deleteUser(api: APIRequestContext, userId: string): Promis
   }
   `);
 }
+
+export async function preApproveOauthApp(api: APIRequestContext, clientId: string, scopes: string[]): Promise<void> {
+  const response = await api.post(`${serverBaseUrl}/api/Testing/pre-approve-oauth-app?clientId=${clientId}&scopes=${scopes.join(' ')}`);
+  if (!response.ok) throw new Error(await response.text());
+}

--- a/frontend/tests/utils/authHelpers.ts
+++ b/frontend/tests/utils/authHelpers.ts
@@ -102,7 +102,7 @@ export async function deleteUser(api: APIRequestContext, userId: string): Promis
   `);
 }
 
-export async function preApproveOauthApp(api: APIRequestContext, clientId: string, scopes: string[]): Promise<void> {
-  const response = await api.post(`${serverBaseUrl}/api/Testing/pre-approve-oauth-app?clientId=${clientId}&scopes=${scopes.join(' ')}`);
+export async function preApproveOauthApp(api: APIRequestContext, clientId: string, scopes: string): Promise<void> {
+  const response = await api.post(`${serverBaseUrl}/api/Testing/pre-approve-oauth-app?clientId=${clientId}&scopes=${scopes}`);
   if (!response.ok) throw new Error(await response.text());
 }


### PR DESCRIPTION
closes #1418, closes #1464

Wrote some tests to ensure our oauth login is working, it tests a matrix of cases, already logged in, or not logged in, and app authorized and not authorized. Each of those combinations takes a different code path. In addition I wrote a test where after the user is logged in they get added to a project, their current token does not know about that project, however the token returned from oauth should know about that project.

updated our `RefreshUser` function to not use `SignIn` for oauth requests as that would return a cookie to the oauth client which gives the client permission it should not have, instead it just sets the `lexbox-jwt-updated` header notifying the client. Updated the `api/crdt/listProjects` route to use `RefreshUser`. Added a delegate to the http client to refresh oauth token in response to a `lexbox-jwt-updated` header.