### PR TITLE
Stabilize EnsureDeleteProject

### DIFF
--- a/backend/FwLite/LcmCrdt.Tests/OpenProjectTests.cs
+++ b/backend/FwLite/LcmCrdt.Tests/OpenProjectTests.cs
@@ -1,6 +1,6 @@
-﻿using Microsoft.Data.Sqlite;
-using Microsoft.Extensions.DependencyInjection;
+﻿using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
+using static LcmCrdt.CrdtProjectsService;
 
 namespace LcmCrdt.Tests;
 
@@ -19,6 +19,37 @@ public class OpenProjectTests
         var crdtProjectsService = asyncScope.ServiceProvider.GetRequiredService<CrdtProjectsService>();
         await crdtProjectsService.CreateExampleProject("ExampleProject");
     }
+
+    [Fact]
+    public async Task ProjectDbIsDeletedIfCreateFails()
+    {
+        var sqliteConnectionString = "CleaningUpAFailedCreateWorks.sqlite";
+        if (File.Exists(sqliteConnectionString)) File.Delete(sqliteConnectionString);
+        var builder = Host.CreateEmptyApplicationBuilder(null);
+        builder.Services.AddTestLcmCrdtClient();
+        using var host = builder.Build();
+        var services = host.Services;
+        var asyncScope = services.CreateAsyncScope();
+        var crdtProjectsService = asyncScope.ServiceProvider.GetRequiredService<CrdtProjectsService>();
+        var projectRequest = new CreateProjectRequest("CleaningUpAFailedCreateWorks", AfterCreate: (_, _) => throw new Exception("Test exception"), SeedNewProjectData: true);
+
+        try
+        {
+            await crdtProjectsService.CreateProject(projectRequest);
+            Assert.Fail("Create should fail");
+        }
+        catch
+        {
+            var counter = 0;
+            while (File.Exists(sqliteConnectionString) && counter < 10)
+            {
+                await Task.Delay(1000);
+                counter++;
+            }
+            File.Exists(sqliteConnectionString).Should().BeFalse();
+        }
+    }
+
     [Fact]
     public async Task OpeningAProjectWorks()
     {

--- a/backend/FwLite/LcmCrdt/CrdtProjectsService.cs
+++ b/backend/FwLite/LcmCrdt/CrdtProjectsService.cs
@@ -135,6 +135,8 @@ public partial class CrdtProjectsService(IServiceProvider provider, ILogger<Crdt
             {
                 EnsureDeleteProject(sqliteFile);
             }
+
+            throw;
         }
         return crdtProject;
     }


### PR DESCRIPTION
When https://github.com/sillsdev/harmony/pull/29 caused the import of the sbe-flex project into Harmony to fail, the sqlite database failed to be deleted. This change fixed that for me.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Enhanced error handling during project creation, introducing a two-tiered mechanism for database deletion to improve reliability.

- **Tests**
  - Added a new test to verify that the database is deleted if project creation fails, ensuring better validation of error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->