### PR TITLE
Use central package managment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,6 @@ backend/FwLite/FwLiteShared/wwwroot/viewer
 *.csproj.user
 *.log
 failedSyncs/
+
+# just ignore everything rider related
+.idea

--- a/backend/.editorconfig
+++ b/backend/.editorconfig
@@ -7,11 +7,11 @@ indent_style = space
 
 # XML project files
 [*.{csproj,vbproj,vcxproj,vcxproj.filters,proj,projitems,shproj}]
-indent_size = 4
+indent_size = 2
 
 # XML config files
 [*.{props,targets,ruleset,config,nuspec,resx,vsixmanifest,vsct}]
-indent_size = 4
+indent_size = 2
 
 # Code files
 [*.{cs,csx}]

--- a/backend/Directory.Build.props
+++ b/backend/Directory.Build.props
@@ -1,22 +1,18 @@
 <Project>
-    <PropertyGroup>
-        <DefaultItemExcludes>$(DefaultItemExcludes);$(MSBuildProjectDirectory)/obj/**/*</DefaultItemExcludes>
-        <DefaultItemExcludes>$(DefaultItemExcludes);$(MSBuildProjectDirectory)/bin/**/*</DefaultItemExcludes>
-    </PropertyGroup>
-
-    <PropertyGroup Condition="'$(DOTNET_RUNNING_IN_CONTAINER)' == 'true'">
-        <BaseIntermediateOutputPath>$(MSBuildProjectDirectory)/obj/container/</BaseIntermediateOutputPath>
-        <BaseOutputPath>$(MSBuildProjectDirectory)/bin/container/</BaseOutputPath>
-    </PropertyGroup>
-    <PropertyGroup>
-        <InformationalVersion>dev</InformationalVersion>
-        <TargetFramework Condition="'$(TargetFramework)' == ''">net9.0</TargetFramework>
-        <EnforceCodeStyleInBuild>false</EnforceCodeStyleInBuild>
-        <ImplicitUsings>enable</ImplicitUsings>
-        <Nullable>enable</Nullable>
-        <WarningsAsErrors>Nullable</WarningsAsErrors>
-    </PropertyGroup>
-    <ItemGroup>
-        <PackageReference Include="Microsoft.VisualStudio.Threading.Analyzers" Version="17.11.20" PrivateAssets="all"/>
-    </ItemGroup>
+  <PropertyGroup>
+    <DefaultItemExcludes>$(DefaultItemExcludes);$(MSBuildProjectDirectory)/obj/**/*</DefaultItemExcludes>
+    <DefaultItemExcludes>$(DefaultItemExcludes);$(MSBuildProjectDirectory)/bin/**/*</DefaultItemExcludes>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(DOTNET_RUNNING_IN_CONTAINER)' == 'true'">
+    <BaseIntermediateOutputPath>$(MSBuildProjectDirectory)/obj/container/</BaseIntermediateOutputPath>
+    <BaseOutputPath>$(MSBuildProjectDirectory)/bin/container/</BaseOutputPath>
+  </PropertyGroup>
+  <PropertyGroup>
+    <InformationalVersion>dev</InformationalVersion>
+    <TargetFramework Condition="'$(TargetFramework)' == ''">net9.0</TargetFramework>
+    <EnforceCodeStyleInBuild>false</EnforceCodeStyleInBuild>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <WarningsAsErrors>Nullable</WarningsAsErrors>
+  </PropertyGroup>
 </Project>

--- a/backend/Directory.Packages.props
+++ b/backend/Directory.Packages.props
@@ -106,20 +106,13 @@
     <PackageVersion Include="Squidex.Assets.TusClient" Version="6.6.4"/>
     <PackageVersion Include="structuremap.patched" Version="4.7.3"/>
     <PackageVersion Include="Swashbuckle.AspNetCore" Version="7.2.0"/>
-    <PackageVersion Include="System.Collections" Version="4.3.0"/>
     <PackageVersion Include="System.CommandLine" Version="2.0.0-beta4.22272.1"/>
     <PackageVersion Include="System.IdentityModel.Tokens.Jwt" Version="8.2.0"/>
-    <PackageVersion Include="System.IO" Version="4.3.0"/>
     <PackageVersion Include="System.Linq.Async" Version="6.0.1"/>
-    <PackageVersion Include="System.Net.NameResolution" Version="4.3.0"/>
-    <PackageVersion Include="System.Private.Uri" Version="4.3.2"/>
     <PackageVersion Include="System.Reactive" Version="6.0.1"/>
-    <PackageVersion Include="System.Runtime.Extensions" Version="4.3.0"/>
-    <PackageVersion Include="System.Runtime.InteropServices" Version="4.3.0"/>
     <PackageVersion Include="System.Security.Cryptography.Xml" Version="9.0.0"/>
     <PackageVersion Include="System.Text.Encodings.Web" Version="9.0.0"/>
     <PackageVersion Include="System.Text.Json" Version="9.0.0"/>
-    <PackageVersion Include="System.Threading.ThreadPool" Version="4.3.0"/>
     <PackageVersion Include="SystemTextJson.JsonDiffPatch" Version="2.0.0"/>
     <PackageVersion Include="SystemTextJsonPatch" Version="3.2.1"/>
     <PackageVersion Include="tusdotnet" Version="2.8.0"/>

--- a/backend/Directory.Packages.props
+++ b/backend/Directory.Packages.props
@@ -3,6 +3,7 @@
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
     <CentralPackageTransitivePinningEnabled>true</CentralPackageTransitivePinningEnabled>
     <NoWarn>$(NoWarn);NU1507</NoWarn>
+    <MauiVersion>9.0.50</MauiVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageVersion Include="AppAny.Quartz.EntityFrameworkCore.Migrations.PostgreSQL" Version="0.5.1"/>
@@ -33,7 +34,7 @@
     <PackageVersion Include="Microsoft.AspNetCore.Authentication.Google" Version="8.0.10"/>
     <PackageVersion Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="9.0.0"/>
     <PackageVersion Include="Microsoft.AspNetCore.Components.Web" Version="9.0.0"/>
-    <PackageVersion Include="Microsoft.AspNetCore.Components.WebView.Maui"/>
+    <PackageVersion Include="Microsoft.AspNetCore.Components.WebView.Maui" Version="$(MauiVersion)"/>
     <PackageVersion Include="Microsoft.AspNetCore.OpenApi" Version="9.0.0"/>
     <PackageVersion Include="Microsoft.AspNetCore.SignalR.Client" Version="9.0.0"/>
     <PackageVersion Include="Microsoft.EntityFrameworkCore" Version="8.0.11"/>
@@ -60,8 +61,8 @@
     <PackageVersion Include="Microsoft.ICU.ICU4C.Runtime" Version="72.1.0.3"/>
     <PackageVersion Include="Microsoft.Identity.Client.Extensions.Msal" Version="4.67.2"/>
     <PackageVersion Include="Microsoft.IdentityModel.Protocols.OpenIdConnect" Version="8.2.0"/>
-    <PackageVersion Include="Microsoft.Maui.Controls"/>
-    <PackageVersion Include="Microsoft.Maui.Controls.Compatibility"/>
+    <PackageVersion Include="Microsoft.Maui.Controls" Version="$(MauiVersion)"/>
+    <PackageVersion Include="Microsoft.Maui.Controls.Compatibility" Version="$(MauiVersion)"/>
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.11.1"/>
     <PackageVersion Include="Microsoft.Toolkit.Uwp.Notifications" Version="7.1.3"/>
     <PackageVersion Include="MongoDB.Analyzer" Version="1.5.0"/>
@@ -94,7 +95,7 @@
     <PackageVersion Include="Refit.HttpClientFactory" Version="8.0.0"/>
     <PackageVersion Include="Reinforced.Typings" Version="1.6.5"/>
     <PackageVersion Include="Scalar.AspNetCore" Version="1.2.22"/>
-    <PackageVersion Include="SIL.Chorus.LibChorus" Version="6.0.0-beta0049"/>
+    <PackageVersion Include="SIL.Chorus.LibChorus" Version="6.0.0-beta0055"/>
     <PackageVersion Include="SIL.Chorus.Mercurial" Version="6.5.1.43"/>
     <PackageVersion Include="SIL.ChorusPlugin.LfMergeBridge" Version="4.2.0-beta0028"/>
     <PackageVersion Include="SIL.Core" Version="14.2.0-beta0022"/>

--- a/backend/Directory.Packages.props
+++ b/backend/Directory.Packages.props
@@ -40,20 +40,20 @@
     <PackageVersion Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.11"/>
     <PackageVersion Include="Microsoft.Extensions.Caching.Hybrid" Version="9.0.0-preview.9.24556.5"/>
     <PackageVersion Include="Microsoft.Extensions.Caching.Memory" Version="9.0.0"/>
-    <PackageVersion Include="Microsoft.Extensions.Configuration" Version="9.0.0"/>
-    <PackageVersion Include="Microsoft.Extensions.Configuration.Binder" Version="9.0.0"/>
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="9.0.1"/>
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.0"/>
+    <PackageVersion Include="Microsoft.Extensions.Configuration" Version="9.0.2"/>
+    <PackageVersion Include="Microsoft.Extensions.Configuration.Binder" Version="9.0.2"/>
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="9.0.2"/>
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.2"/>
     <PackageVersion Include="Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore" Version="8.0.11"/>
     <PackageVersion Include="Microsoft.Extensions.FileProviders.Embedded" Version="9.0.0"/>
-    <PackageVersion Include="Microsoft.Extensions.Hosting" Version="9.0.0"/>
-    <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions" Version="9.0.0"/>
+    <PackageVersion Include="Microsoft.Extensions.Hosting" Version="9.0.2"/>
+    <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions" Version="9.0.2"/>
     <PackageVersion Include="Microsoft.Extensions.Http.Resilience" Version="9.2.0"/>
-    <PackageVersion Include="Microsoft.Extensions.Logging" Version="9.0.0"/>
-    <PackageVersion Include="Microsoft.Extensions.Logging.Console" Version="9.0.0"/>
-    <PackageVersion Include="Microsoft.Extensions.Logging.Debug" Version="9.0.1"/>
-    <PackageVersion Include="Microsoft.Extensions.Options" Version="9.0.0"/>
-    <PackageVersion Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="9.0.0"/>
+    <PackageVersion Include="Microsoft.Extensions.Logging" Version="9.0.2"/>
+    <PackageVersion Include="Microsoft.Extensions.Logging.Console" Version="9.0.2"/>
+    <PackageVersion Include="Microsoft.Extensions.Logging.Debug" Version="9.0.2"/>
+    <PackageVersion Include="Microsoft.Extensions.Options" Version="9.0.2"/>
+    <PackageVersion Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="9.0.2"/>
     <PackageVersion Include="Microsoft.Extensions.Options.DataAnnotations" Version="9.0.0"/>
     <PackageVersion Include="Microsoft.Extensions.ServiceDiscovery" Version="9.0.0"/>
     <PackageVersion Include="Microsoft.Extensions.TimeProvider.Testing" Version="9.0.0"/>

