### PR TITLE
Bug/1525 using code instead of name broke existing projects

### DIFF
--- a/backend/FwHeadless/Services/SyncHostedService.cs
+++ b/backend/FwHeadless/Services/SyncHostedService.cs
@@ -209,6 +209,7 @@ public class SyncWorker(
             }
 
             return await projectsService.CreateProject(new("crdt",
+                "crdt",
                 SeedNewProjectData: false,
                 Id: projectId,
                 Path: projectFolder,

--- a/backend/FwLite/FwLiteProjectSync.Tests/Fixtures/Sena3SyncFixture.cs
+++ b/backend/FwLite/FwLiteProjectSync.Tests/Fixtures/Sena3SyncFixture.cs
@@ -55,7 +55,7 @@ public class Sena3Fixture : IAsyncLifetime
         var fwDataMiniLcmApi = services.GetRequiredService<FwDataFactory>().GetFwDataMiniLcmApi(fwDataProject, false);
 
         var crdtProject = await services.GetRequiredService<CrdtProjectsService>()
-            .CreateProject(new(projectName, FwProjectId: fwDataMiniLcmApi.ProjectId, SeedNewProjectData: false));
+            .CreateProject(new(projectName, projectName, FwProjectId: fwDataMiniLcmApi.ProjectId, SeedNewProjectData: false));
         var crdtMiniLcmApi = (CrdtMiniLcmApi)await services.OpenCrdtProject(crdtProject);
         return (crdtMiniLcmApi, fwDataMiniLcmApi, services, cleanup);
     }

--- a/backend/FwLite/FwLiteProjectSync.Tests/Fixtures/SyncFixture.cs
+++ b/backend/FwLite/FwLiteProjectSync.Tests/Fixtures/SyncFixture.cs
@@ -66,7 +66,7 @@ public class SyncFixture : IAsyncLifetime
             _services.ServiceProvider.GetRequiredService<IOptions<LcmCrdtConfig>>().Value.ProjectPath;
         Directory.CreateDirectory(crdtProjectsFolder);
         var crdtProject = await _services.ServiceProvider.GetRequiredService<CrdtProjectsService>()
-            .CreateProject(new(_projectName, FwProjectId: FwDataApi.ProjectId, SeedNewProjectData: false));
+            .CreateProject(new(_projectName, _projectName, FwProjectId: FwDataApi.ProjectId, SeedNewProjectData: false));
         CrdtApi = (CrdtMiniLcmApi) await _services.ServiceProvider.OpenCrdtProject(crdtProject);
     }
 

