### PR TITLE
Ensure json is streamed from the reqest into the db

### DIFF
--- a/backend/FwLite/FwLiteWeb/Routes/ProjectRoutes.cs
+++ b/backend/FwLite/FwLiteWeb/Routes/ProjectRoutes.cs
@@ -42,6 +42,7 @@ public static class ProjectRoutes
             async (SyncService syncService,
                 IOptions<AuthConfig> options,
                 string serverAuthority,
+                [FromRoute(Name = CrdtMiniLcmApiHub.ProjectRouteKey)]string project,
                 [FromQuery] Guid lexboxProjectId) =>
             {
                 var server = options.Value.GetServerByAuthority(serverAuthority);

--- a/backend/LexBoxApi/Models/StreamJsonAsyncEnumerable.cs
+++ b/backend/LexBoxApi/Models/StreamJsonAsyncEnumerable.cs
@@ -1,0 +1,57 @@
+﻿using System.Reflection;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.ModelBinding;
+using Microsoft.Extensions.Options;
+
+namespace LexBoxApi.Models;
+
+/// <summary>
+/// by default if you set IAsyncEnumerable<T> as a parameter type, it will be created using JsonSerializer.DeserializeAsync
+/// this will buffer the data into a list, rather than streaming it. This class exists to allow streaming
+/// </summary>
+[UseStreamingBinder]
+public class StreamJsonAsyncEnumerable<T>(IAsyncEnumerable<T> stream): IAsyncEnumerable<T>
+{
+    public IAsyncEnumerator<T> GetAsyncEnumerator(CancellationToken cancellationToken = new CancellationToken())
+    {
+        return stream.GetAsyncEnumerator(cancellationToken);
+    }
+}
+
+internal class UseStreamingBinderAttribute() : ModelBinderAttribute(typeof(StreamJsonAsyncEnumerableConverter))
+{
+    public override BindingSource? BindingSource => BindingSource.Body;
+}
+public class StreamJsonAsyncEnumerableConverter(ILogger<StreamJsonAsyncEnumerableConverter> logger): IModelBinder
+{
+    private static readonly MethodInfo BindMethod = new Action<ModelBindingContext>(Bind<object>).Method.GetGenericMethodDefinition();
+    public Task BindModelAsync(ModelBindingContext bindingContext)
+    {
+        if (!bindingContext.ModelType.IsGenericType)
+        {
+            throw new InvalidOperationException("Model type must be generic");
+        }
+        var genericType = bindingContext.ModelType.GetGenericArguments()[0];
+        var bindMethodGeneric = BindMethod.MakeGenericMethod(genericType);
+        bindMethodGeneric.Invoke(null, [bindingContext]);
+        try
+        {
+        }
+        catch (Exception e)
+        {
+            logger.LogError(e, "problem deserializing json");
+            bindingContext.ModelState.TryAddModelException("this", e);
+        }
+        return Task.CompletedTask;
+    }
+
+    private static void Bind<T>(ModelBindingContext bindingContext) where T : class
+    {
+        var options = bindingContext.HttpContext.RequestServices.GetRequiredService<IOptions<JsonOptions>>().Value
+            .JsonSerializerOptions;
+        var enumerable = JsonSerializer.DeserializeAsyncEnumerable<T>(bindingContext.HttpContext.Request.BodyReader.AsStream(), options, bindingContext.HttpContext.RequestAborted);
+        bindingContext.Result = ModelBindingResult.Success(new StreamJsonAsyncEnumerable<T>(enumerable.OfType<T>()));
+    }
+}

--- a/backend/LexBoxApi/Models/StreamJsonAsyncEnumerable.cs
+++ b/backend/LexBoxApi/Models/StreamJsonAsyncEnumerable.cs
@@ -33,11 +33,11 @@ public class StreamJsonAsyncEnumerableConverter(ILogger<StreamJsonAsyncEnumerabl
         {
             throw new InvalidOperationException("Model type must be generic");
         }
-        var genericType = bindingContext.ModelType.GetGenericArguments()[0];
-        var bindMethodGeneric = BindMethod.MakeGenericMethod(genericType);
-        bindMethodGeneric.Invoke(null, [bindingContext]);
         try
         {
+            var genericType = bindingContext.ModelType.GetGenericArguments()[0];
+            var bindMethodGeneric = BindMethod.MakeGenericMethod(genericType);
+            bindMethodGeneric.Invoke(null, [bindingContext]);
         }
         catch (Exception e)
         {


### PR DESCRIPTION
After doing some testing it turned out that we weren't actually streaming, if you use `IAsyncEnumerable<T>` as the body of a request in a controller then aspnet core will use `JsonSerializer.DeserializeAsync` this uses buffering implementation of `IAsyncEnumerable<T>` and does not stream the results. A new class `StreamJsonAsyncEnumerable<T>` was introduced to solve that problem.

In addition using linq2db merge directly from a list of objects turned out to have very poor performance and memory use, largely because it was constructing huge SQL strings behind the scenes (those would also be logged causing more issues). By creating a temporary table we're able to stream the data directly into the database (also ignoring any duplicate commit issues). Once the data is in the temporary table we're able to use the merge feature to merge the data from the temp table into the actual table, ignoring duplicates. Once done the temp table is dropped.