--- a/backend/Directory.Packages.props
+++ b/backend/Directory.Packages.props
@@ -1,0 +1,136 @@
+<Project>
+  <PropertyGroup>
+    <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+    <CentralPackageTransitivePinningEnabled>true</CentralPackageTransitivePinningEnabled>
+    <NoWarn>$(NoWarn);NU1507</NoWarn>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageVersion Include="AppAny.Quartz.EntityFrameworkCore.Migrations.PostgreSQL" Version="0.5.1"/>
+    <PackageVersion Include="BeaKona.AutoInterfaceGenerator" Version="1.0.42"/>
+    <PackageVersion Include="coverlet.collector" Version="6.0.2"/>
+    <PackageVersion Include="CrystalQuartz.AspNetCore" Version="7.2.0-beta"/>
+    <PackageVersion Include="DataAnnotatedModelValidations" Version="6.0.0"/>
+    <PackageVersion Include="EntityFrameworkCore.Projectables" Version="3.0.4"/>
+    <PackageVersion Include="EntityFrameworkCore.Projectables.Abstractions" Version="4.0.0-preview.4"/>
+    <PackageVersion Include="FluentAssertions" Version="7.0.0-alpha.5"/>
+    <PackageVersion Include="FluentValidation" Version="11.11.0"/>
+    <PackageVersion Include="GitHubActionsTestLogger" Version="2.4.1"/>
+    <PackageVersion Include="Gridify" Version="2.16.2"/>
+    <PackageVersion Include="Gridify.EntityFramework" Version="2.15.0"/>
+    <PackageVersion Include="HotChocolate.Analyzers" Version="13.9.14"/>
+    <PackageVersion Include="HotChocolate.AspNetCore" Version="14.0.0"/>
+    <PackageVersion Include="HotChocolate.AspNetCore.Authorization" Version="14.0.0"/>
+    <PackageVersion Include="HotChocolate.Data.EntityFramework" Version="14.0.0"/>
+    <PackageVersion Include="HotChocolate.Diagnostics" Version="14.0.0"/>
+    <PackageVersion Include="HotChocolate.Types.Analyzers" Version="14.0.0"/>
+    <PackageVersion Include="HtmlAgilityPack" Version="1.12.0"/>
+    <PackageVersion Include="Humanizer.Core" Version="2.14.1"/>
+    <PackageVersion Include="icu.net" Version="3.0.0-beta.297"/>
+    <PackageVersion Include="linq2db.AspNet" Version="5.4.1"/>
+    <PackageVersion Include="linq2db.EntityFrameworkCore" Version="8.1.0"/>
+    <PackageVersion Include="MailKit" Version="4.7.1.1"/>
+    <PackageVersion Include="Meziantou.Extensions.Logging.Xunit" Version="1.0.7"/>
+    <PackageVersion Include="Microsoft.AspNetCore.Authentication.Google" Version="8.0.10"/>
+    <PackageVersion Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="9.0.0"/>
+    <PackageVersion Include="Microsoft.AspNetCore.Components.Web" Version="9.0.0"/>
+    <PackageVersion Include="Microsoft.AspNetCore.Components.WebView.Maui"/>
+    <PackageVersion Include="Microsoft.AspNetCore.OpenApi" Version="9.0.0"/>
+    <PackageVersion Include="Microsoft.AspNetCore.SignalR.Client" Version="9.0.0"/>
+    <PackageVersion Include="Microsoft.EntityFrameworkCore" Version="8.0.11"/>
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.11"/>
+    <PackageVersion Include="Microsoft.Extensions.Caching.Hybrid" Version="9.0.0-preview.9.24556.5"/>
+    <PackageVersion Include="Microsoft.Extensions.Caching.Memory" Version="9.0.0"/>
+    <PackageVersion Include="Microsoft.Extensions.Configuration" Version="9.0.0"/>
+    <PackageVersion Include="Microsoft.Extensions.Configuration.Binder" Version="9.0.0"/>
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="9.0.1"/>
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.0"/>
+    <PackageVersion Include="Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore" Version="8.0.11"/>
+    <PackageVersion Include="Microsoft.Extensions.FileProviders.Embedded" Version="9.0.0"/>
+    <PackageVersion Include="Microsoft.Extensions.Hosting" Version="9.0.0"/>
+    <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions" Version="9.0.0"/>
+    <PackageVersion Include="Microsoft.Extensions.Http.Resilience" Version="9.2.0"/>
+    <PackageVersion Include="Microsoft.Extensions.Logging" Version="9.0.0"/>
+    <PackageVersion Include="Microsoft.Extensions.Logging.Console" Version="9.0.0"/>
+    <PackageVersion Include="Microsoft.Extensions.Logging.Debug" Version="9.0.1"/>
+    <PackageVersion Include="Microsoft.Extensions.Options" Version="9.0.0"/>
+    <PackageVersion Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="9.0.0"/>
+    <PackageVersion Include="Microsoft.Extensions.Options.DataAnnotations" Version="9.0.0"/>
+    <PackageVersion Include="Microsoft.Extensions.ServiceDiscovery" Version="9.0.0"/>
+    <PackageVersion Include="Microsoft.Extensions.TimeProvider.Testing" Version="9.0.0"/>
+    <PackageVersion Include="Microsoft.ICU.ICU4C.Runtime" Version="72.1.0.3"/>
+    <PackageVersion Include="Microsoft.Identity.Client.Extensions.Msal" Version="4.67.2"/>
+    <PackageVersion Include="Microsoft.IdentityModel.Protocols.OpenIdConnect" Version="8.2.0"/>
+    <PackageVersion Include="Microsoft.Maui.Controls"/>
+    <PackageVersion Include="Microsoft.Maui.Controls.Compatibility"/>
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.11.1"/>
+    <PackageVersion Include="Microsoft.Toolkit.Uwp.Notifications" Version="7.1.3"/>
+    <PackageVersion Include="MongoDB.Analyzer" Version="1.5.0"/>
+    <PackageVersion Include="MongoDB.Driver" Version="2.28.0"/>
+    <PackageVersion Include="MongoDB.Driver.Core.Extensions.DiagnosticSources" Version="1.5.0"/>
+    <PackageVersion Include="Moq" Version="4.20.70"/>
+    <PackageVersion Include="Moq.Contrib.HttpClient" Version="1.4.0"/>
+    <PackageVersion Include="Nito.AsyncEx.Coordination" Version="5.1.2"/>
+    <PackageVersion Include="Npgsql" Version="8.0.6"/>
+    <PackageVersion Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="8.0.11"/>
+    <PackageVersion Include="Npgsql.OpenTelemetry" Version="8.0.6"/>
+    <PackageVersion Include="NReco.Logging.File" Version="1.2.1"/>
+    <PackageVersion Include="OpenIddict.AspNetCore" Version="5.8.0"/>
+    <PackageVersion Include="OpenIddict.EntityFrameworkCore" Version="5.8.0"/>
+    <PackageVersion Include="OpenIddict.Quartz" Version="5.8.0"/>
+    <PackageVersion Include="OpenTelemetry.Exporter.Console" Version="1.10.0"/>
+    <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.10.0"/>
+    <PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="1.10.0"/>
+    <PackageVersion Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.9.0"/>
+    <PackageVersion Include="OpenTelemetry.Instrumentation.EntityFrameworkCore" Version="1.11.0-beta.1"/>
+    <PackageVersion Include="OpenTelemetry.Instrumentation.Http" Version="1.9.0"/>
+    <PackageVersion Include="OpenTelemetry.Instrumentation.Process" Version="1.11.0-beta.1"/>
+    <PackageVersion Include="OpenTelemetry.Instrumentation.Quartz" Version="1.0.0-beta.1"/>
+    <PackageVersion Include="OpenTelemetry.Instrumentation.Runtime" Version="1.9.0"/>
+    <PackageVersion Include="Polly" Version="8.4.2"/>
+    <PackageVersion Include="Polly.Extensions" Version="8.4.2"/>
+    <PackageVersion Include="Quartz.AspNetCore" Version="3.13.0"/>
+    <PackageVersion Include="Quartz.Serialization.SystemTextJson" Version="3.13.0"/>
+    <PackageVersion Include="Refit" Version="8.0.0"/>
+    <PackageVersion Include="Refit.HttpClientFactory" Version="8.0.0"/>
+    <PackageVersion Include="Reinforced.Typings" Version="1.6.5"/>
+    <PackageVersion Include="Scalar.AspNetCore" Version="1.2.22"/>
+    <PackageVersion Include="SIL.Chorus.LibChorus" Version="6.0.0-beta0049"/>
+    <PackageVersion Include="SIL.Chorus.Mercurial" Version="6.5.1.43"/>
+    <PackageVersion Include="SIL.ChorusPlugin.LfMergeBridge" Version="4.2.0-beta0028"/>
+    <PackageVersion Include="SIL.Core" Version="14.2.0-beta0022"/>
+    <PackageVersion Include="SIL.LCModel" Version="11.0.0-beta0111"/>
+    <PackageVersion Include="SIL.LCModel.FixData" Version="11.0.0-beta0109"/>
+    <PackageVersion Include="SIL.WritingSystems" Version="14.2.0-beta0022"/>
+    <PackageVersion Include="Soenneker.Utils.AutoBogus" Version="3.0.410"/>
+    <PackageVersion Include="Squidex.Assets.TusClient" Version="6.6.4"/>
+    <PackageVersion Include="structuremap.patched" Version="4.7.3"/>
+    <PackageVersion Include="Swashbuckle.AspNetCore" Version="7.2.0"/>
+    <PackageVersion Include="System.Collections" Version="4.3.0"/>
+    <PackageVersion Include="System.CommandLine" Version="2.0.0-beta4.22272.1"/>
+    <PackageVersion Include="System.IdentityModel.Tokens.Jwt" Version="8.2.0"/>
+    <PackageVersion Include="System.IO" Version="4.3.0"/>
+    <PackageVersion Include="System.Linq.Async" Version="6.0.1"/>
+    <PackageVersion Include="System.Net.NameResolution" Version="4.3.0"/>
+    <PackageVersion Include="System.Private.Uri" Version="4.3.2"/>
+    <PackageVersion Include="System.Reactive" Version="6.0.1"/>
+    <PackageVersion Include="System.Runtime.Extensions" Version="4.3.0"/>
+    <PackageVersion Include="System.Runtime.InteropServices" Version="4.3.0"/>
+    <PackageVersion Include="System.Security.Cryptography.Xml" Version="9.0.0"/>
+    <PackageVersion Include="System.Text.Encodings.Web" Version="9.0.0"/>
+    <PackageVersion Include="System.Text.Json" Version="9.0.0"/>
+    <PackageVersion Include="System.Threading.ThreadPool" Version="4.3.0"/>
+    <PackageVersion Include="SystemTextJson.JsonDiffPatch" Version="2.0.0"/>
+    <PackageVersion Include="SystemTextJsonPatch" Version="3.2.1"/>
+    <PackageVersion Include="tusdotnet" Version="2.8.0"/>
+    <PackageVersion Include="Verify.Xunit" Version="28.2.1"/>
+    <PackageVersion Include="xunit" Version="2.9.2"/>
+    <PackageVersion Include="xunit.runner.visualstudio" Version="2.8.2"/>
+    <PackageVersion Include="XunitXml.TestLogger" Version="3.1.17"/>
+    <PackageVersion Include="Yarp.ReverseProxy" Version="2.2.0"/>
+    <PackageVersion Include="Yarp.Telemetry.Consumption" Version="2.2.0"/>
+    <PackageVersion Include="zxcvbn-core" Version="7.0.92"/>
+  </ItemGroup>
+  <ItemGroup>
+    <GlobalPackageReference Include="Microsoft.VisualStudio.Threading.Analyzers" Version="17.11.20"/>
+  </ItemGroup>
+</Project>

--- a/backend/FixFwData/FixFwData.csproj
+++ b/backend/FixFwData/FixFwData.csproj
@@ -1,5 +1,4 @@
 <Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
     <RootNamespace>FixFwData</RootNamespace>
@@ -9,10 +8,9 @@
     <Product>LexBoxApi Testing</Product>
     <Copyright>Copyright © 2024 SIL Global</Copyright>
   </PropertyGroup>
-
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="9.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="9.0.0" />
-    <PackageReference Include="SIL.LCModel.FixData" Version="11.0.0-beta0109" />
+    <PackageReference Include="Microsoft.Extensions.Logging" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" />
+    <PackageReference Include="SIL.LCModel.FixData" />
   </ItemGroup>
 </Project>

--- a/backend/FwHeadless/FwHeadless.csproj
+++ b/backend/FwHeadless/FwHeadless.csproj
@@ -10,7 +10,7 @@
     <PackageReference Include="OpenTelemetry.Instrumentation.EntityFrameworkCore" Version="1.11.0-beta.1" />
     <PackageReference Include="Scalar.AspNetCore" Version="1.2.22" />
     <PackageReference Include="SIL.ChorusPlugin.LfMergeBridge" Version="4.2.0-beta0027" />
