### PR TITLE
Read only multi strings

### DIFF
--- a/backend/FwLite/FwDataMiniLcmBridge/Api/FwDataMiniLcmApi.cs
+++ b/backend/FwLite/FwDataMiniLcmBridge/Api/FwDataMiniLcmApi.cs
@@ -629,7 +629,12 @@ public class FwDataMiniLcmApi(Lazy<LcmCache> cacheLazy, bool onCloseSave, ILogge
         for (var i = 0; i < multiString.StringCount; i++)
         {
             var tsString = multiString.GetStringFromIndex(i, out var ws);
-            result.Values.Add(GetWritingSystemId(ws), tsString.Text);
+            var wsId = GetWritingSystemId(ws);
+            result.Values.Add(wsId, tsString.Text);
+            if (tsString.RunCount > 1)
+            {
+                result.Metadata.Add(wsId, new() { RunCount = tsString.RunCount });
+            }
         }
 
         return result;

--- a/backend/FwLite/FwLiteProjectSync.Tests/MultiStringDiffTests.cs
+++ b/backend/FwLite/FwLiteProjectSync.Tests/MultiStringDiffTests.cs
@@ -1,4 +1,5 @@
-﻿using MiniLcm.Models;
+﻿using MiniLcm.Exceptions;
+using MiniLcm.Models;
 using MiniLcm.SyncHelpers;
 using Spart.Parsers;
 using SystemTextJsonPatch.Operations;
@@ -83,5 +84,36 @@ public class MultiStringDiffTests
             new Operation<Placeholder>("add", "/test/fr", null, "monde"),
             new Operation<Placeholder>("remove", "/test/es", null)
         ]);
+    }
+
+    [Fact]
+    public void DiffAttemptToUpdateReadonlyFails()
+    {
+        var before = new MultiString();
+        before.Values.Add("en", "hello");
+        before.Metadata.Add("en", new(){RunCount = 2});
+        var after = new MultiString();
+        after.Values.Add("en", "world");
+        var act = () =>
+        {
+            MultiStringDiff.GetMultiStringDiff<Placeholder>("test", before, after).ToArray();
+        };
+        act.Should().Throw<MultiStringReadonlyException>();
+    }
+
+    [Fact]
+    public void DiffWithoutChangeToReadonlyStringWorks()
+    {
+        var before = new MultiString();
+        before.Values.Add("en", "hello");
+        before.Values.Add("es", "hola");
+        before.Metadata.Add("en", new(){RunCount = 2});
+        var after = new MultiString();
+        after.Values.Add("en", "hello");
+        var act = () =>
+        {
+            MultiStringDiff.GetMultiStringDiff<Placeholder>("test", before, after).ToArray();
+        };
+        act.Should().NotThrow();
     }
 }

--- a/backend/FwLite/MiniLcm.Tests/MultiStringTests.cs
+++ b/backend/FwLite/MiniLcm.Tests/MultiStringTests.cs
@@ -5,6 +5,25 @@ namespace MiniLcm.Tests;
 
 public class MultiStringTests
 {
+    [Fact]
+    public void CanSerializeMultiString()
+    {
+        //lang=json
+        var expectedJson = """{"en":"test"}""";
+        var ms = new MultiString() { Values = { { "en", "test" } } };
+        var actualJson = JsonSerializer.Serialize(ms);
+        actualJson.Should().Be(expectedJson);
+    }
+
+    [Fact]
+    public void CanSerializeMultiString_WithMetadata()
+    {
+        //lang=json
+        var expectedJson = """{"en":"test","x-meta-en":{"RunCount":2}}""";
+        var ms = new MultiString() { Values = { { "en", "test" } }, Metadata = { {"en", new(){RunCount = 2}} }};
+        var actualJson = JsonSerializer.Serialize(ms);
+        actualJson.Should().Be(expectedJson);
+    }
 
     [Fact]
     public void CanDeserializeMultiString()
@@ -12,6 +31,22 @@ public class MultiStringTests
         //lang=json
         var json = """{"en": "test"}""";
         var expectedMs = new MultiString() { Values = { { "en", "test" } } };
+        var actualMs = JsonSerializer.Deserialize<MultiString>(json);
+        actualMs.Should().NotBeNull();
+        actualMs.Values.Should().ContainKey("en");
+        actualMs.Should().BeEquivalentTo(expectedMs);
+    }
+
+    [Fact]
+    public void CanDeserializeMultiString_WithMetadata()
+    {
+        //lang=json
+        var json = """{"en": "test", "x-meta-en": {"runCount": 2}}""";
+        var expectedMs = new MultiString()
+        {
+            Values = { { "en", "test" } },
+            Metadata = { { "en", new() { RunCount = 2 } } }
+        };
         var actualMs = JsonSerializer.Deserialize<MultiString>(json);
         actualMs.Should().NotBeNull();
         actualMs.Values.Should().ContainKey("en");

--- a/backend/FwLite/MiniLcm/Exceptions/MultiStringReadonlyException.cs
+++ b/backend/FwLite/MiniLcm/Exceptions/MultiStringReadonlyException.cs
@@ -1,0 +1,3 @@
+﻿namespace MiniLcm.Exceptions;
+
+public class MultiStringReadonlyException(string path, string ws) : Exception($"value {path}:{ws} is readonly");

--- a/backend/FwLite/MiniLcm/SyncHelpers/MultiStringDiff.cs
+++ b/backend/FwLite/MiniLcm/SyncHelpers/MultiStringDiff.cs
@@ -1,4 +1,5 @@
-﻿using MiniLcm.Models;
+﻿using MiniLcm.Exceptions;
+using MiniLcm.Models;
 using SystemTextJsonPatch.Operations;
 
 namespace MiniLcm.SyncHelpers;
@@ -14,8 +15,15 @@ public static class MultiStringDiff
         {
             if (after.Values.TryGetValue(key, out var afterValue))
             {
+
                 if (!beforeValue.Equals(afterValue))
+                {
+                    if (before.IsReadonly(key) || after.IsReadonly(key))
+                    {
+                        throw new MultiStringReadonlyException(path, key);
+                    }
                     yield return new Operation<T>("replace", $"/{path}/{key}", null, afterValue);
+                }
             }
             else
             {


### PR DESCRIPTION
closes #1307
FieldWorks supports text runs, at this time minilcm does not. For now we should make those strings readonly so we don't lose data. In order to do that our multistring needs to track additional information. I've done that by adding a Metadata dictionary to multistring, which gets serialized like this 
```json
{
  "en": "test",
  "x-meta-en": {
    "RunCount": 2
  }
}
```

I'm currently just tracking the run count, but we might want to simplify that or make it more complicated, I'm not sure right now.

todo
- [ ] determine how we want to handle attempts to modify values that should be readonly
- [ ] allow syncs from fw which may have changed readonly values to update data in harmony
- [ ] determine exactly what data we want to store in harmony