### PR TITLE
Bug/1502 changesets are not updated after uploading zip

### DIFF
--- a/backend/LexCore/Entities/Project.cs
+++ b/backend/LexCore/Entities/Project.cs
@@ -36,11 +36,12 @@ public class Project : EntityBase
     public async Task<Changeset[]> GetChangesets(IHgService hgService)
     {
         var age = DateTimeOffset.UtcNow.Subtract(CreatedDate);
-        if (age.TotalSeconds < 40)
+        if (age.TotalSeconds < 6) // slightly longer than the refreshinterval (5s) in hgweb.hgrc
         {
             // The repo is unstable and potentially unavailable for a short while after creation, so don't read from it right away.
             // See: https://github.com/sillsdev/languageforge-lexbox/issues/173#issuecomment-1665478630
-            return Array.Empty<Changeset>();
+            // Update: Although we've greatly improved stability here, we're still at the will of the hgweb refresh interval.
+            return [];
         }
         else
         {

--- a/frontend/gql-codegen.ts
+++ b/frontend/gql-codegen.ts
@@ -1,5 +1,5 @@
-import type { Options } from 'vite-plugin-graphql-codegen';
-import type { TypeScriptPluginConfig } from '@graphql-codegen/typescript';
+import type {Options} from 'vite-plugin-graphql-codegen';
+import type {TypeScriptPluginConfig} from '@graphql-codegen/typescript';
 
 //https://the-guild.dev/graphql/codegen/docs/guides/svelte
 //config passed into vite instead of via codegen file, works the same though
@@ -29,7 +29,10 @@ const clientGeneration: Record<string, ConfiguredOutput> = {
   './src/lib/gql/generated/': {
     preset: 'client',
     config: generationConfig,
-    plugins: []
+    plugins: [],
+    presetConfig: {
+      fragmentMasking: false,
+    }
   }
 };
 
@@ -41,7 +44,7 @@ export const gqlOptions: Options = {
     ignoreNoDocuments: true, // for better experience with the watcher
     // verbose: true,
     generates: {
-      ...clientGeneration
+      ...clientGeneration,
     }
   }
 };

--- a/frontend/src/routes/(authenticated)/project/[project_code]/+page.ts
+++ b/frontend/src/routes/(authenticated)/project/[project_code]/+page.ts
@@ -73,9 +73,10 @@ export async function load(event: PageLoadEvent) {
 						isConfidential
             isLanguageForgeProject
             hasHarmonyCommits
-						organizations {
-							id
-						}
+            organizations {
+              id
+              name
+            }
             users {
               id
               role
@@ -116,10 +117,6 @@ export async function load(event: PageLoadEvent) {
                   isDefault
                 }
               }
-            }
-            organizations {
-              id
-              name
             }
 					}
 				}

--- a/frontend/src/routes/(authenticated)/project/[project_code]/+page.ts
+++ b/frontend/src/routes/(authenticated)/project/[project_code]/+page.ts
@@ -38,6 +38,19 @@ export type ProjectUser = NonNullable<Project['users']>[number];
 export type User = ProjectUser['user'];
 export type Org = Pick<Organization, 'id' | 'name'>;
 
+graphql(`
+  fragment Changesets on Project {
+    changesets {
+      node
+      rev
+      parents
+      date
+      user
+      desc
+    }
+  }
+`);
+
 export async function load(event: PageLoadEvent) {
   const client = getClient();
   const user = (await event.parent()).user;
@@ -120,14 +133,7 @@ export async function load(event: PageLoadEvent) {
           projectByCode(code: $projectCode) {
             id
             code
-            changesets {
-              node
-              rev
-              parents
-              date
-              user
-              desc
-            }
+            ...Changesets
           }
         }
       `),
@@ -598,13 +604,7 @@ export async function _refreshProjectRepoInfo(projectCode: string): Promise<void
                 id
                 resetStatus
                 lastCommit
-                changesets {
-                  node
-                  parents
-                  date
-                  user
-                  desc
-                }
+                ...Changesets
             }
         }
     `), { projectCode }, { requestPolicy: 'network-only' });

--- a/frontend/tests/fixtures.ts
+++ b/frontend/tests/fixtures.ts
@@ -24,6 +24,7 @@ export interface TempProject {
   id: UUID
   code: string
   name: string
+  createdAt: number
 }
 
 export type CreateProjectResponse = {data: {createProject: {createProjectResponse: {id: UUID}}}}
