### PR TITLE
Make error trace link time-frame non-specific

### DIFF
--- a/frontend/src/lib/error/UnexpectedError.svelte
+++ b/frontend/src/lib/error/UnexpectedError.svelte
@@ -42,11 +42,12 @@
     })
   );
 
+  const TIME_RANGE_2024_TO_2040 = 'trace_start_ts=1704286862&trace_end_ts=2209042862';
   function onTraceIdClick(event: MouseEvent): void {
     if (event.ctrlKey) {
       const traceId = (event.target as HTMLElement).textContent as string;
       const honeyCombEnv = getHoneyCombEnv();
-      const url = `https://ui.honeycomb.io/sil-language-forge/environments/${honeyCombEnv}/trace?trace_id=${traceId}`;
+      const url = `https://ui.honeycomb.io/sil-language-forge/environments/${honeyCombEnv}/trace?trace_id=${traceId}&${TIME_RANGE_2024_TO_2040}`;
       window.open(url, '_blank')?.focus();
     }
   }


### PR DESCRIPTION
This should effectively make our error trace links time-frame non-specific, by just giving them an insanely large timeframe.

Currently the error trace url defaults to a timeframe of -2h to now, which means:
- if you click it before the whole trace has arrived, the Reload Trace button will likely not really work, because the end of the timeframe is locked in at the time when the trace was first loaded
- In theory if we click on the link long after the fact it wouldn't work

FYI I also have this bookmarked:
https://ui.honeycomb.io/sil-language-forge/environments/prod/trace?trace_start_ts=1704286862&trace_end_ts=2209042862&trace_id=

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced trace lookup: Selecting a trace now appends a predefined time range filter to the URL, ensuring that added time-based details are automatically included for a more comprehensive trace view.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->