### PR TITLE
update Taskfile for MacOS development

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -37,7 +37,7 @@ tasks:
       - git submodule init
       - git submodule update --recursive
       - git config --local submodule.recurse true
-      - cmd: setup-k8s
+      - task: setup-k8s
       - docker build -t local-dev-init data/
   setup-k8s:
     cmds:


### PR DESCRIPTION
When developing on MacOS, I needed this tweak to avoid a "command not found" error in the Taskfile on MacOS.  I assume this change does not affect Windows or Linux users, but I didn't test it.