-    <PackageReference Include="SIL.Chorus.Mercurial" Version="6.5.1.*" />
+    <PackageReference Include="SIL.Chorus.Mercurial" Version="6.5.1.43" />
     <PackageReference Include="System.Security.Cryptography.Xml" Version="9.0.0" />
   </ItemGroup>
 

--- a/backend/FwHeadless/FwHeadless.csproj
+++ b/backend/FwHeadless/FwHeadless.csproj
@@ -1,19 +1,16 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
-
   <PropertyGroup>
     <Mercurial4ChorusDestDir>$(MSBuildProjectDirectory)</Mercurial4ChorusDestDir>
   </PropertyGroup>
-
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.0" />
-    <PackageReference Include="Npgsql.OpenTelemetry" Version="8.0.6" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.EntityFrameworkCore" Version="1.11.0-beta.1" />
-    <PackageReference Include="Scalar.AspNetCore" Version="1.2.22" />
-    <PackageReference Include="SIL.ChorusPlugin.LfMergeBridge" Version="4.2.0-beta0027" />
-    <PackageReference Include="SIL.Chorus.Mercurial" Version="6.5.1.43" />
-    <PackageReference Include="System.Security.Cryptography.Xml" Version="9.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.OpenApi" />
+    <PackageReference Include="Npgsql.OpenTelemetry" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.EntityFrameworkCore" />
+    <PackageReference Include="Scalar.AspNetCore" />
+    <PackageReference Include="SIL.ChorusPlugin.LfMergeBridge" />
+    <PackageReference Include="SIL.Chorus.Mercurial" />
+    <PackageReference Include="System.Security.Cryptography.Xml" />
   </ItemGroup>
-
   <ItemGroup>
     <ProjectReference Include="../harmony/src/SIL.Harmony/SIL.Harmony.csproj" />
     <ProjectReference Include="../FwLite/FwDataMiniLcmBridge/FwDataMiniLcmBridge.csproj" />
@@ -23,11 +20,10 @@
     <ProjectReference Include="../LexData/LexData.csproj" />
     <ProjectReference Include="..\WebServiceDefaults\WebServiceDefaults.csproj" />
   </ItemGroup>
-
   <ItemGroup>
-      <!-- json files get imported by default because this is a web project, so exclude those here so they aren't imported again below -->
-      <Content Remove="Mercurial\contrib\asv.conf.json" />
-      <Content Include="Mercurial\**" CopyToOutputDirectory="Always" Watch="false" />
-      <Content Include="MercurialExtensions\**" CopyToOutputDirectory="Always" Watch="false" />
+    <!-- json files get imported by default because this is a web project, so exclude those here so they aren't imported again below -->
+    <Content Remove="Mercurial\contrib\asv.conf.json" />
+    <Content Include="Mercurial\**" CopyToOutputDirectory="Always" Watch="false" />
+    <Content Include="MercurialExtensions\**" CopyToOutputDirectory="Always" Watch="false" />
   </ItemGroup>
 </Project>

--- a/backend/FwLite/FwDataMiniLcmBridge.Tests/FwDataMiniLcmBridge.Tests.csproj
+++ b/backend/FwLite/FwDataMiniLcmBridge.Tests/FwDataMiniLcmBridge.Tests.csproj
@@ -1,46 +1,39 @@
 <Project Sdk="Microsoft.NET.Sdk">
-
-    <PropertyGroup>
-
-        <IsPackable>false</IsPackable>
-        <IsTestProject>true</IsTestProject>
-    </PropertyGroup>
-
-    <ItemGroup>
-        <PackageReference Include="coverlet.collector" Version="6.0.2">
-          <PrivateAssets>all</PrivateAssets>
-          <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-        </PackageReference>
-        <PackageReference Include="GitHubActionsTestLogger" Version="2.4.1">
-          <PrivateAssets>all</PrivateAssets>
-          <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-        </PackageReference>
-        <PackageReference Include="Microsoft.Extensions.Configuration" Version="9.0.0" />
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
-        <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="9.0.0" />
-        <PackageReference Include="FluentAssertions" Version="7.0.0-alpha.5"/>
-        <PackageReference Include="xunit" Version="2.9.2" />
-        <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
-            <PrivateAssets>all</PrivateAssets>
-            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-        </PackageReference>
-        <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.0" />
-    </ItemGroup>
-
-    <ItemGroup>
-        <Using Include="Xunit"/>
-        <Using Include="FluentAssertions"/>
-        <Using Include="MiniLcm"/>
-        <Using Include="MiniLcm.Tests"/>
-    </ItemGroup>
-
-    <ItemGroup>
-      <ProjectReference Include="..\FwDataMiniLcmBridge\FwDataMiniLcmBridge.csproj" />
-      <ProjectReference Include="..\MiniLcm.Tests\MiniLcm.Tests.csproj" />
-    </ItemGroup>
-
-    <ItemGroup>
-      <Folder Include="TestData\" />
-    </ItemGroup>
-
+  <PropertyGroup>
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="GitHubActionsTestLogger">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.Extensions.Configuration" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Debug" />
+    <PackageReference Include="FluentAssertions" />
+    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.runner.visualstudio">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
+  </ItemGroup>
+  <ItemGroup>
+    <Using Include="Xunit" />
+    <Using Include="FluentAssertions" />
+    <Using Include="MiniLcm" />
+    <Using Include="MiniLcm.Tests" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\FwDataMiniLcmBridge\FwDataMiniLcmBridge.csproj" />
+    <ProjectReference Include="..\MiniLcm.Tests\MiniLcm.Tests.csproj" />
+  </ItemGroup>
+  <ItemGroup>
+    <Folder Include="TestData\" />
+  </ItemGroup>
 </Project>

--- a/backend/FwLite/FwDataMiniLcmBridge/FwDataMiniLcmBridge.csproj
+++ b/backend/FwLite/FwDataMiniLcmBridge/FwDataMiniLcmBridge.csproj
@@ -1,31 +1,28 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-
-    <PropertyGroup>
-         <FileVersion>$(ApplicationDisplayVersion)</FileVersion>
-    </PropertyGroup>
-    <ItemGroup>
-        <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="9.0.0" />
-        <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.0" />
-        <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="9.0.0" />
-        <PackageReference Include="Microsoft.Extensions.Logging" Version="9.0.0" />
-        <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="9.0.0" />
-        <PackageReference Include="SIL.Core" Version="14.2.0-beta0022" />
-        <PackageReference Include="Microsoft.ICU.ICU4C.Runtime" Version="72.1.0.3" Condition="$([MSBuild]::IsOsPlatform('Windows'))" />
-        <PackageReference Include="SIL.LCModel" Version="11.0.0-beta0111" />
-        <PackageReference Include="structuremap.patched" Version="4.7.3" />
-        <PackageReference Include="System.Linq.Async" Version="6.0.1" />
-        <PackageReference Include="System.Net.NameResolution" Version="4.3.0" />
-        <PackageReference Include="System.Private.Uri" Version="4.3.2" />
-        <PackageReference Include="System.Threading.ThreadPool" Version="4.3.0" />
-    </ItemGroup>
-
-    <ItemGroup>
-        <InternalsVisibleTo Include="FwDataMiniLcmBridge.Tests" />
-        <InternalsVisibleTo Include="LcmDebugger" />
-    </ItemGroup>
-    <ItemGroup>
-        <ProjectReference Include="..\..\LexCore\LexCore.csproj" />
-        <ProjectReference Include="..\MiniLcm\MiniLcm.csproj" />
-    </ItemGroup>
-
+  <PropertyGroup>
+    <FileVersion>$(ApplicationDisplayVersion)</FileVersion>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Caching.Memory" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" />
+    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" />
+    <PackageReference Include="Microsoft.Extensions.Logging" />
+    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" />
+    <PackageReference Include="SIL.Core" />
+    <PackageReference Include="Microsoft.ICU.ICU4C.Runtime" Condition="$([MSBuild]::IsOsPlatform('Windows'))" />
+    <PackageReference Include="SIL.LCModel" />
+    <PackageReference Include="structuremap.patched" />
+    <PackageReference Include="System.Linq.Async" />
+    <PackageReference Include="System.Net.NameResolution" />
+    <PackageReference Include="System.Private.Uri" />
+    <PackageReference Include="System.Threading.ThreadPool" />
+  </ItemGroup>
+  <ItemGroup>
+    <InternalsVisibleTo Include="FwDataMiniLcmBridge.Tests" />
+    <InternalsVisibleTo Include="LcmDebugger" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\LexCore\LexCore.csproj" />
+    <ProjectReference Include="..\MiniLcm\MiniLcm.csproj" />
+  </ItemGroup>
 </Project>

--- a/backend/FwLite/FwDataMiniLcmBridge/FwDataMiniLcmBridge.csproj
+++ b/backend/FwLite/FwDataMiniLcmBridge/FwDataMiniLcmBridge.csproj
@@ -13,9 +13,6 @@
     <PackageReference Include="SIL.LCModel" />
     <PackageReference Include="structuremap.patched" />
     <PackageReference Include="System.Linq.Async" />
-    <PackageReference Include="System.Net.NameResolution" />
-    <PackageReference Include="System.Private.Uri" />
-    <PackageReference Include="System.Threading.ThreadPool" />
   </ItemGroup>
   <ItemGroup>
     <InternalsVisibleTo Include="FwDataMiniLcmBridge.Tests" />

--- a/backend/FwLite/FwLiteMaui/FwLiteMaui.csproj
+++ b/backend/FwLite/FwLiteMaui/FwLiteMaui.csproj
@@ -1,115 +1,90 @@
 <Project Sdk="Microsoft.NET.Sdk.Razor">
-
-	<PropertyGroup>
-        <!--        override the target framework set in Directory.Build.props, we will use what is defined in TargetFrameworks below instead-->
-        <TargetFramework/>
-
-        <TargetFrameworks>net9.0-android;net9.0-ios;net9.0-maccatalyst</TargetFrameworks>
-        <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows'))">$(TargetFrameworks);net9.0-windows10.0.19041.0</TargetFrameworks>
-        <LangVersion>preview</LangVersion>
-
-		<!-- Note for MacCatalyst:
+  <PropertyGroup>
+    <!--        override the target framework set in Directory.Build.props, we will use what is defined in TargetFrameworks below instead-->
+    <TargetFramework />
+    <TargetFrameworks>net9.0-android;net9.0-ios;net9.0-maccatalyst</TargetFrameworks>
+    <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows'))">$(TargetFrameworks);net9.0-windows10.0.19041.0</TargetFrameworks>
+    <LangVersion>preview</LangVersion>
+    <!-- Note for MacCatalyst:
 		The default runtime is maccatalyst-x64, except in Release config, in which case the default is maccatalyst-x64;maccatalyst-arm64.
 		When specifying both architectures, use the plural <RuntimeIdentifiers> instead of the singular <RuntimeIdentifier>.
 		The Mac App Store will NOT accept apps with ONLY maccatalyst-arm64 indicated;
 		either BOTH runtimes must be indicated or ONLY macatalyst-x64. -->
