### PR TITLE
Fix project list empty after web app login

### DIFF
--- a/backend/FwLite/FwLiteShared/Auth/OAuthClient.cs
+++ b/backend/FwLite/FwLiteShared/Auth/OAuthClient.cs
@@ -135,7 +135,6 @@ public class OAuthClient
 
     public async Task<OAuthService.SignInResult> SignIn(string returnUrl, CancellationToken cancellation = default)
     {
-        InvalidateProjectCache();
         await ConfigureCache();
         return await _oAuthService.SubmitLoginRequest(_application, returnUrl, _lexboxServer, cancellation);
     }
@@ -149,13 +148,7 @@ public class OAuthClient
         {
             await _application.RemoveAsync(account);
         }
-        InvalidateProjectCache();
-        _globalEventBus.PublishEvent(new AuthenticationChangedEvent(_lexboxServer.Id));
-    }
-
-    private void InvalidateProjectCache()
-    {
-        _lexboxProjectService.InvalidateProjectsCache(_lexboxServer);
+        _globalEventBus.PublishEvent(new AuthenticationChangedEvent(_lexboxServer));
     }
 
     private async ValueTask<AuthenticationResult?> GetAuth(bool forceRefresh = false)

--- a/backend/FwLite/FwLiteShared/Auth/OAuthService.cs
+++ b/backend/FwLite/FwLiteShared/Auth/OAuthService.cs
@@ -27,7 +27,7 @@ public class OAuthService(
         if (options.Value.SystemWebViewLogin)
         {
             await HandleSystemWebViewLogin(application, cancellation);
-            globalEventBus.PublishEvent(new AuthenticationChangedEvent(lexboxServer.Id));
+            globalEventBus.PublishEvent(new AuthenticationChangedEvent(lexboxServer));
             return new(null, true);
         }
 
@@ -68,7 +68,7 @@ public class OAuthService(
             await request.GetAuthenticationResult(applicationLifetime?.ApplicationStopping.Merge(cancellation) ??
                                                   cancellation),
             request.ClientReturnUrl);
-        globalEventBus.PublishEvent(new AuthenticationChangedEvent(request.LexboxServer.Id));
+        globalEventBus.PublishEvent(new AuthenticationChangedEvent(request.LexboxServer));
         return result;
         //step 8
     }

--- a/backend/FwLite/FwLiteShared/Events/AuthenticationChangedEvent.cs
+++ b/backend/FwLite/FwLiteShared/Events/AuthenticationChangedEvent.cs
@@ -1,6 +1,8 @@
-﻿namespace FwLiteShared.Events;
+﻿using FwLiteShared.Auth;
 