@@ -189,7 +190,8 @@ export const test = base.extend<Fixtures>({
       }
 `);
     const id = gqlResponse.data.createProject.createProjectResponse.id;
-    await use({id, code, name});
+    const createdAt = Date.now();
+    await use({id, code, name, createdAt});
     const deleteResponse = await page.request.delete(`${testEnv.serverBaseUrl}/api/project/${id}`);
     expect(deleteResponse.ok()).toBeTruthy();
   },

--- a/frontend/tests/resetProject.test.ts
+++ b/frontend/tests/resetProject.test.ts
@@ -1,11 +1,12 @@
 import * as testEnv from './envVars';
 
-import { AdminDashboardPage } from './pages/adminDashboardPage';
-import { ProjectPage } from './pages/projectPage';
-import { expect } from '@playwright/test';
-import { join } from 'path';
-import { loginAs } from './utils/authHelpers';
-import { test } from './fixtures';
+import {AdminDashboardPage} from './pages/adminDashboardPage';
+import {ProjectPage} from './pages/projectPage';
+import {expect} from '@playwright/test';
+import {join} from 'path';
+import {loginAs} from './utils/authHelpers';
+import {test, type TempProject} from './fixtures';
+import {delay} from '$lib/util/time';
 
 type HgWebFileJson = {
   abspath: string
@@ -17,7 +18,7 @@ type HgWebJson = {
   files: HgWebFileJson[]
 }
 
-test('reset project and upload .zip file', async ({ page, tempProject, tempDir }) => {
+test('reset project and upload .zip file', async ({page, tempProject, tempDir}) => {
   test.slow();
 
   const allZeroHash = '0000000000000000000000000000000000000000';
@@ -31,6 +32,7 @@ test('reset project and upload .zip file', async ({ page, tempProject, tempDir }
   await resetProjectModel.clickNextStepButton('I have a working backup');
   await resetProjectModel.confirmProjectBackupReceived(tempProject.code);
   await resetProjectModel.clickNextStepButton('Reset project');
+  await waitUntilProjectIsOldEnoughToReturnRealChangesets(tempProject);
   await resetProjectModel.uploadProjectZipFile('tests/data/test-project-one-commit.zip');
   await expect(page.getByText('Project successfully reset')).toBeVisible();
   await page.getByRole('button', { name: 'Close' }).click();
@@ -41,13 +43,14 @@ test('reset project and upload .zip file', async ({ page, tempProject, tempDir }
   const beforeResetJson = await beforeResetResponse.json() as HgWebJson;
   expect(beforeResetJson).toHaveProperty('node');
   expect(beforeResetJson.node).not.toEqual(allZeroHash);
+  const linkToHgWebTip = page.locator(`a[href="/hg/${tempProject.code}/file/${beforeResetJson.node}"]`);
+  await expect(linkToHgWebTip).toBeVisible();
   expect(beforeResetJson).toHaveProperty('files');
   expect(beforeResetJson.files).toHaveLength(1);
   expect(beforeResetJson.files[0]).toHaveProperty('basename');
   expect(beforeResetJson.files[0].basename).toBe('hello.txt');
 
   // Step 3: reset project, do not upload zip file
-  await projectPage.goto();
   await projectPage.clickResetProject();
   const download = await resetProjectModel.downloadProjectBackup();
   await download.saveAs(join(tempDir, 'reset-project-test-step-1.zip'));
@@ -62,11 +65,11 @@ test('reset project and upload .zip file', async ({ page, tempProject, tempDir }
   const afterResetResponse = await page.request.get(`${testEnv.serverBaseUrl}/hg/${tempProject.code}/file/tip?style=json-lex`);
   const afterResetJson = await afterResetResponse.json() as HgWebJson;
   expect(afterResetJson.node).toEqual(allZeroHash);
+  await expect(linkToHgWebTip).not.toBeVisible();
   expect(afterResetJson).toHaveProperty('files');
   expect(afterResetJson.files).toHaveLength(0);
 
   // Step 5: reset project again, uploading zip file downloaded from step 1
-  await projectPage.goto();
   await projectPage.clickResetProject();
   await resetProjectModel.clickNextStepButton('I have a working backup');
   await resetProjectModel.confirmProjectBackupReceived(tempProject.code);
@@ -80,4 +83,16 @@ test('reset project and upload .zip file', async ({ page, tempProject, tempDir }
   const afterUploadResponse = await page.request.get(`${testEnv.serverBaseUrl}/hg/${tempProject.code}/file/tip?style=json-lex`);
   const afterResetJSon = await afterUploadResponse.json() as HgWebJson;
   expect(afterResetJSon).toEqual(beforeResetJson); // NOT .toBe(), which would check that they're the same object.
+  // and the UI has updated
+  await expect(linkToHgWebTip).toBeVisible();
 });
+
+async function waitUntilProjectIsOldEnoughToReturnRealChangesets(tempProject: TempProject): Promise<void> {
+  const projectAge = Date.now() - tempProject.createdAt;
+  const requiredAge = 6_000; // see C#'s Project.GetChangesets
+  const grace = 2_000;
+  if (projectAge < requiredAge) {
+    const waitTime = requiredAge - projectAge;
+    await delay(waitTime + grace);
+  }
+}


### PR DESCRIPTION
Resolves #1502 

A long long time ago we broke updating changesets in the UI when a zip is uploaded, because the refresh query didn't select all the changeset fields we selected in the original query store. (rev was currently missing)

This fixes that by sharing a GQL fragement, so that they stay in sync.

Then, partially, so that the test doesn't have to take so long and partially, because it was just time, I drastically decreased the time we "block" requesting the real changesets on a project.

Then, I extended the reset project test to ensure the UI updates as we expect.