### PR TITLE
Bug/1482 after clicking try fw lite and closing the dialog it still says try fw lite

### DIFF
--- a/frontend/src/hooks.shared.ts
+++ b/frontend/src/hooks.shared.ts
@@ -1,10 +1,10 @@
+import {getErrorMessage as baseGetErrorMessage} from '$lib/error/utils';
 import {redirect} from '@sveltejs/kit';
-import {tryGetErrorMessage} from '$lib/error/utils';
 
 const sayWuuuuuuut = 'We\'re not sure what happened.';
 
 export function getErrorMessage(error: unknown): string {
-  return tryGetErrorMessage(error) ?? sayWuuuuuuut;
+  return baseGetErrorMessage(error, sayWuuuuuuut);
 }
 
 export function validateFetchResponse(

--- a/frontend/src/lib/error/utils.ts
+++ b/frontend/src/lib/error/utils.ts
@@ -1,16 +1,17 @@
-export function tryGetErrorMessage(error: unknown): string | undefined {
+export function getErrorMessage(error: unknown, fallback = 'Unknown error'): string {
   if (error === null || error === undefined) {
-    return undefined;
+    return fallback;
   } else if (typeof error === 'string') {
     return error;
   }
 
   const _error = (error ?? {}) as Record<string, string>;
   return (
-      _error.message ??
-      _error.reason ??
-      _error.cause ??
-      _error.error ??
-      _error.code
+    _error.message ??
+    _error.reason ??
+    _error.cause ??
+    _error.error ??
+    _error.code ??
+    fallback
   );
 }

--- a/frontend/src/lib/i18n/locales/en.json
+++ b/frontend/src/lib/i18n/locales/en.json
@@ -291,6 +291,8 @@ Are you ready to try FieldWorks Lite?",
 [lexbox_support@groups.sil.org](mailto:lexbox_support@groups.sil.org?subject={subject}), \
 so we can get this fixed!",
       "email_subject": "FieldWorks Lite setup error ({projectCode})",
+      "sync_failed": "Sync failed, please contact support",
+      "sync_trigger_failed": "Failed to sync: {statusText} ({status})",
     },
   },
   "org_page": {

--- a/frontend/src/lib/i18n/locales/en.json
+++ b/frontend/src/lib/i18n/locales/en.json
@@ -291,6 +291,7 @@ Are you ready to try FieldWorks Lite?",
 [lexbox_support@groups.sil.org](mailto:lexbox_support@groups.sil.org?subject={subject}), \
 so we can get this fixed!",
       "email_subject": "FieldWorks Lite setup error ({projectCode})",
+      "empty_project": "You'll need to set up this project with FieldWorks before you can try FieldWorks Lite.",
       "sync_failed": "Sync failed, please contact support",
       "sync_trigger_failed": "Failed to sync: {statusText} ({status})",
     },

