### PR TITLE
Fix issue querying commits with json in json

### DIFF
--- a/backend/LexData/Entities/CommitEntityConfiguration.cs
+++ b/backend/LexData/Entities/CommitEntityConfiguration.cs
@@ -11,6 +11,10 @@ namespace LexData.Entities;
 
 public class CommitEntityConfiguration : IEntityTypeConfiguration<ServerCommit>
 {
+    private static JsonSerializerOptions Options = new JsonSerializerOptions()
+    {
+        Converters = { new ServerJsonChangeConverter() }
+    };
     public void Configure(EntityTypeBuilder<ServerCommit> builder)
     {
         builder.ToTable("CrdtCommits");
@@ -24,12 +28,37 @@ public class CommitEntityConfiguration : IEntityTypeConfiguration<ServerCommit>
             json => JsonSerializer.Deserialize<CommitMetadata>(json, (JsonSerializerOptions?)null) ?? new()
         );
         builder.Property(c => c.ChangeEntities).HasConversion(
-            c => JsonSerializer.Serialize(c, (JsonSerializerOptions?)null),
-            json => JsonSerializer.Deserialize<List<ChangeEntity<ServerJsonChange>>>(json, (JsonSerializerOptions?)null) ?? new()
+            c => JsonSerializer.Serialize(c, Options),
+            json => JsonSerializer.Deserialize<List<ChangeEntity<ServerJsonChange>>>(json, Options) ?? new()
         ).HasColumnType("jsonb").IsRequired(false);
     }
 
     private static ServerJsonChange Deserialize(string s) => JsonSerializer.Deserialize<ServerJsonChange>(s)!;
 
     private static string Serialize(ServerJsonChange c) => JsonSerializer.Serialize(c);
+
+    private class ServerJsonChangeConverter: JsonConverter<ServerJsonChange>
+    {
+        public override ServerJsonChange? Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions _)
+        {
+            //ignoring JsonSerializerOptions, otherwise we would stack overflow recursively using this converter
+            if (typeToConvert != typeof(ServerJsonChange))
+                throw new SerializationException("type not supported " + typeToConvert.FullName);
+            //special case, this object type used to be encoded as a string in json like this: {"Change": "{\"Prop\": 1}"}
+            if (reader.TokenType == JsonTokenType.String)
+            {
+                var json = reader.GetString();
+                if (json is null) return null;
+                return JsonSerializer.Deserialize<ServerJsonChange>(json);
+            }
+
+            return JsonSerializer.Deserialize<ServerJsonChange>(ref reader);
+        }
+
+        public override void Write(Utf8JsonWriter writer, ServerJsonChange value, JsonSerializerOptions options)
+        {
+            //not passing in options otherwise it would just use this converter again
+            JsonSerializer.Serialize(writer, value);
+        }
+    }
 }


### PR DESCRIPTION
closes #1601

before #1569 we were unintentionally storing our ChangeEntties like this:
```json
[
  {
    "Index": 0,
    "Change": "{\"$type\":\"CreatePartOfSpeechChange\",\"name\":{\"en\":\"Possessive pronoun\"},\"predefined\":true,\"entityId\":\"64e3b502-90f5-4df0-9212-65f6e5c96c30\"}",
    "CommitId": "f2b2ed7d-bfc6-42a2-bcd4-67b3438a4dce",
    "EntityId": "64e3b502-90f5-4df0-9212-65f6e5c96c30"
  }
]
```
notice that `Change` is just a string, containing JSON. That's changed so we're not storing the whole thing as Json like this:
```json
[
  {
    "Index": 0,
    "Change": {
      "name": {
        "en": "Possessive pronoun"
      },
      "$type": "CreatePartOfSpeechChange",
      "entityId": "64e3b502-90f5-4df0-9212-65f6e5c96c30",
      "predefined": true
    },
    "CommitId": "f2b2ed7d-bfc6-42a2-bcd4-67b3438a4dce",
    "EntityId": "64e3b502-90f5-4df0-9212-65f6e5c96c30"
  }
]
```

however we still have commits in that old format, we could migrate them, but the sql script I wrote:
```SQL
update "CrdtCommits" up
set "ChangeEntities" = sub.agg
from (select Crdt."Id",
          jsonb_agg(json_build_object(
                  'Index', J -> 'Index',
                  'Change', (J ->> 'Change')::json, --convert json string into json object
                  'CommitId', J -> 'CommitId',
                  'EntityId', J -> 'EntityId')) agg
      from "CrdtCommits" Crdt,
          jsonb_array_elements(Crdt."ChangeEntities") J
      where jsonb_typeof("ChangeEntities" -> 0 -> 'Change') = 'string' and jsonb_array_length("ChangeEntities") < 10
      group by Crdt."Id") AS sub
where up."Id" = sub."Id";
```
it works fine for small commits, but we have some large ones and the server was failing to process larger commits. It may just make sense to apply this migration manually later.