### PR TITLE
Bug/1555 auto update check uses hours component of timespan rather than totalhours

### DIFF
--- a/backend/FwLite/FwLiteMaui/Platforms/Windows/AppUpdateService.cs
+++ b/backend/FwLite/FwLiteMaui/Platforms/Windows/AppUpdateService.cs
@@ -203,7 +203,7 @@ public class AppUpdateService(
     {
         if (ValidPositiveEnvVarValues.Contains(Environment.GetEnvironmentVariable(ForceUpdateCheckEnvVar) ?? ""))
         {
-            logger.LogInformation("Should check for update based on env var {EnvVar}", PreventUpdateCheckEnvVar);
+            logger.LogInformation("Should check for update based on env var {EnvVar}", ForceUpdateCheckEnvVar);
             return true;
         }
         var lastChecked = preferences.Get(LastUpdateCheck, DateTime.MinValue);

--- a/backend/FwLite/FwLiteMaui/Platforms/Windows/AppUpdateService.cs
+++ b/backend/FwLite/FwLiteMaui/Platforms/Windows/AppUpdateService.cs
@@ -202,17 +202,26 @@ public class AppUpdateService(
     private bool ShouldCheckForUpdate()
     {
         if (ValidPositiveEnvVarValues.Contains(Environment.GetEnvironmentVariable(ForceUpdateCheckEnvVar) ?? ""))
+        {
+            logger.LogInformation("Should check for update based on env var {EnvVar}", PreventUpdateCheckEnvVar);
             return true;
+        }
         var lastChecked = preferences.Get(LastUpdateCheck, DateTime.MinValue);
         var timeSinceLastCheck = DateTime.UtcNow - lastChecked;
         //if last checked is in the future (should never happen), then we want to reset the time and check again
         if (timeSinceLastCheck.Hours < -1)
         {
             preferences.Set(LastUpdateCheck, DateTime.UtcNow);
+            logger.LogInformation("Should check for update, because last check was in the future: {LastCheck}", lastChecked);
             return true;
         }
-        if (timeSinceLastCheck.Hours < 20) return false;
+        if (timeSinceLastCheck.Hours < 20)
+        {
+            logger.LogInformation("Should not check for update, because last check was too recent: {LastCheck}", lastChecked);
+            return false;
+        }
         preferences.Set(LastUpdateCheck, DateTime.UtcNow);
+        logger.LogInformation("Should check for update based on last check time: {LastCheck}", lastChecked);
         return true;
     }
 

--- a/backend/FwLite/FwLiteMaui/Platforms/Windows/AppUpdateService.cs
+++ b/backend/FwLite/FwLiteMaui/Platforms/Windows/AppUpdateService.cs
@@ -209,13 +209,13 @@ public class AppUpdateService(
         var lastChecked = preferences.Get(LastUpdateCheck, DateTime.MinValue);
         var timeSinceLastCheck = DateTime.UtcNow - lastChecked;
         //if last checked is in the future (should never happen), then we want to reset the time and check again
-        if (timeSinceLastCheck.Hours < -1)
+        if (timeSinceLastCheck.TotalHours < -1)
         {
             preferences.Set(LastUpdateCheck, DateTime.UtcNow);
             logger.LogInformation("Should check for update, because last check was in the future: {LastCheck}", lastChecked);
             return true;
         }
-        if (timeSinceLastCheck.Hours < 20)
+        if (timeSinceLastCheck.TotalHours < 20)
         {
             logger.LogInformation("Should not check for update, because last check was too recent: {LastCheck}", lastChecked);
             return false;

--- a/backend/FwLite/FwLiteMaui/Platforms/Windows/AppUpdateService.cs
+++ b/backend/FwLite/FwLiteMaui/Platforms/Windows/AppUpdateService.cs
@@ -215,7 +215,7 @@ public class AppUpdateService(
             logger.LogInformation("Should check for update, because last check was in the future: {LastCheck}", lastChecked);
             return true;
         }
-        if (timeSinceLastCheck.TotalHours < 20)
+        if (timeSinceLastCheck.TotalHours < 8)
         {
             logger.LogInformation("Should not check for update, because last check was too recent: {LastCheck}", lastChecked);
             return false;


### PR DESCRIPTION
Resolves #1555 

ShouldCheckForUpdate is no longer unintentionaly dependant on the time of day the code runs.

I tried to add a test, but couldn't figure out how to properly reference the Maui project or the Windows specific code or how to run the tests. 🙃 

You can see my effort here: https://github.com/sillsdev/languageforge-lexbox/pull/1557

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Adjusted the update check mechanism to ensure version evaluations occur reliably and at the proper intervals.
- **Chores**
  - Enhanced logging to provide clearer insights into when update checks are initiated, aiding in smoother system monitoring.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->