### PR TITLE
Double test await sync timeout

### DIFF
--- a/backend/Testing/FwHeadless/MergeFwDataWithHarmonyTests.cs
+++ b/backend/Testing/FwHeadless/MergeFwDataWithHarmonyTests.cs
@@ -31,7 +31,7 @@ public class MergeFwDataWithHarmonyTests : ApiTestBase, IAsyncLifetime
 
     private async Task<SyncResult?> AwaitSyncFinished(Guid projectId)
     {
-        var giveUpAt = DateTime.UtcNow + TimeSpan.FromSeconds(130);
+        var giveUpAt = DateTime.UtcNow + TimeSpan.FromMinutes(4);
         while (giveUpAt > DateTime.UtcNow)
         {
             try


### PR DESCRIPTION
Timeout appears to not be long enough: https://github.com/sillsdev/languageforge-lexbox/actions/runs/14194742814/job/39767482345