### PR TITLE
Fix duplicate component issues

### DIFF
--- a/backend/FwLite/FwDataMiniLcmBridge.Tests/MiniLcmTests/ComplexFormComponentTests.cs
+++ b/backend/FwLite/FwDataMiniLcmBridge.Tests/MiniLcmTests/ComplexFormComponentTests.cs
@@ -43,6 +43,32 @@ public class ComplexFormComponentTestsMultipleRefs(ProjectLoaderFixture fixture)
     [Fact]
     public async Task DuplicateComplexFormComponents_AreNotDuplicated()
     {
+        await AddDuplicateComponent();
+
+        var entry = await Api.GetEntry(_complexFormEntryId);
+        entry.Should().NotBeNull();
+        entry.Components.Should().HaveCount(1);
+        var component = await Api.GetEntry(_componentEntryId);
+        component.Should().NotBeNull();
+        component.ComplexForms.Should().HaveCount(1);
+    }
+
+
+    [Fact]
+    public async Task DuplicateComplexFormComponents_BothAreRemoved()
+    {
+        await AddDuplicateComponent();
+
+        var entry = await Api.GetEntry(_complexFormEntryId);
+        await Api.DeleteComplexFormComponent(entry!.Components.Single());
+
+        entry = await Api.GetEntry(_complexFormEntryId);
+        entry.Should().NotBeNull();
+        entry.Components.Should().BeEmpty();
+    }
+
+    private async Task AddDuplicateComponent()
+    {
         var fwDataApi = (FwDataMiniLcmApi)Api;
         var complexFormEntry = fwDataApi.EntriesRepository.GetObject(_complexFormEntryId);
         var componentEntry = fwDataApi.EntriesRepository.GetObject(_componentEntryId);
@@ -54,17 +80,32 @@ public class ComplexFormComponentTestsMultipleRefs(ProjectLoaderFixture fixture)
                 complexFormEntry.EntryRefsOS[1].ComponentLexemesRS.Add(componentEntry);
                 return ValueTask.CompletedTask;
             });
-
-        var entry = await Api.GetEntry(_complexFormEntryId);
-        entry.Should().NotBeNull();
-        entry.Components.Should().HaveCount(1);
-        var component = await Api.GetEntry(_componentEntryId);
-        component.Should().NotBeNull();
-        component.ComplexForms.Should().HaveCount(1);
     }
 
     [Fact]
     public async Task DuplicateComplexFormTypes_AreNotDuplicated()
+    {
+        await AddDuplicateFormType();
+
+        var entry = await Api.GetEntry(_complexFormEntryId);
+        entry.Should().NotBeNull();
+        entry.ComplexFormTypes.Should().HaveCount(1);
+    }
+
+    [Fact]
+    public async Task DuplicateComplexFormTypes_BothAreRemoved()
+    {
+        await AddDuplicateFormType();
+
+        var entry = await Api.GetEntry(_complexFormEntryId);
+        await Api.RemoveComplexFormType(_complexFormEntryId, entry!.ComplexFormTypes.Single().Id);
+
+        entry = await Api.GetEntry(_complexFormEntryId);
+        entry.Should().NotBeNull();
+        entry.ComplexFormTypes.Should().BeEmpty();
+    }
+
+    private async Task AddDuplicateFormType()
     {
         var fwDataApi = (FwDataMiniLcmApi)Api;
         var complexFormEntry = fwDataApi.EntriesRepository.GetObject(_complexFormEntryId);
@@ -77,9 +118,5 @@ public class ComplexFormComponentTestsMultipleRefs(ProjectLoaderFixture fixture)
                 complexFormEntry.EntryRefsOS[1].ComplexEntryTypesRS.Add(complexFormType);
                 return ValueTask.CompletedTask;
             });
-
-        var entry = await Api.GetEntry(_complexFormEntryId);
-        entry.Should().NotBeNull();
-        entry.ComplexFormTypes.Should().HaveCount(1);
     }
 }

--- a/backend/FwLite/FwDataMiniLcmBridge.Tests/MiniLcmTests/ComplexFormComponentTests.cs
+++ b/backend/FwLite/FwDataMiniLcmBridge.Tests/MiniLcmTests/ComplexFormComponentTests.cs
@@ -39,4 +39,47 @@ public class ComplexFormComponentTestsMultipleRefs(ProjectLoaderFixture fixture)
                 return ValueTask.CompletedTask;
             });
     }