--- a/frontend/src/routes/(authenticated)/project/[project_code]/+page.svelte
+++ b/frontend/src/routes/(authenticated)/project/[project_code]/+page.svelte
@@ -334,7 +334,7 @@
       {/if}
       {#if project.type === ProjectType.FlEx}
         <FeatureFlagContent flag="FwLiteBeta">
-          <CrdtSyncButton {project} />
+          <CrdtSyncButton {project} {isEmpty} />
         </FeatureFlagContent>
       {/if}
       {#if project.type === ProjectType.FlEx && $isDev && !isEmpty}

--- a/frontend/src/routes/(authenticated)/project/[project_code]/+page.svelte
+++ b/frontend/src/routes/(authenticated)/project/[project_code]/+page.svelte
@@ -334,7 +334,7 @@
       {/if}
       {#if project.type === ProjectType.FlEx}
         <FeatureFlagContent flag="FwLiteBeta">
-          <CrdtSyncButton {project} hasHarmonyCommits={project.hasHarmonyCommits} />
+          <CrdtSyncButton {project} />
         </FeatureFlagContent>
       {/if}
       {#if project.type === ProjectType.FlEx && $isDev && !isEmpty}

--- a/frontend/src/routes/(authenticated)/project/[project_code]/+page.svelte
+++ b/frontend/src/routes/(authenticated)/project/[project_code]/+page.svelte
@@ -337,7 +337,7 @@
           <CrdtSyncButton {project} hasHarmonyCommits={project.hasHarmonyCommits} />
         </FeatureFlagContent>
       {/if}
-      {#if project.type === ProjectType.FlEx && $isDev}
+      {#if project.type === ProjectType.FlEx && $isDev && !isEmpty}
         <OpenInFlexModal bind:this={openInFlexModal} {project}/>
         <OpenInFlexButton projectId={project.id} on:click={openInFlexModal.open}/>
       {:else if canAskToJoinProject}

--- a/frontend/src/routes/(authenticated)/project/[project_code]/+page.ts
+++ b/frontend/src/routes/(authenticated)/project/[project_code]/+page.ts
@@ -598,6 +598,7 @@ export async function _refreshProjectRepoInfo(projectCode: string): Promise<void
                 id
                 resetStatus
                 lastCommit
+                hasHarmonyCommits
                 changesets {
                   node
                   parents

--- a/frontend/src/routes/(authenticated)/project/[project_code]/CrdtSyncButton.svelte
+++ b/frontend/src/routes/(authenticated)/project/[project_code]/CrdtSyncButton.svelte
@@ -11,13 +11,14 @@
   import {NewTabLinkMarkdown} from '$lib/components/Markdown';
 
   export let project: Project;
+  export let isEmpty: boolean;
   type SyncResult = {crdtChanges: number, fwdataChanges: number};
 
   const { notifySuccess, notifyWarning } = useNotifications();
 
   let syncing = false;
   let done = false;
-  $: state = done ? 'done' : syncing ? 'syncing' : 'idle';
+  $: state = isEmpty ? 'empty' : done ? 'done' : syncing ? 'syncing' : 'idle';
   let error: string | undefined = undefined;
 
   async function triggerSync(): Promise<string | undefined> {
@@ -129,6 +130,10 @@
       <div class="prose max-w-none underline-links">
         <NewTabLinkMarkdown md={$t('project.crdt.to_start_using')} />
       </div>
+    {:else if state === 'empty'}
+      <div class="prose max-w-none">
+        {$t('project.crdt.empty_project')}
+      </div>
     {:else}
       <div class="prose max-w-none underline-links">
         <NewTabLinkMarkdown md={$t('project.crdt.try_info')} />
@@ -147,6 +152,10 @@
         </Button>
         <Button on:click={close}>
           {$t('project.crdt.cancel')}
+        </Button>
+      {:else if state === 'empty'}
+        <Button on:click={close}>
+          {$t('common.close')}
         </Button>
       {:else if state === 'done'}
         <Button variant="btn-primary" on:click={close}>

--- a/frontend/src/routes/(authenticated)/project/[project_code]/CrdtSyncButton.svelte
+++ b/frontend/src/routes/(authenticated)/project/[project_code]/CrdtSyncButton.svelte
@@ -6,12 +6,11 @@
   import {useNotifications} from '$lib/notify';
   import {bounceIn} from 'svelte/easing';
   import {scale} from 'svelte/transition';
-  import type {Project} from './+page';
+  import {_refreshProjectRepoInfo, type Project} from './+page';
   import {Modal} from '$lib/components/modals';
   import {NewTabLinkMarkdown} from '$lib/components/Markdown';
 
   export let project: Project;
-  export let hasHarmonyCommits: boolean;
   type SyncResult = {crdtChanges: number, fwdataChanges: number};
 
   const { notifySuccess, notifyWarning } = useNotifications();
@@ -33,6 +32,7 @@
         if (typeof syncResults === 'string') {
           return syncResults;
         }
+        await _refreshProjectRepoInfo(project.code);
         notifySuccess($t('project.crdt.sync_result', { fwdataChanges: syncResults.fwdataChanges, crdtChanges: syncResults.crdtChanges }));
         done = true;
         return;
@@ -87,7 +87,7 @@
   let modal: Modal;
 </script>
 
-{#if hasHarmonyCommits}
+{#if project.hasHarmonyCommits}
   <Button variant="btn-primary" class="gap-1 indicator" on:click={syncProject} loading={state === 'syncing'} active={state === 'syncing'} customLoader>
     <span class="indicator-item badge badge-sm badge-accent translate-x-[calc(50%-16px)] shadow">Beta</span>
     {$t('project.crdt.sync_fwlite')}

--- a/frontend/src/routes/(authenticated)/project/[project_code]/CrdtSyncButton.svelte
+++ b/frontend/src/routes/(authenticated)/project/[project_code]/CrdtSyncButton.svelte
@@ -110,65 +110,66 @@
       {$t('project.crdt.try_fw_lite')}
     </span>
   </Button>
-  <Modal bind:this={modal} showCloseButton={false} hideActions={state === 'syncing'} closeOnClickOutside={false}>
-    <h2 class="text-xl mb-6">
-      {#if state === 'syncing'}
-        {$t('project.crdt.making_available')}
-      {:else if state === 'done'}
-        {$t('project.crdt.now_available')}
-      {:else}
-        {$t('project.crdt.try_fw_lite')}
-      {/if}
-    </h2>
-    {#if state === 'syncing'}
-      <p class="text-center my-6">
-        <span class="loading loading-lg"></span>
-      </p>
-      <div class="prose max-w-none underline-links">
-        <NewTabLinkMarkdown md={$t('project.crdt.while_you_wait')} />
-      </div>
-    {:else if state === 'done'}
-      <p class="text-center my-6">
-        <span
-          class="i-mdi-check-circle-outline text-7xl text-center text-success"
-          transition:scale={{ duration: 600, start: 0.7, easing: bounceIn }}
-        ></span>
-      </p>
-      <div class="prose max-w-none underline-links">
-        <NewTabLinkMarkdown md={$t('project.crdt.to_start_using')} />
-      </div>
-    {:else if state === 'empty'}
-      <div class="prose max-w-none">
-        {$t('project.crdt.empty_project')}
-      </div>
-    {:else}
-      <div class="prose max-w-none underline-links">
-        <NewTabLinkMarkdown md={$t('project.crdt.try_info')} />
-        {#if error}
-          <NewTabLinkMarkdown
-            md={`${$t('errors.apology')} ${$t('project.crdt.reach_out_for_help', { subject: encodeURIComponent($t('project.crdt.email_subject', { projectCode: project.code }))})}`}
-          />
-        {/if}
-      </div>
-      <FormError {error} right/>
-    {/if}
-    <svelte:fragment slot="actions" let:close>
-      {#if state === 'idle'}
-        <Button variant="btn-primary" on:click={onSubmit}>
-          {$t('project.crdt.submit')}
-        </Button>
-        <Button on:click={close}>
-          {$t('project.crdt.cancel')}
-        </Button>
-      {:else if state === 'empty'}
-        <Button on:click={close}>
-          {$t('common.close')}
-        </Button>
-      {:else if state === 'done'}
-        <Button variant="btn-primary" on:click={close}>
-          {$t('project.crdt.finish')}
-        </Button>
-      {/if}
-    </svelte:fragment>
-  </Modal>
 {/if}
+
+<Modal bind:this={modal} showCloseButton={false} hideActions={state === 'syncing'} closeOnClickOutside={false}>
+  <h2 class="text-xl mb-6">
+    {#if state === 'syncing'}
+      {$t('project.crdt.making_available')}
+    {:else if state === 'done'}
+      {$t('project.crdt.now_available')}
+    {:else}
+      {$t('project.crdt.try_fw_lite')}
+    {/if}
+  </h2>
+  {#if state === 'syncing'}
+    <p class="text-center my-6">
+      <span class="loading loading-lg"></span>
+    </p>
+    <div class="prose max-w-none underline-links">
+      <NewTabLinkMarkdown md={$t('project.crdt.while_you_wait')} />
+    </div>
+  {:else if state === 'done'}
+    <p class="text-center my-6">
+      <span
+        class="i-mdi-check-circle-outline text-7xl text-center text-success"
+        transition:scale={{ duration: 600, start: 0.7, easing: bounceIn }}
+      ></span>
+    </p>
+    <div class="prose max-w-none underline-links">
+      <NewTabLinkMarkdown md={$t('project.crdt.to_start_using')} />
+    </div>
+  {:else if state === 'empty'}
+    <div class="prose max-w-none">
+      {$t('project.crdt.empty_project')}
+    </div>
+  {:else}
+    <div class="prose max-w-none underline-links">
+      <NewTabLinkMarkdown md={$t('project.crdt.try_info')} />
+      {#if error}
+        <NewTabLinkMarkdown
+          md={`${$t('errors.apology')} ${$t('project.crdt.reach_out_for_help', { subject: encodeURIComponent($t('project.crdt.email_subject', { projectCode: project.code }))})}`}
+        />
+      {/if}
+    </div>
+    <FormError {error} right/>
+  {/if}
+  <svelte:fragment slot="actions" let:close>
+    {#if state === 'idle'}
+      <Button variant="btn-primary" on:click={onSubmit}>
+        {$t('project.crdt.submit')}
+      </Button>
+      <Button on:click={close}>
+        {$t('project.crdt.cancel')}
+      </Button>
+    {:else if state === 'empty'}
+      <Button on:click={close}>
+        {$t('common.close')}
+      </Button>
+    {:else if state === 'done'}
+      <Button variant="btn-primary" on:click={close}>
+        {$t('project.crdt.finish')}
+      </Button>
+    {/if}
+  </svelte:fragment>
+</Modal>

--- a/frontend/src/routes/(authenticated)/project/[project_code]/CrdtSyncButton.svelte
+++ b/frontend/src/routes/(authenticated)/project/[project_code]/CrdtSyncButton.svelte
@@ -9,6 +9,7 @@
   import {_refreshProjectRepoInfo, type Project} from './+page';
   import {Modal} from '$lib/components/modals';
   import {NewTabLinkMarkdown} from '$lib/components/Markdown';
+  import {Duration} from '$lib/util/time';
 
   export let project: Project;
   export let isEmpty: boolean;
@@ -34,7 +35,13 @@
           return syncResults;
         }
         await _refreshProjectRepoInfo(project.code);
-        notifySuccess($t('project.crdt.sync_result', { fwdataChanges: syncResults.fwdataChanges, crdtChanges: syncResults.crdtChanges }));
+        notifySuccess(
+          $t('project.crdt.sync_result', {
+            fwdataChanges: syncResults.fwdataChanges,
+            crdtChanges: syncResults.crdtChanges,
+          }),
+          Duration.Persistent,
+        );
         done = true;
         return;
       }
@@ -42,7 +49,7 @@
         status: response.status,
         statusText: response.statusText,
       });
-      notifyWarning(error);
+      notifyWarning(error, Duration.Persistent);
       console.error(error, await response.text());
       return error;
     } catch (error) {
@@ -79,7 +86,7 @@
 
   async function syncProject(): Promise<void> {
     let error = await triggerSync();
-    if (error) notifyWarning(error);
+    if (error) notifyWarning(error, Duration.Persistent);
   }
 
   async function useInFwLite(): Promise<void> {

--- a/frontend/src/routes/(authenticated)/project/[project_code]/CrdtSyncButton.svelte
+++ b/frontend/src/routes/(authenticated)/project/[project_code]/CrdtSyncButton.svelte
@@ -89,7 +89,7 @@
     <span class="indicator-item badge badge-sm badge-accent translate-x-[calc(50%-16px)] shadow">Beta</span>
     {$t('project.crdt.sync_fwlite')}
     <span style="transform: rotateY(180deg)">
-      <Icon icon="i-mdi-sync" spin={state === 'syncing'} spinReverse/>
+      <Icon icon="i-mdi-sync" spin={state === 'syncing'} spinReverse />
     </span>
   </Button>
 {:else}
@@ -110,21 +110,21 @@
       {/if}
     </h2>
     {#if state === 'syncing'}
-      <div class="mb-6 prose max-w-none underline-links">
-        <NewTabLinkMarkdown md={$t('project.crdt.while_you_wait')} />
-      </div>
-      <p class="text-center">
+      <p class="text-center my-6">
         <span class="loading loading-lg"></span>
       </p>
+      <div class="prose max-w-none underline-links">
+        <NewTabLinkMarkdown md={$t('project.crdt.while_you_wait')} />
+      </div>
     {:else if state === 'done'}
+      <p class="text-center my-6">
+        <span
+          class="i-mdi-check-circle-outline text-7xl text-center text-success"
+          transition:scale={{ duration: 600, start: 0.7, easing: bounceIn }}
+        ></span>
+      </p>
       <div class="prose max-w-none underline-links">
         <NewTabLinkMarkdown md={$t('project.crdt.to_start_using')} />
-        <p class="text-center">
-          <span
-            class="i-mdi-check-circle-outline text-7xl text-center text-success"
-            transition:scale={{ duration: 600, start: 0.7, easing: bounceIn }}
-          ></span>
-        </p>
       </div>
     {:else}
       <div class="prose max-w-none underline-links">

--- a/frontend/src/routes/(authenticated)/project/[project_code]/CrdtSyncButton.svelte
+++ b/frontend/src/routes/(authenticated)/project/[project_code]/CrdtSyncButton.svelte
@@ -37,7 +37,10 @@
         done = true;
         return;
       }
-      const error = `Failed to sync: ${response.statusText} (${response.status})`;
+      const error = $t('project.crdt.sync_trigger_failed', {
+        status: response.status,
+        statusText: response.statusText,
+      });
       notifyWarning(error);
       console.error(error, await response.text());
       return error;
@@ -53,7 +56,7 @@
       try {
         const response = await fetch(`/api/fw-lite/sync/await-sync-finished/${project.id}`, {signal: AbortSignal.timeout(30_000)});
         if (response.status === 500) {
-          return 'Sync failed, please contact support';
+          return $t('project.crdt.sync_failed');
         }
         if (response.status === 200) {
           const result = await response.json() as SyncResult;

--- a/frontend/src/routes/(authenticated)/project/[project_code]/CrdtSyncButton.svelte
+++ b/frontend/src/routes/(authenticated)/project/[project_code]/CrdtSyncButton.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import {tryGetErrorMessage} from '$lib/error/utils';
+  import {getErrorMessage} from '$lib/error/utils';
   import {Button, FormError} from '$lib/forms';
   import t from '$lib/i18n';
   import {Icon} from '$lib/icons';
@@ -45,7 +45,7 @@
       console.error(error, await response.text());
       return error;
     } catch (error) {
-      return tryGetErrorMessage(error);
+      return getErrorMessage(error);
     } finally {
       syncing = false;
     }
@@ -66,7 +66,7 @@
         if (error instanceof DOMException && (error.name === 'AbortError' || error.name === 'TimeoutError')) {
           continue;
         }
-        return tryGetErrorMessage(error) ?? 'Unknown error';
+        return getErrorMessage(error);
       }
 
     }

--- a/frontend/src/routes/(authenticated)/project/[project_code]/ResetProjectModal.svelte
+++ b/frontend/src/routes/(authenticated)/project/[project_code]/ResetProjectModal.svelte
@@ -9,6 +9,7 @@
   import { _refreshProjectRepoInfo } from './+page';
   import { scale } from 'svelte/transition';
   import { bounceIn } from 'svelte/easing';
+  import {getErrorMessage} from '$lib/error/utils';
 
   enum ResetSteps {
     Download,
@@ -58,14 +59,18 @@
 
   let { form, errors, enhance, reset, submitting } = lexSuperForm(verify, async () => {
     const url = `/api/project/resetProject/${code}`;
-    const resetResponse = await fetch(url, { method: 'post' });
-    //we should do the reset via a mutation, but this is easier for now
-    //we need to refresh the status so if the admin closes the dialog they can resume back where they left off.
-    await _refreshProjectRepoInfo(code);
-    if (resetResponse.ok) {
-      nextStep();
-    } else {
-      error = resetResponse.statusText;
+    try {
+      const resetResponse = await fetch(url, { method: 'post' });
+      //we should do the reset via a mutation, but this is easier for now
+      //we need to refresh the status so if the admin closes the dialog they can resume back where they left off.
+      await _refreshProjectRepoInfo(code);
+      if (resetResponse.ok) {
+        nextStep();
+      } else {
+        error = resetResponse.statusText;
+      }
+    } catch (e) {
+      error = getErrorMessage(e);
     }
   });
 


### PR DESCRIPTION
Fixed the problem by updating:
- The try FWL button
- The changesets (though this will only really be fixed by #1502)

Some changes:
- Made all the sync notifications persistent, because I often missed them due to them being triggered after long-running tasks
- In dev mode (and later "real" mode) we were showing "Open with FieldWorks" even when the project was empty, which meant we weren't showing the "Set up project" info. I changed that.
- Found some more messages to "translate"
- New empty project state:
![image](https://github.com/user-attachments/assets/a9a3ecc9-787f-4183-8735-49a85e835464)

- Moved the loader and green checkmark up underneath the modal title, because that seemed more appropriate:
![image](https://github.com/user-attachments/assets/743f5a0d-2e0e-4122-844a-3c77f057e7ac)
![image](https://github.com/user-attachments/assets/015fda39-6df3-4e76-86c3-b0e05801517d)
