### PR TITLE
Bug/stabilize harmony sync tests

### DIFF
--- a/backend/Testing/FwHeadless/MergeFwDataWithHarmonyTests.cs
+++ b/backend/Testing/FwHeadless/MergeFwDataWithHarmonyTests.cs
@@ -17,6 +17,7 @@ public class MergeFwDataWithHarmonyTests : ApiTestBase, IAsyncLifetime
             $"api/Testing/copyToNewProject?newProjectCode={newProjectCode}&existingProjectCode={existingProjectCode}",
             null);
         result.EnsureSuccessStatusCode();
+        await Utils.WaitForHgRefreshIntervalAsync();
         return await result.Content.ReadFromJsonAsync<Guid>();
     }
 


### PR DESCRIPTION
Presumably due to the hgweb refresh interval the 2 `[MergeFwDataWithHarmonyTests](https://github.com/sillsdev/languageforge-lexbox/compare/bug/stabilize-harmony-sync-tests?expand=1#diff-a44cb2ed33dccf7e2e74601e44a2232029eaa1726bdcb053570f408a285d7be7)` are flaky when run in a batch.

Also, there was a wait missing in the hg-service, which is perhaps only relevant in aws and is not enough to fix the tests.