### PR TITLE
Only display "Project code already used" if we're certain.

### DIFF
--- a/backend/LexData/DbError.cs
+++ b/backend/LexData/DbError.cs
@@ -8,6 +8,7 @@ public enum DbErrorCode
 {
     Unknown,
     Duplicate,
+    DuplicateProjectCode,
 }
 
 public class DbError
@@ -19,9 +20,10 @@ public class DbError
 
     public static DbError CreateErrorFrom(PostgresException exception)
     {
-        return exception.SqlState switch
+        return exception switch
         {
-            PostgresErrorCodes.UniqueViolation => new DbError($"{exception.TableName.Humanize().Singularize(false)} already exists", DbErrorCode.Duplicate),
+            { SqlState: PostgresErrorCodes.UniqueViolation, ConstraintName: "IX_Projects_Code" } => new DbError($"{exception.TableName.Humanize().Singularize(false)} already exists", DbErrorCode.DuplicateProjectCode),
+            { SqlState: PostgresErrorCodes.UniqueViolation } => new DbError($"{exception.TableName.Humanize().Singularize(false)} already exists", DbErrorCode.Duplicate),
             _ => new DbError(exception.Message)
         };
     }

--- a/frontend/schema.graphql
+++ b/frontend/schema.graphql
@@ -1205,6 +1205,7 @@ enum CreateProjectResult {
 enum DbErrorCode {
   UNKNOWN
   DUPLICATE
+  DUPLICATE_PROJECT_CODE
 }
 
 enum FeatureFlag {

--- a/frontend/src/routes/(authenticated)/project/create/+page.svelte
+++ b/frontend/src/routes/(authenticated)/project/create/+page.svelte
@@ -65,7 +65,7 @@
       forceDraft
     });
     if (result.error) {
-      if (result.error.byCode(DbErrorCode.Duplicate)) {
+      if (result.error.byCode(DbErrorCode.DuplicateProjectCode)) {
         $errors.code = [$t('project.create.code_exists')];
       } else {
         $message = result.error.message;


### PR DESCRIPTION
Resolves #1599 

Now we just display Unknown error if any constraint other than the project code constraint was violated:

![image](https://github.com/user-attachments/assets/31c96341-dd7c-4f5a-ac5d-f29c3398c01e)


Project code specific message still works:

![image](https://github.com/user-attachments/assets/8ff3c8d4-c071-4919-b3ba-fe8b0962ac4a)
