### PR TITLE
Skip Send/Receive steps if no pending changes

### DIFF
--- a/backend/FwHeadless/Services/SyncHostedService.cs
+++ b/backend/FwHeadless/Services/SyncHostedService.cs
@@ -190,7 +190,7 @@ public class SyncWorker(
             else
             {
                 var srResult = await srService.SendReceive(fwDataProject, projectCode);
-                logger.LogInformation("Send/Receive result: {srResult}", srResult.Output);
+                logger.LogInformation("Send/Receive result before CRDT sync: {srResult}", srResult.Output);
             }
         }
         else

--- a/backend/FwHeadless/Services/SyncHostedService.cs
+++ b/backend/FwHeadless/Services/SyncHostedService.cs
@@ -161,8 +161,15 @@ public class SyncWorker(
             result.FwdataChanges);
 
         await crdtSyncService.SyncHarmonyProject();
-        var srResult2 = await srService.SendReceive(fwDataProject, projectCode);
-        logger.LogInformation("Send/Receive result after CRDT sync: {srResult2}", srResult2.Output);
+        if (result.FwdataChanges == 0)
+        {
+            logger.LogInformation("No Send/Receive needed after CRDT sync as no FW changes were made by the sync");
+        }
+        else
+        {
+            var srResult2 = await srService.SendReceive(fwDataProject, projectCode);
+            logger.LogInformation("Send/Receive result after CRDT sync: {srResult2}", srResult2.Output);
+        }
         activity?.SetStatus(ActivityStatusCode.Ok, "Sync finished");
         return new SyncJobResult(SyncJobResultEnum.Success, null, result);
     }
@@ -175,8 +182,16 @@ public class SyncWorker(
     {
         if (File.Exists(fwDataProject.FilePath))
         {
-            var srResult = await srService.SendReceive(fwDataProject, projectCode);
-            logger.LogInformation("Send/Receive result: {srResult}", srResult.Output);
+            var pendingHgCommits = await srService.PendingCommitCount(fwDataProject, projectCode);
+            if (pendingHgCommits == 0)
+            {
+                logger.LogInformation("No Send/Receive needed before CRDT sync as there are no pending commits");
+            }
+            else
+            {
+                var srResult = await srService.SendReceive(fwDataProject, projectCode);
+                logger.LogInformation("Send/Receive result: {srResult}", srResult.Output);
+            }
         }
         else
         {


### PR DESCRIPTION
Fixes #1610 by skipping one (or both) of the Send/Receive steps if we can tell ahead of time that they won't do anything.

Incoming changes are detected by using PendingCommitCount; if it's 0 then there are no Mercurial changes sitting in Lexbox, so a Send/Receive would do nothing and we can save some time by skipping it.

Outgoing changes are detected by looking at the FwdataChanges result from the CRDT sync code. If that is 0 then the Send/Receive would not push any new commits so we can safely skip it and save more time.