### PR TITLE
Dockerignore FwLite app folders

### DIFF
--- a/backend/.dockerignore
+++ b/backend/.dockerignore
@@ -6,8 +6,8 @@ FwLite/FwLiteWeb
 FwLite/FwLiteMaui
 FwLite/FwLiteShared
 **/artifacts/publish
-CrdtMerge/Mercurial
-CrdtMerge/MercurialExtensions
+FwHeadless/Mercurial
+FwHeadless/MercurialExtensions
 *.sqlite
 *.sqlite-shm
 *.sqlite-wal

--- a/backend/.dockerignore
+++ b/backend/.dockerignore
@@ -2,6 +2,9 @@
 **/obj
 *Dockerfile
 Testing
+FwLite/FwLiteWeb
+FwLite/FwLiteMaui
+FwLite/FwLiteShared
 **/artifacts/publish
 CrdtMerge/Mercurial
 CrdtMerge/MercurialExtensions


### PR DESCRIPTION
Initially I was ignoring these with the tiltfile, but then I realized we never need them in docker atm.
It was working in the tiltfile. I guess I need to observe it for a while to see if it actually works in the dockerignore file.