### PR TITLE
allow fw headless sync tests to gracefully timeout and retry

### DIFF
--- a/backend/Testing/FwHeadless/MergeFwDataWithHarmonyTests.cs
+++ b/backend/Testing/FwHeadless/MergeFwDataWithHarmonyTests.cs
@@ -30,9 +30,21 @@ public class MergeFwDataWithHarmonyTests : ApiTestBase, IAsyncLifetime
 
     private async Task<SyncResult?> AwaitSyncFinished(Guid projectId)
     {
-        var result = await HttpClient.GetAsync($"api/fw-lite/sync/await-sync-finished/{projectId}");
-        result.EnsureSuccessStatusCode();
-        return await result.Content.ReadFromJsonAsync<SyncResult>();
+        var giveUpAt = DateTime.UtcNow + TimeSpan.FromSeconds(60);
+        while (giveUpAt > DateTime.UtcNow)
+        {
+            try
+            {
+                var result = await HttpClient.GetAsync($"api/fw-lite/sync/await-sync-finished/{projectId}", new CancellationTokenSource(TimeSpan.FromSeconds(25)).Token);
+                result.EnsureSuccessStatusCode();
+                return await result.Content.ReadFromJsonAsync<SyncResult>();
+            }
+            catch (OperationCanceledException)
+            {
+            }
+        }
+        Assert.Fail("timed out waiting for sync to finish");
+        return null;
     }
 
     private async Task AddTestCommit(Guid projectId)


### PR DESCRIPTION
from time to time gha integration tests would fail with a 500 error when running the `MergeFwDataWithHarmonyTests` this was just due to a timeout waiting for the sync to finish, this is fine and we just need to try again.