### PR TITLE
Touch up menu items and theme picker

### DIFF
--- a/frontend/viewer/src/app.postcss
+++ b/frontend/viewer/src/app.postcss
@@ -156,3 +156,11 @@ html:has(.Dialog) {
 .menu-items .options {
   @apply overscroll-contain;
 }
+
+.x-ellipsis {
+  max-width: 100%;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  /* Ensures dangling letters are not clipped (e.g. "g") */
+  line-height: 1.3em;
+}

--- a/frontend/viewer/src/lib/ThemePicker.svelte
+++ b/frontend/viewer/src/lib/ThemePicker.svelte
@@ -1,38 +1,40 @@
 <script lang="ts">
-  import * as Popover from '$lib/components/ui/popover';
-  import {Button, type ButtonProps} from '$lib/components/ui/button';
-  import {Label} from '$lib/components/ui/label/index.js';
-  import type {WithChildren} from 'bits-ui';
+  import {Button} from '$lib/components/ui/button';
   import {Icon} from '$lib/components/ui/icon';
-  import {setMode, mode, userPrefersMode, resetMode, theme, setTheme} from 'mode-watcher';
+  import {Label} from '$lib/components/ui/label/index.js';
+  import * as Popover from '$lib/components/ui/popover';
   import {cn} from '$lib/utils';
-  const { children, button = {} }: WithChildren<{ button?: ButtonProps }> = $props();
+  import {mode, resetMode, setMode, setTheme, theme, userPrefersMode} from 'mode-watcher';
 
   const themes = ['green', 'blue', 'rose', 'orange', 'violet', 'stone'];
 </script>
 <Popover.Root>
   <Popover.Trigger>
     {#snippet child({props})}
-      <Button {...props} {...button}>
-        {#if children}
-          {@render children()}
-        {/if}
+      <Button variant="ghost" size="icon" {...props}>
+        <Icon icon="i-mdi-white-balance-sunny"
+          class="h-[1.2rem] w-[1.2rem] rotate-0 scale-100 transition-all dark:-rotate-90 dark:scale-0 text-primary"
+        />
+        <Icon icon="i-mdi-weather-night"
+          class="absolute h-[1.2rem] w-[1.2rem] rotate-90 scale-0 transition-all dark:rotate-0 dark:scale-100 text-primary"
+        />
+        <span class="sr-only">Toggle theme</span>
       </Button>
     {/snippet}
   </Popover.Trigger>
   <Popover.Content class="w-96">
-    <Popover.Close>
-      {#snippet child({props})}
-        <Button {...props} variant="ghost" size="sm" class="absolute top-2 right-2">
-          <Icon icon="i-mdi-close"/>
-        </Button>
-      {/snippet}
-    </Popover.Close>
-
-
     <div class="flex flex-1 flex-col space-y-4 md:space-y-6">
       <div class="space-y-1">
-        <Label class="text-xs">Color</Label>
+        <div class="flex items-baseline justify-between">
+          <Label class="text-xs">Color</Label>
+          <Popover.Close>
+            {#snippet child({props})}
+              <Button {...props} variant="ghost" size="icon">
+                <Icon icon="i-mdi-close"/>
+              </Button>
+            {/snippet}
+          </Popover.Close>
+        </div>
         <div class="grid grid-cols-3 gap-2">
           {#each themes as themeName (themeName)}
             {@const isActive = $theme === themeName}
@@ -51,10 +53,12 @@
                 $mode === 'light' && 'light')}
               >
                 {#if isActive}
-                  <Icon icon="i-mdi-check" class="text-white"/>
+                  <Icon icon="i-mdi-check" class="text-white size-4"/>
                 {/if}
               </span>
-              {themeName}
+              <span class="capitalize">
+                {themeName}
+              </span>
             </Button>
           {/each}
         </div>

--- a/frontend/viewer/src/lib/components/ui/button/button.svelte
+++ b/frontend/viewer/src/lib/components/ui/button/button.svelte
@@ -19,7 +19,7 @@
         default: 'h-10 px-4 py-2',
         sm: 'h-9 rounded-md px-3',
         lg: 'h-11 rounded-md px-8',
-        icon: 'h-10 w-10',
+        icon: 'h-10 w-10 min-h-10 min-w-10',
       },
     },
     defaultVariants: {

--- a/frontend/viewer/src/lib/components/ui/icon/icon.svelte
+++ b/frontend/viewer/src/lib/components/ui/icon/icon.svelte
@@ -13,4 +13,4 @@
   const { icon, class: className, ...restProps }: IconProps = $props();
 </script>
 
-<span {...restProps} class={cn('size-6 inline-block', className, icon)}></span>
+<span {...restProps} class={cn('size-6 inline-block shrink-0', className, icon)}></span>

--- a/frontend/viewer/src/lib/components/ui/sidebar/sidebar-menu-sub-button.svelte
+++ b/frontend/viewer/src/lib/components/ui/sidebar/sidebar-menu-sub-button.svelte
@@ -2,7 +2,7 @@
   import {cn} from '$lib/utils.js';
   import type {WithElementRef} from 'bits-ui';
   import type {Snippet} from 'svelte';
-  import type {HTMLAnchorAttributes} from 'svelte/elements';
+  import type {HTMLButtonAttributes} from 'svelte/elements';
 
   let {
     ref = $bindable(null),
@@ -12,7 +12,7 @@
     size = 'md',
     isActive,
     ...restProps
-  }: WithElementRef<HTMLAnchorAttributes> & {
+  }: WithElementRef<HTMLButtonAttributes> & {
     child?: Snippet<[{ props: Record<string, unknown> }]>;
     size?: 'sm' | 'md';
     isActive?: boolean;
@@ -22,6 +22,7 @@
     class: cn(
       'text-sidebar-foreground ring-sidebar-ring hover:bg-sidebar-accent hover:text-sidebar-accent-foreground active:bg-sidebar-accent active:text-sidebar-accent-foreground [&>svg]:text-sidebar-accent-foreground flex h-7 min-w-0 -translate-x-px items-center gap-2 overflow-hidden rounded-md px-2 outline-none focus-visible:ring-2 disabled:pointer-events-none disabled:opacity-50 aria-disabled:pointer-events-none aria-disabled:opacity-50 [&>span:last-child]:truncate [&>svg]:size-4 [&>svg]:shrink-0',
       'data-[active=true]:bg-sidebar-accent data-[active=true]:text-sidebar-accent-foreground',
+      'w-full',
       size === 'sm' && 'text-xs',
       size === 'md' && 'text-sm',
       'group-data-[collapsible=icon]:hidden',
@@ -37,7 +38,7 @@
 {#if child}
   {@render child({ props: mergedProps })}
 {:else}
-  <a bind:this={ref} {...mergedProps}>
+  <button bind:this={ref} {...mergedProps}>
     {@render children?.()}
-  </a>
+  </button>
 {/if}

--- a/frontend/viewer/src/project/ProjectDropdown.svelte
+++ b/frontend/viewer/src/project/ProjectDropdown.svelte
@@ -5,6 +5,7 @@
   import { Icon } from '$lib/components/ui/icon';
   import { cn } from '$lib/utils';
   import {t} from 'svelte-i18n-lingui';
+  import {tick} from 'svelte';
 
   let { projectName, onSelect } = $props<{
     projectName: string;
@@ -22,6 +23,7 @@
 
   let open = $state(false);
   let loading = $state(false);
+  let triggerRef = $state<HTMLButtonElement>(null!);
 
   // Simulate loading delay
   function handleOpen(isOpen: boolean) {
@@ -37,26 +39,42 @@
   function handleSelect(project: { id: string; name: string }) {
     onSelect(project.name);
     open = false;
+    closeAndFocusTrigger();
+  }
+
+  // We want to refocus the trigger button when the user selects
+  // an item from the list so users can continue navigating the
+  // rest of the form with the keyboard.
+  function closeAndFocusTrigger() {
+    open = false;
+    void tick().then(() => {
+      triggerRef.focus();
+    });
   }
 </script>
 
 <Popover.Root bind:open onOpenChange={handleOpen}>
-  <Popover.Trigger>
-    <Button
-      variant="ghost"
-      role="combobox"
-      aria-expanded={open}
-      class="w-full justify-between"
-    >
-      <div class="flex items-center gap-2">
-        <Icon icon="i-mdi-book" class="size-4" />
-        {projectName}
-      </div>
-      <Icon
-        icon="i-mdi-chevron-down"
-        class={cn('ml-2 size-4 shrink-0 opacity-50', open && 'rotate-180')}
-      />
-    </Button>
+  <Popover.Trigger bind:ref={triggerRef}>
+    {#snippet child({ props })}
+      <Button
+        variant="ghost"
+        role="combobox"
+        aria-expanded={open}
+        class="w-full justify-between overflow-hidden gap-0"
+        {...props}
+      >
+        <div class="flex items-center gap-2 overflow-hidden">
+          <Icon icon="i-mdi-book" class="size-4" />
+          <span class="x-ellipsis">
+            {projectName}
+          </span>
+        </div>
+        <Icon
+          icon="i-mdi-chevron-down"
+          class={cn('ml-2 size-4 shrink-0 opacity-50', open && 'rotate-180')}
+        />
+      </Button>
+    {/snippet}
   </Popover.Trigger>
   <Popover.Content class="w-full p-0">
     <Command.Root>

--- a/frontend/viewer/src/project/ProjectSidebar.svelte
+++ b/frontend/viewer/src/project/ProjectSidebar.svelte
@@ -33,44 +33,38 @@
 </script>
 
 {#snippet ViewButton(view: View, icon: IconClass, label: string)}
-  <Sidebar.MenuSubItem>
-    <Sidebar.MenuSubButton onclick={() => (currentView = view)} isActive={currentView === view}>
+  <Sidebar.MenuItem>
+    <Sidebar.MenuButton onclick={() => (currentView = view)} isActive={currentView === view}>
       <Icon {icon} />
       <span>{label}</span>
-    </Sidebar.MenuSubButton>
-  </Sidebar.MenuSubItem>
+    </Sidebar.MenuButton>
+  </Sidebar.MenuItem>
 {/snippet}
 <Sidebar.Root variant="inset">
   <Sidebar.Header>
-    <div class="flex flex-col gap-2">
-      <div class="flex flex-row items-center gap-2">
+    <div class="flex flex-col gap-2 overflow-hidden">
+      <div class="flex flex-row items-center gap-1">
         <ProjectDropdown
           {projectName}
           onSelect={handleProjectSelect}
         />
         <div class="flex-1" ></div>
-        <ThemePicker button={{variant: 'ghost', size: 'icon'}}>
-          <div class="size-3 rounded-full bg-primary"></div>
-        </ThemePicker>
+        <ThemePicker />
       </div>
       <Button variant="default" size="sm" class="px-3 max-w-72 m-auto" icon="i-mdi-plus">{$t`Create Entry`}</Button>
     </div>
   </Sidebar.Header>
   <Sidebar.Content>
     <Sidebar.Group>
-      <Sidebar.Menu>
-        <Sidebar.MenuItem>
-          <Sidebar.MenuButton>
-            <span>{$t`Dictionary`}</span>
-          </Sidebar.MenuButton>
-          <Sidebar.MenuSub>
-            {@render ViewButton('dashboard', 'i-mdi-view-dashboard', $t`Dashboard`)}
-            {@render ViewButton('browse', 'i-mdi-book-alphabet', $t`Browse`)}
-            {@render ViewButton('tasks', 'i-mdi-checkbox-marked', $t`Tasks`)}
-            {@render ViewButton('activity', 'i-mdi-chart-line', $t`Activity`)}
-          </Sidebar.MenuSub>
-        </Sidebar.MenuItem>
-      </Sidebar.Menu>
+      <Sidebar.GroupLabel>{$t`Dictionary`}</Sidebar.GroupLabel>
+      <Sidebar.GroupContent>
+        <Sidebar.Menu>
+          {@render ViewButton('dashboard', 'i-mdi-view-dashboard', $t`Dashboard`)}
+          {@render ViewButton('browse', 'i-mdi-book-alphabet', $t`Browse`)}
+          {@render ViewButton('tasks', 'i-mdi-checkbox-marked', $t`Tasks`)}
+          {@render ViewButton('activity', 'i-mdi-chart-line', $t`Activity`)}
+        </Sidebar.Menu>
+      </Sidebar.GroupContent>
     </Sidebar.Group>
   </Sidebar.Content>
   <Sidebar.Footer>


### PR DESCRIPTION
- Use light/dark mode icon instead of color ball
- Better close button positioning
![image](https://github.com/user-attachments/assets/6d125335-647a-4e40-acf6-79d60cdd41f8)

Changes:
- Fixed view menu items hover effect in Maui
- Removed hover effect from unclickable "Dictionary" item
- Fixed project name text overflow
- Fixed focus after selecting a project
- Fixed project dropdown target was a button inside a button
![image](https://github.com/user-attachments/assets/72805c14-35b0-4f99-93ae-9c329930a036)
