### PR TITLE
add back close function to FormModal

### DIFF
--- a/frontend/src/lib/components/modals/FormModal.svelte
+++ b/frontend/src/lib/components/modals/FormModal.svelte
@@ -62,6 +62,10 @@
     return superForm.form;
   }
 
+  export function close(): void {
+    modal?.close();
+  }
+
   async function openModal(onSubmit: SubmitCallback): Promise<DialogResponse> {
     const result = await modal.openModal();
     if (result == DialogResponse.Cancel) return result;


### PR DESCRIPTION
closes #1510 

`FormModal.close` was removed in https://github.com/sillsdev/languageforge-lexbox/pull/1375/commits/ffee90257154ec97e21d4b08605b474a856c74cc, I'm not super clear on why, so I've just added it back to fix this bug. @myieye do you remember why?

`FormModal.close` is used in `EditUserAccount.close` when deleting a user and this was causing the issue. I'm not sure why linting didn't catch this issue, maybe we could fix that too?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a new option to programmatically close the modal, providing more flexible and dynamic control over modal dialogs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->