### PR TITLE
Shadcn multi-select component in sandbox reactive editor

### DIFF
--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -428,8 +428,8 @@ importers:
         specifier: 'catalog:'
         version: 3.0.5(vitest@3.0.5)
       bits-ui:
-        specifier: ^1.3.10
-        version: 1.3.10(svelte@5.20.0)
+        specifier: 1.3.16
+        version: 1.3.16(svelte@5.20.0)
       clsx:
         specifier: ^2.1.1
         version: 2.1.1
@@ -2940,8 +2940,8 @@ packages:
     resolution: {integrity: sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==}
     engines: {node: '>=8'}
 
-  bits-ui@1.3.10:
-    resolution: {integrity: sha512-Mg6ENVlI/dwHX9hR1cSiAp5gqzwzowPbXPRW32RxFdUKakuL8qYyewwr446VC7UkZLEpNeoHn7HICcBscJhYdw==}
+  bits-ui@1.3.16:
+    resolution: {integrity: sha512-eBifcu68EspZ1n7mpiyCEjbNAaPoaWLuQZ4aw4lYFt4kJYsOXeAiwKS3+IXwDvYZ9NzBDSSrWbst2k6kKU+8SQ==}
     engines: {node: '>=18', pnpm: '>=8.7.0'}
     peerDependencies:
       svelte: ^5.11.0
@@ -9227,7 +9227,7 @@ snapshots:
 
   binary-extensions@2.3.0: {}
 
-  bits-ui@1.3.10(svelte@5.20.0):
+  bits-ui@1.3.16(svelte@5.20.0):
     dependencies:
       '@floating-ui/core': 1.6.9
       '@floating-ui/dom': 1.6.13

--- a/frontend/viewer/package.json
+++ b/frontend/viewer/package.json
@@ -48,7 +48,7 @@
     "@typescript-eslint/parser": "catalog:",
     "@vitest/ui": "catalog:",
     "autoprefixer": "^10.4.20",
-    "bits-ui": "^1.3.10",
+    "bits-ui": "1.3.16",
     "clsx": "^2.1.1",
     "eslint": "catalog:",
     "eslint-plugin-svelte": "catalog:",