-		<!-- For example: <RuntimeIdentifiers>maccatalyst-x64;maccatalyst-arm64</RuntimeIdentifiers> -->
-        <RuntimeIdentifiers Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'android'">android-arm;android-arm64;android-x86;android-x64</RuntimeIdentifiers>
-
-        <OutputType>Exe</OutputType>
-		<RootNamespace>FwLiteMaui</RootNamespace>
-		<UseMaui>true</UseMaui>
-		<SingleProject>true</SingleProject>
-		<ImplicitUsings>enable</ImplicitUsings>
-        <EnableDefaultCssItems>false</EnableDefaultCssItems>
-		<Nullable>enable</Nullable>
-        <SelfContained>true</SelfContained>
-        <EnableWindowsTargeting Condition="$([MSBuild]::IsOSPlatform('linux'))">true</EnableWindowsTargeting>
-        <IncludeFwDataBridge>false</IncludeFwDataBridge>
-        <IncludeFwDataBridge Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'windows'">true</IncludeFwDataBridge>
-        <DefineConstants Condition="$(IncludeFwDataBridge)">$(DefineConstants);INCLUDE_FWDATA_BRIDGE</DefineConstants>
-
-		<!-- controls display name in Package.appxmanifest -->
-		<ApplicationTitle>FieldWorks Lite</ApplicationTitle>
-
-		<!-- App Identifier -->
-		<ApplicationId>org.sil.FwLiteMaui</ApplicationId>
-
-		<!-- Versions -->
-		<ApplicationDisplayVersion>1.0</ApplicationDisplayVersion>
-		<ApplicationVersion>1</ApplicationVersion>
-
-        <SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'ios'">15.0</SupportedOSPlatformVersion>
-        <SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'maccatalyst'">15.0</SupportedOSPlatformVersion>
-        <SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'android'">24.0</SupportedOSPlatformVersion>
-        <SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'windows'">10.0.19041.0</SupportedOSPlatformVersion>
-        <TargetPlatformMinVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'windows'">10.0.19041.0</TargetPlatformMinVersion>
-        <SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'tizen'">6.5</SupportedOSPlatformVersion>
-	</PropertyGroup>
-    <PropertyGroup Condition="'$(Configuration)' == 'Debug' ">
-        <WindowsPackageType>None</WindowsPackageType>
-        <PublishReadyToRun>false</PublishReadyToRun>
-    </PropertyGroup>
-    <PropertyGroup Condition="'$(Configuration)' == 'Release' And $([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'windows'">
-        <!--        single file disabled as it's less efficient for updates-->
-        <PublishSingleFile>false</PublishSingleFile>
-    </PropertyGroup>
-    <PropertyGroup Condition="'$(Configuration)' == 'Release' And $([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'windows' And $(WindowsPackageType) == 'None'">
-        <PublishSingleFile>true</PublishSingleFile>
-    </PropertyGroup>
-
-    <PropertyGroup>
-        <TargetPlatform>$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)'))</TargetPlatform>
-    </PropertyGroup>
-
-	<ItemGroup>
-		<!-- App Icon -->
-        <!-- background color is required for mac per: https://learn.microsoft.com/en-us/dotnet/maui/user-interface/images/app-icons?view=net-maui-8.0&tabs=windows#recolor-the-background -->
-        <MauiIcon Condition="'$(TargetPlatform)' == 'ios' Or '$(TargetPlatform)' == 'maccatalyst'"
-            Include="Resources\AppIcon\logo_light.svg"
-            Color="#1c4e80" />
-
-		<MauiIcon Condition="'$(TargetPlatform)' == 'android'"
-            Include="Resources\AppIcon\logo_background.svg"
-            ForegroundFile="Resources\AppIcon\logo_light_padding.svg"
-            ForegroundScale="0.8" />
-
-        <MauiIcon Condition="'$(TargetPlatform)' != 'ios' And '$(TargetPlatform)' != 'maccatalyst' And '$(TargetPlatform)' != 'android'"
-            Include="Resources\AppIcon\logo_light.svg" />
-
-		<!-- Splash Screen -->
-		<MauiSplashScreen Include="Resources\AppIcon\logo_light_padding.svg" Color="#1c4e80" BaseSize="512,512" />
-
-		<!-- Images -->
-		<MauiImage Include="Resources\Images\*" />
-
-		<!-- Custom Fonts -->
-		<MauiFont Include="Resources\Fonts\*" />
-
-		<!-- Raw Assets (also remove the "Resources\Raw" prefix) -->
-		<MauiAsset Include="Resources\Raw\**" LogicalName="%(RecursiveDir)%(Filename)%(Extension)" />
-	</ItemGroup>
-
-	<ItemGroup>
-		<PackageReference Include="Microsoft.Maui.Controls" Version="$(MauiVersion)" />
-		<PackageReference Include="Microsoft.Maui.Controls.Compatibility" Version="$(MauiVersion)" />
-        <PackageReference Include="Microsoft.AspNetCore.Components.WebView.Maui" Version="$(MauiVersion)"/>
-        <PackageReference Include="Microsoft.Toolkit.Uwp.Notifications" Version="7.1.3" />
-        <PackageReference Include="NReco.Logging.File" Version="1.2.1" />
-        <PackageReference Include="System.Collections" Version="4.3.0" />
-        <PackageReference Include="System.IO" Version="4.3.0" />
-        <PackageReference Include="System.Runtime.Extensions" Version="4.3.0" />
-        <PackageReference Include="System.Runtime.InteropServices" Version="4.3.0" />
-	</ItemGroup>
-
-	<ItemGroup>
-        <ProjectReference Include="..\FwLiteShared\FwLiteShared.csproj" />
-        <ProjectReference Include="..\LcmCrdt\LcmCrdt.csproj" />
-        <ProjectReference Include="..\MiniLcm\MiniLcm.csproj" />
-	</ItemGroup>
-    <ItemGroup Condition="$(IncludeFwDataBridge)">
-        <ProjectReference Include="..\FwDataMiniLcmBridge\FwDataMiniLcmBridge.csproj"/>
-        <ProjectReference Include="..\FwLiteProjectSync\FwLiteProjectSync.csproj"/>
-    </ItemGroup>
-
+    <!-- For example: <RuntimeIdentifiers>maccatalyst-x64;maccatalyst-arm64</RuntimeIdentifiers> -->
+    <RuntimeIdentifiers Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'android'">android-arm;android-arm64;android-x86;android-x64</RuntimeIdentifiers>
+    <OutputType>Exe</OutputType>
+    <RootNamespace>FwLiteMaui</RootNamespace>
+    <UseMaui>true</UseMaui>
+    <SingleProject>true</SingleProject>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <EnableDefaultCssItems>false</EnableDefaultCssItems>
+    <Nullable>enable</Nullable>
+    <SelfContained>true</SelfContained>
+    <EnableWindowsTargeting Condition="$([MSBuild]::IsOSPlatform('linux'))">true</EnableWindowsTargeting>
+    <IncludeFwDataBridge>false</IncludeFwDataBridge>
+    <IncludeFwDataBridge Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'windows'">true</IncludeFwDataBridge>
+    <DefineConstants Condition="$(IncludeFwDataBridge)">$(DefineConstants);INCLUDE_FWDATA_BRIDGE</DefineConstants>
+    <!-- controls display name in Package.appxmanifest -->
+    <ApplicationTitle>FieldWorks Lite</ApplicationTitle>
+    <!-- App Identifier -->
+    <ApplicationId>org.sil.FwLiteMaui</ApplicationId>
+    <!-- Versions -->
+    <ApplicationDisplayVersion>1.0</ApplicationDisplayVersion>
+    <ApplicationVersion>1</ApplicationVersion>
+    <SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'ios'">15.0</SupportedOSPlatformVersion>
+    <SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'maccatalyst'">15.0</SupportedOSPlatformVersion>
+    <SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'android'">24.0</SupportedOSPlatformVersion>
+    <SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'windows'">10.0.19041.0</SupportedOSPlatformVersion>
+    <TargetPlatformMinVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'windows'">10.0.19041.0</TargetPlatformMinVersion>
+    <SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'tizen'">6.5</SupportedOSPlatformVersion>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)' == 'Debug' ">
+    <WindowsPackageType>None</WindowsPackageType>
+    <PublishReadyToRun>false</PublishReadyToRun>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)' == 'Release' And $([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'windows'">
+    <!--        single file disabled as it's less efficient for updates-->
+    <PublishSingleFile>false</PublishSingleFile>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)' == 'Release' And $([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'windows' And $(WindowsPackageType) == 'None'">
+    <PublishSingleFile>true</PublishSingleFile>
+  </PropertyGroup>
+  <PropertyGroup>
+    <TargetPlatform>$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)'))</TargetPlatform>
+  </PropertyGroup>
+  <ItemGroup>
+    <!-- App Icon -->
+    <!-- background color is required for mac per: https://learn.microsoft.com/en-us/dotnet/maui/user-interface/images/app-icons?view=net-maui-8.0&tabs=windows#recolor-the-background -->
+    <MauiIcon Condition="'$(TargetPlatform)' == 'ios' Or '$(TargetPlatform)' == 'maccatalyst'" Include="Resources\AppIcon\logo_light.svg" Color="#1c4e80" />
+    <MauiIcon Condition="'$(TargetPlatform)' == 'android'" Include="Resources\AppIcon\logo_background.svg" ForegroundFile="Resources\AppIcon\logo_light_padding.svg" ForegroundScale="0.8" />
+    <MauiIcon Condition="'$(TargetPlatform)' != 'ios' And '$(TargetPlatform)' != 'maccatalyst' And '$(TargetPlatform)' != 'android'" Include="Resources\AppIcon\logo_light.svg" />
+    <!-- Splash Screen -->
+    <MauiSplashScreen Include="Resources\AppIcon\logo_light_padding.svg" Color="#1c4e80" BaseSize="512,512" />
+    <!-- Images -->
+    <MauiImage Include="Resources\Images\*" />
+    <!-- Custom Fonts -->
+    <MauiFont Include="Resources\Fonts\*" />
+    <!-- Raw Assets (also remove the "Resources\Raw" prefix) -->
+    <MauiAsset Include="Resources\Raw\**" LogicalName="%(RecursiveDir)%(Filename)%(Extension)" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Maui.Controls" />
+    <PackageReference Include="Microsoft.Maui.Controls.Compatibility" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebView.Maui" />
+    <PackageReference Include="Microsoft.Toolkit.Uwp.Notifications" />
+    <PackageReference Include="NReco.Logging.File" />
+    <PackageReference Include="System.Collections" />
+    <PackageReference Include="System.IO" />
+    <PackageReference Include="System.Runtime.Extensions" />
+    <PackageReference Include="System.Runtime.InteropServices" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\FwLiteShared\FwLiteShared.csproj" />
+    <ProjectReference Include="..\LcmCrdt\LcmCrdt.csproj" />
+    <ProjectReference Include="..\MiniLcm\MiniLcm.csproj" />
+  </ItemGroup>
+  <ItemGroup Condition="$(IncludeFwDataBridge)">
+    <ProjectReference Include="..\FwDataMiniLcmBridge\FwDataMiniLcmBridge.csproj" />
+    <ProjectReference Include="..\FwLiteProjectSync\FwLiteProjectSync.csproj" />
+  </ItemGroup>
 </Project>

--- a/backend/FwLite/FwLiteMaui/FwLiteMaui.csproj
+++ b/backend/FwLite/FwLiteMaui/FwLiteMaui.csproj
@@ -73,10 +73,6 @@
     <PackageReference Include="Microsoft.AspNetCore.Components.WebView.Maui" />
     <PackageReference Include="Microsoft.Toolkit.Uwp.Notifications" />
     <PackageReference Include="NReco.Logging.File" />
-    <PackageReference Include="System.Collections" />
-    <PackageReference Include="System.IO" />
-    <PackageReference Include="System.Runtime.Extensions" />
-    <PackageReference Include="System.Runtime.InteropServices" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\FwLiteShared\FwLiteShared.csproj" />

--- a/backend/FwLite/FwLiteProjectSync.Tests/FwLiteProjectSync.Tests.csproj
+++ b/backend/FwLite/FwLiteProjectSync.Tests/FwLiteProjectSync.Tests.csproj
@@ -26,7 +26,7 @@
         </PackageReference>
         <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.1"/>
         <PackageReference Include="SIL.ChorusPlugin.LfMergeBridge" Version="4.2.0-beta0028" />
-        <PackageReference Include="SIL.Chorus.Mercurial" Version="6.5.1.*" />
+        <PackageReference Include="SIL.Chorus.Mercurial" Version="6.5.1.43" />
     </ItemGroup>
 
     <ItemGroup>

--- a/backend/FwLite/FwLiteProjectSync.Tests/FwLiteProjectSync.Tests.csproj
+++ b/backend/FwLite/FwLiteProjectSync.Tests/FwLiteProjectSync.Tests.csproj
@@ -1,51 +1,45 @@
 <Project Sdk="Microsoft.NET.Sdk">
