### PR TITLE
Prevent duplicte click events

### DIFF
--- a/frontend/viewer/src/home/HomeView.svelte
+++ b/frontend/viewer/src/home/HomeView.svelte
@@ -147,16 +147,17 @@
           <div>
             {#each projects.filter(p => p.crdt) as project, i (project.id ?? i)}
               {@const server = project.server}
+              {@const loading = deletingProject === project.name}
               <AnchorListItem href={`/project/${project.name}`}>
                 <ListItem title={project.name}
                           icon={mdiBookEditOutline}
                           subheading={!server ? 'Local only' : ('Synced with ' + server.displayName)}
-                          loading={deletingProject === project.name}>
+                          {loading}>
                   <div slot="actions">
                     {#if $isDev}
                       <Button icon={mdiDelete} title="Delete" class="p-2" on:click={(e) => {
                         e.preventDefault();
-                        void deleteProject(project.name);
+                        if (!loading) void deleteProject(project.name);
                       }} />
                     {/if}
                     <Button icon={mdiChevronRight} class="p-2 pointer-events-none"/>
@@ -174,7 +175,11 @@
               </AnchorListItem>
             </DevContent>
             {#if !projects.some(p => p.name === exampleProjectName) || $isDev}
-              <ListItem title="Create Example Project" on:click={() => createExampleProject()} loading={createProjectLoading}>
+              <ListItem
+                title="Create Example Project"
+                on:click={() => {if(!createProjectLoading) void createExampleProject()}}
+                loading={createProjectLoading}
+              >
                 <div slot="actions" class="flex flex-nowrap gap-2">
                   {#if $isDev}
                     <TextField bind:value={customExampleProjectName} placeholder="Project name..." on:click={(e) => e.stopPropagation()} />

--- a/frontend/viewer/src/home/HomeView.svelte
+++ b/frontend/viewer/src/home/HomeView.svelte
@@ -20,7 +20,7 @@
     useImportFwdataService,
     useProjectsService, useTroubleshootingService
   } from '$lib/services/service-provider';
-  import AnchorListItem from '$lib/utils/AnchorListItem.svelte';
+  import ButtonListItem from '$lib/utils/ButtonListItem.svelte';
   import TroubleshootDialog from '$lib/troubleshoot/TroubleshootDialog.svelte';
   import ServersList from './ServersList.svelte';
 
@@ -148,45 +148,46 @@
             {#each projects.filter(p => p.crdt) as project, i (project.id ?? i)}
               {@const server = project.server}
               {@const loading = deletingProject === project.name}
-              <AnchorListItem href={`/project/${project.name}`}>
+              <ButtonListItem href={`/project/${project.name}`}>
                 <ListItem title={project.name}
                           icon={mdiBookEditOutline}
                           subheading={!server ? 'Local only' : ('Synced with ' + server.displayName)}
                           {loading}>
                   <div slot="actions">
                     {#if $isDev}
-                      <Button icon={mdiDelete} title="Delete" class="p-2" on:click={(e) => {
+                      <Button icon={mdiDelete} title="Delete" class="p-2" disabled={loading} on:click={(e) => {
                         e.preventDefault();
-                        if (!loading) void deleteProject(project.name);
+                        void deleteProject(project.name);
                       }} />
                     {/if}
                     <Button icon={mdiChevronRight} class="p-2 pointer-events-none"/>
                   </div>
                 </ListItem>
-              </AnchorListItem>
+              </ButtonListItem>
             {/each}
             <DevContent>
-              <AnchorListItem href={`/testing/project-view`}>
+              <ButtonListItem href={`/testing/project-view`}>
                 <ListItem title="Test Project" icon={mdiTestTube}>
                   <div slot="actions" class="pointer-events-none">
                     <Button icon={mdiChevronRight} class="p-2"/>
                   </div>
                 </ListItem>
-              </AnchorListItem>
+              </ButtonListItem>
             </DevContent>
             {#if !projects.some(p => p.name === exampleProjectName) || $isDev}
-              <ListItem
-                title="Create Example Project"
-                on:click={() => {if(!createProjectLoading) void createExampleProject()}}
-                loading={createProjectLoading}
-              >
-                <div slot="actions" class="flex flex-nowrap gap-2">
-                  {#if $isDev}
-                    <TextField bind:value={customExampleProjectName} placeholder="Project name..." on:click={(e) => e.stopPropagation()} />
-                  {/if}
-                  <Button icon={mdiBookPlusOutline} class="pointer-events-none p-2"/>
-                </div>
-              </ListItem>
+              <ButtonListItem on:click={() => createExampleProject()} disabled={createProjectLoading}>
+                <ListItem
+                  title="Create Example Project"
+                  loading={createProjectLoading}
+                >
+                  <div slot="actions" class="flex flex-nowrap gap-2">
+                    {#if $isDev}
+                      <TextField bind:value={customExampleProjectName} placeholder="Project name..." on:click={(e) => e.stopPropagation()} />
+                    {/if}
+                    <Button icon={mdiBookPlusOutline} class="pointer-events-none p-2"/>
+                  </div>
+                </ListItem>
+              </ButtonListItem>
             {/if}
           </div>
         </div>
@@ -196,7 +197,7 @@
             <p class="sub-title">Classic FieldWorks Projects</p>
             <div>
               {#each projects.filter(p => p.fwdata) as project (project.id ?? project.name)}
-                <AnchorListItem href={`/fwdata/${project.name}`}>
+                <ButtonListItem href={`/fwdata/${project.name}`}>
                   <ListItem title={project.name}>
                     <img slot="avatar" src={flexLogo} alt="FieldWorks logo" class="h-6"/>
                     <div slot="actions">
@@ -215,7 +216,7 @@
                       </DevContent>
                     </div>
                   </ListItem>
-                </AnchorListItem>
+                </ButtonListItem>
               {/each}
             </div>
           </div>

--- a/frontend/viewer/src/home/Server.svelte
+++ b/frontend/viewer/src/home/Server.svelte
@@ -23,13 +23,21 @@
 
   async function downloadCrdtProject(project: Project, server: ILexboxServer | undefined) {
     if (!server) throw new Error('Server is undefined');
+    else if (matchesProject(localProjects, project)) return;
+
     downloading = project.name;
     if (project.id == null) throw new Error('Project id is null');
     try {
       await projectsService.downloadProject(project.id, project.name, server);
+      localProjects.push({
+        ...project,
+        server,
+      });
       dispatch('refreshAll');
     } finally {
-      downloading = '';
+      setTimeout(() => {
+        downloading = '';
+      }, 100);
     }
   }
 
@@ -95,10 +103,12 @@
             </ListItem>
           </AnchorListItem>
         {:else}
+          {@const loading = downloading === project.name}
           <ListItem icon={mdiCloud}
                     title={project.name}
-                    on:click={() => void downloadCrdtProject(project, server)}
-                    loading={downloading === project.name}>
+                    class={loading ? 'pointer-events-none' : ''}
+                    on:click={() => {if (!loading) void downloadCrdtProject(project, server)}}
+                    {loading}>
             <div slot="actions" class="pointer-events-none">
               <Button icon={mdiBookArrowDownOutline} class="p-2">
                 Download

--- a/frontend/viewer/src/home/Server.svelte
+++ b/frontend/viewer/src/home/Server.svelte
@@ -5,7 +5,7 @@
   import {mdiBookArrowDownOutline, mdiBookSyncOutline, mdiCloud, mdiRefresh} from '@mdi/js';
   import LoginButton from '$lib/auth/LoginButton.svelte';
   import {Button, ListItem, Settings} from 'svelte-ux';
-  import AnchorListItem from '$lib/utils/AnchorListItem.svelte';
+  import ButtonListItem from '$lib/utils/ButtonListItem.svelte';
   import {useProjectsService} from '$lib/services/service-provider';
 
   const projectsService = useProjectsService();
@@ -29,15 +29,13 @@
     if (project.id == null) throw new Error('Project id is null');
     try {
       await projectsService.downloadProject(project.id, project.name, server);
-      localProjects.push({
+      dispatch('refreshAll');
+      localProjects.push({ // the refresh will take a moment
         ...project,
         server,
       });
-      dispatch('refreshAll');
     } finally {
-      setTimeout(() => {
-        downloading = '';
-      }, 100);
+      downloading = '';
     }
   }
 
@@ -91,7 +89,7 @@
       {#each projects as project}
         {@const localProject = matchesProject(localProjects, project)}
         {#if localProject?.crdt}
-          <AnchorListItem href={`/project/${project.name}`}>
+          <ButtonListItem href={`/project/${project.name}`}>
             <ListItem icon={mdiCloud}
                       title={project.name}
                       loading={downloading === project.name}>
@@ -101,20 +99,20 @@
                 </Button>
               </div>
             </ListItem>
-          </AnchorListItem>
+          </ButtonListItem>
         {:else}
           {@const loading = downloading === project.name}
-          <ListItem icon={mdiCloud}
-                    title={project.name}
-                    class={loading ? 'pointer-events-none' : ''}
-                    on:click={() => {if (!loading) void downloadCrdtProject(project, server)}}
-                    {loading}>
-            <div slot="actions" class="pointer-events-none">
-              <Button icon={mdiBookArrowDownOutline} class="p-2">
-                Download
-              </Button>
-            </div>
-          </ListItem>
+          <ButtonListItem on:click={() => downloadCrdtProject(project, server)} disabled={loading}>
+            <ListItem icon={mdiCloud}
+                      title={project.name}
+                      {loading}>
+              <div slot="actions" class="pointer-events-none">
+                <Button icon={mdiBookArrowDownOutline} class="p-2">
+                  Download
+                </Button>
+              </div>
+            </ListItem>
+          </ButtonListItem>
         {/if}
       {/each}
     {/if}

--- a/frontend/viewer/src/lib/sandbox/Sandbox.svelte
+++ b/frontend/viewer/src/lib/sandbox/Sandbox.svelte
@@ -13,6 +13,7 @@
   import OverrideFields from '$lib/OverrideFields.svelte';
   import type {FieldIds} from '$lib/entry-editor/field-data';
   import {dndzone} from 'svelte-dnd-action';
+  import {delay} from '$lib/utils/time';
 
 
   const crdtOptions: MenuOption[] = [
@@ -47,6 +48,14 @@
 
   function updateFields(e: CustomEvent<{ items: ({ id: FieldIds })[] }>) {
     senseFields = e.detail.items;
+  }
+  let count = 0;
+  let loading = false;
+  async function incrementAsync() {
+    loading = true;
+    await delay(1000);
+    count++;
+    loading = false;
   }
 </script>
 
@@ -86,6 +95,15 @@
       </Button>
       <Button variant="fill" on:click={() => triggerNotificationWithLargeDetail()}>Notification with a large detail
       </Button>
+    </div>
+  </div>
+  <div class="flex flex-col gap-2 border p-4 justify-between">
+    <div class="flex flex-col gap-2">
+      Button
+      <Button variant="fill" disabled={loading} {loading} on:click={incrementAsync}>
+        Increment Async
+      </Button>
+      click count: {count}
     </div>
   </div>
   <div class="border grid" style="grid-template-columns: auto 1fr">

--- a/frontend/viewer/src/lib/sandbox/Sandbox.svelte
+++ b/frontend/viewer/src/lib/sandbox/Sandbox.svelte
@@ -14,6 +14,7 @@
   import type {FieldIds} from '$lib/entry-editor/field-data';
   import {dndzone} from 'svelte-dnd-action';
   import {delay} from '$lib/utils/time';
+  import ButtonListItem from '$lib/utils/ButtonListItem.svelte';
 
 
   const crdtOptions: MenuOption[] = [
@@ -103,6 +104,13 @@
       <Button variant="fill" disabled={loading} {loading} on:click={incrementAsync}>
         Increment Async
       </Button>
+      click count: {count}
+    </div>
+    <div class="flex flex-col gap-2">
+      ButtonListItem
+      <ButtonListItem disabled={loading} on:click={incrementAsync}>
+        Increment Async
+      </ButtonListItem>
       click count: {count}
     </div>
   </div>

--- a/frontend/viewer/src/lib/services/service-provider.ts
+++ b/frontend/viewer/src/lib/services/service-provider.ts
@@ -17,6 +17,7 @@ import type {
 import type {ITestingService} from '$lib/dotnet-types/generated-types/FwLiteShared/Services/ITestingService';
 import type {IMultiWindowService} from '$lib/dotnet-types/generated-types/FwLiteShared/Services/IMultiWindowService';
 import type {IJsEventListener} from '$lib/dotnet-types/generated-types/FwLiteShared/Events/IJsEventListener';
+import type {IFwEvent} from '$lib/dotnet-types/generated-types/FwLiteShared/Events/IFwEvent';
 
 export type ServiceKey = keyof LexboxServiceRegistry;
 export type LexboxServiceRegistry = {
@@ -37,7 +38,14 @@ export type LexboxServiceRegistry = {
 export const SERVICE_KEYS = Object.values(DotnetService);
 
 export class LexboxServiceProvider {
-  private services: LexboxServiceRegistry = {} as LexboxServiceRegistry;
+  private services: LexboxServiceRegistry = {
+    [DotnetService.JsEventListener]: {
+      nextEventAsync(): Promise<IFwEvent> {
+        console.warn('using default JsEvent listener which does nothing');
+        return new Promise<IFwEvent>(() => {});
+      }
+    }
+  } as LexboxServiceRegistry;
 
   public setService<K extends ServiceKey>(key: K, service: LexboxServiceRegistry[K]): void {
     this.validateServiceKey(key);

--- a/frontend/viewer/src/lib/utils/ButtonListItem.svelte
+++ b/frontend/viewer/src/lib/utils/ButtonListItem.svelte
@@ -1,15 +1,22 @@
 <script lang="ts">
-  export let href: string;
+  export let href: string | undefined = undefined;
 </script>
 
-<a {href} class="anchor-list-item">
+<svelte:element
+  this={href ? 'a' : 'button'}
+  on:click
+  {href}
+  {...$$restProps}
+  class="button-list-item w-full text-start"
+  role="button"
+  tabindex="0">
   <div></div> <!-- avoid internal first: styles -->
   <slot />
   <div></div> <!-- avoid internal last: styles -->
-</a>
+</svelte:element>
 
 <style lang="postcss">
-  .anchor-list-item {
+  .button-list-item {
     &:first-child :global(.ListItem) {
       @apply border-t-0 rounded-t;
     }


### PR DESCRIPTION
Resolves #1494 

Wow, this is messy. I'm not sure what to think.
On the Download button, click events while a project is downloading get queued up and triggered after the download is finished. So...that's why there's so much weird code in there.

This is not the way, but, I'm not quite sure what is. Probably different async context management in .NET?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced asynchronous count increment functionality with a loading state in the sandbox component.
	- Enhanced project download handling to prevent multiple concurrent downloads and improve user experience with loading indicators.
	- Updated UI components to use buttons instead of anchors for better interaction and loading state management.
	- Added a new button for creating example projects with improved loading state management.

- **Bug Fixes**
	- Prevented duplicate project deletion and creation actions by disabling interactions during ongoing operations.
	- Improved project download handling by avoiding redundant downloads and temporarily blocking repeated requests during the process.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->