### PR TITLE
Don't cancel completed task-completion-source

### DIFF
--- a/backend/FwLite/FwLiteShared/Auth/OAuthService.cs
+++ b/backend/FwLite/FwLiteShared/Auth/OAuthService.cs
@@ -137,7 +137,11 @@ public class OAuthLoginRequest(IPublicClientApplication app, string clientReturn
         Uri redirectUri,
         CancellationToken cancellationToken)
     {
-        cancellationToken.Register(_resultTcs.SetCanceled);
+        cancellationToken.Register(() =>
+        {
+            if (!_resultTcs.Task.IsCompleted)
+                _resultTcs.SetCanceled();
+        });
         State = HttpUtility.ParseQueryString(authorizationUri.Query).Get("state");
         //triggers step 1 to finish awaiting
         _authUriTcs.SetResult(authorizationUri);


### PR DESCRIPTION
On a regular basis my Maui app (maybe web only?) was getting killed with:
`An attempt was made to transition a task to a final state when it had already completed`.

I debugged all the places we complete stuff in the `OAuthService` and I'm pretty sure this one is the culprit. I didn't dig very deep, but it seems somewhat unpredictable when or why the `cancellationToken` gets canceled, but it does.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Enhanced the cancellation handling during user authentication to prevent unexpected behavior, ensuring a smoother login experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->