### PR TITLE
use the local folder as the template folder so that FwLiteWeb sdk does not try to create the template folder in Program Files if it doesn't exist

### DIFF
--- a/backend/FwLite/FwLiteWeb/appsettings.sdk.json
+++ b/backend/FwLite/FwLiteWeb/appsettings.sdk.json
@@ -6,7 +6,8 @@
     "OpenBrowser": false
   },
   "FwDataBridge": {
-    "ProjectsFolder": "./fw-projects"
+    "ProjectsFolder": "./fw-projects",
+    "TemplatesFolder": "."
   },
   "LcmCrdt": {
     "ProjectPath": "./fw-lite-projects"


### PR DESCRIPTION
this fixes an issue Jason reported where users who don't have FieldWorks installed try to run the sdk would get a permission error due to us trying to create the Templates folder if it doesn't exist