### PR TITLE
support all androids ABIs

### DIFF
--- a/backend/FwLite/FwLiteMaui/FwLiteMaui.csproj
+++ b/backend/FwLite/FwLiteMaui/FwLiteMaui.csproj
@@ -14,6 +14,7 @@
 		The Mac App Store will NOT accept apps with ONLY maccatalyst-arm64 indicated;
 		either BOTH runtimes must be indicated or ONLY macatalyst-x64. -->
 		<!-- For example: <RuntimeIdentifiers>maccatalyst-x64;maccatalyst-arm64</RuntimeIdentifiers> -->
+        <RuntimeIdentifiers Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'android'">android-arm;android-arm64;android-x86;android-x64</RuntimeIdentifiers>
 
         <OutputType>Exe</OutputType>
 		<RootNamespace>FwLiteMaui</RootNamespace>


### PR DESCRIPTION
currently we only support `arm64-v8a, x86_64`, this covers 10,711 devices today. However google lists 24,028 devices, meaning we're currently excluding 13,317 I think that's mostly due to our ABI target. This PR should expand that to reach many more device types.

This PR adds support for `armeabi-v7a` and `x86` to android

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Expanded Android compatibility with support for multiple runtime architectures (including ARM, ARM64, x86, and x64) to enhance performance and device support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->