-
-    <PropertyGroup>
-        <IsPackable>false</IsPackable>
-        <IsTestProject>true</IsTestProject>
-        <Mercurial4ChorusDestDir>$(MSBuildProjectDirectory)</Mercurial4ChorusDestDir>
-    </PropertyGroup>
-
-    <ItemGroup>
-        <PackageReference Include="coverlet.collector" Version="6.0.2">
-          <PrivateAssets>all</PrivateAssets>
-          <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-        </PackageReference>
-        <PackageReference Include="GitHubActionsTestLogger" Version="2.4.1">
-          <PrivateAssets>all</PrivateAssets>
-          <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-        </PackageReference>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
-        <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="9.0.1"/>
-        <PackageReference Include="FluentAssertions" Version="7.0.0-alpha.5"/>
-        <PackageReference Include="Soenneker.Utils.AutoBogus" Version="3.0.410" />
-        <PackageReference Include="xunit" Version="2.9.2" />
-        <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
-            <PrivateAssets>all</PrivateAssets>
-            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-        </PackageReference>
-        <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.1"/>
-        <PackageReference Include="SIL.ChorusPlugin.LfMergeBridge" Version="4.2.0-beta0028" />
-        <PackageReference Include="SIL.Chorus.Mercurial" Version="6.5.1.43" />
-    </ItemGroup>
-
-    <ItemGroup>
-        <Using Include="Xunit"/>
-        <Using Include="FluentAssertions"/>
-    </ItemGroup>
-
-    <ItemGroup>
-      <ProjectReference Include="..\FwDataMiniLcmBridge.Tests\FwDataMiniLcmBridge.Tests.csproj" />
-      <ProjectReference Include="..\FwLiteProjectSync\FwLiteProjectSync.csproj" />
-      <ProjectReference Include="..\FwLiteWeb\FwLiteWeb.csproj" />
-    </ItemGroup>
-
-    <ItemGroup>
-        <!-- json files get imported by default in web projects, so exclude those here so they aren't imported again below -->
-        <!-- TODO: Determine if this step is actually necessary -->
-        <Content Remove="Mercurial\contrib\asv.conf.json"/>
-        <Content Include="Mercurial\**" CopyToOutputDirectory="PreserveNewest" Watch="false" />
-        <Content Include="MercurialExtensions\**" CopyToOutputDirectory="PreserveNewest" Watch="false" />
-    </ItemGroup>
-
+  <PropertyGroup>
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+    <Mercurial4ChorusDestDir>$(MSBuildProjectDirectory)</Mercurial4ChorusDestDir>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="GitHubActionsTestLogger">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Debug" />
+    <PackageReference Include="FluentAssertions" />
+    <PackageReference Include="Soenneker.Utils.AutoBogus" />
+    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.runner.visualstudio">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
+    <PackageReference Include="SIL.ChorusPlugin.LfMergeBridge" />
+    <PackageReference Include="SIL.Chorus.Mercurial" />
+  </ItemGroup>
+  <ItemGroup>
+    <Using Include="Xunit" />
+    <Using Include="FluentAssertions" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\FwDataMiniLcmBridge.Tests\FwDataMiniLcmBridge.Tests.csproj" />
+    <ProjectReference Include="..\FwLiteProjectSync\FwLiteProjectSync.csproj" />
+    <ProjectReference Include="..\FwLiteWeb\FwLiteWeb.csproj" />
+  </ItemGroup>
+  <ItemGroup>
+    <!-- json files get imported by default in web projects, so exclude those here so they aren't imported again below -->
+    <!-- TODO: Determine if this step is actually necessary -->
+    <Content Remove="Mercurial\contrib\asv.conf.json" />
+    <Content Include="Mercurial\**" CopyToOutputDirectory="PreserveNewest" Watch="false" />
+    <Content Include="MercurialExtensions\**" CopyToOutputDirectory="PreserveNewest" Watch="false" />
+  </ItemGroup>
 </Project>

--- a/backend/FwLite/FwLiteProjectSync/FwLiteProjectSync.csproj
+++ b/backend/FwLite/FwLiteProjectSync/FwLiteProjectSync.csproj
@@ -1,23 +1,18 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-
-    <PropertyGroup>
-        <FileVersion>$(ApplicationDisplayVersion)</FileVersion>
-    </PropertyGroup>
-
-    <ItemGroup>
-      <ProjectReference Include="..\FwDataMiniLcmBridge\FwDataMiniLcmBridge.csproj" />
-      <ProjectReference Include="..\LcmCrdt\LcmCrdt.csproj" />
-    </ItemGroup>
-
-    <ItemGroup>
-      <PackageReference Include="BeaKona.AutoInterfaceGenerator" Version="1.0.42"/>
-      <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="9.0.0" />
-      <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="9.0.0" />
-      <PackageReference Include="System.CommandLine" Version="2.0.0-beta4.22272.1" />
-    </ItemGroup>
-
-    <ItemGroup>
-        <InternalsVisibleTo Include="FwLiteProjectSync.Tests"/>
-    </ItemGroup>
-
+  <PropertyGroup>
+    <FileVersion>$(ApplicationDisplayVersion)</FileVersion>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\FwDataMiniLcmBridge\FwDataMiniLcmBridge.csproj" />
+    <ProjectReference Include="..\LcmCrdt\LcmCrdt.csproj" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="BeaKona.AutoInterfaceGenerator" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Debug" />
+    <PackageReference Include="System.CommandLine" />
+  </ItemGroup>
+  <ItemGroup>
+    <InternalsVisibleTo Include="FwLiteProjectSync.Tests" />
+  </ItemGroup>
 </Project>

--- a/backend/FwLite/FwLiteShared/FwLiteShared.csproj
+++ b/backend/FwLite/FwLiteShared/FwLiteShared.csproj
@@ -1,30 +1,22 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Razor">
-
-    <PropertyGroup>
-    </PropertyGroup>
-
-
-    <ItemGroup>
-        <SupportedPlatform Include="browser"/>
-    </ItemGroup>
-
-    <ItemGroup>
-        <PackageReference Include="BeaKona.AutoInterfaceGenerator" Version="1.0.42" />
-        <PackageReference Include="Humanizer.Core" Version="2.14.1"/>
-        <PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="9.0.0"/>
-        <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="9.0.0"/>
-        <PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.0"/>
-        <PackageReference Include="Microsoft.Extensions.Http.Resilience" Version="9.1.0" />
-        <PackageReference Include="Microsoft.Extensions.Options.DataAnnotations" Version="9.0.0"/>
-        <PackageReference Include="Microsoft.Identity.Client.Extensions.Msal" Version="4.67.2" />
-        <PackageReference Include="Reinforced.Typings" Version="1.6.5" />
-        <PackageReference Include="System.Reactive" Version="6.0.1"/>
-    </ItemGroup>
-
-    <ItemGroup>
-        <ProjectReference Include="..\..\LexCore\LexCore.csproj" />
-        <ProjectReference Include="..\LcmCrdt\LcmCrdt.csproj"/>
-        <ProjectReference Include="..\MiniLcm\MiniLcm.csproj" />
-    </ItemGroup>
-
+  <ItemGroup>
+    <SupportedPlatform Include="browser" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="BeaKona.AutoInterfaceGenerator" />
+    <PackageReference Include="Humanizer.Core" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.Web" />
+    <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" />
+    <PackageReference Include="Microsoft.Extensions.Http.Resilience" />
+    <PackageReference Include="Microsoft.Extensions.Options.DataAnnotations" />
+    <PackageReference Include="Microsoft.Identity.Client.Extensions.Msal" />
+    <PackageReference Include="Reinforced.Typings" />
+    <PackageReference Include="System.Reactive" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\LexCore\LexCore.csproj" />
+    <ProjectReference Include="..\LcmCrdt\LcmCrdt.csproj" />
+    <ProjectReference Include="..\MiniLcm\MiniLcm.csproj" />
+  </ItemGroup>
 </Project>

--- a/backend/FwLite/FwLiteWeb/FwLiteWeb.csproj
+++ b/backend/FwLite/FwLiteWeb/FwLiteWeb.csproj
@@ -1,67 +1,61 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
-
-    <PropertyGroup>
-        <DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>
-        <GenerateEmbeddedFilesManifest>true</GenerateEmbeddedFilesManifest>
-        <ServerGarbageCollection>false</ServerGarbageCollection>
-        <SelfContained>true</SelfContained>
-        <FileVersion>$(ApplicationDisplayVersion)</FileVersion>
-        <LangVersion>preview</LangVersion>
-    </PropertyGroup>
-    <PropertyGroup Condition="'$(Configuration)' == 'Release' ">
-<!--        single file disabled as it's less efficient for updates-->
-        <PublishSingleFile>false</PublishSingleFile>
-        <PublishTrimmed>false</PublishTrimmed>
-    </PropertyGroup>
-
-    <ItemGroup>
-        <PackageReference Include="Humanizer.Core" Version="2.14.1" />
-        <PackageReference Include="icu.net" Version="3.0.0-beta.297" GeneratePathProperty="true" />
-        <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.0" />
-        <PackageReference Include="Microsoft.Extensions.FileProviders.Embedded" Version="9.0.0" />
-        <PackageReference Include="NReco.Logging.File" Version="1.2.1" />
-        <PackageReference Include="Swashbuckle.AspNetCore" Version="6.7.3" />
-        <PackageReference Include="System.Reactive" Version="6.0.1" />
-    </ItemGroup>
-
-    <ItemGroup>
-      <Content Include="..\.dockerignore">
-        <Link>.dockerignore</Link>
-      </Content>
-      <Content Include="*.md" CopyToPublishDirectory="PreserveNewest" />
-
-      <None Include="$(Pkgicu_net)\contentFiles\any\any\icu.net.dll.config">
-          <Link>icu.net.dll.config</Link>
-          <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-      </None>
-    </ItemGroup>
-
-    <ItemGroup>
-      <ProjectReference Include="..\FwLiteProjectSync\FwLiteProjectSync.csproj" />
-      <ProjectReference Include="..\FwDataMiniLcmBridge\FwDataMiniLcmBridge.csproj" />
-      <ProjectReference Include="..\FwLiteShared\FwLiteShared.csproj" />
-      <ProjectReference Include="..\LcmCrdt\LcmCrdt.csproj" />
-      <ProjectReference Include="..\MiniLcm\MiniLcm.csproj" />
-    </ItemGroup>
-
-    <ItemGroup Condition="$([MSBuild]::IsOsPlatform('macOS'))">
-        <!--
+  <PropertyGroup>
+    <DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>
+    <GenerateEmbeddedFilesManifest>true</GenerateEmbeddedFilesManifest>
+    <ServerGarbageCollection>false</ServerGarbageCollection>
+    <SelfContained>true</SelfContained>
+    <FileVersion>$(ApplicationDisplayVersion)</FileVersion>
+    <LangVersion>preview</LangVersion>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)' == 'Release' ">
+    <!--        single file disabled as it's less efficient for updates-->
+    <PublishSingleFile>false</PublishSingleFile>
+    <PublishTrimmed>false</PublishTrimmed>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Humanizer.Core" />
+    <PackageReference Include="icu.net" GeneratePathProperty="true" />
+    <PackageReference Include="Microsoft.AspNetCore.OpenApi" />
+    <PackageReference Include="Microsoft.Extensions.FileProviders.Embedded" />
+    <PackageReference Include="NReco.Logging.File" />
+    <PackageReference Include="Swashbuckle.AspNetCore" />
+    <PackageReference Include="System.Reactive" />
+  </ItemGroup>
+  <ItemGroup>
+    <Content Include="..\.dockerignore">
+      <Link>.dockerignore</Link>
+    </Content>
+    <Content Include="*.md" CopyToPublishDirectory="PreserveNewest" />
+    <None Include="$(Pkgicu_net)\contentFiles\any\any\icu.net.dll.config">
+      <Link>icu.net.dll.config</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\FwLiteProjectSync\FwLiteProjectSync.csproj" />
+    <ProjectReference Include="..\FwDataMiniLcmBridge\FwDataMiniLcmBridge.csproj" />
+    <ProjectReference Include="..\FwLiteShared\FwLiteShared.csproj" />
+    <ProjectReference Include="..\LcmCrdt\LcmCrdt.csproj" />
+    <ProjectReference Include="..\MiniLcm\MiniLcm.csproj" />
+  </ItemGroup>
+  <ItemGroup Condition="$([MSBuild]::IsOsPlatform('macOS'))">
+    <!--
           This assumes that icu4c libs are installed under "/opt/local/lib" on macOS. This is the default
           location for libs that MacPorts installs. If we need to start bundling icu4c libs from
           somewhere other than "/opt/local/lib", this path and some other paths in the build scripts will
           need to be updated. We have to bundle the icu4c libs somehow unless macOS starts to include them
           by default.
           -->