+
+    [Fact]
+    public async Task DuplicateComplexFormComponents_AreNotDuplicated()
+    {
+        var fwDataApi = (FwDataMiniLcmApi)Api;
+        var complexFormEntry = fwDataApi.EntriesRepository.GetObject(_complexFormEntryId);
+        var componentEntry = fwDataApi.EntriesRepository.GetObject(_componentEntryId);
+        await fwDataApi.Cache.DoUsingNewOrCurrentUOW("Add ComplexFormEntryRef",
+            "Remove ComplexFormEntryRef",
+            () =>
+            {
+                complexFormEntry.EntryRefsOS[0].ComponentLexemesRS.Add(componentEntry);
+                complexFormEntry.EntryRefsOS[1].ComponentLexemesRS.Add(componentEntry);
+                return ValueTask.CompletedTask;
+            });
+
+        var entry = await Api.GetEntry(_complexFormEntryId);
+        entry.Should().NotBeNull();
+        entry.Components.Should().HaveCount(1);
+        var component = await Api.GetEntry(_componentEntryId);
+        component.Should().NotBeNull();
+        component.ComplexForms.Should().HaveCount(1);
+    }
+
+    [Fact]
+    public async Task DuplicateComplexFormTypes_AreNotDuplicated()
+    {
+        var fwDataApi = (FwDataMiniLcmApi)Api;
+        var complexFormEntry = fwDataApi.EntriesRepository.GetObject(_complexFormEntryId);
+        var complexFormType = fwDataApi.ComplexFormTypesFlattened.First();
+        await fwDataApi.Cache.DoUsingNewOrCurrentUOW("Add ComplexFormEntryRef",
+            "Remove ComplexFormEntryRef",
+            () =>
+            {
+                complexFormEntry.EntryRefsOS[0].ComplexEntryTypesRS.Add(complexFormType);
+                complexFormEntry.EntryRefsOS[1].ComplexEntryTypesRS.Add(complexFormType);
+                return ValueTask.CompletedTask;
+            });
+
+        var entry = await Api.GetEntry(_complexFormEntryId);
+        entry.Should().NotBeNull();
+        entry.ComplexFormTypes.Should().HaveCount(1);
+    }
 }

--- a/backend/FwLite/FwDataMiniLcmBridge/Api/FwDataMiniLcmApi.cs
+++ b/backend/FwLite/FwDataMiniLcmBridge/Api/FwDataMiniLcmApi.cs
@@ -961,7 +961,7 @@ public class FwDataMiniLcmApi(
 
         foreach (var entryRef in lexEntry.ComplexFormEntryRefs)
         {
-            if (entryRef.ComponentLexemesRS.Remove(lexComponent)) return;
+            entryRef.ComponentLexemesRS.Remove(lexComponent);
         }
         //not throwing to match CRDT behavior
     }
