### PR TITLE
Support reset fw headless

### DIFF
--- a/backend/FwHeadless/FwHeadlessConfig.cs
+++ b/backend/FwHeadless/FwHeadlessConfig.cs
@@ -1,4 +1,6 @@
 using System.ComponentModel.DataAnnotations;
+using System.IO;
+using FwDataMiniLcmBridge;
 
 namespace FwHeadless;
 
@@ -14,4 +16,19 @@ public class FwHeadlessConfig
     [Required]
     public required string ProjectStorageRoot { get; init; }
     public string FdoDataModelVersion { get; init; } = "7000072";
+
+    public string GetProjectFolder(string projectCode, Guid projectId)
+    {
+        return Path.Join(ProjectStorageRoot, $"{projectCode}-{projectId}");
+    }
+
+    public string GetCrdtFile(string projectCode, Guid projectId)
+    {
+        return Path.Join(GetProjectFolder(projectCode, projectId), "crdt.sqlite");
+    }
+
+    public FwDataProject GetFwDataProject(string projectCode, Guid projectId)
+    {
+        return new FwDataProject("fw", GetProjectFolder(projectCode, projectId));
+    }
 }

--- a/backend/FwHeadless/Program.cs
+++ b/backend/FwHeadless/Program.cs
@@ -87,7 +87,7 @@ app.MapDelete("/api/manage/repo/{projectId}", async (Guid projectId,
     if (projectCode is null)
     {
         logger.LogInformation("DELETE repo request for non-existent project {ProjectId}", projectId);
-        return Results.Ok(new { message = "Project not found" });
+        return Results.NotFound(new { message = "Project not found" });
     }
     // Delete associated project folder if it exists
     var fwDataProject = config.Value.GetFwDataProject(projectCode, projectId);

--- a/backend/FwHeadless/Program.cs
+++ b/backend/FwHeadless/Program.cs
@@ -141,9 +141,9 @@ static async Task<Results<Ok<ProjectSyncStatus>, NotFound>> GetMergeStatus(
         return TypedResults.NotFound();
     }
     activity?.SetTag("app.project_code", lexboxProject.Code);
-    var projectFolder = Path.Join(config.Value.ProjectStorageRoot, $"{lexboxProject.Code}-{projectId}");
+    var projectFolder = config.Value.GetProjectFolder(lexboxProject.Code, projectId);
     if (!Directory.Exists(projectFolder)) Directory.CreateDirectory(projectFolder);
-    var fwDataProject = new FwDataProject("fw", projectFolder);
+    var fwDataProject = config.Value.GetFwDataProject(lexboxProject.Code, projectId);
     var pendingHgCommits = srService.PendingCommitCount(fwDataProject, lexboxProject.Code); // NOT awaited here so that this long-running task can run in parallel with others
 
     var crdtCommitsOnServer = await lexBoxDb.Set<ServerCommit>().CountAsync(c => c.ProjectId == projectId);

--- a/backend/FwHeadless/Program.cs
+++ b/backend/FwHeadless/Program.cs
@@ -81,8 +81,13 @@ app.MapGet("/api/await-sync-finished", AwaitSyncFinished);
 app.MapDelete("/api/manage/repo/{projectId}", async (Guid projectId,
     ProjectLookupService projectLookupService,
     IOptions<FwHeadlessConfig> config,
+    SyncJobStatusService syncJobStatusService,
     ILogger<Program> logger) =>
 {
+    if (syncJobStatusService.SyncStatus(projectId) is SyncJobStatus.Running)
+    {
+        return Results.Conflict(new {message = "Sync job is running"});
+    }
     var projectCode = await projectLookupService.GetProjectCode(projectId);
     if (projectCode is null)
     {

--- a/backend/FwHeadless/Services/ProjectContextFromIdService.cs
+++ b/backend/FwHeadless/Services/ProjectContextFromIdService.cs
@@ -14,8 +14,7 @@ public class ProjectContextFromIdService(IOptions<FwHeadlessConfig> config, Crdt
             var projectCode = await projectLookupService.GetProjectCode(projectId);
             if (projectCode is not null)
             {
-                var projectFolder = Path.Join(config.Value.ProjectStorageRoot, $"{projectCode}-{projectId}");
-                var crdtFile = Path.Join(projectFolder, "crdt.sqlite");
+                var crdtFile = config.Value.GetCrdtFile(projectCode, projectId);
                 if (File.Exists(crdtFile))
                 {
                     var project = new CrdtProject("crdt", crdtFile, memoryCache);

--- a/backend/FwHeadless/Services/SyncHostedService.cs
+++ b/backend/FwHeadless/Services/SyncHostedService.cs
@@ -133,12 +133,11 @@ public class SyncWorker(
             return new SyncJobResult(SyncJobResultEnum.UnableToAuthenticate, "Unable to authenticate with Lexbox");
         }
 
-        var projectFolder = Path.Join(config.Value.ProjectStorageRoot, $"{projectCode}-{projectId}");
+        var projectFolder = config.Value.GetProjectFolder(projectCode, projectId);
         if (!Directory.Exists(projectFolder)) Directory.CreateDirectory(projectFolder);
 
-        var crdtFile = Path.Join(projectFolder, "crdt.sqlite");
-
-        var fwDataProject = new FwDataProject("fw", projectFolder);
+        var crdtFile = config.Value.GetCrdtFile(projectCode, projectId);
+        var fwDataProject = config.Value.GetFwDataProject(projectCode, projectId);
         logger.LogDebug("crdtFile: {crdtFile}", crdtFile);
         logger.LogDebug("fwDataFile: {fwDataFile}", fwDataProject.FilePath);
 

--- a/backend/FwLite/FwDataMiniLcmBridge/FwDataProject.cs
+++ b/backend/FwLite/FwDataMiniLcmBridge/FwDataProject.cs
@@ -12,14 +12,16 @@ namespace FwDataMiniLcmBridge;
 /// </param>
 public class FwDataProject(string name, string projectsPath) : IProjectIdentifier
 {
-    public string Name { get; } = name;
-    public string FileName { get; } = name + ".fwdata";
-    public string FilePath { get; } = Path.Combine(projectsPath, name, name + ".fwdata");
+    public string Name => name;
+    public string FileName => name + ".fwdata";
+    public string FilePath => Path.Combine(ProjectFolder, FileName);
     public string ProjectFolder => Path.Combine(projectsPath, name);
+
     /// <summary>
     /// A path to the projects folder, there must be a folder with the same name as the project name and a fwdata file in it.
     /// eg: Project name : "MyProject", path: "/data/projects/" is the value of this property, then the fwdata file must be in /data/projects/MyProject/MyProject.fwdata
     /// </summary>
-    public string ProjectsPath { get; } = projectsPath;
+    public string ProjectsPath => projectsPath;
+
     public ProjectDataFormat DataFormat => ProjectDataFormat.FwData;
 }

--- a/backend/FwLite/FwDataMiniLcmBridge/FwDataProject.cs
+++ b/backend/FwLite/FwDataMiniLcmBridge/FwDataProject.cs
@@ -15,6 +15,7 @@ public class FwDataProject(string name, string projectsPath) : IProjectIdentifie
     public string Name { get; } = name;
     public string FileName { get; } = name + ".fwdata";
     public string FilePath { get; } = Path.Combine(projectsPath, name, name + ".fwdata");
+    public string ProjectFolder => Path.Combine(projectsPath, name);
     /// <summary>
     /// A path to the projects folder, there must be a folder with the same name as the project name and a fwdata file in it.
     /// eg: Project name : "MyProject", path: "/data/projects/" is the value of this property, then the fwdata file must be in /data/projects/MyProject/MyProject.fwdata

--- a/backend/LexBoxApi/Services/FwHeadlessClient.cs
+++ b/backend/LexBoxApi/Services/FwHeadlessClient.cs
@@ -1,4 +1,5 @@
 ﻿using System.Net;
+using LexCore.Exceptions;
 using LexCore.Sync;
 
 namespace LexBoxApi.Services;
@@ -56,6 +57,8 @@ public class FwHeadlessClient(HttpClient httpClient, ILogger<FwHeadlessClient> l
         var response = await httpClient.DeleteAsync($"/api/manage/repo/{projectId}", cancellationToken);
         if (response.IsSuccessStatusCode || response.StatusCode == HttpStatusCode.NotFound)
             return true;
+        if (response.StatusCode == HttpStatusCode.Conflict)
+            throw new ProjectSyncInProgressException(projectId);
         logger.LogError("Failed to delete repo: {StatusCode} {StatusDescription}, projectId: {ProjectId}, response: {Response}",
             response.StatusCode,
             response.ReasonPhrase,

--- a/backend/LexBoxApi/Services/FwHeadlessClient.cs
+++ b/backend/LexBoxApi/Services/FwHeadlessClient.cs
@@ -54,7 +54,7 @@ public class FwHeadlessClient(HttpClient httpClient, ILogger<FwHeadlessClient> l
     public async Task<bool> DeleteRepo(Guid projectId, CancellationToken cancellationToken = default)
     {
         var response = await httpClient.DeleteAsync($"/api/manage/repo/{projectId}", cancellationToken);
-        if (response.IsSuccessStatusCode)
+        if (response.IsSuccessStatusCode || response.StatusCode == HttpStatusCode.NotFound)
             return true;
         logger.LogError("Failed to delete repo: {StatusCode} {StatusDescription}, projectId: {ProjectId}, response: {Response}",
             response.StatusCode,

--- a/backend/LexBoxApi/Services/FwHeadlessClient.cs
+++ b/backend/LexBoxApi/Services/FwHeadlessClient.cs
@@ -50,4 +50,17 @@ public class FwHeadlessClient(HttpClient httpClient, ILogger<FwHeadlessClient> l
             await response.Content.ReadAsStringAsync());
         return null;
     }
+
+    public async Task<bool> DeleteRepo(Guid projectId, CancellationToken cancellationToken = default)
+    {
+        var response = await httpClient.DeleteAsync($"/api/manage/repo/{projectId}", cancellationToken);
+        if (response.IsSuccessStatusCode)
+            return true;
+        logger.LogError("Failed to delete repo: {StatusCode} {StatusDescription}, projectId: {ProjectId}, response: {Response}",
+            response.StatusCode,
+            response.ReasonPhrase,
+            projectId,
+            await response.Content.ReadAsStringAsync(cancellationToken));
+        return false;
+    }
 }

--- a/backend/LexBoxApi/Services/ProjectService.cs
+++ b/backend/LexBoxApi/Services/ProjectService.cs
@@ -17,7 +17,13 @@ using Path = System.IO.Path; // Resolves ambiguous reference with HotChocolate.P
 
 namespace LexBoxApi.Services;
 
-public class ProjectService(LexBoxDbContext dbContext, IHgService hgService, IOptions<HgConfig> hgConfig, IMemoryCache memoryCache, IEmailService emailService)
+public class ProjectService(
+    LexBoxDbContext dbContext,
+    IHgService hgService,
+    IOptions<HgConfig> hgConfig,
+    IMemoryCache memoryCache,
+    IEmailService emailService,
+    FwHeadlessClient fwHeadless)
 {
     public async Task<Guid> CreateProject(CreateProjectInput input)
     {
@@ -162,6 +168,7 @@ public class ProjectService(LexBoxDbContext dbContext, IHgService hgService, IOp
         if (rowsAffected == 0) throw new NotFoundException($"project {input.Code} not ready for reset, either already reset or not found", nameof(Project));
         await ResetLexEntryCount(input.Code);
         await hgService.ResetRepo(input.Code);
+        await fwHeadless.DeleteRepo(await LookupProjectId(input.Code));
     }
 
     public async Task FinishReset(string code, Stream? zipFile = null)

--- a/backend/LexCore/Exceptions/ProjectSyncInProgress.cs
+++ b/backend/LexCore/Exceptions/ProjectSyncInProgress.cs
@@ -1,0 +1,4 @@
+﻿namespace LexCore.Exceptions;
+
+public class ProjectSyncInProgressException(Guid projectId)
+    : Exception($"project {projectId} sync is in progress");


### PR DESCRIPTION
closes #1548 

this will delete the repo in the fw-headless volume when a project is reset. FW Headless should just download the repo again next time a sync happens.

Also deletes the repo when the project is soft deleted.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced an API endpoint that allows for the deletion of project repositories by ID.
  - Enhanced the project reset process to automatically remove associated repository data.
  - Added client functionality to support efficient repository deletion.
  - New methods for constructing project folder paths and accessing project data.
  - Added a property to access the project folder path directly.
  - Introduced a new exception class to handle ongoing project synchronization scenarios.

- **Refactor**
  - Streamlined internal operations for file path management and project data handling, resulting in improved consistency and reliability.
  - Simplified the logic for obtaining project-related paths and objects through configuration methods.
  - Updated dependency injection for better integration of services.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->