-        <Content Include="/opt/local/lib/libicu*.??.dylib" Condition="Exists('/opt/local/lib/')">
-            <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-        </Content>
-        <!--
+    <Content Include="/opt/local/lib/libicu*.??.dylib" Condition="Exists('/opt/local/lib/')">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <!--
         Homebrew installation of icu4c libraries typically resides in /usr/local/lib.
         The following line includes these libraries and copies them to the output directory if the OS is macOS.
         -->
-        <Content Include="/opt/homebrew/Cellar/icu4c/*/lib/libicu*.??.dylib" Condition="Exists('/opt/homebrew/Cellar/icu4c/74.2/lib/')">
-            <Link>%(Filename)%(Extension)</Link>
-            <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-        </Content>
-    </ItemGroup>
+    <Content Include="/opt/homebrew/Cellar/icu4c/*/lib/libicu*.??.dylib" Condition="Exists('/opt/homebrew/Cellar/icu4c/74.2/lib/')">
+      <Link>%(Filename)%(Extension)</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+  </ItemGroup>
 </Project>

--- a/backend/FwLite/LcmCrdt.Tests/LcmCrdt.Tests.csproj
+++ b/backend/FwLite/LcmCrdt.Tests/LcmCrdt.Tests.csproj
@@ -1,44 +1,38 @@
 <Project Sdk="Microsoft.NET.Sdk">
-
-    <PropertyGroup>
-
-        <IsPackable>false</IsPackable>
-        <IsTestProject>true</IsTestProject>
-    </PropertyGroup>
-
-    <ItemGroup>
-        <PackageReference Include="coverlet.collector" Version="6.0.2">
-          <PrivateAssets>all</PrivateAssets>
-          <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-        </PackageReference>
-        <PackageReference Include="Microsoft.Extensions.Hosting" Version="8.0.1" />
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
-        <PackageReference Include="FluentAssertions" Version="7.0.0-alpha.5"/>
-        <PackageReference Include="Soenneker.Utils.AutoBogus" Version="3.0.410" />
-        <PackageReference Include="Verify.Xunit" Version="28.2.1" />
-        <PackageReference Include="xunit" Version="2.9.2" />
-        <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
-            <PrivateAssets>all</PrivateAssets>
-            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-        </PackageReference>
-        <PackageReference Include="GitHubActionsTestLogger" Version="2.4.1">
-            <PrivateAssets>all</PrivateAssets>
-            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-        </PackageReference>
-    </ItemGroup>
-
-    <ItemGroup>
-        <Using Include="Xunit"/>
-        <Using Include="FluentAssertions"/>
-        <Using Include="MiniLcm.Models"/>
-        <Using Include="SIL.Harmony"/>
-        <Using Include="MiniLcm"/>
-        <Using Include="MiniLcm.Tests"/>
-    </ItemGroup>
-
-    <ItemGroup>
-      <ProjectReference Include="..\LcmCrdt\LcmCrdt.csproj" />
-      <ProjectReference Include="..\MiniLcm.Tests\MiniLcm.Tests.csproj" />
-    </ItemGroup>
-
+  <PropertyGroup>
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.Extensions.Hosting" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="FluentAssertions" />
+    <PackageReference Include="Soenneker.Utils.AutoBogus" />
+    <PackageReference Include="Verify.Xunit" />
+    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.runner.visualstudio">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="GitHubActionsTestLogger">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+  <ItemGroup>
+    <Using Include="Xunit" />
+    <Using Include="FluentAssertions" />
+    <Using Include="MiniLcm.Models" />
+    <Using Include="SIL.Harmony" />
+    <Using Include="MiniLcm" />
+    <Using Include="MiniLcm.Tests" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\LcmCrdt\LcmCrdt.csproj" />
+    <ProjectReference Include="..\MiniLcm.Tests\MiniLcm.Tests.csproj" />
+  </ItemGroup>
 </Project>

--- a/backend/FwLite/LcmCrdt/LcmCrdt.csproj
+++ b/backend/FwLite/LcmCrdt/LcmCrdt.csproj
@@ -1,30 +1,26 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-
-    <PropertyGroup>
-        <FileVersion>$(ApplicationDisplayVersion)</FileVersion>
-    </PropertyGroup>
-
-    <ItemGroup>
-        <InternalsVisibleTo Include="LcmCrdt.Tests"/>
-    </ItemGroup>
-
-    <ItemGroup>
-        <PackageReference Include="Gridify.EntityFramework" Version="2.15.0" />
-        <PackageReference Include="Humanizer.Core" Version="2.14.1"/>
-        <PackageReference Include="linq2db.AspNet" Version="5.4.1"/>
-        <PackageReference Include="linq2db.EntityFrameworkCore" Version="8.1.0" />
-        <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.11">
-          <PrivateAssets>all</PrivateAssets>
-          <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-        </PackageReference>
-        <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="8.0.0"/>
-        <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="9.0.0" />
-        <PackageReference Include="Refit" Version="8.0.0"/>
-        <PackageReference Include="Refit.HttpClientFactory" Version="8.0.0"/>
-    </ItemGroup>
-
-    <ItemGroup>
-      <ProjectReference Include="..\..\harmony\src\SIL.Harmony\SIL.Harmony.csproj" />
-      <ProjectReference Include="..\MiniLcm\MiniLcm.csproj" />
-    </ItemGroup>
+  <PropertyGroup>
+    <FileVersion>$(ApplicationDisplayVersion)</FileVersion>
+  </PropertyGroup>
+  <ItemGroup>
+    <InternalsVisibleTo Include="LcmCrdt.Tests" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Gridify.EntityFramework" />
+    <PackageReference Include="Humanizer.Core" />
+    <PackageReference Include="linq2db.AspNet" />
+    <PackageReference Include="linq2db.EntityFrameworkCore" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" />
+    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" />
+    <PackageReference Include="Refit" />
+    <PackageReference Include="Refit.HttpClientFactory" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\harmony\src\SIL.Harmony\SIL.Harmony.csproj" />
+    <ProjectReference Include="..\MiniLcm\MiniLcm.csproj" />
+  </ItemGroup>
 </Project>

--- a/backend/FwLite/MiniLcm.Tests/MiniLcm.Tests.csproj
+++ b/backend/FwLite/MiniLcm.Tests/MiniLcm.Tests.csproj
@@ -1,37 +1,32 @@
 <Project Sdk="Microsoft.NET.Sdk">
-
-    <PropertyGroup>
-        <IsPackable>false</IsPackable>
-        <IsTestProject>true</IsTestProject>
-    </PropertyGroup>
-
-    <ItemGroup>
-        <PackageReference Include="coverlet.collector" Version="6.0.0"/>
-        <PackageReference Include="Meziantou.Extensions.Logging.Xunit" Version="1.0.7" />
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
-        <PackageReference Include="xunit" Version="2.9.2" />
-        <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
-            <PrivateAssets>all</PrivateAssets>
-            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-        </PackageReference>
-        <PackageReference Include="GitHubActionsTestLogger" Version="2.4.1">
-            <PrivateAssets>all</PrivateAssets>
-            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-        </PackageReference>
-        <PackageReference Include="FluentAssertions" Version="7.0.0-alpha.5"/>
-        <PackageReference Include="Soenneker.Utils.AutoBogus" Version="3.0.410" />
-        <PackageReference Include="System.Linq.Async" Version="6.0.1"/>
-        <PackageReference Include="Moq" Version="4.20.70" />
-    </ItemGroup>
-
-    <ItemGroup>
-        <Using Include="Xunit"/>
-        <Using Include="FluentAssertions"/>
-        <Using Include="MiniLcm.Models"/>
-    </ItemGroup>
-
-    <ItemGroup>
-      <ProjectReference Include="..\MiniLcm\MiniLcm.csproj" />
-    </ItemGroup>
-
+  <PropertyGroup>
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" />
+    <PackageReference Include="Meziantou.Extensions.Logging.Xunit" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.runner.visualstudio">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="GitHubActionsTestLogger">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="FluentAssertions" />
+    <PackageReference Include="Soenneker.Utils.AutoBogus" />
+    <PackageReference Include="System.Linq.Async" />
+    <PackageReference Include="Moq" />
+  </ItemGroup>
+  <ItemGroup>
+    <Using Include="Xunit" />
+    <Using Include="FluentAssertions" />
+    <Using Include="MiniLcm.Models" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\MiniLcm\MiniLcm.csproj" />
+  </ItemGroup>
 </Project>

--- a/backend/FwLite/MiniLcm/MiniLcm.csproj
+++ b/backend/FwLite/MiniLcm/MiniLcm.csproj
@@ -9,7 +9,7 @@
       <PackageReference Include="HtmlAgilityPack" Version="1.12.0" />
       <PackageReference Include="Gridify" Version="2.16.2" />
       <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.0" />
-      <PackageReference Include="SIL.WritingSystems" Version="14.2.0-beta*" />
+      <PackageReference Include="SIL.WritingSystems" Version="14.2.0-beta0022" />
       <PackageReference Include="System.Text.Json" Version="9.0.0" />
       <PackageReference Include="SystemTextJson.JsonDiffPatch" Version="2.0.0" />
       <PackageReference Include="SystemTextJsonPatch" Version="3.2.1" />

--- a/backend/FwLite/MiniLcm/MiniLcm.csproj
+++ b/backend/FwLite/MiniLcm/MiniLcm.csproj
@@ -1,21 +1,18 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-
-    <PropertyGroup>
-        <FileVersion>$(ApplicationDisplayVersion)</FileVersion>
-    </PropertyGroup>
-
-    <ItemGroup>
-      <PackageReference Include="FluentValidation" Version="11.11.0" />
-      <PackageReference Include="HtmlAgilityPack" Version="1.12.0" />
-      <PackageReference Include="Gridify" Version="2.16.2" />
-      <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.0" />
-      <PackageReference Include="SIL.WritingSystems" Version="14.2.0-beta0022" />
-      <PackageReference Include="System.Text.Json" Version="9.0.0" />
-      <PackageReference Include="SystemTextJson.JsonDiffPatch" Version="2.0.0" />
-      <PackageReference Include="SystemTextJsonPatch" Version="3.2.1" />
-    </ItemGroup>
-
-    <ItemGroup>
-        <InternalsVisibleTo Include="MiniLcm.Tests" />
-    </ItemGroup>
+  <PropertyGroup>
+    <FileVersion>$(ApplicationDisplayVersion)</FileVersion>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="FluentValidation" />
+    <PackageReference Include="HtmlAgilityPack" />
+    <PackageReference Include="Gridify" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" />
+    <PackageReference Include="SIL.WritingSystems" />
+    <PackageReference Include="System.Text.Json" />
+    <PackageReference Include="SystemTextJson.JsonDiffPatch" />
+    <PackageReference Include="SystemTextJsonPatch" />
+  </ItemGroup>
+  <ItemGroup>
+    <InternalsVisibleTo Include="MiniLcm.Tests" />
+  </ItemGroup>
 </Project>

