### PR TITLE
Retry maildev api calls

### DIFF
--- a/frontend/tests/email/maildev-mailbox.ts
+++ b/frontend/tests/email/maildev-mailbox.ts
@@ -1,6 +1,8 @@
 import type {APIRequestContext} from '@playwright/test';
 import {type EmailSubjects} from './email-page';
 import {Mailbox, type Email} from './mailbox';
+import {delay} from '$lib/util/time';
+import {getErrorMessage} from '$lib/error/utils';
 
 interface MaildevEmail {
   subject: string;
@@ -21,9 +23,23 @@ export class MaildevMailbox extends Mailbox {
   }
 
   async fetchMyEmails(): Promise<MaildevEmail[]> {
-    // Maildev REST API docs: https://github.com/maildev/maildev/blob/master/docs/rest.md
-    const response = await this.api.get(`http://localhost:1080/email`);
-    const emails = await response.json() as MaildevEmail[];
-    return emails.filter(email => email.to.some(to => to.address === this.email));
+    const MAX_TRIES = 3;
+
+    for (let tries = 1; tries <= MAX_TRIES; tries++) {
+      try {
+        // Maildev REST API docs: https://github.com/maildev/maildev/blob/master/docs/rest.md
+        const response = await this.api.get(`http://localhost:1080/email`);
+        const emails = await response.json() as MaildevEmail[];
+        return emails.filter(email => email.to.some(to => to.address === this.email));
+      } catch (error) {
+        const message = getErrorMessage(error);
+        console.error(`Error fetching emails, attempt ${tries}/${MAX_TRIES}.`, message);
+        if (tries >= MAX_TRIES) throw error;
+        await delay(1000);
+      }
+    }
+
+    // This line should never be reached but TypeScript requires a return statement
+    throw new Error('Reached unreachable code');
   }
 }


### PR DESCRIPTION
This maildev api call often fails with "Error: apiRequestContext.get: socket hang up"
See: https://github.com/sillsdev/languageforge-lexbox/actions/runs/14191941142