### PR TITLE
Bug/1527 race condition when awaiting sync results results in 500

### DIFF
--- a/backend/FwHeadless/Program.cs
+++ b/backend/FwHeadless/Program.cs
@@ -166,7 +166,6 @@ static async Task<Results<Ok<SyncJobResult>, NotFound, StatusCodeHttpResult>> Aw
     Guid projectId)
 {
     using var activity = FwHeadlessActivitySource.Value.StartActivity();
-    if (!syncHostedService.IsJobQueuedOrRunning(projectId)) return TypedResults.NotFound();
     try
     {
         var result = await syncHostedService.AwaitSyncFinished(projectId, cancellationToken);

--- a/backend/FwHeadless/Services/SyncHostedService.cs
+++ b/backend/FwHeadless/Services/SyncHostedService.cs
@@ -37,10 +37,10 @@ public class SyncHostedService(IServiceProvider services, ILogger<SyncHostedServ
                 logger.LogError(e, "Sync job failed");
                 result = new SyncJobResult(SyncJobResultEnum.UnknownError, e.Message);
             }
-            _projectsQueuedOrRunning.TryRemove(projectId, out var tcs);
-            tcs?.TrySetResult(result);
             // Give clients a bit more time to poll the status
             CacheRecentSyncResult(projectId, result);
+            _projectsQueuedOrRunning.TryRemove(projectId, out var tcs);
+            tcs?.TrySetResult(result);
         }
     }
 
@@ -81,7 +81,7 @@ public class SyncHostedService(IServiceProvider services, ILogger<SyncHostedServ
 
     private void CacheRecentSyncResult(Guid projectId, SyncJobResult result)
     {
-        memoryCache.Set($"SyncResult|{projectId}", result, TimeSpan.FromSeconds(5));
+        memoryCache.Set($"SyncResult|{projectId}", result, TimeSpan.FromSeconds(30));
     }
 
     private SyncJobResult? TryGetRecentSyncResult(Guid projectId)

--- a/backend/Testing/FwHeadless/MergeFwDataWithHarmonyTests.cs
+++ b/backend/Testing/FwHeadless/MergeFwDataWithHarmonyTests.cs
@@ -26,7 +26,7 @@ public class MergeFwDataWithHarmonyTests : ApiTestBase, IAsyncLifetime
         var result = await HttpClient.PostAsync($"api/fw-lite/sync/trigger/{projectId}", null);
         if (result.IsSuccessStatusCode) return;
         var responseString = await result.Content.ReadAsStringAsync();
-        Assert.Fail($"trigger failed with error {result.ReasonPhrase}, body: {responseString}" );
+        Assert.Fail($"trigger failed with error {result.ReasonPhrase}, body: {responseString}");
     }
 
     private async Task<SyncResult?> AwaitSyncFinished(Guid projectId)
@@ -110,6 +110,10 @@ public class MergeFwDataWithHarmonyTests : ApiTestBase, IAsyncLifetime
         result.Should().NotBeNull();
         result.CrdtChanges.Should().BeGreaterThan(100);
         result.FwdataChanges.Should().Be(0);
+
+        // there should be a short grace period during which the result remains available
+        var result2 = await AwaitSyncFinished(_projectId);
+        result2.Should().BeEquivalentTo(result);
     }
 
     [Fact]


### PR DESCRIPTION
Resolves #1527

(Code rabbit is probably gonna explain this just as well as me)
This PR caches sync results in memory for 5s after a sync, so that late awaiters can still get it.

Because sync results were immediately discarded and thus only provided to **current** "awaiters", if a sync ended between await requests, it would not get the result and the api would return a 500.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced caching for sync results to enable faster and more responsive updates.
- **Refactor**
	- Streamlined the synchronization process for improved consistency in job status handling.
- **Tests**
	- Expanded automated tests to ensure that sync results remain consistent across repeated checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->