--- a/backend/LexBoxApi/LexBoxApi.csproj
+++ b/backend/LexBoxApi/LexBoxApi.csproj
@@ -1,72 +1,68 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
-
-    <PropertyGroup>
-        <DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>
-        <IncludeOpenAPIAnalyzers>true</IncludeOpenAPIAnalyzers>
-        <UserSecretsId>7392cddf-9b3b-441c-9316-203bb5c4a6bc</UserSecretsId>
-        <GarbageCollectionAdaptationMode>1</GarbageCollectionAdaptationMode>
-        <LangVersion>preview</LangVersion>
-    </PropertyGroup>
-
-    <ItemGroup>
-        <PackageReference Include="AppAny.Quartz.EntityFrameworkCore.Migrations.PostgreSQL" Version="0.5.1" />
-        <PackageReference Include="CrystalQuartz.AspNetCore" Version="7.2.0-beta" />
-        <PackageReference Include="DataAnnotatedModelValidations" Version="6.0.0" />
-        <PackageReference Include="HotChocolate.Analyzers" Version="13.9.14" />
-        <PackageReference Include="HotChocolate.Types.Analyzers" Version="14.0.0">
-            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-            <PrivateAssets>all</PrivateAssets>
-        </PackageReference>
-        <PackageReference Include="HotChocolate.AspNetCore" Version="14.0.0" />
-        <PackageReference Include="HotChocolate.AspNetCore.Authorization" Version="14.0.0" />
-        <PackageReference Include="HotChocolate.Data.EntityFramework" Version="14.0.0" />
-        <PackageReference Include="HotChocolate.Diagnostics" Version="14.0.0" />
-        <PackageReference Include="Humanizer.Core" Version="2.14.1" />
-        <PackageReference Include="MailKit" Version="4.7.1.1" />
-        <PackageReference Include="Microsoft.AspNetCore.Authentication.Google" Version="8.0.10" />
-        <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="9.0.0" />
-        <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.0" />
-        <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.11" />
-        <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.11">
-          <PrivateAssets>all</PrivateAssets>
-          <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-        </PackageReference>
-        <PackageReference Include="Microsoft.Extensions.Caching.Hybrid" Version="9.0.0-preview.9.24556.5" />
-        <PackageReference Include="Microsoft.Extensions.ServiceDiscovery" Version="9.0.0" />
-        <PackageReference Include="Microsoft.IdentityModel.Protocols.OpenIdConnect" Version="8.2.0" />
-        <PackageReference Include="Nito.AsyncEx.Coordination" Version="5.1.2" />
-        <PackageReference Include="Npgsql.OpenTelemetry" Version="8.0.6" />
-        <PackageReference Include="OpenIddict.AspNetCore" Version="5.8.0" />
-        <PackageReference Include="OpenIddict.EntityFrameworkCore" Version="5.8.0" />
-        <PackageReference Include="OpenIddict.Quartz" Version="5.8.0" />
-        <PackageReference Include="OpenTelemetry.Exporter.Console" Version="1.10.0" />
-        <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.10.0" />
-        <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.10.0" />
-        <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.9.0" />
-        <PackageReference Include="OpenTelemetry.Instrumentation.EntityFrameworkCore" Version="1.0.0-beta.8" />
-        <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.9.0" />
-        <PackageReference Include="OpenTelemetry.Instrumentation.Process" Version="0.5.0-beta.3" />
-        <PackageReference Include="OpenTelemetry.Instrumentation.Quartz" Version="1.0.0-beta.1" />
-        <PackageReference Include="OpenTelemetry.Instrumentation.Runtime" Version="1.9.0" />
-        <PackageReference Include="Polly" Version="8.4.2" />
-        <PackageReference Include="Polly.Extensions" Version="8.4.2" />
-        <PackageReference Include="Quartz.AspNetCore" Version="3.13.0" />
-        <PackageReference Include="Quartz.Serialization.SystemTextJson" Version="3.13.0" />
-        <PackageReference Include="Swashbuckle.AspNetCore" Version="7.2.0" />
-        <PackageReference Include="System.Text.Encodings.Web" Version="9.0.0" />
-        <PackageReference Include="tusdotnet" Version="2.8.0" />
-        <PackageReference Include="zxcvbn-core" Version="7.0.92" />
-    </ItemGroup>
-
-    <ItemGroup>
-      <ProjectReference Include="..\harmony\src\SIL.Harmony.Core\SIL.Harmony.Core.csproj" />
-      <ProjectReference Include="..\LexCore\LexCore.csproj" />
-      <ProjectReference Include="..\LexData\LexData.csproj" />
-      <ProjectReference Include="..\LfClassicData\LfClassicData.csproj" />
-      <ProjectReference Include="..\SyncReverseProxy\SyncReverseProxy.csproj" />
-    </ItemGroup>
-
-    <ItemGroup>
-      <Content Include="Services\HgEmptyRepo\**" CopyToOutputDirectory="PreserveNewest" />
-    </ItemGroup>
+  <PropertyGroup>
+    <DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>
+    <IncludeOpenAPIAnalyzers>true</IncludeOpenAPIAnalyzers>
+    <UserSecretsId>7392cddf-9b3b-441c-9316-203bb5c4a6bc</UserSecretsId>
+    <GarbageCollectionAdaptationMode>1</GarbageCollectionAdaptationMode>
+    <LangVersion>preview</LangVersion>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="AppAny.Quartz.EntityFrameworkCore.Migrations.PostgreSQL" />
+    <PackageReference Include="CrystalQuartz.AspNetCore" />
+    <PackageReference Include="DataAnnotatedModelValidations" />
+    <PackageReference Include="HotChocolate.Analyzers" />
+    <PackageReference Include="HotChocolate.Types.Analyzers">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="HotChocolate.AspNetCore" />
+    <PackageReference Include="HotChocolate.AspNetCore.Authorization" />
+    <PackageReference Include="HotChocolate.Data.EntityFramework" />
+    <PackageReference Include="HotChocolate.Diagnostics" />
+    <PackageReference Include="Humanizer.Core" />
+    <PackageReference Include="MailKit" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.Google" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" />
+    <PackageReference Include="Microsoft.AspNetCore.OpenApi" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.Extensions.Caching.Hybrid" />
+    <PackageReference Include="Microsoft.Extensions.ServiceDiscovery" />
+    <PackageReference Include="Microsoft.IdentityModel.Protocols.OpenIdConnect" />
+    <PackageReference Include="Nito.AsyncEx.Coordination" />
+    <PackageReference Include="Npgsql.OpenTelemetry" />
+    <PackageReference Include="OpenIddict.AspNetCore" />
+    <PackageReference Include="OpenIddict.EntityFrameworkCore" />
+    <PackageReference Include="OpenIddict.Quartz" />
+    <PackageReference Include="OpenTelemetry.Exporter.Console" />
+    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" />
+    <PackageReference Include="OpenTelemetry.Extensions.Hosting" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.EntityFrameworkCore" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.Http" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.Process" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.Quartz" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.Runtime" />
+    <PackageReference Include="Polly" />
+    <PackageReference Include="Polly.Extensions" />
+    <PackageReference Include="Quartz.AspNetCore" />
+    <PackageReference Include="Quartz.Serialization.SystemTextJson" />
+    <PackageReference Include="Swashbuckle.AspNetCore" />
+    <PackageReference Include="System.Text.Encodings.Web" />
+    <PackageReference Include="tusdotnet" />
+    <PackageReference Include="zxcvbn-core" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\harmony\src\SIL.Harmony.Core\SIL.Harmony.Core.csproj" />
+    <ProjectReference Include="..\LexCore\LexCore.csproj" />
+    <ProjectReference Include="..\LexData\LexData.csproj" />
+    <ProjectReference Include="..\LfClassicData\LfClassicData.csproj" />
+    <ProjectReference Include="..\SyncReverseProxy\SyncReverseProxy.csproj" />
+  </ItemGroup>
+  <ItemGroup>
+    <Content Include="Services\HgEmptyRepo\**" CopyToOutputDirectory="PreserveNewest" />
+  </ItemGroup>
 </Project>

--- a/backend/LexCore/LexCore.csproj
+++ b/backend/LexCore/LexCore.csproj
@@ -1,11 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
-
-    <PropertyGroup>
-      <LangVersion>preview</LangVersion>
-    </PropertyGroup>
-
-    <ItemGroup>
-      <PackageReference Include="EntityFrameworkCore.Projectables.Abstractions" Version="4.0.0-preview.4" />
-    </ItemGroup>
-
+  <PropertyGroup>
+    <LangVersion>preview</LangVersion>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="EntityFrameworkCore.Projectables.Abstractions" />
+  </ItemGroup>
 </Project>

--- a/backend/LexData/LexData.csproj
+++ b/backend/LexData/LexData.csproj
@@ -1,26 +1,20 @@
 <Project Sdk="Microsoft.NET.Sdk">
-
-    <PropertyGroup>
-    </PropertyGroup>
-
-    <ItemGroup>
-      <PackageReference Include="EntityFrameworkCore.Projectables" Version="3.0.4" />
-      <PackageReference Include="Humanizer.Core" Version="2.14.1" />
-      <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.11">
-        <PrivateAssets>all</PrivateAssets>
-        <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-      </PackageReference>
-      <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore" Version="8.0.11" />
-      <PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.0" />
-      <PackageReference Include="Microsoft.Extensions.Options.DataAnnotations" Version="9.0.0" />
-      <PackageReference Include="Npgsql" Version="8.0.6" />
-      <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="8.0.11" />
-      <PackageReference Include="OpenIddict.EntityFrameworkCore" Version="5.8.0" />
-    </ItemGroup>
-
-    <ItemGroup>
-      <ProjectReference Include="..\harmony\src\SIL.Harmony.Core\SIL.Harmony.Core.csproj" />
-      <ProjectReference Include="..\LexCore\LexCore.csproj" />
-    </ItemGroup>
-
+  <ItemGroup>
+    <PackageReference Include="EntityFrameworkCore.Projectables" />
+    <PackageReference Include="Humanizer.Core" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" />
+    <PackageReference Include="Microsoft.Extensions.Options.DataAnnotations" />
+    <PackageReference Include="Npgsql" />
+    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" />
+    <PackageReference Include="OpenIddict.EntityFrameworkCore" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\harmony\src\SIL.Harmony.Core\SIL.Harmony.Core.csproj" />
+    <ProjectReference Include="..\LexCore\LexCore.csproj" />
+  </ItemGroup>
 </Project>

--- a/backend/LfClassicData/LfClassicData.csproj
+++ b/backend/LfClassicData/LfClassicData.csproj
@@ -1,20 +1,14 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-
-    <PropertyGroup>
-    </PropertyGroup>
-
-    <ItemGroup>
-        <FrameworkReference Include="Microsoft.AspNetCore.App"/>
-        <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="9.0.0" />
-        <PackageReference Include="Microsoft.Extensions.Options" Version="9.0.0" />
-        <PackageReference Include="MongoDB.Analyzer" Version="1.5.0" />
-        <PackageReference Include="MongoDB.Driver" Version="2.28.0" />
-        <PackageReference Include="MongoDB.Driver.Core.Extensions.DiagnosticSources" Version="1.5.0" />
-        <PackageReference Include="System.Linq.Async" Version="6.0.1" />
-    </ItemGroup>
-
-    <ItemGroup>
-        <ProjectReference Include="..\FwLite\MiniLcm\MiniLcm.csproj"/>
-    </ItemGroup>
-
+  <ItemGroup>
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" />
+    <PackageReference Include="Microsoft.Extensions.Options" />
+    <PackageReference Include="MongoDB.Analyzer" />
+    <PackageReference Include="MongoDB.Driver" />
+    <PackageReference Include="MongoDB.Driver.Core.Extensions.DiagnosticSources" />
+    <PackageReference Include="System.Linq.Async" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\FwLite\MiniLcm\MiniLcm.csproj" />
+  </ItemGroup>
 </Project>

