### PR TITLE
Fix: UI errors on authentication-changed events

### DIFF
--- a/frontend/viewer/src/lib/services/event-bus.ts
+++ b/frontend/viewer/src/lib/services/event-bus.ts
@@ -41,12 +41,13 @@ export class EventBus {
 
   public onEntryUpdated(projectName: string, callback: (entry: IEntry) => void): () => void {
     // eslint-disable-next-line func-style
-    const onEventCallback = (event: IFwEvent) => {
-      const projectEvent = event as IProjectEvent;
-      if (projectEvent.project.name !== projectName) return;
-      if (projectEvent.event.type !== FwEventType.EntryChanged) return;
+    const onEventCallback = (event: IFwEvent | IProjectEvent) => {
+      if (!('project' in event)) return;
 
-      const entryChangedEvent = projectEvent.event as IEntryChangedEvent;
+      if (event.project.name !== projectName) return;
+      if (event.event.type !== FwEventType.EntryChanged) return;
+
+      const entryChangedEvent = event.event as IEntryChangedEvent;
       callback(entryChangedEvent.entry);
     };
     this._onEvent.add(onEventCallback);


### PR DESCRIPTION
With 2 tabs open, when playing with authentication in one tab the other tab throws errors, because `projectEvent.project` is not defined on `IAuthenticationChangedEvent`s.