-public record AuthenticationChangedEvent(string ServerId) : IFwEvent
+namespace FwLiteShared.Events;
+
+public record AuthenticationChangedEvent(LexboxServer Server) : IFwEvent
 {
     public FwEventType Type => FwEventType.AuthenticationChanged;
     public bool IsGlobal => true;

--- a/backend/FwLite/FwLiteShared/FwLiteSharedKernel.cs
+++ b/backend/FwLite/FwLiteShared/FwLiteSharedKernel.cs
@@ -27,7 +27,6 @@ public static class FwLiteSharedKernel
         services.AddScoped<SyncService>();
         services.AddScoped<ProjectServicesProvider>();
         services.AddSingleton<LexboxProjectService>();
-        services.AddSingleton<IHostedService>(s => s.GetRequiredService<LexboxProjectService>());
         services.AddSingleton<CombinedProjectsService>();
         services.AddSingleton<GlobalEventBus>();
         services.AddSingleton<ProjectEventBus>();

--- a/backend/FwLite/FwLiteShared/FwLiteSharedKernel.cs
+++ b/backend/FwLite/FwLiteShared/FwLiteSharedKernel.cs
@@ -27,6 +27,7 @@ public static class FwLiteSharedKernel
         services.AddScoped<SyncService>();
         services.AddScoped<ProjectServicesProvider>();
         services.AddSingleton<LexboxProjectService>();
+        services.AddSingleton<IHostedService>(s => s.GetRequiredService<LexboxProjectService>());
         services.AddSingleton<CombinedProjectsService>();
         services.AddSingleton<GlobalEventBus>();
         services.AddSingleton<ProjectEventBus>();

--- a/backend/FwLite/FwLiteShared/Projects/CombinedProjectsService.cs
+++ b/backend/FwLite/FwLiteShared/Projects/CombinedProjectsService.cs
@@ -1,4 +1,4 @@
-﻿using FwLiteShared.Auth;
+using FwLiteShared.Auth;
 using FwLiteShared.Sync;
 using LcmCrdt;
 using Microsoft.Extensions.DependencyInjection;
@@ -35,21 +35,21 @@ public class CombinedProjectsService(LexboxProjectService lexboxProjectService,
     [JSInvokable]
     public bool SupportsFwData() => FwDataProjectProvider is not null;
     [JSInvokable]
-    public async Task<ServerProjects[]> RemoteProjects(bool forceRefresh)
+    public async Task<ServerProjects[]> RemoteProjects()
     {
         var lexboxServers = lexboxProjectService.Servers();
         ServerProjects[] serverProjects = new ServerProjects[lexboxServers.Length];
         for (var i = 0; i < lexboxServers.Length; i++)
         {
             var server = lexboxServers[i];
-            var projectModels = await ServerProjects(server, forceRefresh);
+            var projectModels = await ServerProjects(server);
             serverProjects[i] = new ServerProjects(server, projectModels);
         }
 
         return serverProjects;
     }
 
-    private async Task<ProjectModel[]> ServerProjects(LexboxServer server, bool forceRefresh)
+    private async Task<ProjectModel[]> ServerProjects(LexboxServer server, bool forceRefresh = false)
     {
         if (forceRefresh) lexboxProjectService.InvalidateProjectsCache(server);
         var lexboxProjects = await lexboxProjectService.GetLexboxProjects(server);

--- a/backend/FwLite/FwLiteWeb/Routes/ProjectRoutes.cs
+++ b/backend/FwLite/FwLiteWeb/Routes/ProjectRoutes.cs
@@ -1,4 +1,4 @@
-﻿using System.Text.RegularExpressions;
+using System.Text.RegularExpressions;
 using FwDataMiniLcmBridge;
 using FwLiteShared;
 using FwLiteShared.Auth;
@@ -22,7 +22,7 @@ public static class ProjectRoutes
         group.MapGet("/remoteProjects",
             async (CombinedProjectsService combinedProjectsService) =>
             {
-                return (await combinedProjectsService.RemoteProjects(false)).ToDictionary(p => p.Server.Authority.Authority, p => p.Projects);
+                return (await combinedProjectsService.RemoteProjects()).ToDictionary(p => p.Server.Authority.Authority, p => p.Projects);
             });
         group.MapGet("/localProjects",
             (CombinedProjectsService combinedProjectsService) => combinedProjectsService.LocalProjects());

--- a/frontend/viewer/src/home/ServersList.svelte
+++ b/frontend/viewer/src/home/ServersList.svelte
@@ -1,4 +1,4 @@
-﻿<script lang="ts">
+<script lang="ts">
   import type {ILexboxServer} from '$lib/dotnet-types';
   import {type Project} from '$lib/services/projects-service';
   import {useAuthService, useProjectsService} from '$lib/services/service-provider';
@@ -13,10 +13,10 @@
   let remoteProjects: { [server: string]: Project[] } = {};
   let loadingRemoteProjects = false;
 
-  async function fetchRemoteProjects(force: boolean = false): Promise<void> {
+  async function fetchRemoteProjects(): Promise<void> {
     loadingRemoteProjects = true;
     try {
-      let result = await projectsService.remoteProjects(force);
+      let result = await projectsService.remoteProjects();
       for (let serverProjects of result) {
         remoteProjects[serverProjects.server.id] = serverProjects.projects;
       }

--- a/frontend/viewer/src/lib/dotnet-types/generated-types/FwLiteShared/Events/IAuthenticationChangedEvent.ts
+++ b/frontend/viewer/src/lib/dotnet-types/generated-types/FwLiteShared/Events/IAuthenticationChangedEvent.ts
@@ -4,11 +4,12 @@
 //     the code is regenerated.
 
 import type {IFwEvent} from './IFwEvent';
+import type {ILexboxServer} from '../Auth/ILexboxServer';
 import type {FwEventType} from './FwEventType';
 
 export interface IAuthenticationChangedEvent extends IFwEvent
 {
-	serverId: string;
+	server: ILexboxServer;
 	type: FwEventType;
 	isGlobal: boolean;
 }

--- a/frontend/viewer/src/lib/dotnet-types/generated-types/FwLiteShared/Projects/ICombinedProjectsService.ts
+++ b/frontend/viewer/src/lib/dotnet-types/generated-types/FwLiteShared/Projects/ICombinedProjectsService.ts
@@ -10,7 +10,7 @@ import type {ILexboxServer} from '../Auth/ILexboxServer';
 export interface ICombinedProjectsService
 {
 	supportsFwData() : Promise<boolean>;
-	remoteProjects(forceRefresh: boolean) : Promise<IServerProjects[]>;
+	remoteProjects() : Promise<IServerProjects[]>;
 	serverProjects(serverId: string, forceRefresh: boolean) : Promise<IProjectModel[]>;
 	localProjects() : Promise<IProjectModel[]>;
 	downloadProject(lexboxProjectId: string, projectName: string, server: ILexboxServer) : Promise<void>;


### PR DESCRIPTION
The FWL web app currently has a bug:
When you log in the project list is empty until explicitly refreshed

The cause is:
- The cache is invalidated at the beginning of the log in flow
- But during the log in the page reloads before being authenticated, which results in the cache being repopulated with an empty list

This PR fixes that by relying on the AuthenticationChanged events to know when to invalidate the project cache.
The events are only fired when the user has actually been logged in or out. So, we know the next project list fetch will use the current auth state.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
	- Enhanced the authentication flow with improved state notifications.
	- Streamlined the project retrieval process to simplify configuration.
	- Optimized dependency management for more consistent system behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->