### PR TITLE
Improve Linux README and add install-launcher script

### DIFF
--- a/backend/FwLite/FwLiteWeb/FwLiteWeb.csproj
+++ b/backend/FwLite/FwLiteWeb/FwLiteWeb.csproj
@@ -26,6 +26,8 @@
       <Link>.dockerignore</Link>
     </Content>
     <Content Include="*.md" CopyToPublishDirectory="PreserveNewest" />
+    <Content Include="install-launcher.sh" CopyToPublishDirectory="PreserveNewest" />
+    <Content Include="fwlite.desktop.template" CopyToPublishDirectory="PreserveNewest" />
     <None Include="$(Pkgicu_net)\contentFiles\any\any\icu.net.dll.config">
       <Link>icu.net.dll.config</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>

--- a/backend/FwLite/FwLiteWeb/README-linux.md
+++ b/backend/FwLite/FwLiteWeb/README-linux.md
@@ -1,6 +1,20 @@
-﻿## To start up the web server
+﻿## FieldWorks Lite Web runs as a terminal application with a web front-end in your browser
 
-1. Open a terminal and start FwLiteWeb
-2. It should open your browser by default
-3. a port will be chosen randomly, you can find it in the terminal
-4. settings are configured in appsettings.json, you can configure the port and project folders there
+## Install a FieldWorks Lite shortcut into the Ubuntu launcher
+
+1. Run install-launcher.sh
+2. Open the Ubuntu launcher and search for "FieldWorks Lite"
+3. You will see the FW Lite icon, click on that to run the application
+
+## Run FieldWorks Lite manually
+1. Open a terminal and run ./FwLiteWeb
+2. On some systems you may be able to double-click the file
+
+# App Configuration
+1. On startup, a port will be chosen randomly, visible in the terminal output
+2. Settings are configured in appsettings.json; you can configure the port and project folders there
+
+# Closing the program
+1. Close the web browser window or tab
+2. Close the terminal window that is running FieldWorks Lite or Ctrl-C
+3. If you never had a terminal window (e.g. double-clicked the FwLiteWeb file), you can kill the process in a terminal with `killall FwLiteWeb`

--- a/backend/FwLite/FwLiteWeb/fwlite.desktop.template
+++ b/backend/FwLite/FwLiteWeb/fwlite.desktop.template
@@ -1,0 +1,12 @@
+[Desktop Entry]
+Version=1.0
+Type=Application
+Name=FieldWorks Lite
+Comment=Run FieldWorks Lite Desktop in the terminal
+Exec="./FwLiteWeb"
+Path=APPDIR/
+Keywords=FieldWorks;lexbox;language forge;sfm;fw-lite;fw lite;
+Categories=Utility;
+Terminal=true
+Icon=APPDIR/wwwroot/_content/FwLiteShared/viewer/logo-dark.svg
+X-Desktop-File-Install-Version=0.27

--- a/backend/FwLite/FwLiteWeb/install-launcher.sh
+++ b/backend/FwLite/FwLiteWeb/install-launcher.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+# Get the full path to the current directory
+APPDIR="$(pwd)"
+
+# Replace APPDIR in the template and create the actual .desktop file
+sed "s|APPDIR|$APPDIR|g" fwlite.desktop.template > fwlite.desktop
+
+# Make it executable
+chmod +x fwlite.desktop
+
+# Ensure the applications folder exists
+mkdir -p ~/.local/share/applications
+
+# Copy the desktop file to the launcher
+cp fwlite.desktop ~/.local/share/applications/fwlite.desktop
+
+echo "Installed FieldWorks Lite launcher!"
+


### PR DESCRIPTION
I updated the Linux readme to reflect the new install script and provide additional instructions for running and closing the app manually.

The install script uses the fwlite.desktop.template file as a template and then inserts the appropriate path and copies the .desktop file into the user's application directory so it is visible in the Ubuntu launcher.

I tested out this PR's artifact build and the install script works as expected.

https://github.com/user-attachments/assets/c6b59fb7-688b-45a5-ad41-61bdb1116a83

