### PR TITLE
Disambiguate complex-forms that reference same entry

### DIFF
--- a/backend/FwLite/MiniLcm.Tests/ComplexFormComponentTestsBase.cs
+++ b/backend/FwLite/MiniLcm.Tests/ComplexFormComponentTestsBase.cs
@@ -115,6 +115,12 @@ public abstract class ComplexFormComponentTestsBase : MiniLcmTestBase
         component2.ComplexFormEntryId.Should().Be(_complexFormEntryId);
         component2.ComponentEntryId.Should().Be(_componentEntryId);
         component2.ComponentSenseId.Should().Be(_componentSenseId2);
+
+        // ensure our sync code can handle them too
+        _complexFormEntry = (await Api.GetEntry(_complexFormEntryId))!;
+        await Api.UpdateEntry(_complexFormEntry, _complexFormEntry);
+        _componentEntry = (await Api.GetEntry(_componentEntryId))!;
+        await Api.UpdateEntry(_componentEntry, _componentEntry);
     }
 
     [Fact]
@@ -137,7 +143,8 @@ public abstract class ComplexFormComponentTestsBase : MiniLcmTestBase
     {
         var entry3 = await Api.CreateEntry(new()
         {
-            Id = Guid.NewGuid(), LexemeForm = { { "en", "entry3" } }
+            Id = Guid.NewGuid(),
+            LexemeForm = { { "en", "entry3" } }
         });
         await Api.CreateComplexFormComponent(ComplexFormComponent.FromEntries(_complexFormEntry, entry3));
         await Api.CreateComplexFormComponent(ComplexFormComponent.FromEntries(entry3, _componentEntry));
@@ -150,7 +157,8 @@ public abstract class ComplexFormComponentTestsBase : MiniLcmTestBase
     {
         var entry3 = await Api.CreateEntry(new()
         {
-            Id = Guid.NewGuid(), LexemeForm = { { "en", "entry3" } }
+            Id = Guid.NewGuid(),
+            LexemeForm = { { "en", "entry3" } }
         });
         await Api.CreateComplexFormComponent(ComplexFormComponent.FromEntries(_complexFormEntry, entry3));
         var complexFormComponent = await Api.CreateComplexFormComponent(ComplexFormComponent.FromEntries(entry3, _componentEntry));

--- a/backend/FwLite/MiniLcm/SyncHelpers/EntrySync.cs
+++ b/backend/FwLite/MiniLcm/SyncHelpers/EntrySync.cs
@@ -130,12 +130,12 @@ public static class EntrySync
         }
     }
 
-    private class ComplexFormsDiffApi(IMiniLcmApi api) : CollectionDiffApi<ComplexFormComponent, Guid>
+    private class ComplexFormsDiffApi(IMiniLcmApi api) : CollectionDiffApi<ComplexFormComponent, (Guid, Guid, Guid?)>
     {
-        public override Guid GetId(ComplexFormComponent component)
+        public override (Guid, Guid, Guid?) GetId(ComplexFormComponent component)
         {
             //we can't use the ID as there's none defined by Fw so it won't work as a sync key
-            return component.ComplexFormEntryId;
+            return (component.ComplexFormEntryId, component.ComponentEntryId, component.ComponentSenseId);
         }
 
         public override async Task<int> Add(ComplexFormComponent after)


### PR DESCRIPTION
Resolves #1563

Notes:

- I considered adding the new test code to the test's `DisposeAsync()`. That would have picked up this bug as well, but that would be meaningless for most of the tests in these classes. @hahn-kev do you at all prefer that idea?
- I left the component diff ID the same: `component.ComponentSenseId ?? component.ComponentEntryId`. I can change it back to (Guid, Guid, Guid?) to be consistent if desired. But, I'm pretty sure it's not necessary and would require a lot more changes than this (albeit not a ton). One of the reasons we ran into this problem is, because we're putting all the complex forms of the entry and the senses into a single list. Components don't have that problem, because there is no "complex-form sense".

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced multi-component form handling now synchronizes updates accurately, ensuring a smoother and more reliable user experience.

- **Tests**
  - Refined testing procedures validate these improvements, reinforcing system stability during complex form interactions.

- **Style**
  - Improved internal formatting enhances clarity and maintainability, indirectly contributing to overall performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->