--- a/backend/LfNext/LcmDebugger/LcmDebugger.csproj
+++ b/backend/LfNext/LcmDebugger/LcmDebugger.csproj
@@ -1,15 +1,11 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-
-    <PropertyGroup>
-        <OutputType>Exe</OutputType>
-    </PropertyGroup>
-
-    <ItemGroup>
-      <ProjectReference Include="..\..\FwLite\FwDataMiniLcmBridge\FwDataMiniLcmBridge.csproj" />
-    </ItemGroup>
-
-    <ItemGroup>
-      <PackageReference Include="Microsoft.Extensions.Hosting" Version="8.0.0" />
-    </ItemGroup>
-
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\FwLite\FwDataMiniLcmBridge\FwDataMiniLcmBridge.csproj" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Hosting" />
+  </ItemGroup>
 </Project>

--- a/backend/SyncReverseProxy/SyncReverseProxy.csproj
+++ b/backend/SyncReverseProxy/SyncReverseProxy.csproj
@@ -1,36 +1,28 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
-
-    <PropertyGroup>
-        <DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>
-        <RootNamespace>LexSyncReverseProxy</RootNamespace>
-    </PropertyGroup>
-
-    <ItemGroup>
-        <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.0" />
-        <PackageReference Include="Microsoft.Extensions.Options" Version="9.0.0" />
-        <PackageReference Include="Swashbuckle.AspNetCore" Version="7.2.0" />
-        <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="8.2.0" />
-        <PackageReference Include="Yarp.ReverseProxy" Version="2.2.0" />
-
-        <PackageReference Include="OpenTelemetry.Exporter.Console" Version="1.10.0" />
-        <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.10.0" />
-        <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.10.0" />
-        <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.9.0" />
-        <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.9.0" />
-        <PackageReference Include="Yarp.Telemetry.Consumption" Version="2.2.0" />
-
-    </ItemGroup>
-
-    <ItemGroup>
-      <Folder Include="Controllers" />
-    </ItemGroup>
-
-    <ItemGroup>
-      <Compile Remove="Controllers\WeatherForecastController.cs" />
-    </ItemGroup>
-
-    <ItemGroup>
-      <ProjectReference Include="..\LexCore\LexCore.csproj" />
-    </ItemGroup>
-
+  <PropertyGroup>
+    <DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>
+    <RootNamespace>LexSyncReverseProxy</RootNamespace>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.OpenApi" />
+    <PackageReference Include="Microsoft.Extensions.Options" />
+    <PackageReference Include="Swashbuckle.AspNetCore" />
+    <PackageReference Include="System.IdentityModel.Tokens.Jwt" />
+    <PackageReference Include="Yarp.ReverseProxy" />
+    <PackageReference Include="OpenTelemetry.Exporter.Console" />
+    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" />
+    <PackageReference Include="OpenTelemetry.Extensions.Hosting" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.Http" />
+    <PackageReference Include="Yarp.Telemetry.Consumption" />
+  </ItemGroup>
+  <ItemGroup>
+    <Folder Include="Controllers" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Remove="Controllers\WeatherForecastController.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\LexCore\LexCore.csproj" />
+  </ItemGroup>
 </Project>

--- a/backend/Testing/Testing.csproj
+++ b/backend/Testing/Testing.csproj
@@ -34,7 +34,7 @@
         <PackageReference Include="Moq.Contrib.HttpClient" Version="1.4.0" />
         <PackageReference Include="FluentAssertions" Version="7.0.0-alpha.5"/>
         <PackageReference Include="SIL.ChorusPlugin.LfMergeBridge" Version="4.1.0" />
-        <PackageReference Include="SIL.Core" Version="14.2.0-*" />
+        <PackageReference Include="SIL.Core" Version="14.2.0-beta0022" />
         <PackageReference Include="xunit" Version="2.9.2" />
         <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
             <PrivateAssets>all</PrivateAssets>

--- a/backend/Testing/Testing.csproj
+++ b/backend/Testing/Testing.csproj
@@ -1,71 +1,66 @@
 <Project Sdk="Microsoft.NET.Sdk">
-
-    <PropertyGroup>
-        <IsPackable>false</IsPackable>
-        <Mercurial4ChorusDestDir>$(MSBuildProjectDirectory)</Mercurial4ChorusDestDir>
-        <!-- To switch Mercurial versions, do dotnet build /p:MercurialVersion=3 followed by dotnet test -->
-        <!-- Note that if you run dotnet test /p:MercurialVersion=3 it will not work as expected; you must run dotnet build first in order to switch Mercurial versions -->
-        <MercurialVersion Condition=" '$(MercurialVersion)' == '' ">6</MercurialVersion>
-    </PropertyGroup>
-
-    <Choose>
-        <When Condition=" '$(MercurialVersion)' == '6' ">
-            <ItemGroup>
-                <PackageReference Include="SIL.Chorus.LibChorus" Version="6.0.0-beta0049" />
-                <PackageReference Include="SIL.Chorus.Mercurial" Version="6.5.1.43" />
-            </ItemGroup>
-        </When>
-        <Otherwise>
-            <ItemGroup>
-                <PackageReference Include="SIL.Chorus.LibChorus" Version="6.0.0-beta0041" />
-                <PackageReference Include="SIL.Chorus.Mercurial" Version="3.0.3.11" />
-            </ItemGroup>
-        </Otherwise>
-    </Choose>
-    <ItemGroup>
-        <PackageReference Include="Microsoft.Extensions.Http.Resilience" Version="9.0.0" />
-        <PackageReference Include="Microsoft.Extensions.TimeProvider.Testing" Version="9.0.0" />
-        <PackageReference Include="Squidex.Assets.TusClient" Version="6.6.4" />
-        <PackageReference Include="Microsoft.Extensions.Configuration" Version="9.0.0" />
-        <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.0" />
-        <PackageReference Include="Microsoft.Extensions.Options" Version="9.0.0" />
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
-        <PackageReference Include="Moq" Version="4.20.70" />
-        <PackageReference Include="Moq.Contrib.HttpClient" Version="1.4.0" />
-        <PackageReference Include="FluentAssertions" Version="7.0.0-alpha.5"/>
-        <PackageReference Include="SIL.ChorusPlugin.LfMergeBridge" Version="4.1.0" />
-        <PackageReference Include="SIL.Core" Version="14.2.0-beta0022" />
-        <PackageReference Include="xunit" Version="2.9.2" />
-        <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
-            <PrivateAssets>all</PrivateAssets>
-            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-        </PackageReference>
-        <PackageReference Include="coverlet.collector" Version="6.0.2">
-            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-            <PrivateAssets>all</PrivateAssets>
-        </PackageReference>
-        <PackageReference Include="GitHubActionsTestLogger" Version="2.4.1">
-          <PrivateAssets>all</PrivateAssets>
-          <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-        </PackageReference>
-        <PackageReference Include="XunitXml.TestLogger" Version="3.1.17" />
-    </ItemGroup>
-
-    <ItemGroup>
-      <ProjectReference Include="..\LexBoxApi\LexBoxApi.csproj" />
-      <ProjectReference Include="..\LexCore\LexCore.csproj" />
-      <ProjectReference Include="..\LexData\LexData.csproj" />
-      <ProjectReference Include="..\FixFwData\FixFwData.csproj" />
-      <!-- <ProjectReference Include="../../../csharp/flexbridge/src/LfMergeBridge/LfMergeBridge.csproj" />
+  <PropertyGroup>
+    <IsPackable>false</IsPackable>
+    <Mercurial4ChorusDestDir>$(MSBuildProjectDirectory)</Mercurial4ChorusDestDir>
+    <!-- To switch Mercurial versions, do dotnet build /p:MercurialVersion=3 followed by dotnet test -->
+    <!-- Note that if you run dotnet test /p:MercurialVersion=3 it will not work as expected; you must run dotnet build first in order to switch Mercurial versions -->
+    <MercurialVersion Condition=" '$(MercurialVersion)' == '' ">6</MercurialVersion>
+  </PropertyGroup>
+  <Choose>
+    <When Condition=" '$(MercurialVersion)' == '6' ">
+      <ItemGroup>
+        <PackageReference Include="SIL.Chorus.LibChorus" />
+        <PackageReference Include="SIL.Chorus.Mercurial" />
+      </ItemGroup>
+    </When>
+    <Otherwise>
+      <ItemGroup>
+        <PackageReference Include="SIL.Chorus.LibChorus" />
+        <PackageReference Include="SIL.Chorus.Mercurial" />
+      </ItemGroup>
+    </Otherwise>
+  </Choose>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Http.Resilience" />
+    <PackageReference Include="Microsoft.Extensions.TimeProvider.Testing" />
+    <PackageReference Include="Squidex.Assets.TusClient" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
+    <PackageReference Include="Microsoft.Extensions.Options" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="Moq" />
+    <PackageReference Include="Moq.Contrib.HttpClient" />
+    <PackageReference Include="FluentAssertions" />
+    <PackageReference Include="SIL.ChorusPlugin.LfMergeBridge" />
+    <PackageReference Include="SIL.Core" />
+    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.runner.visualstudio">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="GitHubActionsTestLogger">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="XunitXml.TestLogger" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\LexBoxApi\LexBoxApi.csproj" />
+    <ProjectReference Include="..\LexCore\LexCore.csproj" />
+    <ProjectReference Include="..\LexData\LexData.csproj" />
+    <ProjectReference Include="..\FixFwData\FixFwData.csproj" />
+    <!-- <ProjectReference Include="../../../csharp/flexbridge/src/LfMergeBridge/LfMergeBridge.csproj" />
       <ProjectReference Include="..\..\..\csharp\chorus\src\LibChorus\LibChorus.csproj" /> -->
-    </ItemGroup>
-
-    <ItemGroup>
-      <Content Include="Mercurial\**" CopyToOutputDirectory="Always" />
-      <Content Include="MercurialExtensions\**" CopyToOutputDirectory="Always" />
-      <Content Include="test-template-repo.zip" CopyToOutputDirectory="PreserveNewest" />
-    </ItemGroup>
-
+  </ItemGroup>
+  <ItemGroup>
+    <Content Include="Mercurial\**" CopyToOutputDirectory="Always" />
+    <Content Include="MercurialExtensions\**" CopyToOutputDirectory="Always" />
+    <Content Include="test-template-repo.zip" CopyToOutputDirectory="PreserveNewest" />
+  </ItemGroup>
   <Target Name="CreateFixFwDataExe" AfterTargets="Build" Condition="Exists('$(OutputPath)/FixFwData') And !Exists('$(OutputPath)/FixFwData.exe')">
     <Message Text="Creating FixFwData.exe in $(OutputPath) on Linux since FLExBridge requires the .exe extension" />
     <Exec Command="ln FixFwData FixFwData.exe" WorkingDirectory="$(OutputPath)" />

--- a/backend/WebServiceDefaults/WebServiceDefaults.csproj
+++ b/backend/WebServiceDefaults/WebServiceDefaults.csproj
@@ -1,22 +1,18 @@
 <Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
     <TargetFramework>net9.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>
-
   <ItemGroup>
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
-
-    <PackageReference Include="Microsoft.Extensions.Http.Resilience" Version="9.2.0" />
-    <PackageReference Include="Microsoft.Extensions.ServiceDiscovery" Version="9.0.0" />
-    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.9.0" />
-    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.9.0" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.9.0" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.9.0" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.Runtime" Version="1.9.0" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.Process" Version="1.11.0-beta.1"/>
+    <PackageReference Include="Microsoft.Extensions.Http.Resilience" />
+    <PackageReference Include="Microsoft.Extensions.ServiceDiscovery" />
+    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" />
+    <PackageReference Include="OpenTelemetry.Extensions.Hosting" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.Http" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.Runtime" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.Process" />
   </ItemGroup>
-
 </Project>


### PR DESCRIPTION
This will make it much easier to upgrade nuget packages in the future, even doing this I found some mismatched stuff. Once this is merged in I'm going to try the latest EF core and see if they've fixed out issues yet.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated repository settings to ignore IDE-specific files.
  - Refined configuration files and streamlined project settings.
  - Simplified dependency management by removing fixed package versions, allowing for dynamic version resolution.
  - Standardized formatting in configuration files to enhance maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->