### PR TITLE
Extract tasks to ui:fw-lite-infra

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -100,7 +100,7 @@ tasks:
     aliases:
       - web
       - web-for-develop
-    deps: [ ui:viewer-dev, fw-lite:web, ui:https-oauth-authority ]
+    deps: [ fw-lite:web, ui:fw-lite-infr]
 
   fw-lite-win:
-    deps: [fw-lite:maui-windows, ui:viewer-dev, ui:https-oauth-authority]
+    deps: [fw-lite:maui-windows, ui:fw-lite-infr]

--- a/frontend/Taskfile.yml
+++ b/frontend/Taskfile.yml
@@ -21,6 +21,13 @@ tasks:
     cmds:
       - corepack enable || true
       - pnpm install
+
+  fw-lite-infr:
+    desc: The extra UI stuff the FW Lite Maui app needs to run. I.e. if you want to debug Maui, run this first, otherwise use a task that depends on this.
+    aliases:
+      - fi
+    deps: [ viewer-dev, https-oauth-authority ]
+
   playwright-tests:
     aliases: [ pt ]
     cmd: pnpm run test {{.CLI_ARGS}}


### PR DESCRIPTION
Extracts the "UI infrastructure" tasks to a seperate task, so they can be easily run when wanting to debug Maui

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a new task to support enhanced UI component operations with an easy-to-use alias.
  
- **Chores**
  - Revised existing task configurations to streamline dependency management for both web and windows functionalities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->