### PR TITLE
chore/reduce-import-spans

### DIFF
--- a/backend/FwHeadless/OtelSampler.cs
+++ b/backend/FwHeadless/OtelSampler.cs
@@ -1,0 +1,57 @@
+﻿using System.Diagnostics;
+using System.Text;
+using FwLiteProjectSync;
+using OpenTelemetry.Trace;
+
+namespace FwHeadless;
+
+public class OtelSampler(ILogger<OtelSampler> logger) : Sampler
+{
+    private const string SqliteTraceName = "OpenTelemetry.Instrumentation.EntityFrameworkCore.Execute";
+    public override SamplingResult ShouldSample(in SamplingParameters samplingParameters)
+    {
+        if (IsImportEfSpan(samplingParameters))
+        {
+            return new SamplingResult(SamplingDecision.Drop);
+        }
+
+        return new SamplingResult(true);
+    }
+
+    private bool IsImportEfSpan(in SamplingParameters samplingParameters)
+    {
+        var parent = Activity.Current;
+        if (logger.IsEnabled(LogLevel.Trace))
+            logger.LogTrace("sampling params {Sampling}, current activity {Activity}", Format(samplingParameters), Format(parent));
+        if (parent is null) return false;
+
+        if (parent.OperationName == nameof(MiniLcmImport.ImportProject) && samplingParameters.Name == SqliteTraceName)
+        {
+            return true;
+        }
+        return false;
+    }
+
+    private string Format(in SamplingParameters parameters)
+    {
+        var sb = new StringBuilder();
+        sb.Append("Kind: ").Append(parameters.Kind).AppendLine();
+        sb.Append("TraceId: ").Append(parameters.TraceId).AppendLine();
+        sb.Append("Name: ").Append(parameters.Name).AppendLine();
+        sb.Append("Tags: [").AppendJoin(", ", parameters.Tags ?? []).AppendLine("]");
+        sb.Append("ParentContext.TraceFlags: ").Append(parameters.ParentContext.TraceFlags).AppendLine();
+        sb.Append("ParentContext.TraceId: ").Append(parameters.ParentContext.TraceId).AppendLine();
+        sb.Append("ParentContext.SpanId: ").Append(parameters.ParentContext.SpanId).AppendLine();
+        sb.Append("ParentContext.TraceState: ").Append(parameters.ParentContext.TraceState).AppendLine();
+        return sb.ToString();
+    }
+
+    private string Format(Activity? activity)
+    {
+        if (activity is null) return "none";
+        var sb = new StringBuilder();
+        sb.Append("Activity: ").AppendLine(activity.OperationName);
+
+        return sb.ToString();
+    }
+}

--- a/backend/FwHeadless/OtelSampler.cs
+++ b/backend/FwHeadless/OtelSampler.cs
@@ -1,4 +1,5 @@
 ﻿using System.Diagnostics;
+using System.Runtime.CompilerServices;
 using System.Text;
 using FwLiteProjectSync;
 using OpenTelemetry.Trace;
@@ -25,9 +26,22 @@ public class OtelSampler(ILogger<OtelSampler> logger) : Sampler
             logger.LogTrace("sampling params {Sampling}, current activity {Activity}", Format(samplingParameters), Format(parent));
         if (parent is null) return false;
 
-        if (parent.OperationName == nameof(MiniLcmImport.ImportProject) && samplingParameters.Name == SqliteTraceName)
+        if (samplingParameters.Name == SqliteTraceName && IsImportProjectSpan(parent))
         {
             return true;
+        }
+        return false;
+    }
+
+    private bool IsImportProjectSpan(Activity? activity)
+    {
+        while (activity is not null)
+        {
+            if (activity.OperationName == nameof(MiniLcmImport.ImportProject))
+            {
+                return true;
+            }
+            activity = activity.Parent;
         }
         return false;
     }

--- a/backend/FwHeadless/Program.cs
+++ b/backend/FwHeadless/Program.cs
@@ -42,7 +42,8 @@ builder.AddServiceDefaults(AppVersion.Get(typeof(Program))).ConfigureAdditionalO
         .AddSource(FwHeadlessActivitySource.ActivitySourceName,
             FwLiteProjectSyncActivitySource.ActivitySourceName,
             FwDataMiniLcmBridgeActivitySource.ActivitySourceName,
-            LcmCrdtActivitySource.ActivitySourceName));
+            LcmCrdtActivitySource.ActivitySourceName)
+        .SetSampler<OtelSampler>());
 });
 
 var app = builder.Build();

--- a/backend/FwLite/LcmCrdt/CrdtProjectsService.cs
+++ b/backend/FwLite/LcmCrdt/CrdtProjectsService.cs
@@ -94,8 +94,9 @@ public partial class CrdtProjectsService(IServiceProvider provider, ILogger<Crdt
         activity?.SetTag("app.project_id", request.Id);
         if (!ProjectName().IsMatch(request.Name))
         {
-            activity?.SetStatus(ActivityStatusCode.Error, "Project name is invalid");
-            throw new InvalidOperationException("Project name is invalid");
+            var nameIsInvalid = $"Project name '{request.Name}' is invalid";
+            activity?.SetStatus(ActivityStatusCode.Error, nameIsInvalid);
+            throw new InvalidOperationException(nameIsInvalid);
         }
 
         //poor man's sanitation
@@ -103,8 +104,9 @@ public partial class CrdtProjectsService(IServiceProvider provider, ILogger<Crdt
         var sqliteFile = Path.Combine(request.Path ?? config.Value.ProjectPath, $"{name}.sqlite");
         if (File.Exists(sqliteFile))
         {
-            activity?.SetStatus(ActivityStatusCode.Error, "Project already exists");
-            throw new InvalidOperationException("Project already exists");
+            var alreadyExists = $"Project already exists at '{sqliteFile}'";
+            activity?.SetStatus(ActivityStatusCode.Error, alreadyExists);
+            throw new InvalidOperationException(alreadyExists);
         }
 
         var crdtProject = new CrdtProject(name, sqliteFile);


### PR DESCRIPTION
should reduce spans created during an import which should help us avoid crashing our otel collector and going over our usage limit in honeycomb

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a custom telemetry sampling mechanism that refines tracing accuracy.
  - Updated the tracing configuration to leverage the new sampling strategy for better observability.
  - Enhanced error tracking and logging during project creation, improving diagnostics in failure scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->