### PR TITLE
don't use C# language preview for now

### DIFF
--- a/backend/LexBoxApi/Config/FwLiteReleaseConfig.cs
+++ b/backend/LexBoxApi/Config/FwLiteReleaseConfig.cs
@@ -17,6 +17,6 @@ public class FwLiteEditionConfig
     [Required]
     public required string FileNameRegex { get; init; }
 
-    [field: AllowNull]
-    public Regex FileName => field ??= new Regex(FileNameRegex);
+    private Regex? _fileName;
+    public Regex FileName => _fileName ??= new Regex(FileNameRegex);
 }

--- a/backend/LexBoxApi/LexBoxApi.csproj
+++ b/backend/LexBoxApi/LexBoxApi.csproj
@@ -4,7 +4,6 @@
     <IncludeOpenAPIAnalyzers>true</IncludeOpenAPIAnalyzers>
     <UserSecretsId>7392cddf-9b3b-441c-9316-203bb5c4a6bc</UserSecretsId>
     <GarbageCollectionAdaptationMode>1</GarbageCollectionAdaptationMode>
-    <LangVersion>preview</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="AppAny.Quartz.EntityFrameworkCore.Migrations.PostgreSQL" />


### PR DESCRIPTION
closes #1570 
workaround https://github.com/dotnet/efcore/issues/35100 by not using language preview in lexbox for now. 

This workaround will no longer be needed in EF Core 8.0.15 or 9.0.4 but those aren't out yet.