@@ -990,11 +990,11 @@ public class FwDataMiniLcmApi(
 
     internal void RemoveComplexFormType(ILexEntry lexEntry, Guid complexFormTypeId)
     {
-        foreach (var entryRef in lexEntry.ComplexFormEntryRefs.Reverse())
+        foreach (var entryRef in lexEntry.ComplexFormEntryRefs)
         {
             var lexEntryType = entryRef.ComplexEntryTypesRS.SingleOrDefault(c => c.Guid == complexFormTypeId);
             if (lexEntryType is null) continue;
-            if (entryRef.ComplexEntryTypesRS.Remove(lexEntryType)) break;
+            entryRef.ComplexEntryTypesRS.Remove(lexEntryType);
         }
     }
 

--- a/backend/FwLite/FwDataMiniLcmBridge/Api/FwDataMiniLcmApi.cs
+++ b/backend/FwLite/FwDataMiniLcmBridge/Api/FwDataMiniLcmApi.cs
@@ -47,7 +47,7 @@ public class FwDataMiniLcmApi(
     private ICmTranslationFactory CmTranslationFactory => Cache.ServiceLocator.GetInstance<ICmTranslationFactory>();
     private ICmPossibilityRepository CmPossibilityRepository => Cache.ServiceLocator.GetInstance<ICmPossibilityRepository>();
     private ICmPossibilityList ComplexFormTypes => Cache.LangProject.LexDbOA.ComplexEntryTypesOA;
-    private IEnumerable<ILexEntryType> ComplexFormTypesFlattened => ComplexFormTypes.PossibilitiesOS.Cast<ILexEntryType>().Flatten();
+    internal IEnumerable<ILexEntryType> ComplexFormTypesFlattened => ComplexFormTypes.PossibilitiesOS.Cast<ILexEntryType>().Flatten();
 
     private ICmPossibilityList VariantTypes => Cache.LangProject.LexDbOA.VariantEntryTypesOA;
     private ICmPossibilityList Publications => Cache.LangProject.LexDbOA.PublicationTypesOA;
@@ -572,6 +572,7 @@ public class FwDataMiniLcmApi(
     {
         return entry.ComplexFormEntryRefs
             .SelectMany(r => r.ComplexEntryTypesRS, (_, type) => ToComplexFormType(type))
+            .DistinctBy(c => c.Id)
             .ToList();
     }
     private IEnumerable<ComplexFormComponent> ToComplexFormComponents(ILexEntry entry)
@@ -582,7 +583,7 @@ public class FwDataMiniLcmApi(
                 ILexEntry component => ToEntryReference(component, entry),
                 ILexSense s => ToSenseReference(s, entry),
                 _ => throw new NotSupportedException($"object type {o.ClassName} not supported")
-            });
+            }).DistinctBy(c => (c.ComponentEntryId, c.ComplexFormEntryId, c.ComponentSenseId));
     }
 
     private Variants? ToVariants(ILexEntry entry)

--- a/backend/LfNext/LcmDebugger/LcmDebugger.csproj
+++ b/backend/LfNext/LcmDebugger/LcmDebugger.csproj
@@ -6,6 +6,7 @@
 
     <ItemGroup>
       <ProjectReference Include="..\..\FwLite\FwDataMiniLcmBridge\FwDataMiniLcmBridge.csproj" />
+      <ProjectReference Include="..\..\FwLite\FwLiteProjectSync\FwLiteProjectSync.csproj" />
     </ItemGroup>
 
     <ItemGroup>

--- a/backend/LfNext/LcmDebugger/Program.cs
+++ b/backend/LfNext/LcmDebugger/Program.cs
@@ -1,16 +1,25 @@
 ﻿// See https://aka.ms/new-console-template for more information
 
 using FwDataMiniLcmBridge;
+using FwLiteProjectSync;
+using LcmCrdt;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 
 var builder = Host.CreateApplicationBuilder();
 builder.Services.AddFwDataBridge();
+builder.Services.AddLcmCrdtClient();
+builder.Services.AddFwLiteProjectSync();
 
-var app = builder.Build();
+using var app = builder.Build();
 
 var fieldWorksProjectList = app.Services.GetRequiredService<FieldWorksProjectList>();
 var fwDataProject = fieldWorksProjectList.GetProject("sena-3") ?? throw new InvalidOperationException("Could not find project");
+
+var importService = app.Services.GetRequiredService<MiniLcmImport>();
+// await importService.Import(fwDataProject);
+
+
 var fwDataFactory = app.Services.GetRequiredService<FwDataFactory>();
 var miniLcmApi = fwDataFactory.GetFwDataMiniLcmApi(fwDataProject, false);
 var entries = await miniLcmApi.GetEntries().ToArrayAsync();


### PR DESCRIPTION
closes #1541 

Turns out duplicate Refs can turn into duplicate components. This fixes that by only ever returning one when duplicated, and ensuring that when we remove that one, that it actually removes both.

@myieye there's still the potential that you can create a duplicate complex form type (not component) if there's 2 refs and the current one is on the second but I'm not going to worry about that.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced new service integrations for enhanced synchronization and system management.
  
- **Bug Fixes**
  - Improved handling of complex form data by ensuring duplicate form elements are managed accurately.
  - Refined deletion and filtering processes for a more consistent user experience.
  
- **Chores**
  - Updated internal dependencies and build configurations for streamlined performance and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->