--- a/frontend/viewer/src/app.postcss
+++ b/frontend/viewer/src/app.postcss
@@ -86,20 +86,37 @@
 }
 
 @layer components {
+  /* shadcn grid start */
   .sm-form {
     grid-template-columns: fit-content(70px) 1fr 1fr;
   }
 
-  .xs-form {
-    grid-template-columns: fit-content(70px) 1fr;
+  .lg-form {
+    grid-template-columns: 180px fit-content(80px) 1fr;
   }
 
   .editor-grid {
     display: grid;
-    grid-template-columns: 170px fit-content(80px) 1fr;
-    @apply sm-form:sm-form;
-    @apply xs-form:xs-form;
+    grid-template-columns: fit-content(70px) 1fr;
+    @apply @lg:sm-form;
+    @apply @3xl:lg-form;
   }
+
+  .field-root {
+    @apply grid grid-cols-subgrid col-span-full items-baseline;
+  }
+
+  .field-title {
+    @apply col-span-full ms-2 me-2 mb-2;
+    @apply @3xl:col-span-1;
+  }
+
+  .field-body {
+    @apply grid grid-cols-subgrid;
+    @apply col-span-full;
+    @apply @3xl:col-span-2;
+  }
+  /* shadcn grid end */
 
   .collapsible-col {
     overflow-x: hidden;

--- a/frontend/viewer/src/app.postcss
+++ b/frontend/viewer/src/app.postcss
@@ -104,6 +104,9 @@
 
   .field-root {
     @apply grid grid-cols-subgrid col-span-full items-baseline;
+    &:not(:last-child) {
+      @apply mb-4;
+    }
   }
 
   .field-title {
@@ -114,7 +117,7 @@
   .field-body {
     @apply grid grid-cols-subgrid;
     @apply col-span-full;
-    @apply @3xl:col-span-2;
+    @apply @3xl:col-start-2 @3xl:col-end-4;
   }
   /* shadcn grid end */
 

--- a/frontend/viewer/src/lib/components/field-editors/field-title.svelte
+++ b/frontend/viewer/src/lib/components/field-editors/field-title.svelte
@@ -1,0 +1,52 @@
+<script lang="ts">
+  import {t} from 'svelte-i18n-lingui';
+  import FieldHelpIcon from '../../entry-editor/FieldHelpIcon.svelte';
+  import {useCurrentView} from '$lib/views/view-service';
+
+  const {
+    liteName,
+    classicName,
+    helpId,
+  }: {
+    liteName: string;
+    classicName: string;
+    helpId: string | undefined;
+  } = $props();
+
+  const view = useCurrentView();
+
+  const { label, title } = $derived(
+    $view.type === 'fw-classic'
+      ? {
+          label: classicName,
+          title: $t`${liteName} (FieldWorks Lite)`,
+        }
+      : {
+          label: liteName,
+          title: $t`${classicName} (FieldWorks)`,
+        },
+  );
+
+  // kind of crazy, but I don't think Svelte's white-space handling let's us use &nbsp; between the label and help icon
+  const { lastWord, otherWords } = $derived.by(() => {
+    const words = label.split(' ');
+    return {
+      lastWord: words.pop(),
+      otherWords: words.join(' '),
+    };
+  })
+</script>
+
+<div class="field-title">
+  <span class="inline-flex items-center relative">
+    <span class="name" {title}>
+      {otherWords}
+      <span class="whitespace-nowrap">
+        {lastWord}
+        {#if helpId}
+          <FieldHelpIcon {helpId} />
+        {/if}
+      </span>
+    </span>
+  </span>
+</div>

--- a/frontend/viewer/src/lib/components/field-editors/multi-select.svelte
+++ b/frontend/viewer/src/lib/components/field-editors/multi-select.svelte
@@ -1,0 +1,191 @@
+<script lang="ts" generics="Value">
+  import { Badge } from '$lib/components/ui/badge';
+  import { Button } from '$lib/components/ui/button';
+  import { Popover, PopoverContent, PopoverTrigger } from '$lib/components/ui/popover';
+  import { IsMobile } from '$lib/hooks/is-mobile.svelte';
+  import { tick } from 'svelte';
+  import { t } from 'svelte-i18n-lingui';
+  import { Checkbox } from '../ui/checkbox';
+  import { Command, CommandEmpty, CommandGroup, CommandInput, CommandItem, CommandList } from '../ui/command';
+  import { Drawer, DrawerContent, DrawerTrigger } from '../ui/drawer';
+  import { Icon } from '../ui/icon';
+  import type {ConditionalKeys, Primitive} from 'type-fest';
+  import {cn} from '$lib/utils';
+  import DrawerFooter from '../ui/drawer/drawer-footer.svelte';
+  import {slide} from 'svelte/transition';
+  import {watch} from 'runed';
+
+  let {
+    values = $bindable(),
+    ...constProps
+  }: {
+    values: Value[];
+    options: Value[];
+    /* eslint-disable @typescript-eslint/no-redundant-type-constituents */
+    idSelector: ConditionalKeys<Value, Primitive> | ((value: Value) => Primitive);
+    labelSelector: ConditionalKeys<Value, string> | ((value: Value) => string);
+    /* eslint-enable @typescript-eslint/no-redundant-type-constituents */
+    placeholder?: string;
+    filterPlaceholder?: string;
+    emptyResultsPlaceholder?: string;
+  } = $props();
+
+  const { options, idSelector, labelSelector, placeholder, filterPlaceholder, emptyResultsPlaceholder } = $derived(constProps);
+
+  const getId = $derived.by(() => {
+    if (typeof idSelector === 'function') return idSelector;
+    return (value: Value) => value[idSelector] as Primitive;
+  });
+
+  const getLabel = $derived.by(() => {
+    if (typeof labelSelector === 'function') return labelSelector;
+    return (value: Value) => value[labelSelector] as string;
+  });
+
+  let open = $state(false);
+  let dirty = $state(false);
+  let pendingValues = $state<Value[]>([]);
+  let displayValues = $derived(dirty ? pendingValues : values);
+  let triggerRef = $state<HTMLButtonElement | null>(null);
+
+  watch(() => open, () => {
+    dirty = false;
+    if (open) {
+      pendingValues = [...values];
+    }
+  });
+
+  function submit() {
+    open = false;
+    values = [...pendingValues];
+    void tick().then(() => {
+      triggerRef?.focus();
+    });
+  }
+
+  function onSelect(value: Value, wasSelected: boolean, triggerSubmit: boolean = true) {
+    if (!wasSelected) pendingValues = [...pendingValues, value];
+    else {
+      const id = getId(value);
+      const index = pendingValues.findIndex((v) => getId(v) === id);
+      if (index !== -1) pendingValues.splice(index, 1);
+    }
+    if (triggerSubmit) submit();
+    else dirty = true;
+  }
+
+  let filterValue = $state('');
+
+  const filteredOptions = $derived.by(() => {
+    const filterValueLower = filterValue.toLocaleLowerCase();
+    return options.filter((option) => {
+      const label = getLabel(option).toLocaleLowerCase();
+      return label.includes(filterValueLower);
+    });
+  });
+</script>
+
+{#snippet trigger({ props }: { props: Record<string, unknown> })}
+  <Button bind:ref={triggerRef} variant="outline" {...props} role="combobox" aria-expanded={open} class="w-full h-auto">
+    <div class="flex flex-wrap justify-start gap-2">
+      {#each displayValues as value (getId(value))}
+        <Badge>
+          {getLabel(value)}
+        </Badge>
+      {:else}
+        <span class="text-muted-foreground">
+          {placeholder}
+          &nbsp; <!-- ensures baseline alignment works for consumers of this component -->
+        </span>
+      {/each}
+    </div>
+    <div class="grow"></div>
+    <Icon icon="i-mdi-chevron-down" class="mr-2 size-5 shrink-0 opacity-50" />
+  </Button>
+{/snippet}
+
+{#snippet command()}
+  <Command shouldFilter={false}>
+    <CommandInput bind:value={filterValue} autofocus placeholder={filterPlaceholder ?? $t`Filter...`}>
+      <div class="flex items-center gap-2 flex-nowrap">
+        {#if IsMobile.value}
+          {#if filterValue}
+            <Button variant="ghost" size="xs-icon" onclick={() => (filterValue = '')} aria-label={$t`clear`}>
+              <Icon icon="i-mdi-close" />
+            </Button>
+          {/if}
+        {:else if !dirty}
+          <Button variant="ghost" size="xs" onclick={() => (open = false)} aria-label={$t`Close`}>
+              <Icon icon="i-mdi-close" />
+          </Button>
+        {/if}
+      </div>
+    </CommandInput>
+    {#if !IsMobile.value && dirty}
+      <div class="flex gap-3 p-3 items-center flex-nowrap" transition:slide={{ duration: 200 }}>
+        <Button class="basis-1/4" variant="secondary" onclick={() => (open = false)} aria-label={$t`Close`}>
+            {$t`Cancel`}
+        </Button>
+        <Button class="basis-3/4" onclick={submit}>
+          {$t`Submit`}
+        </Button>
+      </div>
+    {/if}
+    <CommandList class="h-[300px] md:max-h-[50vh]">
+      <CommandEmpty>{emptyResultsPlaceholder ?? $t`No items found`}</CommandEmpty>
+      <CommandGroup>
+        {#each filteredOptions as value}
+          {@const label = getLabel(value)}
+          {@const selected = pendingValues.includes(value)}
+          <CommandItem
+            keywords={[label.toLocaleLowerCase()]}
+            value={label.toLocaleLowerCase()}
+            onSelect={() => onSelect(value, selected, !dirty && !IsMobile.value)}
+            class="group max-md:h-12"
+            aria-label={label}
+          >
+            <Icon icon="i-mdi-check" class={cn('md:hidden', selected || 'invisible')} />
+            <Checkbox
+              checked={selected}
+              class={cn(
+                'max-md:hidden mr-2 border-muted-foreground !text-foreground !bg-transparent group-[&:not(:hover)]:border-transparent',
+                selected || '[&:not(:hover)]:opacity-50')}
+              onclick={(e) => e.stopPropagation()}
+              onCheckedChange={() => onSelect(value, selected, false)}
+            />
+            {label}
+          </CommandItem>
+        {/each}
+      </CommandGroup>
+    </CommandList>
+  </Command>
+{/snippet}
+
+{#if IsMobile.value}
+  <Drawer bind:open dismissible={!dirty}>
+    <DrawerTrigger child={trigger} />
+    <DrawerContent handle={true} class="overflow-hidden">
+      {@render command()}
+      <DrawerFooter>
+        <div class="flex gap-4 items-center flex-nowrap">
+          <Button variant="secondary" class={cn('basis-1/4 transition-all', dirty || 'basis-3/4')} onclick={() => (open = false)}>
+            {$t`Cancel`}
+          </Button>
+          <Button disabled={!dirty} class={cn('basis-3/4 transition-all', dirty || 'basis-1/4')} onclick={() => (open = false)}>
+            {$t`Submit`}
+          </Button>
+        </div>
+      </DrawerFooter>
+    </DrawerContent>
+  </Drawer>
+{:else}
+  <Popover bind:open={() => open, (newOpen) => {
+      // discard changes (i.e. prevent passive dismissing) if dirty
+      if (!dirty) open = newOpen;
+    }}>
+    <PopoverTrigger child={trigger} />
+    <PopoverContent class="p-0" align="start" sticky="always" side="bottom" avoidCollisions={false}>
+      {@render command()}
+    </PopoverContent>
+  </Popover>
+{/if}

--- a/frontend/viewer/src/lib/components/field-editors/multi-select.svelte
+++ b/frontend/viewer/src/lib/components/field-editors/multi-select.svelte
@@ -234,7 +234,7 @@
                 'max-md:hidden mr-2 border-muted-foreground !text-foreground !bg-transparent group-[&:not([data-selected])]:border-transparent',
                 selected || '[&:not(:hover)]:opacity-50')}
               onclick={(e) => {
-                // prevents deault command item selection
+                // prevents command item selection
                 e.stopPropagation();
               }}
               onpointerdown={(e) => {
@@ -263,7 +263,7 @@
           {@render displayBadges()}
         </DrawerDescription>
       </DrawerHeader>
-      {@render command()}
+        {@render command()}
       <DrawerFooter>
         <div class="flex gap-4 items-center flex-nowrap">
           <Button variant="secondary" class={cn('basis-1/4 transition-all', dirty || 'basis-3/4')} onclick={dismiss}>

--- a/frontend/viewer/src/lib/components/field-editors/multi-select.svelte
+++ b/frontend/viewer/src/lib/components/field-editors/multi-select.svelte
@@ -183,12 +183,9 @@
     </DrawerContent>
   </Drawer>
 {:else}
-  <Popover bind:open={() => open, (newOpen) => {
-      // discard changes (i.e. prevent passive dismissing) if dirty
-      if (!dirty) open = newOpen;
-    }}>
+  <Popover bind:open>
     <PopoverTrigger child={trigger} />
-    <PopoverContent class="p-0" align="start" sticky="always" side="bottom" avoidCollisions={false}>
+    <PopoverContent class="p-0" align="start" sticky="always" side="bottom" avoidCollisions interactOutsideBehavior={dirty ? 'ignore' : 'close'}>
       {@render command()}
     </PopoverContent>
   </Popover>

--- a/frontend/viewer/src/lib/components/field-editors/multi-select.svelte
+++ b/frontend/viewer/src/lib/components/field-editors/multi-select.svelte
@@ -55,6 +55,10 @@
     }
   });
 
+  function dismiss() {
+    open = false;
+  }
+
   function submit() {
     open = false;
     values = [...pendingValues];
@@ -115,7 +119,7 @@
             </Button>
           {/if}
         {:else if !dirty}
-          <Button variant="ghost" size="xs" onclick={() => (open = false)} aria-label={$t`Close`}>
+          <Button variant="ghost" size="xs" onclick={dismiss} aria-label={$t`Close`}>
               <Icon icon="i-mdi-close" />
           </Button>
         {/if}
@@ -123,7 +127,7 @@
     </CommandInput>
     {#if !IsMobile.value && dirty}
       <div class="flex gap-3 p-3 items-center flex-nowrap" transition:slide={{ duration: 200 }}>
-        <Button class="basis-1/4" variant="secondary" onclick={() => (open = false)} aria-label={$t`Close`}>
+        <Button class="basis-1/4" variant="secondary" onclick={dismiss} aria-label={$t`Close`}>
             {$t`Cancel`}
         </Button>
         <Button class="basis-3/4" onclick={submit}>
@@ -168,10 +172,10 @@
       {@render command()}
       <DrawerFooter>
         <div class="flex gap-4 items-center flex-nowrap">
-          <Button variant="secondary" class={cn('basis-1/4 transition-all', dirty || 'basis-3/4')} onclick={() => (open = false)}>
+          <Button variant="secondary" class={cn('basis-1/4 transition-all', dirty || 'basis-3/4')} onclick={dismiss}>
             {$t`Cancel`}
           </Button>
-          <Button disabled={!dirty} class={cn('basis-3/4 transition-all', dirty || 'basis-1/4')} onclick={() => (open = false)}>
+          <Button disabled={!dirty} class={cn('basis-3/4 transition-all', dirty || 'basis-1/4')} onclick={submit}>
             {$t`Submit`}
           </Button>
         </div>

--- a/frontend/viewer/src/lib/components/ui/button/button.svelte
+++ b/frontend/viewer/src/lib/components/ui/button/button.svelte
@@ -21,6 +21,7 @@
         xs: 'h-8 rounded-md px-2',
         sm: 'h-9 rounded-md px-3',
         lg: 'h-11 rounded-md px-8',
+        'xs-icon': 'h-8 w-8 min-h-8 min-w-8',
         icon: 'h-10 w-10 min-h-10 min-w-10',
         'extended-fab': 'h-14 pl-4 pr-5',
         'fab': 'h-14 px-4'

--- a/frontend/viewer/src/lib/components/ui/checkbox/checkbox.svelte
+++ b/frontend/viewer/src/lib/components/ui/checkbox/checkbox.svelte
@@ -23,7 +23,7 @@
   {...restProps}
 >
   {#snippet children({ checked, indeterminate })}
-    <div class="flex size-4 items-center justify-center text-current">
+    <div class="flex size-full items-center justify-center text-current">
       {#if indeterminate}
         <Icon icon="i-mdi-minus" class="size-3.5" />
       {:else}

--- a/frontend/viewer/src/lib/components/ui/command/command-input.svelte
+++ b/frontend/viewer/src/lib/components/ui/command/command-input.svelte
@@ -7,6 +7,7 @@
     ref = $bindable(null),
     class: className,
     value = $bindable(''),
+		children,
     ...restProps
   }: CommandPrimitive.InputProps = $props();
 </script>
@@ -22,4 +23,5 @@
     {...restProps}
     bind:value
   />
+	{@render children?.()}
 </div>

--- a/frontend/viewer/src/lib/components/ui/drawer/drawer-content.svelte
+++ b/frontend/viewer/src/lib/components/ui/drawer/drawer-content.svelte
@@ -7,10 +7,12 @@
     ref = $bindable(null),
     class: className,
     portalProps,
+    handle = true,
     children,
     ...restProps
   }: DrawerPrimitive.ContentProps & {
     portalProps?: DrawerPrimitive.PortalProps;
+    handle?: boolean;
   } = $props();
 </script>
 
@@ -24,7 +26,9 @@
     )}
     {...restProps}
   >
-    <div class="bg-muted mx-auto mt-4 h-2 w-[100px] rounded-full"></div>
+    {#if handle}
+      <div class="bg-muted mx-auto mt-4 h-2 w-[100px] rounded-full"></div>
+    {/if}
     {@render children?.()}
   </DrawerPrimitive.Content>
 </DrawerPrimitive.Portal>

--- a/frontend/viewer/src/lib/components/ui/drawer/drawer.svelte
+++ b/frontend/viewer/src/lib/components/ui/drawer/drawer.svelte
@@ -1,4 +1,7 @@
 <script lang="ts">
+  import {IsMobile} from '$lib/hooks/is-mobile.svelte';
+  import {watch} from 'runed';
+  import {onDestroy, onMount} from 'svelte';
   import {Drawer as DrawerPrimitive} from 'vaul-svelte';
 
   let {
@@ -7,6 +10,46 @@
     activeSnapPoint = $bindable(null),
     ...restProps
   }: DrawerPrimitive.RootProps = $props();
+
+  watch(() => open, () => {
+    if (open) {
+      handleOpen();
+    } else {
+      handleClose();
+    }
+  });
+
+  let addedHistory = $state(false);
+
+  function handleOpen() {
+    if (IsMobile.value) {
+      history.pushState({ drawer: true }, '');
+      addedHistory = true;
+    }
+  }
+
+  function handleClose() {
+    if (addedHistory) {
+      addedHistory = false;
+      history.back(); // we need to manually pop our added history
+    }
+  }
+
+  const abortController = new AbortController();
+
+  onMount(() => {
+    window.addEventListener('popstate', () => {
+      if (open && addedHistory) {
+        addedHistory = false; // the user popped our added history
+        open = false;
+      }
+    }, { signal: abortController.signal });
+  });
+
+  onDestroy(() => {
+    if (addedHistory) history.back();
+    abortController.abort();
+  });
 </script>
 
 <DrawerPrimitive.Root {shouldScaleBackground} bind:open bind:activeSnapPoint {...restProps} />

--- a/frontend/viewer/src/lib/entry-editor/FieldTitle.svelte
+++ b/frontend/viewer/src/lib/entry-editor/FieldTitle.svelte
@@ -2,13 +2,13 @@
   import {fieldName} from '../i18n';
   import {useCurrentView} from '$lib/views/view-service';
   import FieldHelpIcon from './FieldHelpIcon.svelte';
-  import {fieldData} from './field-data';
+  import {fieldData, type FieldId} from './field-data';
   import {type View} from '$lib/views/view-data';
 
   export let id: string;
   export let helpId: string | undefined = undefined;
   export let name: string | undefined = undefined;
-  $: if (!helpId) helpId = fieldData[id]?.helpId;
+  $: if (!helpId) helpId = fieldData[id as FieldId]?.helpId;
 
   const currentView = useCurrentView();
 

--- a/frontend/viewer/src/lib/entry-editor/field-data.ts
+++ b/frontend/viewer/src/lib/entry-editor/field-data.ts
@@ -27,5 +27,10 @@ const privateFieldData = {
 /**
  * This is a list of all standard fields with fixed data that is constant across all views.
  */
-export const fieldData: Record<string, FieldData> = privateFieldData;
-export type FieldIds = keyof typeof fieldData;
+export type FieldId = keyof typeof privateFieldData;
+export const fieldData: Record<FieldId, FieldData> = privateFieldData;
+
+/**
+ * @deprecated I think we want a type that's more type safe i.e. FieldId 👆
+ */
+export type FieldIds = string; // this was always just string, it just wasn't obvious 🙃

--- a/frontend/viewer/src/lib/sandbox/OptionSandbox.svelte
+++ b/frontend/viewer/src/lib/sandbox/OptionSandbox.svelte
@@ -30,6 +30,7 @@
 
   const alternateView = {
     id: 'alternate',
+    type: 'fw-classic',
     i18nKey: '',
     label: 'Alternate',
     fields,
@@ -40,6 +41,7 @@
 
   const defaultView = {
     id: 'sandbox',
+    type: 'fw-lite',
     i18nKey: '',
     label: 'Language Forge',
     fields,

--- a/frontend/viewer/src/lib/sandbox/Sandbox.svelte
+++ b/frontend/viewer/src/lib/sandbox/Sandbox.svelte
@@ -26,6 +26,9 @@
   import FieldTitle from '$lib/components/field-editors/field-title.svelte';
   import {t} from 'svelte-i18n-lingui';
   import ThemePicker from '$lib/ThemePicker.svelte';
+  import {Tabs, TabsList, TabsTrigger} from '$lib/components/ui/tabs';
+  import {Label} from '$lib/components/ui/label';
+  import {Switch} from '$lib/components/ui/switch';
 
   const crdtOptions: MenuOption[] = [
     {value: 'a', label: 'Alpha'},
@@ -80,9 +83,20 @@
     allDomains.push({
       label: allDomains[Math.floor(Math.random() * allDomains.length)].label + '-' + i
     });
+    allDomains.sort((a, b) => a.label.localeCompare(b.label));
   }
 
-  let selectedDomains = $state([allDomains[3], allDomains[5]]);
+  function randomSemanticDomainSorter() {
+    return Math.random() - 0.5;
+  }
+
+  let selectedDomains = $state([allDomains[0], allDomains[80]]);
+
+  let semanticDomainOrder = $state<'selectionOrder' | 'optionOrder' | 'randomOrder'>('selectionOrder');
+  const sortSemanticDomainValuesBy = $derived(semanticDomainOrder === 'randomOrder'
+    ? randomSemanticDomainSorter
+    : semanticDomainOrder);
+  let semanticDomainsReadonly = $state(false);
 </script>
 
 <div class="p-6 shadcn-root">
@@ -109,19 +123,44 @@
         </div>
         <div class="editor-grid">
           <div class="field-root">
+            <div class="field-body grid-cols-1">
+              <Label class="mb-2">Order of semantic domains</Label>
+              <Tabs bind:value={semanticDomainOrder} class="mb-1">
+                <TabsList>
+                  <TabsTrigger value="selectionOrder">Selection</TabsTrigger>
+                  <TabsTrigger value="optionOrder">Option</TabsTrigger>
+                  <TabsTrigger value="randomOrder">Random</TabsTrigger>
+                </TabsList>
+              </Tabs>
+              <p class="text-muted-foreground text-sm">
+                Only comes into effect while editing, because we don't want to make any changes implicitly.
+              </p>
+            </div>
+          </div>
+          <div class="field-root">
+            <div class="field-body grid-cols-1">
+              <Switch bind:checked={semanticDomainsReadonly} label="Readonly" />
+            </div>
+          </div>
+          <div class="field-root">
             <FieldTitle
               liteName={$t`Semantic domains`}
               classicName={$t`Semantic domains`}
               helpId={fieldData.semanticDomains.helpId}
             />
-
             <div class="field-body">
               <div class="col-span-full">
                 <MultiSelect
+                  readonly={semanticDomainsReadonly}
                   bind:values={() => selectedDomains,
                   (newValues) => selectedDomains = newValues}
                   idSelector="label"
                   labelSelector={(item) => item.label}
+                  sortValuesBy={sortSemanticDomainValuesBy}
+                  drawerTitle={$t`Semantic domains`}
+                  filterPlaceholder={$t`Filter semantic domains...`}
+                  placeholder={$t`🤷 nothing here`}
+                  emptyResultsPlaceholder={$t`Looked hard, found nothing`}
                   options={allDomains}>
                 </MultiSelect>
               </div>

--- a/frontend/viewer/src/lib/sandbox/Sandbox.svelte
+++ b/frontend/viewer/src/lib/sandbox/Sandbox.svelte
@@ -83,8 +83,8 @@
     allDomains.push({
       label: allDomains[Math.floor(Math.random() * allDomains.length)].label + '-' + i
     });
-    allDomains.sort((a, b) => a.label.localeCompare(b.label));
   }
+  allDomains.sort((a, b) => a.label.localeCompare(b.label));
 
   function randomSemanticDomainSorter() {
     return Math.random() - 0.5;

--- a/frontend/viewer/src/lib/views/view-data.ts
+++ b/frontend/viewer/src/lib/views/view-data.ts
@@ -30,20 +30,22 @@ export const allFields: Record<FieldIds, FieldView> = {
   reference: {show: false, order: 3},
 };
 
-const defaultView: RootView = {
+export const FW_LITE_VIEW: RootView = {
   id: 'fwlite',
+  type: 'fw-lite',
   i18nKey: '',
   label: 'FieldWorks Lite',
   fields: allFields,
-  get alternateView() { return fieldWorksView; }
+  get alternateView() { return FW_CLASSIC_VIEW; }
 };
 
-const fieldWorksView: RootView = {
+export const FW_CLASSIC_VIEW: RootView = {
   id: 'fieldworks',
+  type: 'fw-classic',
   i18nKey: 'fieldworks',
   label: 'FieldWorks',
   fields: recursiveSpread(allFields, {[defaultDef]: {show: true}}),
-  alternateView: defaultView,
+  alternateView: FW_LITE_VIEW,
 };
 
 const viewDefinitions: CustomViewDefinition[] = [
@@ -51,12 +53,12 @@ const viewDefinitions: CustomViewDefinition[] = [
 ];
 
 export const views: [RootView, RootView, ...CustomView[]] = [
-  defaultView,
-  fieldWorksView,
+  FW_LITE_VIEW,
+  FW_CLASSIC_VIEW,
   ...viewDefinitions.map(view => {
     const fields: Record<FieldIds, FieldView> = recursiveSpread<typeof allFields>(allFields, view.fieldOverrides);
     return {
-      ...defaultView,
+      ...FW_LITE_VIEW,
       ...view,
       fields: fields
     };
@@ -88,6 +90,7 @@ function recursiveSpread<T extends Record<string | symbol, unknown>>(obj1: T, ob
 
 interface ViewDefinition {
   id: string;
+  type: 'fw-lite' | 'fw-classic';
   i18nKey: I18nType;
   label: string;
 }

--- a/frontend/viewer/src/project/ProjectDropdown.svelte
+++ b/frontend/viewer/src/project/ProjectDropdown.svelte
@@ -38,7 +38,6 @@
 
   function handleSelect(project: { id: string; name: string }) {
     onSelect(project.name);
-    open = false;
     closeAndFocusTrigger();
   }
 

--- a/frontend/viewer/src/theme.postcss
+++ b/frontend/viewer/src/theme.postcss
@@ -96,7 +96,7 @@
       --foreground: 0 0% 95%;
       --card: 24 9.8% 10%;
       --card-foreground: 0 0% 95%;
-      --popover: 0 0% 9%;
+      --popover: 20 14.3% 4.1%; /* 0 0% 9%; changed to match --background like other themes */
       --popover-foreground: 0 0% 95%;
       --primary: 142.1 70.6% 45.3%;
       --primary-foreground: 144.9 80.4% 10%;
@@ -143,7 +143,7 @@
       --foreground: 0 0% 95%;
       --card: 24 9.8% 10%;
       --card-foreground: 0 0% 95%;
-      --popover: 0 0% 9%;
+      --popover: 20 14.3% 4.1%; /* 0 0% 9%; changed to match --background like other themes */
       --popover-foreground: 0 0% 95%;
       --primary: 346.8 77.2% 49.8%;
       --primary-foreground: 355.7 100% 97.3%;


### PR DESCRIPTION
- Popover for desktop
- Drawer for mobile
- Back button closes drawer (on desktop at least, I haven't tested mobile, which is where it should 😬)
  - I built this into the drawer component for mobile-sized screens
- Always a visible "Dismiss" button
- The "X" behaves differently on desktop and mobile
  - On mobile I think it's especially common for an X by the input to clear the input, so I went with that. But there's always a "Cancel" button
  - On Desktop the "X" closes the popup, BUT it dissappears when in "dirty" state. For 2 reasons: (1) so there aren't 2 close/dismiss buttons so close to each other and (2) I think it slightly helps communicate the fact that the popup is in a different state (it's non-dismissable: can only be closed via Cancel or Submit).

https://github.com/user-attachments/assets/d9a6d5e3-f804-4b5b-b6ca-38c3f94039b3

Updates:
- Badges/header in mobile drawer so the user has context:
![image](https://github.com/user-attachments/assets/3f2f66ca-7a19-4cca-9764-d4fc8d0ee24a)

- keyboard navigation
  - Ctrl + Space to toggle selection of an item
  - No tab navigation through checkboxes, because it's weird having 2 ways to navigate the command-item list
  - Ctrl + Enter submits the selection

- A sort strategy can be specified for the selected values

- Moved the submit button on desktop to inside the filter input, so there isn't a layout shift and it's nice and visible.
![image](https://github.com/user-attachments/assets/67c48b31-c2d0-44ab-860d-3707237d5e53)

- Readonly mode
![image](https://github.com/user-attachments/assets/e083beae-f118-42e1-942a-f1be67d9bda7)