--- a/backend/FwLite/FwLiteProjectSync/MiniLcmImport.cs
+++ b/backend/FwLite/FwLiteProjectSync/MiniLcmImport.cs
@@ -24,6 +24,7 @@ public class MiniLcmImport(
         {
             using var fwDataApi = fwDataFactory.GetFwDataMiniLcmApi(fwDataProject, false);
             var harmonyProject = await crdtProjectsService.CreateProject(new(fwDataProject.Name,
+                fwDataProject.Name,
                 SeedNewProjectData: false,
                 FwProjectId: fwDataApi.ProjectId,
                 AfterCreate: async (provider, _) =>

--- a/backend/FwLite/FwLiteProjectSync/Program.cs
+++ b/backend/FwLite/FwLiteProjectSync/Program.cs
@@ -46,7 +46,7 @@ public class Program
                 Console.WriteLine($"crdtFile: {crdtFile}");
                 Console.WriteLine($"fwDataFile: {fwDataFile}");
                 var fwProjectName = Path.GetFileNameWithoutExtension(fwDataFile);
-                var crdtProjectName = Path.GetFileNameWithoutExtension(crdtFile);
+                var crdtProjectCode = Path.GetFileNameWithoutExtension(crdtFile);
 
                 await using var serviceRoot = SyncServices(crdtFile, fwDataFile, createCrdtDir);
                 await using var scope = serviceRoot.CreateAsyncScope();
@@ -60,10 +60,10 @@ public class Program
                 }
                 var fwdataApi = (FwDataMiniLcmApi) fieldWorksProjectList.OpenProject(fwProject);
                 var projectsService = services.GetRequiredService<CrdtProjectsService>();
-                var crdtProject = projectsService.GetProject(crdtProjectName);
+                var crdtProject = projectsService.GetProject(crdtProjectCode);
                 if (crdtProject is null)
                 {
-                    crdtProject = await projectsService.CreateProject(new(crdtProjectName, FwProjectId:fwdataApi.ProjectId, SeedNewProjectData: false));
+                    crdtProject = await projectsService.CreateProject(new(crdtProjectCode, crdtProjectCode, FwProjectId:fwdataApi.ProjectId, SeedNewProjectData: false));
                 }
                 var syncService = services.GetRequiredService<CrdtFwdataProjectSyncService>();
 

--- a/backend/FwLite/FwLiteShared/Services/ProjectServicesProvider.cs
+++ b/backend/FwLite/FwLiteShared/Services/ProjectServicesProvider.cs
@@ -38,20 +38,20 @@ public class ProjectServicesProvider(
     }
 
     [JSInvokable]
-    public Task<ProjectData> GetCrdtProjectData(Guid projectId)
+    public Task<ProjectData> GetCrdtProjectData(string code)
     {
-        var crdtProject = crdtProjectsService.GetProject(projectId)
-            ?? throw new InvalidOperationException($"Crdt Project {projectId} not found");
+        var crdtProject = crdtProjectsService.GetProject(code)
+            ?? throw new InvalidOperationException($"Crdt Project {code} not found");
         return Task.FromResult(crdtProject.Data ?? throw new InvalidOperationException($"Project data for {crdtProject.Name} not found"));
     }
 
     [JSInvokable]
-    public async Task<ProjectScope> OpenCrdtProject(Guid projectId)
+    public async Task<ProjectScope> OpenCrdtProject(string code)
     {
         var serviceScope = serviceProvider.CreateAsyncScope();
         var scopedServices = serviceScope.ServiceProvider;
-        var project = crdtProjectsService.GetProject(projectId)
-            ?? throw new InvalidOperationException($"Crdt Project {projectId} not found");
+        var project = crdtProjectsService.GetProject(code)
+            ?? throw new InvalidOperationException($"Crdt Project {code} not found");
         var currentProjectService = scopedServices.GetRequiredService<CurrentProjectService>();
         var projectData = await currentProjectService.SetupProjectContext(project);
         await scopedServices.GetRequiredService<SyncService>().SafeExecuteSync(true);

--- a/backend/FwLite/FwLiteShared/Sync/BackgroundSyncService.cs
+++ b/backend/FwLite/FwLiteShared/Sync/BackgroundSyncService.cs
@@ -22,22 +22,22 @@ public class BackgroundSyncService(
 
     public void TriggerSync(Guid projectId, Guid? ignoredClientId = null)
     {
-        var projectData = CurrentProjectService.LookupProjectById(memoryCache, projectId);
-        if (projectData is null)
+        var crdtProject = crdtProjectsService.GetProject(projectId);
+        if (crdtProject is null)
         {
             logger.LogWarning("Received project update for unknown project {ProjectId}", projectId);
             return;
         }
-        if (ignoredClientId == projectData.ClientId)
+
+        if (crdtProject.Data is null)
         {
-            logger.LogInformation("Received project update for {ProjectId} triggered by my own change, ignoring", projectId);
+            logger.LogWarning("Data missing for project {ProjectId}", projectId);
             return;
         }
 
-        var crdtProject = crdtProjectsService.GetProject(projectData.Name);
-        if (crdtProject is null)
+        if (ignoredClientId == crdtProject.Data.ClientId)
         {
-            logger.LogWarning("Received project update for unknown project {ProjectName}", projectData.Name);
+            logger.LogInformation("Received project update for {ProjectId} triggered by my own change, ignoring", projectId);
             return;
         }
 

--- a/backend/FwLite/FwLiteWeb/Routes/ProjectRoutes.cs
+++ b/backend/FwLite/FwLiteWeb/Routes/ProjectRoutes.cs
@@ -48,18 +48,15 @@ public static class ProjectRoutes
                 await syncService.UploadProject(lexboxProjectId, server);
                 return TypedResults.Ok();
             });
-        group.MapPost("/download/crdt/{serverAuthority}/{projectId}",
+        group.MapPost("/download/crdt/{serverAuthority}/{code}",
             async (IOptions<AuthConfig> options,
                 CombinedProjectsService combinedProjectsService,
-                Guid projectId,
-                [FromQuery] string projectName,
+                string code,
                 string serverAuthority
             ) =>
             {
-                if (!CrdtProjectsService.ProjectCode().IsMatch(projectName))
-                    return Results.BadRequest("Project name is invalid");
                 var server = options.Value.GetServerByAuthority(serverAuthority);
-                await combinedProjectsService.DownloadProject(projectId, server);
+                await combinedProjectsService.DownloadProject(code, server);
                 return TypedResults.Ok();
             });
         return group;

--- a/backend/FwLite/FwLiteWeb/Routes/ProjectRoutes.cs
+++ b/backend/FwLite/FwLiteWeb/Routes/ProjectRoutes.cs
@@ -33,7 +33,7 @@ public static class ProjectRoutes
                     return Results.BadRequest("Project name is required");
                 if (projectService.ProjectExists(name))
                     return Results.BadRequest("Project already exists");
-                if (!CrdtProjectsService.ProjectName().IsMatch(name))
+                if (!CrdtProjectsService.ProjectCode().IsMatch(name))
                     return Results.BadRequest("Only letters, numbers, '-' and '_' are allowed");
                 await projectService.CreateExampleProject(name);
                 return TypedResults.Ok();
@@ -56,10 +56,10 @@ public static class ProjectRoutes
                 string serverAuthority
             ) =>
             {
-                if (!CrdtProjectsService.ProjectName().IsMatch(projectName))
+                if (!CrdtProjectsService.ProjectCode().IsMatch(projectName))
                     return Results.BadRequest("Project name is invalid");
                 var server = options.Value.GetServerByAuthority(serverAuthority);
-                await combinedProjectsService.DownloadProject(projectId, projectName, server);
+                await combinedProjectsService.DownloadProject(projectId, server);
                 return TypedResults.Ok();
             });
         return group;

--- a/backend/FwLite/LcmCrdt.Tests/DataModelSnapshotTests.VerifyDbModel.verified.txt
+++ b/backend/FwLite/LcmCrdt.Tests/DataModelSnapshotTests.VerifyDbModel.verified.txt
@@ -3,6 +3,7 @@
     Properties: 
       Id (Guid) Required PK AfterSave:Throw ValueGenerated.OnAdd
       ClientId (Guid) Required
+      Code (string) Required
       FwProjectId (Guid?)
       LastUserId (string)
       LastUserName (string)

--- a/backend/FwLite/LcmCrdt.Tests/DataModelSnapshotTests.cs
+++ b/backend/FwLite/LcmCrdt.Tests/DataModelSnapshotTests.cs
@@ -50,7 +50,7 @@ public class DataModelSnapshotTests : IAsyncLifetime
     {
         await _crdtDbContext.Database.OpenConnectionAsync();
         //can't use ProjectsService.CreateProject because it opens and closes the db context, this would wipe out the in memory db.
-        var projectData = new ProjectData("Sena 3", Guid.NewGuid(), null, Guid.NewGuid());
+        var projectData = new ProjectData("Sena 3", "sena-3", Guid.NewGuid(), null, Guid.NewGuid());
         await CrdtProjectsService.InitProjectDb(_crdtDbContext, projectData);
         _crdtProject.Data = projectData;
         await _services.ServiceProvider.GetRequiredService<CurrentProjectService>().SetupProjectContext(_crdtProject);

--- a/backend/FwLite/LcmCrdt.Tests/MiniLcmApiFixture.cs
+++ b/backend/FwLite/LcmCrdt.Tests/MiniLcmApiFixture.cs
@@ -1,13 +1,9 @@
 ﻿using Meziantou.Extensions.Logging.Xunit;
 using Microsoft.EntityFrameworkCore;
-using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
-using MiniLcm;
-using MiniLcm.Models;
 using Xunit.Abstractions;
 
 namespace LcmCrdt.Tests;
@@ -39,7 +35,7 @@ public class MiniLcmApiFixture : IAsyncLifetime
         await _crdtDbContext.Database.OpenConnectionAsync();
         //can't use ProjectsService.CreateProject because it opens and closes the db context, this would wipe out the in memory db.
         await CrdtProjectsService.InitProjectDb(_crdtDbContext,
-            new ProjectData("Sena 3", Guid.NewGuid(), null, Guid.NewGuid()));
+            new ProjectData("Sena 3", "sena-3", Guid.NewGuid(), null, Guid.NewGuid()));
         await _services.ServiceProvider.GetRequiredService<CurrentProjectService>().RefreshProjectData();
 
         await Api.CreateWritingSystem(WritingSystemType.Vernacular,

--- a/backend/FwLite/LcmCrdt.Tests/OpenProjectTests.cs
+++ b/backend/FwLite/LcmCrdt.Tests/OpenProjectTests.cs
@@ -32,7 +32,7 @@ public class OpenProjectTests
         var asyncScope = services.CreateAsyncScope();
         var crdtProjectsService = asyncScope.ServiceProvider.GetRequiredService<CrdtProjectsService>();
         var exception = new Exception("Test exception");
-        var projectRequest = new CreateProjectRequest("CleaningUpAFailedCreateWorks", AfterCreate: (_, _) => throw exception, SeedNewProjectData: true);
+        var projectRequest = new CreateProjectRequest("CleaningUpAFailedCreateWorks", "CleaningUpAFailedCreateWorks", AfterCreate: (_, _) => throw exception, SeedNewProjectData: true);
 
 
         var act = async () => await crdtProjectsService.CreateProject(projectRequest);
@@ -58,7 +58,12 @@ public class OpenProjectTests
         var services = host.Services;
         var asyncScope = services.CreateAsyncScope();
         var crdtProjectsService = asyncScope.ServiceProvider.GetRequiredService<CrdtProjectsService>();
-        var crdtProject = await crdtProjectsService.CreateProject(new(Name: "OpeningAProjectWorks", Path: "", SeedNewProjectData: true));
+        var crdtProject = await crdtProjectsService.CreateProject(new(
+            Name: "OpeningAProjectWorks",
+            Code: "opening-a-project-works",
+            Path: "",
+            SeedNewProjectData: true
+            ));
 
         var miniLcmApi = (CrdtMiniLcmApi)await asyncScope.ServiceProvider.OpenCrdtProject(crdtProject);
         miniLcmApi.ProjectData.Name.Should().Be("OpeningAProjectWorks");

--- a/backend/FwLite/LcmCrdt/CrdtProject.cs
+++ b/backend/FwLite/LcmCrdt/CrdtProject.cs
@@ -2,14 +2,17 @@
 
 namespace LcmCrdt;
 
-public class CrdtProject(string name, string dbPath) : IProjectIdentifier
+public class CrdtProject(string code, string dbPath) : IProjectIdentifier
 {
-    public CrdtProject(string name, string dbPath, IMemoryCache memoryCache) : this(name, dbPath)
+    public CrdtProject(string code, string dbPath, IMemoryCache memoryCache) : this(code, dbPath)
     {
         Data = CurrentProjectService.LookupProjectData(memoryCache, this);
     }
 
-    public string Name { get; } = name;
+    /// <summary>
+    /// Actually the Lexbox project code, not the name
+    /// </summary>
+    public string Name { get; } = code;
     public ProjectDataFormat DataFormat => ProjectDataFormat.Harmony;
     public string DbPath { get; } = dbPath;
     public ProjectData? Data { get; set; }
@@ -18,12 +21,13 @@ public class CrdtProject(string name, string dbPath) : IProjectIdentifier
 /// <summary>
 ///
 /// </summary>
-/// <param name="Name">Name of the project</param>
+/// <param name="Name">Display name of the project</param>
+/// <param name="Code">Unique code of the project</param>
 /// <param name="Id">Id, consistent across all clients, matches the project Id in Lexbox</param>
 /// <param name="OriginDomain">Server to sync with, null if not synced</param>
 /// <param name="ClientId">Unique id for this client machine</param>
 /// <param name="FwProjectId">FieldWorks project id, aka LangProjectId</param>
-public record ProjectData(string Name, Guid Id, string? OriginDomain, Guid ClientId, Guid? FwProjectId = null, string? LastUserName = null, string? LastUserId = null)
+public record ProjectData(string Name, string Code, Guid Id, string? OriginDomain, Guid ClientId, Guid? FwProjectId = null, string? LastUserName = null, string? LastUserId = null)
 {
     public static string? GetOriginDomain(Uri? uri)
     {

--- a/backend/FwLite/LcmCrdt/CrdtProjectsService.cs
+++ b/backend/FwLite/LcmCrdt/CrdtProjectsService.cs
@@ -176,9 +176,9 @@ public partial class CrdtProjectsService(IServiceProvider provider, ILogger<Crdt
         });
     }
 
-    public async Task DeleteProject(Guid projectId)
+    public async Task DeleteProject(string code)
     {
-        var project = GetProject(projectId) ?? throw new InvalidOperationException($"Project {projectId} not found");
+        var project = GetProject(code) ?? throw new InvalidOperationException($"Project {code} not found");
         await using var serviceScope = provider.CreateAsyncScope();
         var currentProjectService = serviceScope.ServiceProvider.GetRequiredService<CurrentProjectService>();
         currentProjectService.SetupProjectContextForNewDb(project);

--- a/backend/FwLite/LcmCrdt/CrdtProjectsService.cs
+++ b/backend/FwLite/LcmCrdt/CrdtProjectsService.cs
@@ -19,9 +19,9 @@ public partial class CrdtProjectsService(IServiceProvider provider, ILogger<Crdt
         return ListProjects();
     }
 
-    IProjectIdentifier? IProjectProvider.GetProject(string name)
+    IProjectIdentifier? IProjectProvider.GetProject(string code)
     {
-        return GetProject(name);
+        return GetProject(code);
     }
 
     public async ValueTask<IMiniLcmApi> OpenProject(IProjectIdentifier project, IServiceProvider serviceProvider, bool saveChangesOnDispose = true)
@@ -50,25 +50,31 @@ public partial class CrdtProjectsService(IServiceProvider provider, ILogger<Crdt
     {
         return Directory.EnumerateFiles(config.Value.ProjectPath, "*.sqlite").Select(file =>
         {
-            var name = Path.GetFileNameWithoutExtension(file);
-            return new CrdtProject(name, file, memoryCache);
+            var code = Path.GetFileNameWithoutExtension(file);
+            return new CrdtProject(code, file, memoryCache);
         });
     }
 
-    public CrdtProject? GetProject(string name)
+    public CrdtProject? GetProject(string code)
     {
         var file = Directory.EnumerateFiles(config.Value.ProjectPath, "*.sqlite")
-            .FirstOrDefault(file => Path.GetFileNameWithoutExtension(file) == name);
-        return file is null ? null : new CrdtProject(name, file);
+            .FirstOrDefault(file => Path.GetFileNameWithoutExtension(file) == code);
+        return file is null ? null : new CrdtProject(code, file, memoryCache);
     }
 
-    public bool ProjectExists(string name)
+    public CrdtProject? GetProject(Guid id)
     {
-        return GetProject(name) is not null;
+        return ListProjects().FirstOrDefault(p => p.Data?.Id == id);
+    }
+
+    public bool ProjectExists(string code)
+    {
+        return GetProject(code) is not null;
     }
 
     public record CreateProjectRequest(
         string Name,
+        string Code,
         Guid? Id = null,
         Uri? Domain = null,
         Func<IServiceProvider, CrdtProject, Task>? AfterCreate = null,
@@ -80,23 +86,23 @@ public partial class CrdtProjectsService(IServiceProvider provider, ILogger<Crdt
 
     public async Task<CrdtProject> CreateExampleProject(string name)
     {
-        return await CreateProject(new(name, AfterCreate: SampleProjectData, SeedNewProjectData: true));
+        return await CreateProject(new(name, name, AfterCreate: SampleProjectData, SeedNewProjectData: true));
     }
 
     public async Task<CrdtProject> CreateProject(CreateProjectRequest request)
     {
         using var activity = LcmCrdtActivitySource.Value.StartActivity();
         activity?.SetTag("app.project_id", request.Id);
-        if (!ProjectName().IsMatch(request.Name))
+        if (!ProjectCode().IsMatch(request.Code))
         {
-            var nameIsInvalid = $"Project name '{request.Name}' is invalid";
+            var nameIsInvalid = $"Project code '{request.Code}' is invalid";
             activity?.SetStatus(ActivityStatusCode.Error, nameIsInvalid);
             throw new InvalidOperationException(nameIsInvalid);
         }
 
         //poor man's sanitation
-        var name = Path.GetFileName(request.Name);
-        var sqliteFile = Path.Combine(request.Path ?? config.Value.ProjectPath, $"{name}.sqlite");
+        var code = Path.GetFileName(request.Code);
+        var sqliteFile = Path.Combine(request.Path ?? config.Value.ProjectPath, $"{code}.sqlite");
         if (File.Exists(sqliteFile))
         {
             var alreadyExists = $"Project already exists at '{sqliteFile}'";
@@ -104,14 +110,15 @@ public partial class CrdtProjectsService(IServiceProvider provider, ILogger<Crdt
             throw new InvalidOperationException(alreadyExists);
         }
 
-        var crdtProject = new CrdtProject(name, sqliteFile);
+        var crdtProject = new CrdtProject(code, sqliteFile);
         await using var serviceScope = provider.CreateAsyncScope();
         var currentProjectService = serviceScope.ServiceProvider.GetRequiredService<CurrentProjectService>();
         currentProjectService.SetupProjectContextForNewDb(crdtProject);
         var db = serviceScope.ServiceProvider.GetRequiredService<LcmCrdtDbContext>();
         try
         {
-            var projectData = new ProjectData(name,
+            var projectData = new ProjectData(request.Name,
+                code,
                 request.Id ?? Guid.NewGuid(),
                 ProjectData.GetOriginDomain(request.Domain),
                 Guid.NewGuid(), request.FwProjectId, request.AuthenticatedUser, request.AuthenticatedUserId);
@@ -169,9 +176,9 @@ public partial class CrdtProjectsService(IServiceProvider provider, ILogger<Crdt
         });
     }
 
-    public async Task DeleteProject(string name)
+    public async Task DeleteProject(Guid projectId)
     {
-        var project = GetProject(name) ?? throw new InvalidOperationException($"Project {name} not found");
+        var project = GetProject(projectId) ?? throw new InvalidOperationException($"Project {projectId} not found");
         await using var serviceScope = provider.CreateAsyncScope();
         var currentProjectService = serviceScope.ServiceProvider.GetRequiredService<CurrentProjectService>();
         currentProjectService.SetupProjectContextForNewDb(project);
@@ -194,7 +201,7 @@ public partial class CrdtProjectsService(IServiceProvider provider, ILogger<Crdt
     }
 
     [GeneratedRegex("^[a-zA-Z0-9][a-zA-Z0-9-_]+$")]
-    public static partial Regex ProjectName();
+    public static partial Regex ProjectCode();
 
     public static async Task SampleProjectData(IServiceProvider provider, CrdtProject project)
     {

--- a/backend/FwLite/LcmCrdt/CurrentProjectService.cs
+++ b/backend/FwLite/LcmCrdt/CurrentProjectService.cs
@@ -22,7 +22,6 @@ public class CurrentProjectService(IServiceProvider services, IMemoryCache memor
         {
             result = await DbContext.ProjectData.AsNoTracking().FirstAsync();
             memoryCache.Set(CacheKey(Project), result);
-            memoryCache.Set(CacheKey(result.Id), result);
         }
         if (result is null) throw new InvalidOperationException("Project data not found");
 
@@ -39,19 +38,9 @@ public class CurrentProjectService(IServiceProvider services, IMemoryCache memor
         return project.DbPath + "|ProjectData";
     }
 
-    private static string CacheKey(Guid projectId)
-    {
-        return $"ProjectData|{projectId}";
-    }
-
     public static ProjectData? LookupProjectData(IMemoryCache memoryCache, CrdtProject project)
     {
         return memoryCache.Get<ProjectData>(CacheKey(project));
-    }
-
-    public static ProjectData? LookupProjectById(IMemoryCache memoryCache, Guid projectId)
-    {
-        return memoryCache.Get<ProjectData>(CacheKey(projectId));
     }
 
     /// <summary>

--- a/backend/FwLite/LcmCrdt/CurrentProjectService.cs
+++ b/backend/FwLite/LcmCrdt/CurrentProjectService.cs
@@ -17,12 +17,11 @@ public class CurrentProjectService(IServiceProvider services, IMemoryCache memor
 
     public async ValueTask<ProjectData> GetProjectData(bool forceRefresh = false)
     {
-        var key = CacheKey(Project);
-        ProjectData? result = LookupProjectData(memoryCache, Project);
+        var result = LookupProjectData(memoryCache, Project);
         if (result is null || forceRefresh)
         {
             result = await DbContext.ProjectData.AsNoTracking().FirstAsync();
-            memoryCache.Set(key, result);
+            memoryCache.Set(CacheKey(Project), result);
             memoryCache.Set(CacheKey(result.Id), result);
         }
         if (result is null) throw new InvalidOperationException("Project data not found");

--- a/backend/FwLite/LcmCrdt/LcmCrdtDbContext.cs
+++ b/backend/FwLite/LcmCrdt/LcmCrdtDbContext.cs
@@ -1,11 +1,8 @@
-﻿using System.Data.Common;
-using System.Text.Json;
+﻿using System.Text.Json;
 using LcmCrdt.Data;
-using Microsoft.Data.Sqlite;
 using SIL.Harmony;
 using SIL.Harmony.Db;
 using Microsoft.EntityFrameworkCore;
-using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Microsoft.Extensions.Options;
 

--- a/backend/FwLite/LcmCrdt/Migrations/20250306152556_AddCodeToProjectData.Designer.cs
+++ b/backend/FwLite/LcmCrdt/Migrations/20250306152556_AddCodeToProjectData.Designer.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using LcmCrdt;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace LcmCrdt.Migrations
 {
     [DbContext(typeof(LcmCrdtDbContext))]
-    partial class LcmCrdtDbContextModelSnapshot : ModelSnapshot
+    [Migration("20250306152556_AddCodeToProjectData")]
+    partial class AddCodeToProjectData
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder.HasAnnotation("ProductVersion", "8.0.11");

--- a/backend/FwLite/LcmCrdt/Migrations/20250306152556_AddCodeToProjectData.cs
+++ b/backend/FwLite/LcmCrdt/Migrations/20250306152556_AddCodeToProjectData.cs
@@ -1,0 +1,37 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace LcmCrdt.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddCodeToProjectData : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "Code",
+                table: "ProjectData",
+                type: "TEXT",
+                nullable: true);
+
+            migrationBuilder.Sql("UPDATE ProjectData SET Code = Name");
+
+            migrationBuilder.AlterColumn<string>(
+                name: "Code",
+                table: "ProjectData",
+                type: "TEXT",
+                nullable: false,
+                oldNullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "Code",
+                table: "ProjectData");
+        }
+    }
+}

--- a/backend/FwLite/LcmCrdt/RemoteSync/CrdtHttpSyncService.cs
+++ b/backend/FwLite/LcmCrdt/RemoteSync/CrdtHttpSyncService.cs
@@ -67,7 +67,7 @@ public class CrdtHttpSyncService(ILogger<CrdtHttpSyncService> logger, RefitSetti
     public async ValueTask<bool> TestAuth(HttpClient client)
     {
         logger.LogInformation("Testing auth, client base url: {ClientBaseUrl}", client.BaseAddress);
-        var syncable = await CreateProjectSyncable(new ProjectData("test", Guid.Empty, null, Guid.Empty), client);
+        var syncable = await CreateProjectSyncable(new ProjectData("test", "test", Guid.Empty, null, Guid.Empty), client);
         return await syncable.ShouldSync();
     }
 }

--- a/backend/FwLite/MiniLcm/Models/ProjectIdentifier.cs
+++ b/backend/FwLite/MiniLcm/Models/ProjectIdentifier.cs
@@ -2,6 +2,9 @@
 
 public interface IProjectIdentifier
 {
+    /// <summary>
+    /// A human-readable unique identifier for the project
+    /// </summary>
     string Name { get; }
     ProjectDataFormat DataFormat { get; }
 }

--- a/frontend/viewer/src/App.svelte
+++ b/frontend/viewer/src/App.svelte
@@ -76,17 +76,17 @@
   <nav>
   </nav>
   <div class="app">
-    <Route path="/project/:id" let:params>
-      <Router {url} basepath="/project/{params.id}">
-        {#key params.id}
-          <DotnetProjectView projectId={params.id} type="crdt"/>
+    <Route path="/project/:code" let:params>
+      <Router {url} basepath="/project/{params.code}">
+        {#key params.code}
+          <DotnetProjectView code={params.code} type="crdt"/>
         {/key}
       </Router>
     </Route>
     <Route path="/fwdata/:name" let:params>
       <Router {url} basepath="/fwdata/{params.name}">
         {#key params.name}
-          <DotnetProjectView projectId={params.name} type="fwdata"/>
+          <DotnetProjectView code={params.name} type="fwdata"/>
         {/key}
       </Router>
     </Route>

--- a/frontend/viewer/src/App.svelte
+++ b/frontend/viewer/src/App.svelte
@@ -76,17 +76,17 @@
   <nav>
   </nav>
   <div class="app">
-    <Route path="/project/:name" let:params>
-      <Router {url} basepath="/project/{params.name}">
-        {#key params.name}
-          <DotnetProjectView projectName={params.name} type="crdt"/>
+    <Route path="/project/:id" let:params>
+      <Router {url} basepath="/project/{params.id}">
+        {#key params.id}
+          <DotnetProjectView projectId={params.id} type="crdt"/>
         {/key}
       </Router>
     </Route>
     <Route path="/fwdata/:name" let:params>
       <Router {url} basepath="/fwdata/{params.name}">
         {#key params.name}
-          <DotnetProjectView projectName={params.name} type="fwdata"/>
+          <DotnetProjectView projectId={params.name} type="fwdata"/>
         {/key}
       </Router>
     </Route>

--- a/frontend/viewer/src/DotnetProjectView.svelte
+++ b/frontend/viewer/src/DotnetProjectView.svelte
@@ -12,25 +12,25 @@
 
   const projectServicesProvider = useProjectServicesProvider();
 
-  const {projectId, type}: {
-    projectId: string; // Guid for CRDTs, project-name for FWData
+  const {code, type}: {
+    code: string; // Code for CRDTs, project-name for FWData
     type: 'fwdata' | 'crdt'
   } = $props();
 
 
-  let projectName = $state<string>('');
+  let projectName = $state<string>(code);
   let projectScope: IProjectScope;
   let serviceLoaded = $state(false);
   let destroyed = false;
   onMount(async () => {
     console.debug('ProjectView mounted');
     if (type === 'crdt') {
-      const projectData = await projectServicesProvider.getCrdtProjectData(projectId);
+      const projectData = await projectServicesProvider.getCrdtProjectData(code);
       projectName = projectData.name;
-      projectScope = await projectServicesProvider.openCrdtProject(projectId);
+      projectScope = await projectServicesProvider.openCrdtProject(code);
     } else {
-      projectName = projectId;
-      projectScope = await projectServicesProvider.openFwDataProject(projectId);
+      projectName = code;
+      projectScope = await projectServicesProvider.openFwDataProject(code);
     }
     if (destroyed) {
       cleanup();

--- a/frontend/viewer/src/DotnetProjectView.svelte
+++ b/frontend/viewer/src/DotnetProjectView.svelte
@@ -11,17 +11,26 @@
   import ProjectLoader from './ProjectLoader.svelte';
 
   const projectServicesProvider = useProjectServicesProvider();
-  export let projectName: string;
-  export let type: 'fwdata' | 'crdt';
+
+  const {projectId, type}: {
+    projectId: string; // Guid for CRDTs, project-name for FWData
+    type: 'fwdata' | 'crdt'
+  } = $props();
+
+
+  let projectName = $state<string>('');
   let projectScope: IProjectScope;
-  let serviceLoaded = false;
+  let serviceLoaded = $state(false);
   let destroyed = false;
   onMount(async () => {
     console.debug('ProjectView mounted');
     if (type === 'crdt') {
-      projectScope = await projectServicesProvider.openCrdtProject(projectName);
+      const projectData = await projectServicesProvider.getCrdtProjectData(projectId);
+      projectName = projectData.name;
+      projectScope = await projectServicesProvider.openCrdtProject(projectId);
     } else {
-      projectScope = await projectServicesProvider.openFwDataProject(projectName);
+      projectName = projectId;
+      projectScope = await projectServicesProvider.openFwDataProject(projectId);
     }
     if (destroyed) {
       cleanup();

--- a/frontend/viewer/src/home/HomeView.svelte
+++ b/frontend/viewer/src/home/HomeView.svelte
@@ -26,6 +26,7 @@
   import ServersList from './ServersList.svelte';
   import {t} from 'svelte-i18n-lingui';
   import LocalizationPicker from '$lib/i18n/LocalizationPicker.svelte';
+  import ProjectTitle from './ProjectTitle.svelte';
 
   const projectsService = useProjectsService();
   const importFwdataService = useImportFwdataService();
@@ -61,10 +62,10 @@
   }
 
   let deletingProject: undefined | string = undefined;
-  async function deleteProject(projectName: string) {
+  async function deleteProject(projectId: string) {
     try {
-      deletingProject = projectName;
-      await projectsService.deleteProject(projectName);
+      deletingProject = projectId;
+      await projectsService.deleteProject(projectId);
       await refreshProjects();
     } finally {
       deletingProject = undefined;
@@ -137,22 +138,25 @@
     {:then projects}
       <div class="space-y-4 md:space-y-8">
         <div>
-          <div class="flex flex-row">
+          <div class="flex flex-row items-end">
             <p class="sub-title">{$t`Local`}</p>
             <div class="flex-grow"></div>
-            <Button icon={mdiRefresh} title={$t`Refresh Projects`} on:click={() => refreshProjects()} />
+            <Button icon={mdiRefresh}
+                    title={$t`Refresh Projects`}
+                    class="mb-2"
+                    on:click={() => refreshProjects()}/>
           </div>
           <div>
             {#each projects.filter((p) => p.crdt) as project, i (project.id ?? i)}
               {@const server = project.server}
-              {@const loading = deletingProject === project.name}
-              <ButtonListItem href={`/project/${project.name}`}>
+              {@const loading = deletingProject === project.id}
+              <ButtonListItem href={`/project/${project.id}`}>
                 <ListItem
-                  title={project.name}
                   icon={mdiBookEditOutline}
                   subheading={!server ? $t`Local only` : $t`Synced with ${server.displayName}`}
                   {loading}
                 >
+                  <ProjectTitle slot="title" {project}/>
                   <div slot="actions">
                     {#if $isDev}
                       <Button

--- a/frontend/viewer/src/home/HomeView.svelte
+++ b/frontend/viewer/src/home/HomeView.svelte
@@ -27,6 +27,7 @@
   import {t} from 'svelte-i18n-lingui';
   import LocalizationPicker from '$lib/i18n/LocalizationPicker.svelte';
   import ProjectTitle from './ProjectTitle.svelte';
+  import type {IProjectModel} from '$lib/dotnet-types';
 
   const projectsService = useProjectsService();
   const importFwdataService = useImportFwdataService();
@@ -62,10 +63,10 @@
   }
 
   let deletingProject: undefined | string = undefined;
-  async function deleteProject(projectId: string) {
+  async function deleteProject(project: IProjectModel) {
     try {
-      deletingProject = projectId;
-      await projectsService.deleteProject(projectId);
+      deletingProject = project.id;
+      await projectsService.deleteProject(project.code);
       await refreshProjects();
     } finally {
       deletingProject = undefined;
@@ -150,7 +151,7 @@
             {#each projects.filter((p) => p.crdt) as project, i (project.id ?? i)}
               {@const server = project.server}
               {@const loading = deletingProject === project.id}
-              <ButtonListItem href={`/project/${project.id}`}>
+              <ButtonListItem href={`/project/${project.code}`}>
                 <ListItem
                   icon={mdiBookEditOutline}
                   subheading={!server ? $t`Local only` : $t`Synced with ${server.displayName}`}
@@ -165,7 +166,7 @@
                         class="p-2"
                         on:click={(e) => {
                           e.preventDefault();
-                          void deleteProject(project.name);
+                          void deleteProject(project);
                         }}
                       />
                     {/if}

--- a/frontend/viewer/src/home/ProjectTitle.svelte
+++ b/frontend/viewer/src/home/ProjectTitle.svelte
@@ -1,0 +1,13 @@
+<script lang="ts">
+  import type {IProjectModel} from '$lib/dotnet-types';
+
+  const {project} = $props<{ project: IProjectModel }>();
+
+  const name = $derived(project.name);
+  const code = $derived(project.code === project.name ? undefined : project.code);
+</script>
+
+{name}
+{#if code}
+  <span class="opacity-75 text-sm">({code})</span>
+{/if}

--- a/frontend/viewer/src/home/Server.svelte
+++ b/frontend/viewer/src/home/Server.svelte
@@ -8,6 +8,7 @@
   import ButtonListItem from '$lib/utils/ButtonListItem.svelte';
   import {useProjectsService} from '$lib/services/service-provider';
   import {t} from 'svelte-i18n-lingui';
+  import ProjectTitle from './ProjectTitle.svelte';
 
   const projectsService = useProjectsService();
 
@@ -26,10 +27,11 @@
     if (!server) throw new Error('Server is undefined');
     else if (matchesProject(localProjects, project)) return;
 
-    downloading = project.name;
-    if (project.id == null) throw new Error('Project id is null');
+    const projectId = project.id;
+    if (!projectId) throw new Error('Project ID is undefined');
+    downloading = projectId;
     try {
-      await projectsService.downloadProject(project.id, project.name, server);
+      await projectsService.downloadProject(projectId, server);
       dispatch('refreshAll');
       localProjects.push({ // the refresh will take a moment
         ...project,
@@ -61,6 +63,7 @@
       <Button icon={mdiRefresh}
               title={$t`Refresh Projects`}
               disabled={loading}
+              class="mr-2"
               on:click={() => dispatch('refreshProjects')}/>
       <LoginButton {status} on:status={() => dispatch('refreshAll')}/>
     {/if}
@@ -90,10 +93,10 @@
       {#each projects as project}
         {@const localProject = matchesProject(localProjects, project)}
         {#if localProject?.crdt}
-          <ButtonListItem href={`/project/${project.name}`}>
+          <ButtonListItem href={`/project/${project.id}`}>
             <ListItem icon={mdiCloud}
-                      title={project.name}
-                      loading={downloading === project.name}>
+                      loading={downloading === project.id}>
+              <ProjectTitle slot="title" {project}/>
               <div slot="actions" class="pointer-events-none">
                 <Button disabled icon={mdiBookSyncOutline} class="p-2">
                   {$t`Synced`}
@@ -102,11 +105,11 @@
             </ListItem>
           </ButtonListItem>
         {:else}
-          {@const loading = downloading === project.name}
+          {@const loading = downloading === project.id}
           <ButtonListItem on:click={() => downloadCrdtProject(project, server)} disabled={loading}>
             <ListItem icon={mdiCloud}
-                      title={project.name}
                       {loading}>
+              <ProjectTitle slot="title" {project}/>
               <div slot="actions" class="pointer-events-none">
                 <Button icon={mdiBookArrowDownOutline} class="p-2">
                   {$t`Download`}

--- a/frontend/viewer/src/lib/dotnet-types/generated-types/FwLiteShared/Projects/ICombinedProjectsService.ts
+++ b/frontend/viewer/src/lib/dotnet-types/generated-types/FwLiteShared/Projects/ICombinedProjectsService.ts
@@ -13,8 +13,8 @@ export interface ICombinedProjectsService
 	remoteProjects() : Promise<IServerProjects[]>;
 	serverProjects(serverId: string, forceRefresh: boolean) : Promise<IProjectModel[]>;
 	localProjects() : Promise<IProjectModel[]>;
-	downloadProject(lexboxProjectId: string, projectName: string, server: ILexboxServer) : Promise<void>;
+	downloadProject(projectId: string, server: ILexboxServer) : Promise<void>;
 	createProject(name: string) : Promise<void>;
-	deleteProject(name: string) : Promise<void>;
+	deleteProject(projectId: string) : Promise<void>;
 }
 /* eslint-enable */

--- a/frontend/viewer/src/lib/dotnet-types/generated-types/FwLiteShared/Projects/ICombinedProjectsService.ts
+++ b/frontend/viewer/src/lib/dotnet-types/generated-types/FwLiteShared/Projects/ICombinedProjectsService.ts
@@ -5,7 +5,6 @@
 
 import type {IServerProjects} from './IServerProjects';
 import type {IProjectModel} from './IProjectModel';
-import type {ILexboxServer} from '../Auth/ILexboxServer';
 
 export interface ICombinedProjectsService
 {
@@ -13,8 +12,8 @@ export interface ICombinedProjectsService
 	remoteProjects() : Promise<IServerProjects[]>;
 	serverProjects(serverId: string, forceRefresh: boolean) : Promise<IProjectModel[]>;
 	localProjects() : Promise<IProjectModel[]>;
-	downloadProject(projectId: string, server: ILexboxServer) : Promise<void>;
+	downloadProject(project: IProjectModel) : Promise<void>;
 	createProject(name: string) : Promise<void>;
-	deleteProject(projectId: string) : Promise<void>;
+	deleteProject(code: string) : Promise<void>;
 }
 /* eslint-enable */

--- a/frontend/viewer/src/lib/dotnet-types/generated-types/FwLiteShared/Projects/IProjectModel.ts
+++ b/frontend/viewer/src/lib/dotnet-types/generated-types/FwLiteShared/Projects/IProjectModel.ts
@@ -8,6 +8,7 @@ import type {ILexboxServer} from '../Auth/ILexboxServer';
 export interface IProjectModel
 {
 	name: string;
+	code: string;
 	crdt: boolean;
 	fwdata: boolean;
 	lexbox: boolean;

--- a/frontend/viewer/src/lib/dotnet-types/generated-types/FwLiteShared/Services/IProjectServicesProvider.ts
+++ b/frontend/viewer/src/lib/dotnet-types/generated-types/FwLiteShared/Services/IProjectServicesProvider.ts
@@ -11,8 +11,8 @@ import type {IProjectScope} from './IProjectScope';
 export interface IProjectServicesProvider extends IAsyncDisposable
 {
 	disposeService(service: DotNet.DotNetObject) : Promise<void>;
-	getCrdtProjectData(projectId: string) : Promise<IProjectData>;
-	openCrdtProject(projectId: string) : Promise<IProjectScope>;
+	getCrdtProjectData(code: string) : Promise<IProjectData>;
+	openCrdtProject(code: string) : Promise<IProjectScope>;
 	openFwDataProject(projectName: string) : Promise<IProjectScope>;
 }
 /* eslint-enable */

--- a/frontend/viewer/src/lib/dotnet-types/generated-types/FwLiteShared/Services/IProjectServicesProvider.ts
+++ b/frontend/viewer/src/lib/dotnet-types/generated-types/FwLiteShared/Services/IProjectServicesProvider.ts
@@ -5,12 +5,14 @@
 
 import type {IAsyncDisposable} from '../../System/IAsyncDisposable';
 import type {DotNet} from '@microsoft/dotnet-js-interop';
+import type {IProjectData} from '../../LcmCrdt/IProjectData';
 import type {IProjectScope} from './IProjectScope';
 
 export interface IProjectServicesProvider extends IAsyncDisposable
 {
 	disposeService(service: DotNet.DotNetObject) : Promise<void>;
-	openCrdtProject(projectName: string) : Promise<IProjectScope>;
+	getCrdtProjectData(projectId: string) : Promise<IProjectData>;
+	openCrdtProject(projectId: string) : Promise<IProjectScope>;
 	openFwDataProject(projectName: string) : Promise<IProjectScope>;
 }
 /* eslint-enable */

--- a/frontend/viewer/src/lib/dotnet-types/generated-types/LcmCrdt/IProjectData.ts
+++ b/frontend/viewer/src/lib/dotnet-types/generated-types/LcmCrdt/IProjectData.ts
@@ -6,6 +6,7 @@
 export interface IProjectData
 {
 	name: string;
+	code: string;
 	id: string;
 	originDomain?: string;
 	clientId: string;

--- a/frontend/viewer/src/lib/services/projects-service.ts
+++ b/frontend/viewer/src/lib/services/projects-service.ts
@@ -15,7 +15,7 @@ export class ProjectService implements ICombinedProjectsService {
   remoteProjects(): Promise<IServerProjects[]> {
       throw new Error('Method not implemented.');
   }
-  downloadProject(_lexboxProjectId: string, _projectName: string, _server: ILexboxServer): Promise<void> {
+  downloadProject(_projectId: string, _server: ILexboxServer): Promise<void> {
       throw new Error('Method not implemented.');
   }
   deleteProject(_name: string): Promise<void> {

--- a/frontend/viewer/src/lib/services/projects-service.ts
+++ b/frontend/viewer/src/lib/services/projects-service.ts
@@ -1,4 +1,4 @@
-﻿import type {ICombinedProjectsService, ILexboxServer, IProjectModel, IServerProjects, IServerStatus} from '$lib/dotnet-types';
+﻿import type {ICombinedProjectsService, IProjectModel, IServerProjects, IServerStatus} from '$lib/dotnet-types';
 
 import {AppNotification} from '../notifications/notifications';
 
@@ -15,10 +15,10 @@ export class ProjectService implements ICombinedProjectsService {
   remoteProjects(): Promise<IServerProjects[]> {
       throw new Error('Method not implemented.');
   }
-  downloadProject(_projectId: string, _server: ILexboxServer): Promise<void> {
+  downloadProject(_project: IProjectModel): Promise<void> {
       throw new Error('Method not implemented.');
   }
-  deleteProject(_name: string): Promise<void> {
+  deleteProject(_code: string): Promise<void> {
       throw new Error('Method not implemented.');
   }
   async createProject(newProjectName: string): Promise<void> {
@@ -48,10 +48,10 @@ export class ProjectService implements ICombinedProjectsService {
   }
 
   async downloadCrdtProject(project: Project) {
-    const r = await fetch(`/api/download/crdt/${project.server!.authority}/${project.id}?projectName=${project.name}`, {method: 'POST'});
+    const r = await fetch(`/api/download/crdt/${project.server!.authority}/${project.code}`, {method: 'POST'});
     if (!r.ok) {
-      AppNotification.display(`Failed to download project ${project.name}: ${r.statusText} (${r.status})`, 'error', 'long');
-      console.error(`Failed to download project ${project.name}: ${r.statusText} (${r.status})`, r, await r.text())
+      AppNotification.display(`Failed to download project ${project.code}: ${r.statusText} (${r.status})`, 'error', 'long');
+      console.error(`Failed to download project ${project.code}: ${r.statusText} (${r.status})`, r, await r.text())
     }
     return r.ok;
   }


### PR DESCRIPTION
Resolves #1525 

With this PR, in most cases we now load crdt projects by ID. So that we can always find them regardless of whether the name or code was used for the sqlite file name.

Also, we now save both the project code and name in ProjectData, so that we can use the code as a reliably safe file name, but still display the name.
![image](https://github.com/user-attachments/assets/ec7ff20c-1785-47d7-8e4c-9669d06de90c)

If the name and code are identical we only show one.

For routing I now use the guid, which means the name isn't automatically available to display. Initially, I just added the name as a query-param, but felt that was dissatisfying. It was much simpler, so maybe I should have left it 🤷.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Updated project routing now uses unique IDs for navigation, improving access to project details.
  - Enhanced project display provides clearer, more informative titles for each project.

- **Refactor**
  - Streamlined project management across the system with consistent use of unique codes and IDs, ensuring more reliable operations such as project creation, synchronization, and deletion.
  - Introduced a new property `Code` in project data structures to enhance project identification.
  - Improved method signatures across various services to focus on project IDs, simplifying interactions and enhancing clarity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->