### PR TITLE
Migrate Lexbox UI to Svelte 5

### DIFF
--- a/frontend/src/hooks.server.ts
+++ b/frontend/src/hooks.server.ts
@@ -28,7 +28,7 @@ async function initI18n(event: RequestEvent): Promise<void> {
   await loadI18n();
 }
 
-// eslint-disable-next-line func-style, @typescript-eslint/unbound-method
+// eslint-disable-next-line func-style
 export const handle: Handle = ({event, resolve}) => {
   console.log(`HTTP request: ${event.request.method} ${event.request.url}`);
   event.locals.getUser = () => getUser(event.cookies);

--- a/frontend/src/lib/components/Badges/ActionBadge.svelte
+++ b/frontend/src/lib/components/Badges/ActionBadge.svelte
@@ -1,11 +1,12 @@
 <script lang="ts">
+  import type { Snippet } from 'svelte';
   import { Icon, type IconString } from '$lib/icons';
   import { createEventDispatcher } from 'svelte';
   interface Props {
     disabled?: boolean;
     actionIcon: IconString;
     variant?: 'btn-neutral' | 'btn-primary' | 'btn-secondary';
-    children?: import('svelte').Snippet;
+    children?: Snippet;
   }
 
   let {

--- a/frontend/src/lib/components/Badges/ActionBadge.svelte
+++ b/frontend/src/lib/components/Badges/ActionBadge.svelte
@@ -9,12 +9,7 @@
     children?: Snippet;
   }
 
-  let {
-    disabled = false,
-    actionIcon,
-    variant = 'btn-neutral',
-    children
-  }: Props = $props();
+  let { disabled = false, actionIcon, variant = 'btn-neutral', children }: Props = $props();
   let iconHoverColor = $derived(variant === 'btn-neutral' ? 'group-hover:bg-base-200' : 'group-hover:bg-neutral/50');
 
   const dispatch = createEventDispatcher<{
@@ -34,7 +29,8 @@
 <button
   onclick={onAction}
   onkeypress={onAction}
-  class="btn badge {variant} group transition whitespace-nowrap gap-1 {pr} {br}" class:pointer-events-none={disabled}
+  class="btn badge {variant} group transition whitespace-nowrap gap-1 {pr} {br}"
+  class:pointer-events-none={disabled}
 >
   {@render children?.()}
 

--- a/frontend/src/lib/components/Badges/ActionBadge.svelte
+++ b/frontend/src/lib/components/Badges/ActionBadge.svelte
@@ -1,10 +1,20 @@
 <script lang="ts">
   import { Icon, type IconString } from '$lib/icons';
   import { createEventDispatcher } from 'svelte';
-  export let disabled = false;
-  export let actionIcon: IconString;
-  export let variant: 'btn-neutral' | 'btn-primary' | 'btn-secondary' = 'btn-neutral';
-  $: iconHoverColor = variant === 'btn-neutral' ? 'group-hover:bg-base-200' : 'group-hover:bg-neutral/50';
+  interface Props {
+    disabled?: boolean;
+    actionIcon: IconString;
+    variant?: 'btn-neutral' | 'btn-primary' | 'btn-secondary';
+    children?: import('svelte').Snippet;
+  }
+
+  let {
+    disabled = false,
+    actionIcon,
+    variant = 'btn-neutral',
+    children
+  }: Props = $props();
+  let iconHoverColor = $derived(variant === 'btn-neutral' ? 'group-hover:bg-base-200' : 'group-hover:bg-neutral/50');
 
   const dispatch = createEventDispatcher<{
     action: void;
@@ -16,16 +26,16 @@
     }
   }
 
-  $: pr = disabled ? '!pr-0' : '!pr-1';
-  $: br = disabled ? 'border-r-0' : '';
+  let pr = $derived(disabled ? '!pr-0' : '!pr-1');
+  let br = $derived(disabled ? 'border-r-0' : '');
 </script>
 
 <button
-  on:click={onAction}
-  on:keypress={onAction}
+  onclick={onAction}
+  onkeypress={onAction}
   class="btn badge {variant} group transition whitespace-nowrap gap-1 {pr} {br}" class:pointer-events-none={disabled}
 >
-  <slot />
+  {@render children?.()}
 
   {#if !disabled}
     <span class="btn btn-circle btn-xs btn-ghost transition {iconHoverColor}">

--- a/frontend/src/lib/components/Badges/Badge.svelte
+++ b/frontend/src/lib/components/Badges/Badge.svelte
@@ -1,4 +1,5 @@
 <script lang="ts" module>
+  import type { Snippet } from 'svelte';
   // Add more as necessary. Should be as limited as possible to maximize consistency. https://daisyui.com/components/badge/
   export type BadgeVariant = 'badge-neutral' | 'badge-info' | 'badge-primary' | 'badge-warning' | 'badge-success' | undefined;
 </script>
@@ -11,7 +12,7 @@
     icon?: IconString | undefined;
     hoverIcon?: IconString | undefined;
     outline?: boolean;
-    children?: import('svelte').Snippet;
+    children?: Snippet;
   }
 
   let {

--- a/frontend/src/lib/components/Badges/Badge.svelte
+++ b/frontend/src/lib/components/Badges/Badge.svelte
@@ -1,7 +1,13 @@
 <script lang="ts" module>
   import type { Snippet } from 'svelte';
   // Add more as necessary. Should be as limited as possible to maximize consistency. https://daisyui.com/components/badge/
-  export type BadgeVariant = 'badge-neutral' | 'badge-info' | 'badge-primary' | 'badge-warning' | 'badge-success' | undefined;
+  export type BadgeVariant =
+    | 'badge-neutral'
+    | 'badge-info'
+    | 'badge-primary'
+    | 'badge-warning'
+    | 'badge-success'
+    | undefined;
 </script>
 
 <script lang="ts">
@@ -20,7 +26,7 @@
     icon = undefined,
     hoverIcon = undefined,
     outline = false,
-    children
+    children,
   }: Props = $props();
 </script>
 

--- a/frontend/src/lib/components/Badges/Badge.svelte
+++ b/frontend/src/lib/components/Badges/Badge.svelte
@@ -1,4 +1,4 @@
-<script lang="ts" context="module">
+<script lang="ts" module>
   // Add more as necessary. Should be as limited as possible to maximize consistency. https://daisyui.com/components/badge/
   export type BadgeVariant = 'badge-neutral' | 'badge-info' | 'badge-primary' | 'badge-warning' | 'badge-success' | undefined;
 </script>
@@ -6,17 +6,28 @@
 <script lang="ts">
   import { Icon, type IconString } from '$lib/icons';
 
-  export let variant: BadgeVariant = 'badge-neutral';
-  export let icon: IconString | undefined = undefined;
-  export let hoverIcon: IconString | undefined = undefined;
-  export let outline = false;
+  interface Props {
+    variant?: BadgeVariant;
+    icon?: IconString | undefined;
+    hoverIcon?: IconString | undefined;
+    outline?: boolean;
+    children?: import('svelte').Snippet;
+  }
+
+  let {
+    variant = 'badge-neutral',
+    icon = undefined,
+    hoverIcon = undefined,
+    outline = false,
+    children
+  }: Props = $props();
 </script>
 
 <span
   class="badge {variant ?? ''} whitespace-nowrap inline-flex gap-2 items-center group"
   class:badge-outline={outline}
 >
-  <slot />
+  {@render children?.()}
   <span class="contents" class:group-hover:hidden={!!hoverIcon}>
     <Icon {icon} />
   </span>

--- a/frontend/src/lib/components/Badges/BadgeButton.svelte
+++ b/frontend/src/lib/components/Badges/BadgeButton.svelte
@@ -13,14 +13,22 @@
     icon?: IconString | undefined;
     hoverIcon?: IconString | undefined;
     disabled?: boolean;
+    onclick: () => void;
     children?: Snippet;
   }
 
-  let { variant = undefined, icon = undefined, hoverIcon = undefined, disabled = false, children }: Props = $props();
+  let {
+    variant = undefined,
+    icon = undefined,
+    hoverIcon = undefined,
+    disabled = false,
+    onclick,
+    children,
+  }: Props = $props();
 </script>
 
 <button
-  onclick={bubble('click')}
+  {onclick}
   {disabled}
   class="badge btn btn-sm !p-0 bright transition-all border-0"
   class:hover:brightness-90={!disabled}

--- a/frontend/src/lib/components/Badges/BadgeButton.svelte
+++ b/frontend/src/lib/components/Badges/BadgeButton.svelte
@@ -1,17 +1,31 @@
 <script lang="ts">
+  import { createBubbler } from 'svelte/legacy';
+
+  const bubble = createBubbler();
   import type { IconString } from '$lib/icons';
   import Badge from './Badge.svelte';
 
   // Add more as necessary. Should be as limited as possible to maximize consistency.
   type BadgeButtonVariant = 'badge-success' | 'badge-warning' | 'badge-neutral' | undefined;
-  export let variant: BadgeButtonVariant = undefined;
-  export let icon: IconString | undefined = undefined;
-  export let hoverIcon: IconString | undefined = undefined;
-  export let disabled = false;
+  interface Props {
+    variant?: BadgeButtonVariant;
+    icon?: IconString | undefined;
+    hoverIcon?: IconString | undefined;
+    disabled?: boolean;
+    children?: import('svelte').Snippet;
+  }
+
+  let {
+    variant = undefined,
+    icon = undefined,
+    hoverIcon = undefined,
+    disabled = false,
+    children
+  }: Props = $props();
 </script>
 
-<button on:click {disabled} class="badge btn btn-sm !p-0 bright transition-all border-0" class:hover:brightness-90={!disabled}>
+<button onclick={bubble('click')} {disabled} class="badge btn btn-sm !p-0 bright transition-all border-0" class:hover:brightness-90={!disabled}>
   <Badge {variant} {icon} hoverIcon={disabled ? undefined : hoverIcon}>
-    <slot />
+    {@render children?.()}
   </Badge>
 </button>

--- a/frontend/src/lib/components/Badges/BadgeButton.svelte
+++ b/frontend/src/lib/components/Badges/BadgeButton.svelte
@@ -1,8 +1,5 @@
 <script lang="ts">
   import type { Snippet } from 'svelte';
-  import { createBubbler } from 'svelte/legacy';
-
-  const bubble = createBubbler();
   import type { IconString } from '$lib/icons';
   import Badge from './Badge.svelte';
 

--- a/frontend/src/lib/components/Badges/BadgeButton.svelte
+++ b/frontend/src/lib/components/Badges/BadgeButton.svelte
@@ -16,16 +16,15 @@
     children?: Snippet;
   }
 
-  let {
-    variant = undefined,
-    icon = undefined,
-    hoverIcon = undefined,
-    disabled = false,
-    children
-  }: Props = $props();
+  let { variant = undefined, icon = undefined, hoverIcon = undefined, disabled = false, children }: Props = $props();
 </script>
 
-<button onclick={bubble('click')} {disabled} class="badge btn btn-sm !p-0 bright transition-all border-0" class:hover:brightness-90={!disabled}>
+<button
+  onclick={bubble('click')}
+  {disabled}
+  class="badge btn btn-sm !p-0 bright transition-all border-0"
+  class:hover:brightness-90={!disabled}
+>
   <Badge {variant} {icon} hoverIcon={disabled ? undefined : hoverIcon}>
     {@render children?.()}
   </Badge>

--- a/frontend/src/lib/components/Badges/BadgeButton.svelte
+++ b/frontend/src/lib/components/Badges/BadgeButton.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import type { Snippet } from 'svelte';
   import { createBubbler } from 'svelte/legacy';
 
   const bubble = createBubbler();
@@ -12,7 +13,7 @@
     icon?: IconString | undefined;
     hoverIcon?: IconString | undefined;
     disabled?: boolean;
-    children?: import('svelte').Snippet;
+    children?: Snippet;
   }
 
   let {

--- a/frontend/src/lib/components/Badges/BadgeButton.svelte
+++ b/frontend/src/lib/components/Badges/BadgeButton.svelte
@@ -10,7 +10,7 @@
     icon?: IconString | undefined;
     hoverIcon?: IconString | undefined;
     disabled?: boolean;
-    onclick: () => void;
+    onclick?: () => void;
     children?: Snippet;
   }
 

--- a/frontend/src/lib/components/Badges/BadgeList.svelte
+++ b/frontend/src/lib/components/Badges/BadgeList.svelte
@@ -1,9 +1,14 @@
 <script lang="ts">
-  export let grid = false;
+  interface Props {
+    grid?: boolean;
+    children?: import('svelte').Snippet;
+  }
+
+  let { grid = false, children }: Props = $props();
 </script>
 
 <span class:grid class:inline-flex={!grid} class="badge-list flex-wrap gap-3 justify-items-stretch">
-  <slot />
+  {@render children?.()}
 </span>
 
 <style>

--- a/frontend/src/lib/components/Badges/BadgeList.svelte
+++ b/frontend/src/lib/components/Badges/BadgeList.svelte
@@ -1,7 +1,8 @@
 <script lang="ts">
+  import type { Snippet } from 'svelte';
   interface Props {
     grid?: boolean;
-    children?: import('svelte').Snippet;
+    children?: Snippet;
   }
 
   let { grid = false, children }: Props = $props();

--- a/frontend/src/lib/components/Badges/MemberBadge.svelte
+++ b/frontend/src/lib/components/Badges/MemberBadge.svelte
@@ -3,12 +3,16 @@
   import FormatUserProjectRole from '../Projects/FormatUserProjectRole.svelte';
   import ActionBadge from './ActionBadge.svelte';
   import Badge from './Badge.svelte';
-  export let member: { name: string; role: ProjectRole };
-  export let canManage = false;
 
-  export let type: 'existing' | 'new' = 'existing';
-  $: actionIcon = (type === 'existing' ? 'i-mdi-dots-vertical' as const : 'i-mdi-close' as const);
-  $: variant = member.role === ProjectRole.Manager ? 'btn-primary' as const : 'btn-secondary' as const;
+  interface Props {
+    member: { name: string; role: ProjectRole };
+    canManage?: boolean;
+    type?: 'existing' | 'new';
+  }
+
+  let { member, canManage = false, type = 'existing' }: Props = $props();
+  let actionIcon = ($derived(type === 'existing' ? 'i-mdi-dots-vertical' as const : 'i-mdi-close' as const));
+  let variant = $derived(member.role === ProjectRole.Manager ? 'btn-primary' as const : 'btn-secondary' as const);
 </script>
 
 <ActionBadge {actionIcon} {variant} disabled={!canManage} on:action>
@@ -17,7 +21,7 @@
   </span>
 
   <!-- justify the name left and the role right -->
-  <span class="flex-grow" />
+  <span class="flex-grow"></span>
 
   <Badge>
     <FormatUserProjectRole role={member.role} />

--- a/frontend/src/lib/components/Badges/OrgMemberBadge.svelte
+++ b/frontend/src/lib/components/Badges/OrgMemberBadge.svelte
@@ -3,12 +3,16 @@
   import FormatUserOrgRole from '../Orgs/FormatUserOrgRole.svelte';
   import ActionBadge from './ActionBadge.svelte';
   import Badge from './Badge.svelte';
-  export let member: { name: string; role: OrgRole };
-  export let canManage = false;
 
-  export let type: 'existing' | 'new' = 'existing';
-  $: actionIcon = (type === 'existing' ? 'i-mdi-dots-vertical' as const : 'i-mdi-close' as const);
-  $: variant = member.role === OrgRole.Admin ? 'btn-primary' as const : 'btn-secondary' as const;
+  interface Props {
+    member: { name: string; role: OrgRole };
+    canManage?: boolean;
+    type?: 'existing' | 'new';
+  }
+
+  let { member, canManage = false, type = 'existing' }: Props = $props();
+  let actionIcon = ($derived(type === 'existing' ? 'i-mdi-dots-vertical' as const : 'i-mdi-close' as const));
+  let variant = $derived(member.role === OrgRole.Admin ? 'btn-primary' as const : 'btn-secondary' as const);
 </script>
 
 <ActionBadge {actionIcon} {variant} disabled={!canManage} on:action>
@@ -17,7 +21,7 @@
   </span>
 
   <!-- justify the name left and the role right -->
-  <span class="flex-grow" />
+  <span class="flex-grow"></span>
 
   <Badge>
     <FormatUserOrgRole role={member.role} />

--- a/frontend/src/lib/components/ButtonToggle.svelte
+++ b/frontend/src/lib/components/ButtonToggle.svelte
@@ -1,17 +1,29 @@
 <script lang="ts">
-  export let icon1: string;
-  export let icon2: string;
-  export let text1: string;
-  export let text2: string;
-  export let style: string;
-  let isIconOne = true;
+  import { preventDefault } from 'svelte/legacy';
+
+  interface Props {
+    icon1: string;
+    icon2: string;
+    text1: string;
+    text2: string;
+    style: string;
+  }
+
+  let {
+    icon1,
+    icon2,
+    text1,
+    text2,
+    style
+  }: Props = $props();
+  let isIconOne = $state(true);
 
   function handleClick(): void {
     isIconOne = !isIconOne;
   }
 </script>
 
-<button on:click|preventDefault={handleClick} class="btn {style} flex items-center">
+<button onclick={preventDefault(handleClick)} class="btn {style} flex items-center">
   {#if isIconOne}
     <span>{text1} </span>
     <span class="{icon1} text-lg"></span>

--- a/frontend/src/lib/components/BypassCloudflareEmailObfuscation.svelte
+++ b/frontend/src/lib/components/BypassCloudflareEmailObfuscation.svelte
@@ -1,7 +1,15 @@
+<script lang="ts">
+	interface Props {
+		children?: import('svelte').Snippet;
+	}
+
+	let { children }: Props = $props();
+</script>
+
 ﻿<!--cloudflare replaces email addresses with a hash, however this can mess up the dom and break svelte, so sometimes we need to bypass it-->
 <!--because normal html comments are trimmed in svelte we need to use @html to avoid the comment being trimmed-->
 <!--eslint-disable-next-line svelte/no-at-html-tags-->
 {@html '<!--email_off-->'}
-<slot />
+{@render children?.()}
 <!--eslint-disable-next-line svelte/no-at-html-tags-->
 {@html '<!--/email_off-->'}

--- a/frontend/src/lib/components/BypassCloudflareEmailObfuscation.svelte
+++ b/frontend/src/lib/components/BypassCloudflareEmailObfuscation.svelte
@@ -1,12 +1,13 @@
 <script lang="ts">
-	interface Props {
-		children?: import('svelte').Snippet;
-	}
+  import type { Snippet } from 'svelte';
+  interface Props {
+    children?: Snippet;
+  }
 
-	let { children }: Props = $props();
+  let { children }: Props = $props();
 </script>
 
-﻿<!--cloudflare replaces email addresses with a hash, however this can mess up the dom and break svelte, so sometimes we need to bypass it-->
+<!--cloudflare replaces email addresses with a hash, however this can mess up the dom and break svelte, so sometimes we need to bypass it-->
 <!--because normal html comments are trimmed in svelte we need to use @html to avoid the comment being trimmed-->
 <!--eslint-disable-next-line svelte/no-at-html-tags-->
 {@html '<!--email_off-->'}

--- a/frontend/src/lib/components/CopyToClipboardButton.svelte
+++ b/frontend/src/lib/components/CopyToClipboardButton.svelte
@@ -3,13 +3,22 @@
   import IconButton from './IconButton.svelte';
   import t from '$lib/i18n';
 
-  var copyingToClipboard = false;
-  var copiedToClipboard = false;
+  var copyingToClipboard = $state(false);
+  var copiedToClipboard = $state(false);
 
-  export let textToCopy: string;
-  export let delayMs: Duration | number = Duration.Default;
-  export let size: 'btn-sm' | undefined = undefined;
-  export let outline: boolean = true;
+  interface Props {
+    textToCopy: string;
+    delayMs?: Duration | number;
+    size?: 'btn-sm' | undefined;
+    outline?: boolean;
+  }
+
+  let {
+    textToCopy,
+    delayMs = Duration.Default,
+    size = undefined,
+    outline = true
+  }: Props = $props();
 
   async function copyToClipboard(): Promise<void> {
     copyingToClipboard = true;

--- a/frontend/src/lib/components/CopyToClipboardButton.svelte
+++ b/frontend/src/lib/components/CopyToClipboardButton.svelte
@@ -13,12 +13,7 @@
     outline?: boolean;
   }
 
-  let {
-    textToCopy,
-    delayMs = Duration.Default,
-    size = undefined,
-    outline = true
-  }: Props = $props();
+  let { textToCopy, delayMs = Duration.Default, size = undefined, outline = true }: Props = $props();
 
   async function copyToClipboard(): Promise<void> {
     copyingToClipboard = true;
@@ -31,15 +26,21 @@
 </script>
 
 {#if copiedToClipboard}
-<div class="tooltip tooltip-open" data-tip={$t('clipboard.copied')}>
-  <IconButton fake icon="i-mdi-check" {size} variant={outline ? undefined : 'btn-ghost'} class={outline ? 'btn-success' : 'text-success'} />
-</div>
+  <div class="tooltip tooltip-open" data-tip={$t('clipboard.copied')}>
+    <IconButton
+      fake
+      icon="i-mdi-check"
+      {size}
+      variant={outline ? undefined : 'btn-ghost'}
+      class={outline ? 'btn-success' : 'text-success'}
+    />
+  </div>
 {:else}
   <IconButton
-  loading={copyingToClipboard}
-  icon="i-mdi-content-copy"
-  {size}
-  variant={outline ? undefined : 'btn-ghost'}
-  on:click={copyToClipboard}
-/>
+    loading={copyingToClipboard}
+    icon="i-mdi-content-copy"
+    {size}
+    variant={outline ? undefined : 'btn-ghost'}
+    onclick={copyToClipboard}
+  />
 {/if}

--- a/frontend/src/lib/components/DeleteUserModal.svelte
+++ b/frontend/src/lib/components/DeleteUserModal.svelte
@@ -12,7 +12,7 @@
 
   let modal: ConfirmDeleteModal | undefined = $state();
 
-  export async function open(user: { id: string; name: string }): ReturnType<Exclude<typeof modal, undefined>['open']> {
+  export async function open(user: { id: string; name: string }): ReturnType<ConfirmDeleteModal['open']> {
     return await modal!.open(user.name, async () => {
       const deleteUserInput: DeleteUserByAdminOrSelfInput = {
         userId: user.id,

--- a/frontend/src/lib/components/DeleteUserModal.svelte
+++ b/frontend/src/lib/components/DeleteUserModal.svelte
@@ -4,9 +4,13 @@
   import ConfirmDeleteModal, { type DeleteModalI18nShape } from './modals/ConfirmDeleteModal.svelte';
   import { _deleteUserByAdminOrSelf } from '$lib/gql/mutations';
 
-  export let i18nScope: I18nShapeKey<DeleteModalI18nShape>;
+  interface Props {
+    i18nScope: I18nShapeKey<DeleteModalI18nShape>;
+  }
 
-  let modal: ConfirmDeleteModal;
+  let { i18nScope }: Props = $props();
+
+  let modal: ConfirmDeleteModal = $state();
 
   export async function open(user: {id: string, name: string}): ReturnType<(typeof modal)['open']> {
     return await modal.open(user.name, async () => {

--- a/frontend/src/lib/components/DeleteUserModal.svelte
+++ b/frontend/src/lib/components/DeleteUserModal.svelte
@@ -10,10 +10,10 @@
 
   let { i18nScope }: Props = $props();
 
-  let modal: ConfirmDeleteModal = $state()!;
+  let modal: ConfirmDeleteModal | undefined = $state();
 
-  export async function open(user: { id: string; name: string }): ReturnType<(typeof modal)['open']> {
-    return await modal.open(user.name, async () => {
+  export async function open(user: { id: string; name: string }): ReturnType<Exclude<typeof modal, undefined>['open']> {
+    return await modal!.open(user.name, async () => {
       const deleteUserInput: DeleteUserByAdminOrSelfInput = {
         userId: user.id,
       };

--- a/frontend/src/lib/components/DeleteUserModal.svelte
+++ b/frontend/src/lib/components/DeleteUserModal.svelte
@@ -10,9 +10,9 @@
 
   let { i18nScope }: Props = $props();
 
-  let modal: ConfirmDeleteModal = $state();
+  let modal: ConfirmDeleteModal = $state()!;
 
-  export async function open(user: {id: string, name: string}): ReturnType<(typeof modal)['open']> {
+  export async function open(user: { id: string; name: string }): ReturnType<(typeof modal)['open']> {
     return await modal.open(user.name, async () => {
       const deleteUserInput: DeleteUserByAdminOrSelfInput = {
         userId: user.id,

--- a/frontend/src/lib/components/Dropdown.svelte
+++ b/frontend/src/lib/components/Dropdown.svelte
@@ -1,13 +1,19 @@
 <script lang="ts">
   import { overlay } from '$lib/overlay';
 
-  export let disabled = false;
+  interface Props {
+    disabled?: boolean;
+    children?: import('svelte').Snippet;
+    content?: import('svelte').Snippet;
+  }
+
+  let { disabled = false, children, content }: Props = $props();
 </script>
 
 <div class="dropdown-container inline-flex" use:overlay={{ disabled, closeClickSelector: '.menu li' }}>
-  <slot />
+  {@render children?.()}
   <div class="overlay-content">
-    <slot name="content" />
+    {@render content?.()}
   </div>
 </div>
 

--- a/frontend/src/lib/components/Dropdown.svelte
+++ b/frontend/src/lib/components/Dropdown.svelte
@@ -1,10 +1,11 @@
 <script lang="ts">
+  import type { Snippet } from 'svelte';
   import { overlay } from '$lib/overlay';
 
   interface Props {
     disabled?: boolean;
-    children?: import('svelte').Snippet;
-    content?: import('svelte').Snippet;
+    children?: Snippet;
+    content?: Snippet;
   }
 
   let { disabled = false, children, content }: Props = $props();

--- a/frontend/src/lib/components/EditableText.svelte
+++ b/frontend/src/lib/components/EditableText.svelte
@@ -18,14 +18,14 @@
     saveHandler,
     placeholder = undefined,
     multiline = false,
-    validation = z.string()
+    validation = z.string(),
   }: Props = $props();
 
   let initialValue: string | undefined | null;
   let editing = $state(false);
   let saving = $state(false);
 
-  let formElem: Form = $state();
+  let formElem: Form = $state()!;
 
   const formSchema = z.object({ value: validation });
   let { form, errors, reset, enhance, message } = lexSuperForm(
@@ -97,7 +97,10 @@
 
 <span>
   {#if editing || saving}
-    <span class="inline-flex not-prose space-x-2 relative max-sm:flex-col max-w-full max-sm:w-full" class:w-full={multiline}>
+    <span
+      class="inline-flex not-prose space-x-2 relative max-sm:flex-col max-w-full max-sm:w-full"
+      class:w-full={multiline}
+    >
       <!-- svelte-ignore a11y_autofocus -->
       <span
         class="tooltip-error tooltip-open tooltip-bottom"
@@ -114,7 +117,7 @@
               bind:value={$form.value}
               readonly={saving}
               class="textarea textarea-bordered mt-1 h-48"
-></textarea>
+            ></textarea>
           {:else}
             <input
               onkeydown={onKeydown}
@@ -129,8 +132,8 @@
       </span>
 
       <span class="max-sm:mt-2 flex flew-nowrap gap-2 self-end">
-        <IconButton on:click={submit} loading={saving} icon="i-mdi-check-bold" />
-        <IconButton on:click={cancel} disabled={saving} icon="i-mdi-close-thick" />
+        <IconButton onclick={submit} loading={saving} icon="i-mdi-check-bold" />
+        <IconButton onclick={cancel} disabled={saving} icon="i-mdi-close-thick" />
       </span>
     </span>
   {:else}

--- a/frontend/src/lib/components/EditableText.svelte
+++ b/frontend/src/lib/components/EditableText.svelte
@@ -3,18 +3,29 @@
   import { type ZodString, z } from 'zod';
   import IconButton from './IconButton.svelte';
 
-  export let value: string | undefined | null = undefined;
-  export let disabled = false;
-  export let saveHandler: (newValue: string) => Promise<ErrorMessage>;
-  export let placeholder: string | undefined = undefined;
-  export let multiline = false;
-  export let validation: ZodString = z.string();
+  interface Props {
+    value?: string | undefined | null;
+    disabled?: boolean;
+    saveHandler: (newValue: string) => Promise<ErrorMessage>;
+    placeholder?: string | undefined;
+    multiline?: boolean;
+    validation?: ZodString;
+  }
+
+  let {
+    value = $bindable(undefined),
+    disabled = false,
+    saveHandler,
+    placeholder = undefined,
+    multiline = false,
+    validation = z.string()
+  }: Props = $props();
 
   let initialValue: string | undefined | null;
-  let editing = false;
-  let saving = false;
+  let editing = $state(false);
+  let saving = $state(false);
 
-  let formElem: Form;
+  let formElem: Form = $state();
 
   const formSchema = z.object({ value: validation });
   let { form, errors, reset, enhance, message } = lexSuperForm(
@@ -25,7 +36,7 @@
     },
     { taintedMessage: false },
   );
-  $: error = $errors.value?.join(', ') ?? $message;
+  let error = $derived($errors.value?.join(', ') ?? $message);
 
   function startEditing(): void {
     if (disabled) {
@@ -87,7 +98,7 @@
 <span>
   {#if editing || saving}
     <span class="inline-flex not-prose space-x-2 relative max-sm:flex-col max-w-full max-sm:w-full" class:w-full={multiline}>
-      <!-- svelte-ignore a11y-autofocus -->
+      <!-- svelte-ignore a11y_autofocus -->
       <span
         class="tooltip-error tooltip-open tooltip-bottom"
         class:grow={multiline}
@@ -97,16 +108,16 @@
         <Form bind:this={formElem} {enhance}>
           {#if multiline}
             <textarea
-              on:keydown={onKeydown}
+              onkeydown={onKeydown}
               class:textarea-error={error}
               autofocus
               bind:value={$form.value}
               readonly={saving}
               class="textarea textarea-bordered mt-1 h-48"
-            />
+></textarea>
           {:else}
             <input
-              on:keydown={onKeydown}
+              onkeydown={onKeydown}
               class:input-error={error}
               autofocus
               bind:value={$form.value}
@@ -126,8 +137,8 @@
     <button
       class:hover:bg-base-300={!disabled}
       class="content-wrapper inline-flex items-center cursor-text rounded-lg py-1 px-1.5 -mx-1.5"
-      on:click={startEditing}
-      on:keypress={startEditing}
+      onclick={startEditing}
+      onkeypress={startEditing}
     >
       {#if value}
         <span class="mr-2 whitespace-pre-wrap">{value}</span>
@@ -135,7 +146,7 @@
         <span class="mr-2 opacity-75">{placeholder}</span>
       {/if}
       {#if !disabled}
-        <span class="i-mdi-pencil-outline text-lg text-base-content edit-icon mb-1 self-end" />
+        <span class="i-mdi-pencil-outline text-lg text-base-content edit-icon mb-1 self-end"></span>
       {/if}
     </button>
   {/if}

--- a/frontend/src/lib/components/EditableText.svelte
+++ b/frontend/src/lib/components/EditableText.svelte
@@ -25,7 +25,7 @@
   let editing = $state(false);
   let saving = $state(false);
 
-  let formElem: Form = $state()!;
+  let formElem: Form | undefined = $state();
 
   const formSchema = z.object({ value: validation });
   let { form, errors, reset, enhance, message } = lexSuperForm(
@@ -91,7 +91,7 @@
 
   function submit(): void {
     //triggers callback in superForm with validation
-    formElem.requestSubmit();
+    formElem?.requestSubmit();
   }
 </script>
 

--- a/frontend/src/lib/components/FilterBar/ActiveFilter.svelte
+++ b/frontend/src/lib/components/FilterBar/ActiveFilter.svelte
@@ -2,9 +2,14 @@
   import { ActionBadge } from '../Badges';
   import type { Filter } from './FilterBar.svelte';
 
-  export let filter: Filter;
+  interface Props {
+    filter: Filter;
+    children?: import('svelte').Snippet;
+  }
+
+  let { filter, children }: Props = $props();
 </script>
 
 <ActionBadge actionIcon="i-mdi-close" on:action={filter.clear}>
-  <slot />
+  {@render children?.()}
 </ActionBadge>

--- a/frontend/src/lib/components/FilterBar/ActiveFilter.svelte
+++ b/frontend/src/lib/components/FilterBar/ActiveFilter.svelte
@@ -1,10 +1,11 @@
 <script lang="ts">
+  import type { Snippet } from 'svelte';
   import { ActionBadge } from '../Badges';
   import type { Filter } from './FilterBar.svelte';
 
   interface Props {
     filter: Filter;
-    children?: import('svelte').Snippet;
+    children?: Snippet;
   }
 
   let { filter, children }: Props = $props();

--- a/frontend/src/lib/components/FilterBar/FilterBar.svelte
+++ b/frontend/src/lib/components/FilterBar/FilterBar.svelte
@@ -31,11 +31,6 @@
 
   let searchInput: PlainInput = $state();
 
-  
-  
-
-  
-
   interface Props {
     searchKey: keyof ConditionalPick<DumbFilters, string>;
     autofocus?: true | undefined;
@@ -43,8 +38,8 @@
     filterDefaults: Filters;
     hasActiveFilter?: boolean;
     /**
-   * Explicitly specify the filter object keys that should be used from the `filters` (optional)
-   */
+     * Explicitly specify the filter object keys that should be used from the `filters` (optional)
+     */
     filterKeys?: Readonly<(keyof Filters)[]> | undefined;
     loading?: boolean;
     debounce?: number | boolean;
@@ -64,7 +59,7 @@
     debounce = $bindable(false),
     debouncing = $bindable(false),
     activeFilterSlot,
-    filterSlot
+    filterSlot,
   }: Props = $props();
   let undebouncedSearch: string | undefined = $state(undefined);
 
@@ -112,7 +107,7 @@
 </script>
 
 <div class="input filter-bar input-bordered flex items-center gap-2 py-1.5 px-2 flex-wrap h-[unset] min-h-12">
-  {@render activeFilterSlot?.({ activeFilters, })}
+  {@render activeFilterSlot?.({ activeFilters })}
   <div class="flex grow">
     <PlainInput
       bind:value={$allFilters[searchKey]}
@@ -131,7 +126,7 @@
         </div>
       {/if}
       <!-- The user sees the "undebounced" search value, so the X button should consider that (and not the debounced value) -->
-      {#if !!undebouncedSearch || activeFilters.find(f => f.key !== searchKey)}
+      {#if !!undebouncedSearch || activeFilters.find((f) => f.key !== searchKey)}
         <button class="btn btn-square btn-sm join-item" onclick={onClearFiltersClick}>
           <span class="text-lg">✕</span>
         </button>
@@ -143,12 +138,12 @@
               <span class="i-mdi-filter-outline text-xl"></span>
             </button>
             {#snippet content()}
-                        <div  class="card w-[calc(100vw-1rem)] sm:max-w-[35rem]">
+              <div class="card w-[calc(100vw-1rem)] sm:max-w-[35rem]">
                 <div class="card-body max-sm:p-4">
                   {@render filterSlot?.()}
                 </div>
               </div>
-                      {/snippet}
+            {/snippet}
           </Dropdown>
         </div>
       {/if}

--- a/frontend/src/lib/components/FilterBar/FilterBar.svelte
+++ b/frontend/src/lib/components/FilterBar/FilterBar.svelte
@@ -44,7 +44,7 @@
     loading?: boolean;
     debounce?: number | boolean;
     debouncing?: boolean;
-    activeFilterSlot?: Snippet<unknown[]>;
+    activeFilterSlot?: Snippet<[{ activeFilters: Readonly<Filter<Filters>[]> }]>;
     filterSlot?: Snippet;
   }
 

--- a/frontend/src/lib/components/FilterBar/FilterBar.svelte
+++ b/frontend/src/lib/components/FilterBar/FilterBar.svelte
@@ -29,7 +29,7 @@
     change: Readonly<Filter<Filters>[]>;
   }>();
 
-  let searchInput: PlainInput = $state();
+  let searchInput: PlainInput = $state()!;
 
   interface Props {
     searchKey: keyof ConditionalPick<DumbFilters, string>;
@@ -44,7 +44,7 @@
     loading?: boolean;
     debounce?: number | boolean;
     debouncing?: boolean;
-    activeFilterSlot?: Snippet<[unknown]>;
+    activeFilterSlot?: Snippet<unknown[]>;
     filterSlot?: Snippet;
   }
 
@@ -63,7 +63,7 @@
   }: Props = $props();
   let undebouncedSearch: string | undefined = $state(undefined);
 
-  let activeFilters: Readonly<Filter<Filters>[]> = $state();
+  let activeFilters: Readonly<Filter<Filters>[]> = $state([]);
 
   function onClearFiltersClick(): void {
     searchInput.clear();

--- a/frontend/src/lib/components/FilterBar/FilterBar.svelte
+++ b/frontend/src/lib/components/FilterBar/FilterBar.svelte
@@ -29,7 +29,7 @@
     change: Readonly<Filter<Filters>[]>;
   }>();
 
-  let searchInput: PlainInput = $state()!;
+  let searchInput: PlainInput | undefined = $state();
 
   interface Props {
     searchKey: keyof ConditionalPick<DumbFilters, string>;
@@ -66,6 +66,7 @@
   let activeFilters: Readonly<Filter<Filters>[]> = $state([]);
 
   function onClearFiltersClick(): void {
+    if (!searchInput) return;
     searchInput.clear();
     $allFilters = {
       ...$allFilters,

--- a/frontend/src/lib/components/FilterBar/FilterBar.svelte
+++ b/frontend/src/lib/components/FilterBar/FilterBar.svelte
@@ -44,7 +44,7 @@
     loading?: boolean;
     debounce?: number | boolean;
     debouncing?: boolean;
-    activeFilterSlot?: Snippet<[any]>;
+    activeFilterSlot?: Snippet<[unknown]>;
     filterSlot?: Snippet;
   }
 

--- a/frontend/src/lib/components/FilterBar/FilterBar.svelte
+++ b/frontend/src/lib/components/FilterBar/FilterBar.svelte
@@ -1,9 +1,12 @@
 <script lang="ts" module>
-  export type Filter<T = Record<string, unknown>> = Readonly<NonNullable<
-    {
-      [K in keyof T]: { value: T[K]; key: K & string, clear: () => void };
-    }[keyof T]
-  >>;
+  import type { Snippet } from 'svelte';
+  export type Filter<T = Record<string, unknown>> = Readonly<
+    NonNullable<
+      {
+        [K in keyof T]: { value: T[K]; key: K & string; clear: () => void };
+      }[keyof T]
+    >
+  >;
 </script>
 
 <script lang="ts">
@@ -46,8 +49,8 @@
     loading?: boolean;
     debounce?: number | boolean;
     debouncing?: boolean;
-    activeFilterSlot?: import('svelte').Snippet<[any]>;
-    filterSlot?: import('svelte').Snippet;
+    activeFilterSlot?: Snippet<[any]>;
+    filterSlot?: Snippet;
   }
 
   let {

--- a/frontend/src/lib/components/FilterBar/FilterBar.svelte
+++ b/frontend/src/lib/components/FilterBar/FilterBar.svelte
@@ -1,4 +1,4 @@
-<script lang="ts" context="module">
+<script lang="ts" module>
   export type Filter<T = Record<string, unknown>> = Readonly<NonNullable<
     {
       [K in keyof T]: { value: T[K]; key: K & string, clear: () => void };
@@ -7,6 +7,8 @@
 </script>
 
 <script lang="ts">
+  import { run } from 'svelte/legacy';
+
   import { createEventDispatcher } from 'svelte';
   import type { ConditionalPick } from 'type-fest';
   import Loader from '$lib/components/Loader.svelte';
@@ -24,38 +26,46 @@
     change: Readonly<Filter<Filters>[]>;
   }>();
 
-  let searchInput: PlainInput;
+  let searchInput: PlainInput = $state();
 
-  export let searchKey: keyof ConditionalPick<DumbFilters, string>;
-  export let autofocus: true | undefined = undefined;
-  let allFilters: Writable<Filters>;
-  export { allFilters as filters };
-  let allFilterDefaults: Filters;
-  export { allFilterDefaults as filterDefaults };
-  export let hasActiveFilter: boolean = false;
+  
+  
 
-  /**
+  
+
+  interface Props {
+    searchKey: keyof ConditionalPick<DumbFilters, string>;
+    autofocus?: true | undefined;
+    filters: Writable<Filters>;
+    filterDefaults: Filters;
+    hasActiveFilter?: boolean;
+    /**
    * Explicitly specify the filter object keys that should be used from the `filters` (optional)
    */
-  export let filterKeys: Readonly<(keyof Filters)[]> | undefined = undefined;
-
-  export let loading = false;
-  export let debounce: number | boolean = false;
-  export let debouncing = false;
-  let undebouncedSearch: string | undefined = undefined;
-
-  $: filters = Object.freeze(filterKeys ? pick($allFilters, filterKeys) : $allFilters);
-  $: filterDefaults = Object.freeze(filterKeys ? pick(allFilterDefaults, filterKeys) : allFilterDefaults);
-  let activeFilters: Readonly<Filter<Filters>[]>;
-  $: {
-    const currFilters = activeFilters;
-    const newFilters = pickActiveFilters(filters, filterDefaults);
-    if (JSON.stringify(currFilters) !== JSON.stringify(newFilters)) {
-      activeFilters = newFilters;
-      dispatch('change', activeFilters);
-    }
+    filterKeys?: Readonly<(keyof Filters)[]> | undefined;
+    loading?: boolean;
+    debounce?: number | boolean;
+    debouncing?: boolean;
+    activeFilterSlot?: import('svelte').Snippet<[any]>;
+    filterSlot?: import('svelte').Snippet;
   }
-  $: hasActiveFilter = activeFilters.length > 0;
+
+  let {
+    searchKey,
+    autofocus = undefined,
+    filters: allFilters,
+    filterDefaults: allFilterDefaults,
+    hasActiveFilter = $bindable(false),
+    filterKeys = undefined,
+    loading = false,
+    debounce = $bindable(false),
+    debouncing = $bindable(false),
+    activeFilterSlot,
+    filterSlot
+  }: Props = $props();
+  let undebouncedSearch: string | undefined = $state(undefined);
+
+  let activeFilters: Readonly<Filter<Filters>[]> = $state();
 
   function onClearFiltersClick(): void {
     searchInput.clear();
@@ -83,10 +93,23 @@
     }
     return Object.freeze(filters);
   }
+  let filters = $derived(Object.freeze(filterKeys ? pick($allFilters, filterKeys) : $allFilters));
+  let filterDefaults = $derived(Object.freeze(filterKeys ? pick(allFilterDefaults, filterKeys) : allFilterDefaults));
+  run(() => {
+    const currFilters = activeFilters;
+    const newFilters = pickActiveFilters(filters, filterDefaults);
+    if (JSON.stringify(currFilters) !== JSON.stringify(newFilters)) {
+      activeFilters = newFilters;
+      dispatch('change', activeFilters);
+    }
+  });
+  run(() => {
+    hasActiveFilter = activeFilters.length > 0;
+  });
 </script>
 
 <div class="input filter-bar input-bordered flex items-center gap-2 py-1.5 px-2 flex-wrap h-[unset] min-h-12">
-  <slot name="activeFilterSlot" {activeFilters} />
+  {@render activeFilterSlot?.({ activeFilters, })}
   <div class="flex grow">
     <PlainInput
       bind:value={$allFilters[searchKey]}
@@ -106,21 +129,23 @@
       {/if}
       <!-- The user sees the "undebounced" search value, so the X button should consider that (and not the debounced value) -->
       {#if !!undebouncedSearch || activeFilters.find(f => f.key !== searchKey)}
-        <button class="btn btn-square btn-sm join-item" on:click={onClearFiltersClick}>
+        <button class="btn btn-square btn-sm join-item" onclick={onClearFiltersClick}>
           <span class="text-lg">✕</span>
         </button>
       {/if}
-      {#if $$slots.filterSlot}
+      {#if filterSlot}
         <div class="join-item">
           <Dropdown>
             <button class="btn btn-square join-item btn-sm gap-2" aria-label={$t('filter.aria_open_filters')}>
-              <span class="i-mdi-filter-outline text-xl" />
+              <span class="i-mdi-filter-outline text-xl"></span>
             </button>
-            <div slot="content" class="card w-[calc(100vw-1rem)] sm:max-w-[35rem]">
-              <div class="card-body max-sm:p-4">
-                <slot name="filterSlot" />
+            {#snippet content()}
+                        <div  class="card w-[calc(100vw-1rem)] sm:max-w-[35rem]">
+                <div class="card-body max-sm:p-4">
+                  {@render filterSlot?.()}
+                </div>
               </div>
-            </div>
+                      {/snippet}
           </Dropdown>
         </div>
       {/if}

--- a/frontend/src/lib/components/FormatRetentionPolicy.svelte
+++ b/frontend/src/lib/components/FormatRetentionPolicy.svelte
@@ -2,7 +2,11 @@
   import { RetentionPolicy } from '$lib/gql/types';
   import t from '$lib/i18n';
 
-  export let policy: number | RetentionPolicy;
+  interface Props {
+    policy: number | RetentionPolicy;
+  }
+
+  let { policy }: Props = $props();
 
   const policies: Record<number | RetentionPolicy, string | undefined> = {
     1: $t('retention_policy.language_project'),

--- a/frontend/src/lib/components/HgLogView.svelte
+++ b/frontend/src/lib/components/HgLogView.svelte
@@ -104,13 +104,12 @@
     return paths;
   }
 
-  let expandedLog: ExpandedLogEntry[] = $state();
+  let expandedLog: ExpandedLogEntry[] = $state([]);
 
   function trimEntry(orig: string): string {
     // The [program: version string] part of log entries can get quite long, so let's trim it for the graph
     return orig.replace(logEntryRe, '');
   }
-
 
   let heights: number[] = $state([]);
   run(() => {
@@ -128,8 +127,10 @@
 <table class="table table-zebra">
   <thead>
     <tr class="sticky top-0 z-[1] bg-base-100">
-      <th></th> <!-- No header on train-tracks column -->
-      <th>#</th> <!-- "Revision" is too long -->
+      <th></th>
+      <!-- No header on train-tracks column -->
+      <th>#</th>
+      <!-- "Revision" is too long -->
       <th>{$t('project_page.hg.date_header')}</th>
       <th>{$t('project_page.hg.author_header')}</th>
       <th>{$t('project_page.hg.log_header')}</th>
@@ -173,7 +174,8 @@
   table {
     @apply h-1;
 
-    & tr, td {
+    & tr,
+    td {
       height: 100%;
     }
   }

--- a/frontend/src/lib/components/HgWeb.svelte
+++ b/frontend/src/lib/components/HgWeb.svelte
@@ -1,5 +1,9 @@
 <script lang="ts">
-  export let code: string;
+  interface Props {
+    code: string;
+  }
+
+  let { code }: Props = $props();
   function injectStyles(arg: Event | HTMLIFrameElement): void {
     const iframe = 'target' in arg ? (arg.target as HTMLIFrameElement) : arg;
     iframe.contentDocument?.head.insertAdjacentHTML(
@@ -17,9 +21,9 @@
 
 <iframe
   use:injectStyles
-  on:load={injectStyles}
+  onload={injectStyles}
   src="/api/hg-view/{code}"
   title="HG Web view"
   width="100%"
   height="600px"
-/>
+></iframe>

--- a/frontend/src/lib/components/IconButton.svelte
+++ b/frontend/src/lib/components/IconButton.svelte
@@ -5,8 +5,7 @@
   import type { IconString } from '$lib/icons';
   import Loader from './Loader.svelte';
 
-  
-  let loadingSize = size === 'btn-sm' ? 'loading-xs' as const : undefined;
+
   interface Props {
     // See https://icon-sets.iconify.design/mdi/
     icon: IconString;
@@ -33,6 +32,7 @@
     fake = false,
     ...rest
   }: Props = $props();
+  let loadingSize = size === 'btn-sm' ? 'loading-xs' as const : undefined;
 
   const xlIcons: IconString[] = ['i-mdi-refresh'];
   let textSize = $derived(xlIcons.includes(icon) ? 'text-xl' : 'text-lg');

--- a/frontend/src/lib/components/IconButton.svelte
+++ b/frontend/src/lib/components/IconButton.svelte
@@ -1,7 +1,4 @@
 <script lang="ts">
-  import { createBubbler } from 'svelte/legacy';
-
-  const bubble = createBubbler();
   import type { IconString } from '$lib/icons';
   import Loader from './Loader.svelte';
 

--- a/frontend/src/lib/components/IconButton.svelte
+++ b/frontend/src/lib/components/IconButton.svelte
@@ -13,7 +13,7 @@
     size?: 'btn-sm' | undefined;
     outline?: boolean;
     fake?: boolean; // for display purposes only
-    onclick: () => void;
+    onclick?: () => void;
     [key: string]: unknown;
   }
 

--- a/frontend/src/lib/components/IconButton.svelte
+++ b/frontend/src/lib/components/IconButton.svelte
@@ -1,33 +1,53 @@
 <script lang="ts">
+  import { createBubbler } from 'svelte/legacy';
+
+  const bubble = createBubbler();
   import type { IconString } from '$lib/icons';
   import Loader from './Loader.svelte';
 
-  // See https://icon-sets.iconify.design/mdi/
-  export let icon: IconString;
-  export let disabled = false;
-  export let loading = false;
-  export let active = false;
-  export let join = false;
-  export let variant: 'btn-success' | 'btn-ghost' | 'btn-primary' | undefined = undefined;
-  export let size: 'btn-sm' | undefined = undefined;
+  
   let loadingSize = size === 'btn-sm' ? 'loading-xs' as const : undefined;
-  export let outline = variant !== 'btn-ghost';
-  export let fake = false; // for display purposes only
+  interface Props {
+    // See https://icon-sets.iconify.design/mdi/
+    icon: IconString;
+    disabled?: boolean;
+    loading?: boolean;
+    active?: boolean;
+    join?: boolean;
+    variant?: 'btn-success' | 'btn-ghost' | 'btn-primary' | undefined;
+    size?: 'btn-sm' | undefined;
+    outline?: any;
+    fake?: boolean; // for display purposes only
+    [key: string]: any
+  }
+
+  let {
+    icon,
+    disabled = false,
+    loading = false,
+    active = false,
+    join = false,
+    variant = undefined,
+    size = undefined,
+    outline = variant !== 'btn-ghost',
+    fake = false,
+    ...rest
+  }: Props = $props();
 
   const xlIcons: IconString[] = ['i-mdi-refresh'];
-  $: textSize = xlIcons.includes(icon) ? 'text-xl' : 'text-lg';
+  let textSize = $derived(xlIcons.includes(icon) ? 'text-xl' : 'text-lg');
 </script>
 
 <!-- type="button" ensures the button doen't act as a submit button when in a form -->
-<button type="button" on:click
+<button type="button" onclick={bubble('click')}
   disabled={disabled && !loading}
   class:pointer-events-none={fake || loading}
-  class="btn btn-square {variant ?? ''} {size ?? ''} {$$restProps.class ?? ''}"
+  class="btn btn-square {variant ?? ''} {size ?? ''} {rest.class ?? ''}"
   class:btn-outline={outline}
   class:btn-active={active}
   class:join-item={join}>
   {#if !loading}
-    <span class="{icon} {textSize}" />
+    <span class="{icon} {textSize}"></span>
   {:else}
     <Loader loading size={loadingSize} />
   {/if}

--- a/frontend/src/lib/components/IconButton.svelte
+++ b/frontend/src/lib/components/IconButton.svelte
@@ -5,7 +5,6 @@
   import type { IconString } from '$lib/icons';
   import Loader from './Loader.svelte';
 
-
   interface Props {
     // See https://icon-sets.iconify.design/mdi/
     icon: IconString;
@@ -15,9 +14,9 @@
     join?: boolean;
     variant?: 'btn-success' | 'btn-ghost' | 'btn-primary' | undefined;
     size?: 'btn-sm' | undefined;
-    outline?: any;
+    outline?: boolean;
     fake?: boolean; // for display purposes only
-    [key: string]: any
+    [key: string]: unknown;
   }
 
   let {
@@ -32,20 +31,23 @@
     fake = false,
     ...rest
   }: Props = $props();
-  let loadingSize = size === 'btn-sm' ? 'loading-xs' as const : undefined;
+  let loadingSize = size === 'btn-sm' ? ('loading-xs' as const) : undefined;
 
   const xlIcons: IconString[] = ['i-mdi-refresh'];
   let textSize = $derived(xlIcons.includes(icon) ? 'text-xl' : 'text-lg');
 </script>
 
 <!-- type="button" ensures the button doen't act as a submit button when in a form -->
-<button type="button" onclick={bubble('click')}
+<button
+  type="button"
+  onclick={bubble('click')}
   disabled={disabled && !loading}
   class:pointer-events-none={fake || loading}
   class="btn btn-square {variant ?? ''} {size ?? ''} {rest.class ?? ''}"
   class:btn-outline={outline}
   class:btn-active={active}
-  class:join-item={join}>
+  class:join-item={join}
+>
   {#if !loading}
     <span class="{icon} {textSize}"></span>
   {:else}

--- a/frontend/src/lib/components/IconButton.svelte
+++ b/frontend/src/lib/components/IconButton.svelte
@@ -16,6 +16,7 @@
     size?: 'btn-sm' | undefined;
     outline?: boolean;
     fake?: boolean; // for display purposes only
+    onclick: () => void;
     [key: string]: unknown;
   }
 
@@ -29,6 +30,7 @@
     size = undefined,
     outline = variant !== 'btn-ghost',
     fake = false,
+    onclick,
     ...rest
   }: Props = $props();
   let loadingSize = size === 'btn-sm' ? ('loading-xs' as const) : undefined;
@@ -40,7 +42,7 @@
 <!-- type="button" ensures the button doen't act as a submit button when in a form -->
 <button
   type="button"
-  onclick={bubble('click')}
+  {onclick}
   disabled={disabled && !loading}
   class:pointer-events-none={fake || loading}
   class="btn btn-square {variant ?? ''} {size ?? ''} {rest.class ?? ''}"

--- a/frontend/src/lib/components/Loader.svelte
+++ b/frontend/src/lib/components/Loader.svelte
@@ -1,8 +1,12 @@
 <script lang="ts">
-  export let loading = false;
-  export let size: undefined | 'loading-xs' = undefined;
+  interface Props {
+    loading?: boolean;
+    size?: undefined | 'loading-xs';
+  }
+
+  let { loading = false, size = undefined }: Props = $props();
 </script>
 
 {#if loading}
-  <span class="loading loading-spinner {size ?? ''}" />
+  <span class="loading loading-spinner {size ?? ''}"></span>
 {/if}

--- a/frontend/src/lib/components/Markdown/NewTabLinkMarkdown.svelte
+++ b/frontend/src/lib/components/Markdown/NewTabLinkMarkdown.svelte
@@ -2,7 +2,11 @@
   import Markdown, {type ComponentsMap} from 'svelte-exmarkdown';
   import NewTabLinkRenderer from './NewTabLinkRenderer.svelte';
 
-  export let md: string;
+  interface Props {
+    md: string;
+  }
+
+  let { md }: Props = $props();
   const renderer: ComponentsMap = { a: NewTabLinkRenderer };
 </script>
 

--- a/frontend/src/lib/components/Markdown/NewTabLinkRenderer.svelte
+++ b/frontend/src/lib/components/Markdown/NewTabLinkRenderer.svelte
@@ -1,11 +1,16 @@
 <script lang="ts">
-  export let href: string;
-  export let title: string | undefined = undefined;
+  interface Props {
+    href: string;
+    title?: string | undefined;
+    children?: import('svelte').Snippet;
+  }
+
+  let { href, title = undefined, children }: Props = $props();
 </script>
 
 <a {href} {title} target="_blank" class="external-link link link-hover">
   <!-- &nbsp; prevents the link from ever being at the very beginning of a new line -->
-  <slot />&nbsp;<span class="i-mdi-open-in-new external-link-icon" />
+  {@render children?.()}&nbsp;<span class="i-mdi-open-in-new external-link-icon"></span>
 </a>
 
 <style>

--- a/frontend/src/lib/components/Markdown/NewTabLinkRenderer.svelte
+++ b/frontend/src/lib/components/Markdown/NewTabLinkRenderer.svelte
@@ -1,8 +1,9 @@
 <script lang="ts">
+  import type { Snippet } from 'svelte';
   interface Props {
     href: string;
     title?: string | undefined;
-    children?: import('svelte').Snippet;
+    children?: Snippet;
   }
 
   let { href, title = undefined, children }: Props = $props();

--- a/frontend/src/lib/components/MoreSettings.svelte
+++ b/frontend/src/lib/components/MoreSettings.svelte
@@ -1,16 +1,21 @@
-<script>
+<script lang="ts">
   import t from '$lib/i18n';
 
-  export let column = false;
+  interface Props {
+    column?: boolean;
+    children?: import('svelte').Snippet;
+  }
+
+  let { column = false, children }: Props = $props();
 </script>
 
 <div class="collapse border-2 border-base-200 collapse-arrow mt-4">
   <input type="checkbox" />
   <div class="collapse-title text-lg">{$t('more_settings.title')}</div>
   <div class="collapse-content">
-    <div class="divider mt-0" />
+    <div class="divider mt-0"></div>
     <div class="flex justify-end gap-4 max-sm:flex-col" class:flex-col={column} class:sm:items-end={column}>
-      <slot />
+      {@render children?.()}
     </div>
   </div>
 </div>

--- a/frontend/src/lib/components/MoreSettings.svelte
+++ b/frontend/src/lib/components/MoreSettings.svelte
@@ -1,9 +1,10 @@
 <script lang="ts">
+  import type { Snippet } from 'svelte';
   import t from '$lib/i18n';
 
   interface Props {
     column?: boolean;
-    children?: import('svelte').Snippet;
+    children?: Snippet;
   }
 
   let { column = false, children }: Props = $props();

--- a/frontend/src/lib/components/Orgs/FormatUserOrgRole.svelte
+++ b/frontend/src/lib/components/Orgs/FormatUserOrgRole.svelte
@@ -2,7 +2,11 @@
   import { OrgRole } from '$lib/gql/types';
   import t from '$lib/i18n';
 
-  export let role: OrgRole;
+  interface Props {
+    role: OrgRole;
+  }
+
+  let { role }: Props = $props();
 
   const roles: Record<OrgRole, string | undefined> = {
     [OrgRole.Admin]: $t('org_role.admin'),
@@ -10,7 +14,7 @@
     [OrgRole.Unknown]: $t('unknown'),
   };
 
-  $: _role = roles[role];
+  let _role = $derived(roles[role]);
 </script>
 
 {_role ?? $t('unknown')}

--- a/frontend/src/lib/components/PasswordStrengthMeter.svelte
+++ b/frontend/src/lib/components/PasswordStrengthMeter.svelte
@@ -1,5 +1,4 @@
 <script lang="ts">
-  import { untrack } from 'svelte';
   import zxcvbn from 'zxcvbn';
 
   // zxcvbn password strength is an int between 0 and 4 inclusive
@@ -15,24 +14,19 @@
     // Set threshholds for "bad" and "poor" by changing the values below
     bad?: number;
     poor?: number;
-    score: number;
+    onScoreUpdated?: (score: number) => void;
+    scoreOverride?: number;
     password?: string;
   }
 
-  let {
-    bad = 0,
-    poor = 2,
-    score = $bindable(),
-    password = ''
-  }: Props = $props();
+  let { bad = 0, poor = 2, onScoreUpdated, scoreOverride, password = '' }: Props = $props();
 
   let strength = $derived(zxcvbn(password));
-  $effect(() => {
-    score = untrack(() => strength.score);
-  });
+  let score = $derived(scoreOverride ?? strength.score);
+  $effect(() => onScoreUpdated?.(score));
   let progressColor = $derived(passwordStrengthColor(score));
 </script>
 
 <div class="mb-2">
-  <progress class="progress {progressColor} w-100" value={score+0.33} max={4.33}></progress>
+  <progress class="progress {progressColor} w-100" value={score + 0.33} max={4.33}></progress>
 </div>

--- a/frontend/src/lib/components/PasswordStrengthMeter.svelte
+++ b/frontend/src/lib/components/PasswordStrengthMeter.svelte
@@ -1,12 +1,9 @@
 <script lang="ts">
-  import { run } from 'svelte/legacy';
-
+  import { untrack } from 'svelte';
   import zxcvbn from 'zxcvbn';
 
   // zxcvbn password strength is an int between 0 and 4 inclusive
   // Feedback colors are red for bad passwords, yellow for poor, green for good
-  
-
 
   function passwordStrengthColor(score: number): 'progress-error' | 'progress-warning' | 'progress-success' {
     if (score <= bad) return 'progress-error';
@@ -30,8 +27,8 @@
   }: Props = $props();
 
   let strength = $derived(zxcvbn(password));
-  run(() => {
-    score = strength.score;
+  $effect(() => {
+    score = untrack(() => strength.score);
   });
   let progressColor = $derived(passwordStrengthColor(score));
 </script>

--- a/frontend/src/lib/components/PasswordStrengthMeter.svelte
+++ b/frontend/src/lib/components/PasswordStrengthMeter.svelte
@@ -1,13 +1,12 @@
 <script lang="ts">
+  import { run } from 'svelte/legacy';
+
   import zxcvbn from 'zxcvbn';
 
   // zxcvbn password strength is an int between 0 and 4 inclusive
   // Feedback colors are red for bad passwords, yellow for poor, green for good
-  // Set threshholds for "bad" and "poor" by changing the values below
-  export let bad = 0;
-  export let poor = 2;
+  
 
-  export let score: number;
 
   function passwordStrengthColor(score: number): 'progress-error' | 'progress-warning' | 'progress-success' {
     if (score <= bad) return 'progress-error';
@@ -15,13 +14,28 @@
     return 'progress-success';
   }
 
-  export let password: string = '';
+  interface Props {
+    // Set threshholds for "bad" and "poor" by changing the values below
+    bad?: number;
+    poor?: number;
+    score: number;
+    password?: string;
+  }
 
-  $: strength = zxcvbn(password);
-  $: score = strength.score;
-  $: progressColor = passwordStrengthColor(score);
+  let {
+    bad = 0,
+    poor = 2,
+    score = $bindable(),
+    password = ''
+  }: Props = $props();
+
+  let strength = $derived(zxcvbn(password));
+  run(() => {
+    score = strength.score;
+  });
+  let progressColor = $derived(passwordStrengthColor(score));
 </script>
 
 <div class="mb-2">
-  <progress class="progress {progressColor} w-100" value={score+0.33} max={4.33} />
+  <progress class="progress {progressColor} w-100" value={score+0.33} max={4.33}></progress>
 </div>

--- a/frontend/src/lib/components/ProjectList.svelte
+++ b/frontend/src/lib/components/ProjectList.svelte
@@ -6,14 +6,18 @@
   import { getProjectTypeIcon } from './ProjectType';
   import type { ProjectItemWithDraftStatus } from './Projects';
 
-  export let projects: ProjectItemWithDraftStatus[];
+  interface Props {
+    projects: ProjectItemWithDraftStatus[];
+  }
+
+  let { projects }: Props = $props();
 </script>
 
 <div class="grid grid-cols-1 xs:grid-cols-2 sm:grid-cols-3 auto-rows-fr gap-2 md:gap-4 max-xs:justify-items-center">
   {#each projects as project}
     {#if project.isDraft}
       <div class="draft card aspect-square bg-base-200 overflow-hidden">
-        <div class="bg" style="background-image: url('{getProjectTypeIcon(project.type)}')" />
+        <div class="bg" style="background-image: url('{getProjectTypeIcon(project.type)}')"></div>
         <div class="card-body z-[1] max-sm:p-6">
           <h2 class="card-title overflow-hidden text-ellipsis" title={project.name}>
             <span class="text-primary inline-flex gap-2 items-center">
@@ -35,7 +39,7 @@
       </div>
     {:else}
       <a class="card aspect-square bg-base-200 shadow-base-300 overflow-hidden" href={projectUrl(project)}>
-        <div class="bg" style="background-image: url('{getProjectTypeIcon(project.type)}')" />
+        <div class="bg" style="background-image: url('{getProjectTypeIcon(project.type)}')"></div>
         <div class="card-body z-[1] max-sm:p-6">
           <h2 class="card-title overflow-hidden text-ellipsis" title={project.name}>
             <span class="text-primary inline-flex gap-2 items-center">
@@ -44,7 +48,7 @@
           </h2>
           <p>{project.code}</p>
             <p>
-              <span class="i-mdi-account text-xl mb-[-4px]" /> {project.userCount}
+              <span class="i-mdi-account text-xl mb-[-4px]"></span> {project.userCount}
             </p>
             <p class="flex items-end">
               {#if project.lastCommit}

--- a/frontend/src/lib/components/ProjectType/FormatProjectType.svelte
+++ b/frontend/src/lib/components/ProjectType/FormatProjectType.svelte
@@ -1,4 +1,4 @@
-<script context="module" lang="ts">
+<script module lang="ts">
   import { ProjectType } from '$lib/gql/types';
   import t, { type I18nKey } from '$lib/i18n';
 
@@ -17,7 +17,11 @@
 </script>
 
 <script lang="ts">
-  export let type: ProjectType;
+  interface Props {
+    type: ProjectType;
+  }
+
+  let { type }: Props = $props();
 </script>
 
 {$t(getProjectTypeI18nKey(type))}

--- a/frontend/src/lib/components/ProjectType/ProjectTypeBadge.svelte
+++ b/frontend/src/lib/components/ProjectType/ProjectTypeBadge.svelte
@@ -4,7 +4,11 @@
   import type { ProjectType } from '$lib/gql/types';
   import { Badge } from '../Badges';
 
-  export let type: ProjectType;
+  interface Props {
+    type: ProjectType;
+  }
+
+  let { type }: Props = $props();
 </script>
 
 <Badge>

--- a/frontend/src/lib/components/ProjectType/ProjectTypeIcon.svelte
+++ b/frontend/src/lib/components/ProjectType/ProjectTypeIcon.svelte
@@ -1,4 +1,4 @@
-<script lang="ts" context="module">
+<script lang="ts" module>
   import {ProjectType} from '$lib/gql/types';
   import flexLogo from '$lib/assets/flex-logo.png';
   import oneStoryLogo from '$lib/assets/onestory-editor-logo.svg';
@@ -24,14 +24,18 @@
 <script lang="ts">
   import t from '$lib/i18n';
 
-  export let type: ProjectType | undefined;
-  export let size = 'h-6';
+  interface Props {
+    type: ProjectType | undefined;
+    size?: string;
+  }
 
-  $: src = getProjectTypeIcon(type);
+  let { type, size = 'h-6' }: Props = $props();
+
+  let src = $derived(getProjectTypeIcon(type));
 </script>
 
 {#if src}
   <img {src} alt={$t('project_type.logo', { type: type ?? ProjectType.Unknown })} class={size}>
 {:else if type}
-  <span class="i-mdi-help-circle-outline text-2xl" />
+  <span class="i-mdi-help-circle-outline text-2xl"></span>
 {/if}

--- a/frontend/src/lib/components/Projects/FlexModelVersionText.svelte
+++ b/frontend/src/lib/components/Projects/FlexModelVersionText.svelte
@@ -1,4 +1,4 @@
-<script context="module" lang="ts">
+<script module lang="ts">
   import { NULL_LABEL } from '$lib/i18n';
 
   const versionLookupTable: Record<number, string> = {
@@ -23,8 +23,12 @@
 
 <script lang="ts">
 
-  export let modelVersion: number;
-  $: fwModel = versionLookupTable[modelVersion] ?? 'Unknown FieldWorks version';
+  interface Props {
+    modelVersion: number;
+  }
+
+  let { modelVersion }: Props = $props();
+  let fwModel = $derived(versionLookupTable[modelVersion] ?? 'Unknown FieldWorks version');
 </script>
 
 <span title="FieldWorks data model {modelVersion}" class="text-secondary">{fwModel}</span>

--- a/frontend/src/lib/components/Projects/FormatUserProjectRole.svelte
+++ b/frontend/src/lib/components/Projects/FormatUserProjectRole.svelte
@@ -2,7 +2,11 @@
   import { ProjectRole } from '$lib/gql/types';
   import t from '$lib/i18n';
 
-  export let role: ProjectRole;
+  interface Props {
+    role: ProjectRole;
+  }
+
+  let { role }: Props = $props();
 
   const roles: Record<ProjectRole, string | undefined> = {
     [ProjectRole.Manager]: $t('project_role.manager'),
@@ -10,7 +14,7 @@
     [ProjectRole.Unknown]: $t('unknown'),
   };
 
-  $: _role = roles[role];
+  let _role = $derived(roles[role]);
 </script>
 
 {_role ?? $t('unknown')}

--- a/frontend/src/lib/components/Projects/ProjectConfidentialityCombobox.svelte
+++ b/frontend/src/lib/components/Projects/ProjectConfidentialityCombobox.svelte
@@ -5,7 +5,11 @@
   import { Icon } from '$lib/icons';
   import {NewTabLinkMarkdown} from '$lib/components/Markdown';
 
-  export let value: boolean;
+  interface Props {
+    value: boolean;
+  }
+
+  let { value = $bindable() }: Props = $props();
 </script>
 
 <Checkbox

--- a/frontend/src/lib/components/Projects/ProjectConfidentialityFilterSelect.svelte
+++ b/frontend/src/lib/components/Projects/ProjectConfidentialityFilterSelect.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import { Select } from '$lib/forms';
-  import { type Props as SelectProps } from '$lib/forms/Select.svelte';
+  import { type SelectProps } from '$lib/forms/Select.svelte';
   import t, { type I18nKey } from '$lib/i18n';
   import { helpLinks } from '../help';
   import type { Confidentiality } from './ProjectFilter.svelte';

--- a/frontend/src/lib/components/Projects/ProjectConfidentialityFilterSelect.svelte
+++ b/frontend/src/lib/components/Projects/ProjectConfidentialityFilterSelect.svelte
@@ -4,8 +4,13 @@
   import { helpLinks } from '../help';
   import type { Confidentiality } from './ProjectFilter.svelte';
 
-  // eslint-disable-next-line @typescript-eslint/no-redundant-type-constituents -- false positive
-  export let value: Confidentiality | undefined;
+  
+  interface Props {
+    // eslint-disable-next-line @typescript-eslint/no-redundant-type-constituents -- false positive
+    value: Confidentiality | undefined;
+  }
+
+  let { value = $bindable() }: Props = $props();
   const options: Record<Confidentiality, I18nKey> = {
     true: 'project.confidential.confidential',
     false: 'project.confidential.not_confidential',

--- a/frontend/src/lib/components/Projects/ProjectConfidentialityFilterSelect.svelte
+++ b/frontend/src/lib/components/Projects/ProjectConfidentialityFilterSelect.svelte
@@ -5,7 +5,7 @@
   import { helpLinks } from '../help';
   import type { Confidentiality } from './ProjectFilter.svelte';
 
-  interface Props extends SelectProps {
+  interface Props extends Omit<SelectProps, 'label'> {
     // eslint-disable-next-line @typescript-eslint/no-redundant-type-constituents -- false positive
     value: Confidentiality | undefined;
   }

--- a/frontend/src/lib/components/Projects/ProjectConfidentialityFilterSelect.svelte
+++ b/frontend/src/lib/components/Projects/ProjectConfidentialityFilterSelect.svelte
@@ -1,15 +1,16 @@
 <script lang="ts">
   import { Select } from '$lib/forms';
+  import { type Props as SelectProps } from '$lib/forms/Select.svelte';
   import t, { type I18nKey } from '$lib/i18n';
   import { helpLinks } from '../help';
   import type { Confidentiality } from './ProjectFilter.svelte';
 
-  interface Props {
+  interface Props extends SelectProps {
     // eslint-disable-next-line @typescript-eslint/no-redundant-type-constituents -- false positive
     value: Confidentiality | undefined;
   }
 
-  let { value = $bindable() }: Props = $props();
+  let { value = $bindable(), ...rest }: Props = $props();
   const options: Record<Confidentiality, I18nKey> = {
     true: 'project.confidential.confidential',
     false: 'project.confidential.not_confidential',
@@ -18,8 +19,7 @@
 </script>
 
 <div class="relative">
-  <!-- TODO: Used to have an on:change attribute below, let's remove it and see if the bubbler function works as it should -->
-  <Select label={$t('project.confidential.confidentiality')} helpLink={helpLinks.confidentiality} bind:value>
+  <Select {...rest} label={$t('project.confidential.confidentiality')} helpLink={helpLinks.confidentiality} bind:value>
     <option value={undefined}>{$t('common.any')}</option>
     {#each Object.entries(options) as [value, label]}
       <option {value}>{$t(label)}</option>

--- a/frontend/src/lib/components/Projects/ProjectConfidentialityFilterSelect.svelte
+++ b/frontend/src/lib/components/Projects/ProjectConfidentialityFilterSelect.svelte
@@ -18,10 +18,11 @@
 </script>
 
 <div class="relative">
-  <Select label={$t('project.confidential.confidentiality')} helpLink={helpLinks.confidentiality} bind:value on:change>
+  <!-- TODO: Used to have an on:change attribute below, let's remove it and see if the bubbler function works as it should -->
+  <Select label={$t('project.confidential.confidentiality')} helpLink={helpLinks.confidentiality} bind:value>
     <option value={undefined}>{$t('common.any')}</option>
     {#each Object.entries(options) as [value, label]}
-      <option value={value}>{$t(label)}</option>
+      <option {value}>{$t(label)}</option>
     {/each}
   </Select>
 </div>

--- a/frontend/src/lib/components/Projects/ProjectConfidentialityFilterSelect.svelte
+++ b/frontend/src/lib/components/Projects/ProjectConfidentialityFilterSelect.svelte
@@ -4,7 +4,6 @@
   import { helpLinks } from '../help';
   import type { Confidentiality } from './ProjectFilter.svelte';
 
-  
   interface Props {
     // eslint-disable-next-line @typescript-eslint/no-redundant-type-constituents -- false positive
     value: Confidentiality | undefined;

--- a/frontend/src/lib/components/Projects/ProjectFilter.svelte
+++ b/frontend/src/lib/components/Projects/ProjectFilter.svelte
@@ -1,4 +1,4 @@
-<script context="module" lang="ts">
+<script module lang="ts">
   import {type Project, type ProjectType} from '$lib/gql/types';
   import type {DraftProject} from '../../../routes/(authenticated)/admin/+page';
 
@@ -54,12 +54,23 @@
   import BypassCloudflareEmailObfuscation from '$lib/components/BypassCloudflareEmailObfuscation.svelte';
 
   type Filters = Partial<ProjectFilters> & Pick<ProjectFilters, 'projectSearch'>;
-  export let filters: Writable<Filters>;
-  export let filterDefaults: Filters;
-  export let hasActiveFilter: boolean = false;
-  export let autofocus: true | undefined = undefined;
-  export let filterKeys: (keyof Filters)[] = ['projectSearch', 'projectType', 'confidential', 'showDeletedProjects', 'memberSearch', 'hideDraftProjects', 'emptyProjects'];
-  export let loading = false;
+  interface Props {
+    filters: Writable<Filters>;
+    filterDefaults: Filters;
+    hasActiveFilter?: boolean;
+    autofocus?: true | undefined;
+    filterKeys?: (keyof Filters)[];
+    loading?: boolean;
+  }
+
+  let {
+    filters,
+    filterDefaults,
+    hasActiveFilter = $bindable(false),
+    autofocus = undefined,
+    filterKeys = ['projectSearch', 'projectType', 'confidential', 'showDeletedProjects', 'memberSearch', 'hideDraftProjects', 'emptyProjects'],
+    loading = false
+  }: Props = $props();
 
   function filterEnabled(filter: keyof Filters): boolean {
     return filterKeys.includes(filter);
@@ -67,128 +78,132 @@
 </script>
 
 <FilterBar on:change searchKey="projectSearch" {autofocus} {filters} {filterDefaults} bind:hasActiveFilter {filterKeys} {loading}>
-  <svelte:fragment slot="activeFilterSlot" let:activeFilters>
-    {#each activeFilters as filter}
-      {#if filter.key === 'projectType'}
-        <ActiveFilter {filter}>
-          <ProjectTypeIcon type={filter.value} />
-        </ActiveFilter>
-      {:else if filter.key === 'confidential' && filter.value}
-        <ActiveFilter {filter}>
-          {#if filter.value === 'true'}
-            <Icon icon="i-mdi-shield-lock-outline" color="text-warning" />
-            {$t('project.confidential.confidential')}
-          {:else if filter.value === 'false'}
-            <Icon icon="i-mdi-shield-lock-open-outline" />
-            {$t('project.confidential.not_confidential')}
-          {:else}
-            <Icon icon="i-mdi-shield-lock-outline" color="text-warning" />
-            {$t('project.confidential.unspecified')}
-          {/if}
-        </ActiveFilter>
-      {:else if filter.key === 'showDeletedProjects' && filter.value}
-        <ActiveFilter {filter}>
-          <TrashIcon color="text-error" />
-          {$t('project.filter.show_deleted')}
-        </ActiveFilter>
-      {:else if filter.key === 'memberSearch' && filter.value}
-        <ActiveFilter {filter}>
-          <AuthenticatedUserIcon />
-            <BypassCloudflareEmailObfuscation>
-              {filter.value}
-            </BypassCloudflareEmailObfuscation>
-        </ActiveFilter>
-      {:else if filter.key === 'hideDraftProjects' && filter.value}
-        <ActiveFilter {filter}>
-          <Icon icon="i-mdi-script" color="text-warning" />
-          {$t('project.filter.hide_drafts')}
-        </ActiveFilter>
-      {:else if filter.key === 'emptyProjects' && filter.value}
-        <ActiveFilter {filter}>
-          <Icon icon="i-mdi-file-hidden" />
-          {$t('project.filter.empty')}
-        </ActiveFilter>
-      {/if}
-    {/each}
-  </svelte:fragment>
-  <svelte:fragment slot="filterSlot">
-    <h2 class="card-title">{$t('project.filter.title')}</h2>
-    {#if filterEnabled('memberSearch')}
-      <FormField label={$t('project.filter.project_member')}>
-        {#if $filters.memberSearch}
-          <div class="join">
-            <input
-              class="input input-bordered join-item flex-grow"
-              readonly
-              value={$filters.memberSearch}
-            />
-            <div class="join-item isolate">
-              <IconButton icon="i-mdi-close" on:click={() => ($filters.memberSearch = undefined)} />
-            </div>
-          </div>
-        {:else}
-          <div class="alert alert-info gap-2">
-            <Icon icon="i-mdi-information-outline" size="text-2xl" />
-            <div>
-              <span class="mr-1">{$t('project.filter.select_user_from_table')}</span>
-              <span class="btn btn-sm btn-square pointer-events-none">
-                <span class="i-mdi-dots-vertical"></span>
-              </span>
-              <span class="i-mdi-chevron-right"></span>
-              <span class="btn btn-sm pointer-events-none normal-case font-normal">
-                <span class="i-mdi-filter-outline mr-1"></span>
-                {$t('project.filter.filter_user_projects')}
-              </span>
-            </div>
-          </div>
-        {/if}
-      </FormField>
-    {/if}
-    {#if filterEnabled('projectType')}
-      <div class="form-control">
-        <ProjectTypeSelect bind:value={$filters.projectType} undefinedOptionLabel={$t('common.any')} includeUnknown />
-      </div>
-    {/if}
-    {#if filterEnabled('confidential')}
-      <div class="form-control">
-        <ProjectConfidentialityFilterSelect bind:value={$filters.confidential} />
-      </div>
-    {/if}
-    {#if filterEnabled('showDeletedProjects')}
-      <div class="form-control">
-        <label class="cursor-pointer label gap-4">
-          <span class="label-text inline-flex items-center gap-2">
-            {$t('project.filter.show_deleted')}
+  {#snippet activeFilterSlot({ activeFilters })}
+  
+      {#each activeFilters as filter}
+        {#if filter.key === 'projectType'}
+          <ActiveFilter {filter}>
+            <ProjectTypeIcon type={filter.value} />
+          </ActiveFilter>
+        {:else if filter.key === 'confidential' && filter.value}
+          <ActiveFilter {filter}>
+            {#if filter.value === 'true'}
+              <Icon icon="i-mdi-shield-lock-outline" color="text-warning" />
+              {$t('project.confidential.confidential')}
+            {:else if filter.value === 'false'}
+              <Icon icon="i-mdi-shield-lock-open-outline" />
+              {$t('project.confidential.not_confidential')}
+            {:else}
+              <Icon icon="i-mdi-shield-lock-outline" color="text-warning" />
+              {$t('project.confidential.unspecified')}
+            {/if}
+          </ActiveFilter>
+        {:else if filter.key === 'showDeletedProjects' && filter.value}
+          <ActiveFilter {filter}>
             <TrashIcon color="text-error" />
-          </span>
-          <input bind:checked={$filters.showDeletedProjects} type="checkbox" class="toggle toggle-error" />
-        </label>
-      </div>
-    {/if}
-    {#if filterEnabled('hideDraftProjects')}
-      <div class="form-control">
-        <label class="cursor-pointer label gap-4">
-          <span class="label-text inline-flex items-center gap-2">
-            <span>
-              {$t('project.filter.hide_drafts')}
-              <SupHelp helpLink={helpLinks.projectRequest} />
-            </span>
+            {$t('project.filter.show_deleted')}
+          </ActiveFilter>
+        {:else if filter.key === 'memberSearch' && filter.value}
+          <ActiveFilter {filter}>
+            <AuthenticatedUserIcon />
+              <BypassCloudflareEmailObfuscation>
+                {filter.value}
+              </BypassCloudflareEmailObfuscation>
+          </ActiveFilter>
+        {:else if filter.key === 'hideDraftProjects' && filter.value}
+          <ActiveFilter {filter}>
             <Icon icon="i-mdi-script" color="text-warning" />
-          </span>
-          <input bind:checked={$filters.hideDraftProjects} type="checkbox" class="toggle toggle-warning" />
-        </label>
-      </div>
-    {/if}
-    {#if filterEnabled('emptyProjects')}
-      <div class="form-control">
-        <label class="cursor-pointer label gap-4">
-          <span class="label-text inline-flex items-center gap-2">
-            {$t('project.filter.show_empty')}
+            {$t('project.filter.hide_drafts')}
+          </ActiveFilter>
+        {:else if filter.key === 'emptyProjects' && filter.value}
+          <ActiveFilter {filter}>
             <Icon icon="i-mdi-file-hidden" />
-          </span>
-          <input bind:checked={$filters.emptyProjects} type="checkbox" class="toggle toggle-warning" />
-        </label>
-      </div>
-    {/if}
-  </svelte:fragment>
+            {$t('project.filter.empty')}
+          </ActiveFilter>
+        {/if}
+      {/each}
+    
+  {/snippet}
+  {#snippet filterSlot()}
+  
+      <h2 class="card-title">{$t('project.filter.title')}</h2>
+      {#if filterEnabled('memberSearch')}
+        <FormField label={$t('project.filter.project_member')}>
+          {#if $filters.memberSearch}
+            <div class="join">
+              <input
+                class="input input-bordered join-item flex-grow"
+                readonly
+                value={$filters.memberSearch}
+              />
+              <div class="join-item isolate">
+                <IconButton icon="i-mdi-close" on:click={() => ($filters.memberSearch = undefined)} />
+              </div>
+            </div>
+          {:else}
+            <div class="alert alert-info gap-2">
+              <Icon icon="i-mdi-information-outline" size="text-2xl" />
+              <div>
+                <span class="mr-1">{$t('project.filter.select_user_from_table')}</span>
+                <span class="btn btn-sm btn-square pointer-events-none">
+                  <span class="i-mdi-dots-vertical"></span>
+                </span>
+                <span class="i-mdi-chevron-right"></span>
+                <span class="btn btn-sm pointer-events-none normal-case font-normal">
+                  <span class="i-mdi-filter-outline mr-1"></span>
+                  {$t('project.filter.filter_user_projects')}
+                </span>
+              </div>
+            </div>
+          {/if}
+        </FormField>
+      {/if}
+      {#if filterEnabled('projectType')}
+        <div class="form-control">
+          <ProjectTypeSelect bind:value={$filters.projectType} undefinedOptionLabel={$t('common.any')} includeUnknown />
+        </div>
+      {/if}
+      {#if filterEnabled('confidential')}
+        <div class="form-control">
+          <ProjectConfidentialityFilterSelect bind:value={$filters.confidential} />
+        </div>
+      {/if}
+      {#if filterEnabled('showDeletedProjects')}
+        <div class="form-control">
+          <label class="cursor-pointer label gap-4">
+            <span class="label-text inline-flex items-center gap-2">
+              {$t('project.filter.show_deleted')}
+              <TrashIcon color="text-error" />
+            </span>
+            <input bind:checked={$filters.showDeletedProjects} type="checkbox" class="toggle toggle-error" />
+          </label>
+        </div>
+      {/if}
+      {#if filterEnabled('hideDraftProjects')}
+        <div class="form-control">
+          <label class="cursor-pointer label gap-4">
+            <span class="label-text inline-flex items-center gap-2">
+              <span>
+                {$t('project.filter.hide_drafts')}
+                <SupHelp helpLink={helpLinks.projectRequest} />
+              </span>
+              <Icon icon="i-mdi-script" color="text-warning" />
+            </span>
+            <input bind:checked={$filters.hideDraftProjects} type="checkbox" class="toggle toggle-warning" />
+          </label>
+        </div>
+      {/if}
+      {#if filterEnabled('emptyProjects')}
+        <div class="form-control">
+          <label class="cursor-pointer label gap-4">
+            <span class="label-text inline-flex items-center gap-2">
+              {$t('project.filter.show_empty')}
+              <Icon icon="i-mdi-file-hidden" />
+            </span>
+            <input bind:checked={$filters.emptyProjects} type="checkbox" class="toggle toggle-warning" />
+          </label>
+        </div>
+      {/if}
+    
+  {/snippet}
 </FilterBar>

--- a/frontend/src/lib/components/Projects/ProjectTable.svelte
+++ b/frontend/src/lib/components/Projects/ProjectTable.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import type { Snippet } from 'svelte';
   import t, { date, number } from '$lib/i18n';
   import { getProjectTypeI18nKey, ProjectTypeIcon } from '$lib/components/ProjectType';
   import TrashIcon from '$lib/icons/TrashIcon.svelte';
@@ -12,7 +13,7 @@
   interface Props {
     projects: ProjectItemWithDraftStatus[];
     columns?: Readonly<ProjectTableColumn[]>;
-    actions?: import('svelte').Snippet<[any]>;
+    actions?: Snippet<[any]>;
   }
 
   let { projects, columns = allColumns, actions }: Props = $props();

--- a/frontend/src/lib/components/Projects/ProjectTable.svelte
+++ b/frontend/src/lib/components/Projects/ProjectTable.svelte
@@ -6,11 +6,16 @@
   import Icon from '$lib/icons/Icon.svelte';
   import {projectUrl} from '$lib/util/project';
 
-  export let projects: ProjectItemWithDraftStatus[];
 
   const allColumns = ['name', 'code', 'users', 'createdAt', 'lastChange', 'type', 'actions'] as const;
   type ProjectTableColumn = typeof allColumns extends Readonly<Array<infer T>> ? T : never;
-  export let columns: Readonly<ProjectTableColumn[]> = allColumns;
+  interface Props {
+    projects: ProjectItemWithDraftStatus[];
+    columns?: Readonly<ProjectTableColumn[]>;
+    actions?: import('svelte').Snippet<[any]>;
+  }
+
+  let { projects, columns = allColumns, actions }: Props = $props();
 
   function isColumnVisible(column: ProjectTableColumn): boolean {
     return columns.includes(column);
@@ -33,7 +38,7 @@
         {#if isColumnVisible('createdAt')}
           <th class="hidden @xl:table-cell">
             {$t('project.table.created_at')}
-            <span class="i-mdi-sort-descending text-xl align-[-5px] ml-2" />
+            <span class="i-mdi-sort-descending text-xl align-[-5px] ml-2"></span>
           </th>
         {/if}
         {#if isColumnVisible('lastChange')}
@@ -44,8 +49,8 @@
         {#if isColumnVisible('type')}
           <th>{$t('project.table.type')}</th>
         {/if}
-        {#if $$slots.actions}
-          <th />
+        {#if actions}
+          <th></th>
         {/if}
       </tr>
     </thead>
@@ -119,8 +124,8 @@
               </span>
             </td>
           {/if}
-          {#if $$slots.actions}
-            <slot name="actions" {project} />
+          {#if actions}
+            {@render actions?.({ project, })}
           {/if}
         </tr>
       {/each}

--- a/frontend/src/lib/components/Projects/ProjectTable.svelte
+++ b/frontend/src/lib/components/Projects/ProjectTable.svelte
@@ -12,7 +12,7 @@
   interface Props {
     projects: ProjectItemWithDraftStatus[];
     columns?: Readonly<ProjectTableColumn[]>;
-    actions?: Snippet<[unknown]>;
+    actions?: Snippet<[{ project: ProjectItemWithDraftStatus }]>;
   }
 
   let { projects, columns = allColumns, actions }: Props = $props();

--- a/frontend/src/lib/components/Projects/ProjectTable.svelte
+++ b/frontend/src/lib/components/Projects/ProjectTable.svelte
@@ -5,8 +5,7 @@
   import TrashIcon from '$lib/icons/TrashIcon.svelte';
   import type { ProjectItemWithDraftStatus } from '$lib/components/Projects';
   import Icon from '$lib/icons/Icon.svelte';
-  import {projectUrl} from '$lib/util/project';
-
+  import { projectUrl } from '$lib/util/project';
 
   const allColumns = ['name', 'code', 'users', 'createdAt', 'lastChange', 'type', 'actions'] as const;
   type ProjectTableColumn = typeof allColumns extends Readonly<Array<infer T>> ? T : never;
@@ -67,7 +66,8 @@
                   </a>
                   <span
                     class="tooltip text-warning text-xl shrink-0 leading-0"
-                    data-tip={$t('admin_dashboard.is_draft')}>
+                    data-tip={$t('admin_dashboard.is_draft')}
+                  >
                     <Icon icon="i-mdi-script" />
                   </span>
                 {:else if project.deletedDate}
@@ -83,7 +83,8 @@
                 {#if project.isConfidential}
                   <span
                     class="tooltip text-warning text-xl shrink-0 leading-0"
-                    data-tip={$t('project.confidential.confidential')}>
+                    data-tip={$t('project.confidential.confidential')}
+                  >
                     <Icon icon="i-mdi-shield-lock-outline" color="text-warning" />
                   </span>
                 {/if}
@@ -126,7 +127,7 @@
             </td>
           {/if}
           {#if actions}
-            {@render actions?.({ project, })}
+            {@render actions?.({ project })}
           {/if}
         </tr>
       {/each}

--- a/frontend/src/lib/components/Projects/ProjectTable.svelte
+++ b/frontend/src/lib/components/Projects/ProjectTable.svelte
@@ -12,7 +12,7 @@
   interface Props {
     projects: ProjectItemWithDraftStatus[];
     columns?: Readonly<ProjectTableColumn[]>;
-    actions?: Snippet<[any]>;
+    actions?: Snippet<[unknown]>;
   }
 
   let { projects, columns = allColumns, actions }: Props = $props();

--- a/frontend/src/lib/components/Projects/WritingSystemBadge.svelte
+++ b/frontend/src/lib/components/Projects/WritingSystemBadge.svelte
@@ -1,13 +1,21 @@
 <script lang="ts">
+  import { run } from 'svelte/legacy';
+
   import { Badge } from '../Badges';
   import type { BadgeVariant } from '../Badges/Badge.svelte';
 
-  export let tag: string;
-  export let isActive: boolean;
-  export let isDefault: boolean;
+  interface Props {
+    tag: string;
+    isActive: boolean;
+    isDefault: boolean;
+  }
 
-  let variant: BadgeVariant = 'badge-info';
-  $: variant = isActive ? (isDefault ? 'badge-primary' : 'badge-info') : 'badge-neutral';
+  let { tag, isActive, isDefault }: Props = $props();
+
+  let variant: BadgeVariant = $state('badge-info');
+  run(() => {
+    variant = isActive ? (isDefault ? 'badge-primary' : 'badge-info') : 'badge-neutral';
+  });
 
 </script>
 

--- a/frontend/src/lib/components/Projects/WritingSystemBadge.svelte
+++ b/frontend/src/lib/components/Projects/WritingSystemBadge.svelte
@@ -1,6 +1,4 @@
 <script lang="ts">
-  import { run } from 'svelte/legacy';
-
   import { Badge } from '../Badges';
   import type { BadgeVariant } from '../Badges/Badge.svelte';
 
@@ -12,11 +10,9 @@
 
   let { tag, isActive, isDefault }: Props = $props();
 
-  let variant: BadgeVariant = $state('badge-info');
-  run(() => {
-    variant = isActive ? (isDefault ? 'badge-primary' : 'badge-info') : 'badge-neutral';
-  });
-
+  let variant: BadgeVariant = $derived(
+    isActive ? (isDefault ? 'badge-primary' : 'badge-info') : 'badge-neutral'
+  );
 </script>
 
 <Badge {variant}>

--- a/frontend/src/lib/components/Projects/WritingSystemList.svelte
+++ b/frontend/src/lib/components/Projects/WritingSystemList.svelte
@@ -3,7 +3,11 @@
   import BadgeList from '../Badges/BadgeList.svelte';
   import WritingSystemBadge from './WritingSystemBadge.svelte';
 
-  export let writingSystems: FlExWsId[] = [];
+  interface Props {
+    writingSystems?: FlExWsId[];
+  }
+
+  let { writingSystems = [] }: Props = $props();
 </script>
 
 <div class="w-full">

--- a/frontend/src/lib/components/RegisterWithGoogleButton.svelte
+++ b/frontend/src/lib/components/RegisterWithGoogleButton.svelte
@@ -1,7 +1,11 @@
 <script lang="ts">
   import SigninWithGoogleButton from './SigninWithGoogleButton.svelte';
 
-  export let href: string;
+  interface Props {
+    href: string;
+  }
+
+  let { href }: Props = $props();
 </script>
 
 <SigninWithGoogleButton {href} text="register_with_google" />

--- a/frontend/src/lib/components/SigninWithGoogleButton.svelte
+++ b/frontend/src/lib/components/SigninWithGoogleButton.svelte
@@ -1,7 +1,11 @@
 <script lang="ts">
-  export let href: string;
   import t from '$lib/i18n';
-  export let text: 'sign_in_with_google' | 'register_with_google' = 'sign_in_with_google';
+  interface Props {
+    href: string;
+    text?: 'sign_in_with_google' | 'register_with_google';
+  }
+
+  let { href, text = 'sign_in_with_google' }: Props = $props();
 </script>
 
 <!--

--- a/frontend/src/lib/components/Table/RefineFilterMessage.svelte
+++ b/frontend/src/lib/components/Table/RefineFilterMessage.svelte
@@ -1,13 +1,17 @@
 <script lang="ts">
   import t from '$lib/i18n';
 
-  export let total: number;
-  export let showing: number;
+  interface Props {
+    total: number;
+    showing: number;
+  }
+
+  let { total, showing }: Props = $props();
 </script>
 
 {#if showing < total}
   <div class="text px-6 py-4 text-secondary flex gap-2 items-center">
-    <span class="i-mdi-creation-outline text-lg" />
+    <span class="i-mdi-creation-outline text-lg"></span>
     {$t('table.refine_filter', { remainingRows: total - showing })}
   </div>
 {/if}

--- a/frontend/src/lib/components/TrainTracks.svelte
+++ b/frontend/src/lib/components/TrainTracks.svelte
@@ -9,8 +9,6 @@
   import { run } from 'svelte/legacy';
 
   // We need a list of dots and lines, i.e. which dots go to which parents
-  
-
 
   interface Props {
     // Each dot has one or two parents, and needs a Bezier curve to the parent
@@ -22,7 +20,7 @@
     colWidthDefault?: number; // May be auto-calculated in the future
     rowHeightDefault?: number;
     circleSize?: number;
-    colors?: any;
+    colors?: string[];
   }
 
   let {
@@ -35,18 +33,18 @@
     rowHeightDefault = 20,
     circleSize = 5,
     colors = [
-    // Default set of colors works nicely, but allow overriding if needed
-    '#4e79a7',
-    '#f28e2c',
-    '#e15759',
-    '#76b7b2',
-    '#59a14f',
-    '#edc949',
-    '#af7aa1',
-    '#ff9da7',
-    '#9c755f',
-    '#bab0ab',
-  ]
+      // Default set of colors works nicely, but allow overriding if needed
+      '#4e79a7',
+      '#f28e2c',
+      '#e15759',
+      '#76b7b2',
+      '#59a14f',
+      '#edc949',
+      '#af7aa1',
+      '#ff9da7',
+      '#9c755f',
+      '#bab0ab',
+    ],
   }: Props = $props();
   let colorLength = $derived(colors.length);
   function color(colIdx: number): string {
@@ -97,11 +95,11 @@
 
   let rowHeight = $derived((rowIdx: number): number => {
     return cumulativeHeights[rowIdx] ? cumulativeHeights[rowIdx] : rowHeightDefault * rowIdx + firstRowOffset;
-  })
+  });
 
   let colWidth = $derived((colIdx: number): number => {
     return colWidthDefault * colIdx + firstColOffset;
-  })
+  });
 
   run(() => {
     svgDots = circles.map(({ row, col }) => ({
@@ -114,6 +112,7 @@
 
   let maxWidth = $derived(Math.max(...svgDots.map((c) => c.x)) + colWidthDefault);
 </script>
+
 {#if circles?.length > 0}
   <svg width={maxWidth} height="0" style="height: 100%">
     {#if rowHeights?.length > 0}

--- a/frontend/src/lib/components/TusUpload.svelte
+++ b/frontend/src/lib/components/TusUpload.svelte
@@ -1,5 +1,6 @@
 <script module lang="ts">
-  export enum UploadStatus {
+  // svelte-ignore non_reactive_update
+  export const enum UploadStatus {
     NoFile = 'NoFile',
     InvalidFile = 'InvalidFile',
     Ready = 'Ready',

--- a/frontend/src/lib/components/TusUpload.svelte
+++ b/frontend/src/lib/components/TusUpload.svelte
@@ -1,4 +1,4 @@
-﻿<script module lang="ts">
+<script module lang="ts">
   export enum UploadStatus {
     NoFile = 'NoFile',
     InvalidFile = 'InvalidFile',
@@ -33,7 +33,7 @@
     accept,
     inputLabel = $t('tus.select_file'),
     inputDescription = undefined,
-    internalButton = false
+    internalButton = false,
   }: Props = $props();
   const dispatch = createEventDispatcher<{
     uploadComplete: { upload: Upload };
@@ -165,9 +165,11 @@
           oncancel={stopPropagation(bubble('cancel'))}
           onchange={fileChanged}
         />
-        <IconButton icon="i-mdi-close"
-          on:click={clearFile}
-          disabled={status !== UploadStatus.Ready && status !== UploadStatus.InvalidFile} />
+        <IconButton
+          icon="i-mdi-close"
+          onclick={clearFile}
+          disabled={status !== UploadStatus.Ready && status !== UploadStatus.InvalidFile}
+        />
       </div>
     </FormField>
     <FormError error={uploadError} />
@@ -176,7 +178,9 @@
 
 <div class="mt-6 flex items-center gap-6">
   {#if internalButton}
-    <Button variant="btn-success" disabled={status > UploadStatus.Ready} on:click={startUpload}>{$t('tus.upload')}</Button>
+    <Button variant="btn-success" disabled={status > UploadStatus.Ready} onclick={startUpload}
+      >{$t('tus.upload')}</Button
+    >
   {/if}
   <div class="flex-1">
     <p class="label label-text py-0">{$t('tus.upload_progress')}</p>

--- a/frontend/src/lib/components/TusUpload.svelte
+++ b/frontend/src/lib/components/TusUpload.svelte
@@ -11,9 +11,8 @@
 </script>
 
 <script lang="ts">
-  import { run, createBubbler, stopPropagation } from 'svelte/legacy';
+  import { run } from 'svelte/legacy';
 
-  const bubble = createBubbler();
   import { Upload, type DetailedError } from 'tus-js-client';
   import { Button, FormError, FormField } from '$lib/forms';
   import { env } from '$env/dynamic/public';
@@ -163,7 +162,7 @@
           class="file-input file-input-bordered file-input-primary grow"
           disabled={status === UploadStatus.Uploading || status === UploadStatus.Complete}
           bind:this={fileInput}
-          oncancel={stopPropagation(bubble('cancel'))}
+          oncancel={e => e.stopPropagation()}
           onchange={fileChanged}
         />
         <IconButton

--- a/frontend/src/lib/components/Users/CreateUser.svelte
+++ b/frontend/src/lib/components/Users/CreateUser.svelte
@@ -143,7 +143,7 @@
     error={$errors.password}
     autocomplete="new-password"
   />
-  <PasswordStrengthMeter bind:score={$form.score} password={$form.password} />
+  <PasswordStrengthMeter onScoreUpdated={(score) => ($form.score = score)} password={$form.password} />
   <DisplayLanguageSelect bind:value={$form.locale} />
   <FormError error={$message} />
   <SubmitButton loading={$submitting}>{submitButtonText}</SubmitButton>

--- a/frontend/src/lib/components/Users/CreateUser.svelte
+++ b/frontend/src/lib/components/Users/CreateUser.svelte
@@ -44,9 +44,6 @@
     handleSubmit,
     formTainted = $bindable(false),
   }: Props = $props();
-  run(() => {
-    formTainted = !!$tainted;
-  });
 
   const dispatch = createEventDispatcher<{
     submitted: LexAuthUser;
@@ -108,6 +105,9 @@
       return;
     }
     throw new Error('Unknown error, no error from server, but also no user.');
+  });
+  run(() => {
+    formTainted = !!$tainted;
   });
   onMount(() => {
     // query params not available during SSR

--- a/frontend/src/lib/components/Users/CreateUser.svelte
+++ b/frontend/src/lib/components/Users/CreateUser.svelte
@@ -1,4 +1,6 @@
 <script lang="ts">
+  import { run } from 'svelte/legacy';
+
   import PasswordStrengthMeter from '$lib/components/PasswordStrengthMeter.svelte';
   import { SubmitButton, FormError, Input, MaybeProtectedForm, isEmail, lexSuperForm, passwordFormRules, DisplayLanguageSelect } from '$lib/forms';
   import t, { getLanguageCodeFromNavigator, locale } from '$lib/i18n';
@@ -9,13 +11,26 @@
   import { z } from 'zod';
   import type { StringifyValues } from '$lib/type.utils';
 
-  export let allowUsernames = false;
-  export let errorOnChangingEmail = '';
-  export let skipTurnstile = false;
-  export let submitButtonText = $t('register.button_register');
-  export let handleSubmit: (password: string, passwordStrength: number, name: string, email: string, locale: string, turnstileToken: string) => Promise<RegisterResponse>;
-  export let formTainted = false;
-  $: formTainted = !!$tainted;
+  interface Props {
+    allowUsernames?: boolean;
+    errorOnChangingEmail?: string;
+    skipTurnstile?: boolean;
+    submitButtonText?: any;
+    handleSubmit: (password: string, passwordStrength: number, name: string, email: string, locale: string, turnstileToken: string) => Promise<RegisterResponse>;
+    formTainted?: boolean;
+  }
+
+  let {
+    allowUsernames = false,
+    errorOnChangingEmail = '',
+    skipTurnstile = false,
+    submitButtonText = $t('register.button_register'),
+    handleSubmit,
+    formTainted = $bindable(false)
+  }: Props = $props();
+  run(() => {
+    formTainted = !!$tainted;
+  });
 
   const dispatch = createEventDispatcher<{
     submitted: LexAuthUser,
@@ -25,7 +40,7 @@
     name: string;
     email: string;
   };
-  let turnstileToken = '';
+  let turnstileToken = $state('');
   let urlValues = {} as StringifyValues<RegisterPageQueryParams>;
 
   function validateAsEmail(value: string): boolean {

--- a/frontend/src/lib/components/Users/CreateUserModal.svelte
+++ b/frontend/src/lib/components/Users/CreateUserModal.svelte
@@ -12,7 +12,7 @@
     submitted: LexAuthUser;
   }>();
 
-  let createUserModal: Modal = $state()!;
+  let createUserModal: Modal | undefined = $state();
   interface Props {
     handleSubmit: (
       password: string,
@@ -29,7 +29,7 @@
   let formTainted = $state(false);
 
   export async function open(): Promise<void> {
-    await createUserModal.openModal(true, true);
+    await createUserModal?.openModal(true, true);
   }
 </script>
 
@@ -59,8 +59,10 @@
     skipTurnstile
     bind:formTainted
     on:submitted={(event) => {
-      createUserModal.submitModal();
-      dispatch('submitted', event.detail);
+      if (createUserModal) {
+        createUserModal.submitModal();
+        dispatch('submitted', event.detail);
+      }
     }}
     submitButtonText={$t('admin_dashboard.create_user_modal.create_user')}
   />

--- a/frontend/src/lib/components/Users/CreateUserModal.svelte
+++ b/frontend/src/lib/components/Users/CreateUserModal.svelte
@@ -1,20 +1,27 @@
-﻿<script lang="ts">
+<script lang="ts">
   import { Modal } from '$lib/components/modals';
   import t from '$lib/i18n';
   import { helpLinks } from '$lib/components/help';
   import { type LexAuthUser, type RegisterResponse } from '$lib/user';
   import CreateUser from '$lib/components/Users/CreateUser.svelte';
-  import {NewTabLinkMarkdown} from '$lib/components/Markdown';
+  import { NewTabLinkMarkdown } from '$lib/components/Markdown';
   import Icon from '$lib/icons/Icon.svelte';
   import { createEventDispatcher } from 'svelte';
 
   const dispatch = createEventDispatcher<{
-    submitted: LexAuthUser,
+    submitted: LexAuthUser;
   }>();
 
-  let createUserModal: Modal = $state();
+  let createUserModal: Modal = $state()!;
   interface Props {
-    handleSubmit: (password: string, passwordStrength: number, name: string, email: string, locale: string, turnstileToken: string) => Promise<RegisterResponse>;
+    handleSubmit: (
+      password: string,
+      passwordStrength: number,
+      name: string,
+      email: string,
+      locale: string,
+      turnstileToken: string,
+    ) => Promise<RegisterResponse>;
   }
 
   let { handleSubmit }: Props = $props();
@@ -33,16 +40,24 @@
       <h3 class="text-lg">{$t('common.did_you_know')}</h3>
       <div>
         <NewTabLinkMarkdown
-          md={$t('admin_dashboard.create_user_modal.help_create_single_guest_user', { helpLink: helpLinks.addProjectMember })}
+          md={$t('admin_dashboard.create_user_modal.help_create_single_guest_user', {
+            helpLink: helpLinks.addProjectMember,
+          })}
         />
         <NewTabLinkMarkdown
-          md={$t('admin_dashboard.create_user_modal.help_create_bulk_guest_users', { helpLink: helpLinks.bulkAddCreate })}
+          md={$t('admin_dashboard.create_user_modal.help_create_bulk_guest_users', {
+            helpLink: helpLinks.bulkAddCreate,
+          })}
         />
       </div>
     </div>
   </div>
   <h1 class="text-center text-xl">{$t('admin_dashboard.create_user_modal.create_user')}</h1>
-  <CreateUser {handleSubmit} allowUsernames skipTurnstile bind:formTainted
+  <CreateUser
+    {handleSubmit}
+    allowUsernames
+    skipTurnstile
+    bind:formTainted
     on:submitted={(event) => {
       createUserModal.submitModal();
       dispatch('submitted', event.detail);

--- a/frontend/src/lib/components/Users/CreateUserModal.svelte
+++ b/frontend/src/lib/components/Users/CreateUserModal.svelte
@@ -12,10 +12,14 @@
     submitted: LexAuthUser,
   }>();
 
-  let createUserModal: Modal;
-  export let handleSubmit: (password: string, passwordStrength: number, name: string, email: string, locale: string, turnstileToken: string) => Promise<RegisterResponse>;
+  let createUserModal: Modal = $state();
+  interface Props {
+    handleSubmit: (password: string, passwordStrength: number, name: string, email: string, locale: string, turnstileToken: string) => Promise<RegisterResponse>;
+  }
 
-  let formTainted = false;
+  let { handleSubmit }: Props = $props();
+
+  let formTainted = $state(false);
 
   export async function open(): Promise<void> {
     await createUserModal.openModal(true, true);

--- a/frontend/src/lib/components/Users/UserFilter.svelte
+++ b/frontend/src/lib/components/Users/UserFilter.svelte
@@ -1,4 +1,4 @@
-<script  context="module" lang="ts">
+<script  module lang="ts">
   export type UserType = 'admin' | 'nonAdmin' | 'guest' | undefined;
 
   export type UserFilters = {
@@ -18,12 +18,23 @@
 
 
   type Filters = Partial<UserFilters> & Pick<UserFilters, 'userSearch'>;
-  export let filters: Writable<Filters>;
-  export let filterDefaults: Filters;
-  export let hasActiveFilter: boolean = false;
-  export let autofocus: true | undefined = undefined;
-  export let filterKeys: ReadonlyArray<(keyof Filters)> = ['userSearch', 'usersICreated', 'userType'];
-  export let loading = false;
+  interface Props {
+    filters: Writable<Filters>;
+    filterDefaults: Filters;
+    hasActiveFilter?: boolean;
+    autofocus?: true | undefined;
+    filterKeys?: ReadonlyArray<(keyof Filters)>;
+    loading?: boolean;
+  }
+
+  let {
+    filters,
+    filterDefaults,
+    hasActiveFilter = $bindable(false),
+    autofocus = undefined,
+    filterKeys = ['userSearch', 'usersICreated', 'userType'],
+    loading = false
+  }: Props = $props();
 
   function filterEnabled(filter: keyof Filters): boolean {
     return filterKeys.includes(filter);
@@ -41,46 +52,50 @@
   {filterKeys}
   {loading}
 >
-  <svelte:fragment slot="activeFilterSlot" let:activeFilters>
-    {#each activeFilters as filter}
-      {#if filter.key === 'userType' && filter.value}
-        <ActiveFilter {filter}>
-          {#if filter.value === 'admin'}
-            <Icon icon="i-mdi-security" color="text-accent" />
-            {$t('admin_dashboard.user_filter.user_type.admin')}
-          {:else if filter.value === 'nonAdmin'}
-            <Icon icon="i-mdi-account" />
-            {$t('admin_dashboard.user_filter.user_type.nonAdmin')}
-          {:else if filter.value === 'guest'}
-            <Icon icon="i-mdi-account-outline" />
-            {$t('admin_dashboard.user_filter.user_type.guest')}
-          {/if}
-        </ActiveFilter>
-      {:else if filter.key === 'usersICreated' && filter.value}
-        <ActiveFilter {filter}>
-          <Icon icon="i-mdi-account-plus-outline" color="text-warning" />
-          {$t('admin_dashboard.user_filter.guest_users_i_added')}
-        </ActiveFilter>
-      {/if}
-    {/each}
-  </svelte:fragment>
-  <svelte:fragment slot="filterSlot">
-    <h2 class="card-title">{$t('admin_dashboard.user_filter.title')}</h2>
-    {#if filterEnabled('userType')}
-      <div class="form-control">
-        <UserTypeSelect bind:value={$filters.userType} undefinedOptionLabel={$t('common.any')}/>
-      </div>
-    {/if}
-    {#if filterEnabled('usersICreated')}
-      <div class="form-control">
-        <label class="cursor-pointer label gap-4">
-          <span class="label-text inline-flex items-center gap-2">
-            {$t('admin_dashboard.user_filter.guest_users_i_added')}
+  {#snippet activeFilterSlot({ activeFilters })}
+  
+      {#each activeFilters as filter}
+        {#if filter.key === 'userType' && filter.value}
+          <ActiveFilter {filter}>
+            {#if filter.value === 'admin'}
+              <Icon icon="i-mdi-security" color="text-accent" />
+              {$t('admin_dashboard.user_filter.user_type.admin')}
+            {:else if filter.value === 'nonAdmin'}
+              <Icon icon="i-mdi-account" />
+              {$t('admin_dashboard.user_filter.user_type.nonAdmin')}
+            {:else if filter.value === 'guest'}
+              <Icon icon="i-mdi-account-outline" />
+              {$t('admin_dashboard.user_filter.user_type.guest')}
+            {/if}
+          </ActiveFilter>
+        {:else if filter.key === 'usersICreated' && filter.value}
+          <ActiveFilter {filter}>
             <Icon icon="i-mdi-account-plus-outline" color="text-warning" />
-          </span>
-          <input bind:checked={$filters.usersICreated} type="checkbox" class="toggle toggle-warning" />
-        </label>
-      </div>
-    {/if}
-  </svelte:fragment>
+            {$t('admin_dashboard.user_filter.guest_users_i_added')}
+          </ActiveFilter>
+        {/if}
+      {/each}
+    
+  {/snippet}
+  {#snippet filterSlot()}
+  
+      <h2 class="card-title">{$t('admin_dashboard.user_filter.title')}</h2>
+      {#if filterEnabled('userType')}
+        <div class="form-control">
+          <UserTypeSelect bind:value={$filters.userType} undefinedOptionLabel={$t('common.any')}/>
+        </div>
+      {/if}
+      {#if filterEnabled('usersICreated')}
+        <div class="form-control">
+          <label class="cursor-pointer label gap-4">
+            <span class="label-text inline-flex items-center gap-2">
+              {$t('admin_dashboard.user_filter.guest_users_i_added')}
+              <Icon icon="i-mdi-account-plus-outline" color="text-warning" />
+            </span>
+            <input bind:checked={$filters.usersICreated} type="checkbox" class="toggle toggle-warning" />
+          </label>
+        </div>
+      {/if}
+    
+  {/snippet}
 </FilterBar>

--- a/frontend/src/lib/components/Users/UserLockedAlert.svelte
+++ b/frontend/src/lib/components/Users/UserLockedAlert.svelte
@@ -2,7 +2,11 @@
   import t from '$lib/i18n';
   import { Icon } from '$lib/icons';
 
-  export let locked: boolean;
+  interface Props {
+    locked: boolean;
+  }
+
+  let { locked }: Props = $props();
 </script>
 
 {#if locked}

--- a/frontend/src/lib/components/Users/UserModal.svelte
+++ b/frontend/src/lib/components/Users/UserModal.svelte
@@ -1,4 +1,4 @@
-﻿<script lang="ts">
+<script lang="ts">
   import t, { date } from '$lib/i18n';
   import { Modal } from '$lib/components/modals';
   import DevContent from '$lib/layout/DevContent.svelte';
@@ -6,10 +6,10 @@
   import { NULL_LABEL } from '$lib/i18n';
   import IconButton from '$lib/components/IconButton.svelte';
   import AdminContent from '$lib/layout/AdminContent.svelte';
-  import {_sendNewVerificationEmailByAdmin} from '../../../routes/(authenticated)/admin/+page';
-  import type {UUID} from 'crypto';
-  import {useNotifications} from '$lib/notify';
-  import type {FeatureFlag} from '$lib/gql/types';
+  import { _sendNewVerificationEmailByAdmin } from '../../../routes/(authenticated)/admin/+page';
+  import type { UUID } from 'crypto';
+  import { useNotifications } from '$lib/notify';
+  import type { FeatureFlag } from '$lib/gql/types';
 
   type User = {
     id: string;
@@ -19,15 +19,15 @@
     isAdmin: boolean;
     createdDate: string | Date;
     username?: string | null;
-    locked: boolean
-    localizationCode: string
-    updatedDate: string | Date
-    lastActive: string | Date
-    featureFlags: FeatureFlag[]
-    canCreateProjects: boolean
-    createdBy?: Partial<User> | null
+    locked: boolean;
+    localizationCode: string;
+    updatedDate: string | Date;
+    lastActive: string | Date;
+    featureFlags: FeatureFlag[];
+    canCreateProjects: boolean;
+    createdBy?: Partial<User> | null;
   };
-  let userDetailsModal: Modal = $state();
+  let userDetailsModal: Modal = $state()!;
   let user: User = $state();
 
   export async function open(_user: User): Promise<void> {
@@ -64,7 +64,8 @@
             {#if !user.emailVerified}
               <span
                 class="tooltip text-warning text-md shrink-0 leading-0"
-                data-tip={$t('admin_dashboard.email_not_verified')}>
+                data-tip={$t('admin_dashboard.email_not_verified')}
+              >
                 <span class="i-mdi-help-circle-outline"></span>
               </span>
               <AdminContent>
@@ -75,7 +76,7 @@
                     outline={false}
                     variant="btn-primary"
                     loading={sendingVerificationEmail}
-                    on:click={() => sendVerificationEmail(user)}
+                    onclick={() => sendVerificationEmail(user)}
                   />
                 </div>
               </AdminContent>
@@ -107,7 +108,9 @@
       </div>
       <div>
         <h3>{$t('admin_dashboard.user_details_modal.can_create_projects')}</h3>
-        <p class="value" class:!text-success={user.canCreateProjects}>{user.canCreateProjects ? $t('common.yes') : $t('common.no')}</p>
+        <p class="value" class:!text-success={user.canCreateProjects}>
+          {user.canCreateProjects ? $t('common.yes') : $t('common.no')}
+        </p>
       </div>
       <div>
         <h3>{$t('admin_dashboard.user_details_modal.updated')}</h3>
@@ -119,14 +122,14 @@
       </div>
       <div>
         <h3>{$t('admin_dashboard.user_details_modal.createdBy')}</h3>
-        <p class="value">{user.createdBy?.name  ?? NULL_LABEL}</p>
+        <p class="value">{user.createdBy?.name ?? NULL_LABEL}</p>
       </div>
       <AdminContent>
-      {#if user.featureFlags && user.featureFlags.length}
-      <div>
-        Feature flags: {user.featureFlags.join(', ')}
-      </div>
-      {/if}
+        {#if user.featureFlags && user.featureFlags.length}
+          <div>
+            Feature flags: {user.featureFlags.join(', ')}
+          </div>
+        {/if}
       </AdminContent>
       <DevContent>
         <div>

--- a/frontend/src/lib/components/Users/UserModal.svelte
+++ b/frontend/src/lib/components/Users/UserModal.svelte
@@ -47,19 +47,20 @@
 </script>
 
 <Modal bind:this={userDetailsModal} bottom>
+  {#if user}
   <div class="p-4">
     <h2 class="text-secondary">
       <span class="text-2xl">
-        {user?.name}
+        {user.name}
       </span>
     </h2>
     <div class="divider"></div>
-    <UserLockedAlert locked={user?.locked ?? false} />
+    <UserLockedAlert locked={user.locked ?? false} />
     <div class="grid grid-cols-2 gap-4">
       <div>
         <h3>{$t('admin_dashboard.column_email')}</h3>
         <p class="value flex items-center gap-2 text-left">
-          {#if user?.email}
+          {#if user.email}
             {user.email}
             {#if !user.emailVerified}
               <span
@@ -90,44 +91,44 @@
       </div>
       <div>
         <h3>{$t('admin_dashboard.column_role')}</h3>
-        <p class="value">{user?.isAdmin ? $t('user_types.admin') : $t('user_types.user')}</p>
+        <p class="value">{user.isAdmin ? $t('user_types.admin') : $t('user_types.user')}</p>
       </div>
       <div>
         <h3>{$t('admin_dashboard.user_details_modal.registered')}</h3>
         <p class="value">
-          {$date(user?.createdDate)}
+          {$date(user.createdDate)}
         </p>
       </div>
       <div>
         <h3>{$t('admin_dashboard.column_login')}</h3>
         <p class="value">
-          {user?.username ?? NULL_LABEL}
+          {user.username ?? NULL_LABEL}
         </p>
       </div>
       <div>
         <h3>{$t('admin_dashboard.user_details_modal.last_active')}</h3>
-        <p class="value">{$date(user?.lastActive)}</p>
+        <p class="value">{$date(user.lastActive)}</p>
       </div>
       <div>
         <h3>{$t('admin_dashboard.user_details_modal.can_create_projects')}</h3>
-        <p class="value" class:!text-success={user?.canCreateProjects}>
-          {user?.canCreateProjects ? $t('common.yes') : $t('common.no')}
+        <p class="value" class:!text-success={user.canCreateProjects}>
+          {user.canCreateProjects ? $t('common.yes') : $t('common.no')}
         </p>
       </div>
       <div>
         <h3>{$t('admin_dashboard.user_details_modal.updated')}</h3>
-        <p class="value">{$date(user?.updatedDate)}</p>
+        <p class="value">{$date(user.updatedDate)}</p>
       </div>
       <div>
         <h3>{$t('admin_dashboard.user_details_modal.locale')}</h3>
-        <p class="value">{user?.localizationCode}</p>
+        <p class="value">{user.localizationCode}</p>
       </div>
       <div>
         <h3>{$t('admin_dashboard.user_details_modal.createdBy')}</h3>
-        <p class="value">{user?.createdBy?.name ?? NULL_LABEL}</p>
+        <p class="value">{user.createdBy?.name ?? NULL_LABEL}</p>
       </div>
       <AdminContent>
-        {#if user?.featureFlags && user?.featureFlags.length}
+        {#if user.featureFlags && user.featureFlags.length}
           <div>
             Feature flags: {user.featureFlags.join(', ')}
           </div>
@@ -136,11 +137,12 @@
       <DevContent>
         <div>
           <h3>ID</h3>
-          <p class="value">{user?.id}</p>
+          <p class="value">{user.id}</p>
         </div>
       </DevContent>
     </div>
   </div>
+  {/if}
 </Modal>
 
 <style lang="postcss">

--- a/frontend/src/lib/components/Users/UserModal.svelte
+++ b/frontend/src/lib/components/Users/UserModal.svelte
@@ -27,8 +27,8 @@
     canCreateProjects: boolean
     createdBy?: Partial<User> | null
   };
-  let userDetailsModal: Modal;
-  let user: User;
+  let userDetailsModal: Modal = $state();
+  let user: User = $state();
 
   export async function open(_user: User): Promise<void> {
     user = _user;
@@ -37,7 +37,7 @@
 
   const { notifySuccess } = useNotifications();
 
-  var sendingVerificationEmail = false;
+  var sendingVerificationEmail = $state(false);
   async function sendVerificationEmail(user: User): Promise<void> {
     sendingVerificationEmail = true;
     await _sendNewVerificationEmailByAdmin(user.id as UUID);
@@ -53,7 +53,7 @@
         {user.name}
       </span>
     </h2>
-    <div class="divider" />
+    <div class="divider"></div>
     <UserLockedAlert locked={user.locked} />
     <div class="grid grid-cols-2 gap-4">
       <div>
@@ -65,7 +65,7 @@
               <span
                 class="tooltip text-warning text-md shrink-0 leading-0"
                 data-tip={$t('admin_dashboard.email_not_verified')}>
-                <span class="i-mdi-help-circle-outline" />
+                <span class="i-mdi-help-circle-outline"></span>
               </span>
               <AdminContent>
                 <div class="tooltip" data-tip={$t('admin_dashboard.resend_verification_email')}>

--- a/frontend/src/lib/components/Users/UserModal.svelte
+++ b/frontend/src/lib/components/Users/UserModal.svelte
@@ -27,12 +27,12 @@
     canCreateProjects: boolean;
     createdBy?: Partial<User> | null;
   };
-  let userDetailsModal: Modal = $state()!;
-  let user: User = $state();
+  let userDetailsModal: Modal | undefined = $state();
+  let user: User | undefined = $state();
 
   export async function open(_user: User): Promise<void> {
     user = _user;
-    await userDetailsModal.openModal(true, true);
+    await userDetailsModal?.openModal(true, true);
   }
 
   const { notifySuccess } = useNotifications();
@@ -50,16 +50,16 @@
   <div class="p-4">
     <h2 class="text-secondary">
       <span class="text-2xl">
-        {user.name}
+        {user?.name}
       </span>
     </h2>
     <div class="divider"></div>
-    <UserLockedAlert locked={user.locked} />
+    <UserLockedAlert locked={user?.locked ?? false} />
     <div class="grid grid-cols-2 gap-4">
       <div>
         <h3>{$t('admin_dashboard.column_email')}</h3>
         <p class="value flex items-center gap-2 text-left">
-          {#if user.email}
+          {#if user?.email}
             {user.email}
             {#if !user.emailVerified}
               <span
@@ -76,7 +76,9 @@
                     outline={false}
                     variant="btn-primary"
                     loading={sendingVerificationEmail}
-                    onclick={() => sendVerificationEmail(user)}
+                    onclick={() => {
+                      if (user) void sendVerificationEmail(user);
+                    }}
                   />
                 </div>
               </AdminContent>
@@ -88,44 +90,44 @@
       </div>
       <div>
         <h3>{$t('admin_dashboard.column_role')}</h3>
-        <p class="value">{user.isAdmin ? $t('user_types.admin') : $t('user_types.user')}</p>
+        <p class="value">{user?.isAdmin ? $t('user_types.admin') : $t('user_types.user')}</p>
       </div>
       <div>
         <h3>{$t('admin_dashboard.user_details_modal.registered')}</h3>
         <p class="value">
-          {$date(user.createdDate)}
+          {$date(user?.createdDate)}
         </p>
       </div>
       <div>
         <h3>{$t('admin_dashboard.column_login')}</h3>
         <p class="value">
-          {user.username ?? NULL_LABEL}
+          {user?.username ?? NULL_LABEL}
         </p>
       </div>
       <div>
         <h3>{$t('admin_dashboard.user_details_modal.last_active')}</h3>
-        <p class="value">{$date(user.lastActive)}</p>
+        <p class="value">{$date(user?.lastActive)}</p>
       </div>
       <div>
         <h3>{$t('admin_dashboard.user_details_modal.can_create_projects')}</h3>
-        <p class="value" class:!text-success={user.canCreateProjects}>
-          {user.canCreateProjects ? $t('common.yes') : $t('common.no')}
+        <p class="value" class:!text-success={user?.canCreateProjects}>
+          {user?.canCreateProjects ? $t('common.yes') : $t('common.no')}
         </p>
       </div>
       <div>
         <h3>{$t('admin_dashboard.user_details_modal.updated')}</h3>
-        <p class="value">{$date(user.updatedDate)}</p>
+        <p class="value">{$date(user?.updatedDate)}</p>
       </div>
       <div>
         <h3>{$t('admin_dashboard.user_details_modal.locale')}</h3>
-        <p class="value">{user.localizationCode}</p>
+        <p class="value">{user?.localizationCode}</p>
       </div>
       <div>
         <h3>{$t('admin_dashboard.user_details_modal.createdBy')}</h3>
-        <p class="value">{user.createdBy?.name ?? NULL_LABEL}</p>
+        <p class="value">{user?.createdBy?.name ?? NULL_LABEL}</p>
       </div>
       <AdminContent>
-        {#if user.featureFlags && user.featureFlags.length}
+        {#if user?.featureFlags && user?.featureFlags.length}
           <div>
             Feature flags: {user.featureFlags.join(', ')}
           </div>
@@ -134,7 +136,7 @@
       <DevContent>
         <div>
           <h3>ID</h3>
-          <p class="value">{user.id}</p>
+          <p class="value">{user?.id}</p>
         </div>
       </DevContent>
     </div>

--- a/frontend/src/lib/components/Users/UserProjects.svelte
+++ b/frontend/src/lib/components/Users/UserProjects.svelte
@@ -1,4 +1,4 @@
-<script  context="module" lang="ts">
+<script  module lang="ts">
   // We define the Project type that we'll want in here, and export it so that callers can know they're passing in the right type
   export type Project = {
     id: string
@@ -16,11 +16,15 @@
   import FormatUserProjectRole from '../Projects/FormatUserProjectRole.svelte';
   import {projectUrl} from '$lib/util/project';
 
-  export let projects: Project[] = [];
-  export let selectedProjects: string[] = [];
-  export let hideRoleColumn = false;
+  interface Props {
+    projects?: Project[];
+    selectedProjects?: string[];
+    hideRoleColumn?: boolean;
+  }
 
-  $: allSelected = projects && selectedProjects && selectedProjects.length === projects.length;
+  let { projects = [], selectedProjects = $bindable([]), hideRoleColumn = false }: Props = $props();
+
+  let allSelected = $derived(projects && selectedProjects && selectedProjects.length === projects.length);
 
   function handleSelectAllClick(): void {
     if (!selectedProjects || !projects) return;
@@ -36,7 +40,7 @@
   }
 
   // Projects managed by the given user come pre-checked, to save time in typical uses of this component
-  $: projectsStore = writable(projects);
+  let projectsStore = $derived(writable(projects));
   onMount(() => projectsStore.subscribe(projects => {
     if (projects && projects.length > 0) {
       selectedProjects = [... projects.filter(isManager).map(proj => proj.id)];
@@ -51,7 +55,7 @@
         <tr class="bg-base-200">
             <th class="p-0 w-4">
               <label class="px-3 py-2">
-                <input type="checkbox" checked={allSelected} class="align-middle" on:change={handleSelectAllClick} />
+                <input type="checkbox" checked={allSelected} class="align-middle" onchange={handleSelectAllClick} />
               </label>
             </th>
             <th>

--- a/frontend/src/lib/components/Users/UserTable.svelte
+++ b/frontend/src/lib/components/Users/UserTable.svelte
@@ -6,7 +6,11 @@
   import Dropdown from '$lib/components/Dropdown.svelte';
   import type { User } from '../../../routes/(authenticated)/admin/+page';
 
-  export let shownUsers: User[];
+  interface Props {
+    shownUsers: User[];
+  }
+
+  let { shownUsers }: Props = $props();
 
   const dispatch = createEventDispatcher<{
     openUserModal: User
@@ -20,13 +24,13 @@
     <tr class="bg-base-200">
       <th>
         {$t('admin_dashboard.column_name')}
-        <span class="i-mdi-sort-ascending text-xl align-[-5px] ml-2" />
+        <span class="i-mdi-sort-ascending text-xl align-[-5px] ml-2"></span>
       </th>
       <th class="hidden @2xl:table-cell">
         {$t('admin_dashboard.column_login')}
       </th>
       <th>{$t('admin_dashboard.column_email')}</th>
-      <th />
+      <th></th>
     </tr>
   </thead>
   <tbody>
@@ -77,7 +81,7 @@
                 <span
                   class="tooltip text-warning text-xl shrink-0 leading-0"
                   data-tip={$t('admin_dashboard.email_not_verified')}>
-                  <span class="i-mdi-help-circle-outline" />
+                  <span class="i-mdi-help-circle-outline"></span>
                 </span>
               {/if}
             {:else}
@@ -88,22 +92,24 @@
         <td class="p-0">
           <Dropdown>
             <button class="btn btn-ghost btn-square" aria-label={$t('common.actions')}>
-              <span class="i-mdi-dots-vertical text-lg" />
+              <span class="i-mdi-dots-vertical text-lg"></span>
             </button>
-            <ul slot="content" class="menu">
-              <li>
-                <button class="whitespace-nowrap" on:click={() => dispatch('editUser', user)}>
-                  <Icon icon="i-mdi-pencil-outline" />
-                  {$t('admin_dashboard.form_modal.title')}
-                </button>
-              </li>
-              <li>
-                <button class="whitespace-nowrap" on:click={() => dispatch('filterProjectsByUser', user)}>
-                  <Icon icon="i-mdi-filter-outline" />
-                  {$t('project.filter.filter_user_projects')}
-                </button>
-              </li>
-            </ul>
+            {#snippet content()}
+                        <ul  class="menu">
+                <li>
+                  <button class="whitespace-nowrap" onclick={() => dispatch('editUser', user)}>
+                    <Icon icon="i-mdi-pencil-outline" />
+                    {$t('admin_dashboard.form_modal.title')}
+                  </button>
+                </li>
+                <li>
+                  <button class="whitespace-nowrap" onclick={() => dispatch('filterProjectsByUser', user)}>
+                    <Icon icon="i-mdi-filter-outline" />
+                    {$t('project.filter.filter_user_projects')}
+                  </button>
+                </li>
+              </ul>
+                      {/snippet}
           </Dropdown>
         </td>
       </tr>

--- a/frontend/src/lib/components/Users/UserTable.svelte
+++ b/frontend/src/lib/components/Users/UserTable.svelte
@@ -13,9 +13,9 @@
   let { shownUsers }: Props = $props();
 
   const dispatch = createEventDispatcher<{
-    openUserModal: User
-    editUser: User
-    filterProjectsByUser: User
+    openUserModal: User;
+    editUser: User;
+    filterProjectsByUser: User;
   }>();
 </script>
 
@@ -38,24 +38,25 @@
       <tr>
         <td>
           <div class="flex items-center gap-2 max-w-40 @xl:max-w-52">
-            <Button variant="btn-ghost" size="btn-sm" class="max-w-full" on:click={() => dispatch('openUserModal', user)}>
+            <Button
+              variant="btn-ghost"
+              size="btn-sm"
+              class="max-w-full"
+              onclick={() => dispatch('openUserModal', user)}
+            >
               <span class="x-ellipsis" title={user.name}>
                 {user.name}
               </span>
               <Icon icon="i-mdi-card-account-details-outline" />
             </Button>
             {#if user.locked}
-              <span
-                  class="tooltip text-warning text-xl leading-0"
-                  data-tip={$t('admin_dashboard.user_is_locked')}>
+              <span class="tooltip text-warning text-xl leading-0" data-tip={$t('admin_dashboard.user_is_locked')}>
                 <Icon icon="i-mdi-lock" />
               </span>
             {/if}
             {#if user.isAdmin}
-              <span
-                  class="tooltip text-accent text-xl leading-0"
-                  data-tip={$t('user_types.admin')}>
-                  <AdminIcon size="text-xl" />
+              <span class="tooltip text-accent text-xl leading-0" data-tip={$t('user_types.admin')}>
+                <AdminIcon size="text-xl" />
               </span>
             {/if}
           </div>
@@ -80,7 +81,8 @@
               {#if !user.emailVerified}
                 <span
                   class="tooltip text-warning text-xl shrink-0 leading-0"
-                  data-tip={$t('admin_dashboard.email_not_verified')}>
+                  data-tip={$t('admin_dashboard.email_not_verified')}
+                >
                   <span class="i-mdi-help-circle-outline"></span>
                 </span>
               {/if}
@@ -95,7 +97,7 @@
               <span class="i-mdi-dots-vertical text-lg"></span>
             </button>
             {#snippet content()}
-                        <ul  class="menu">
+              <ul class="menu">
                 <li>
                   <button class="whitespace-nowrap" onclick={() => dispatch('editUser', user)}>
                     <Icon icon="i-mdi-pencil-outline" />
@@ -109,7 +111,7 @@
                   </button>
                 </li>
               </ul>
-                      {/snippet}
+            {/snippet}
           </Dropdown>
         </td>
       </tr>

--- a/frontend/src/lib/components/help/SupHelp.svelte
+++ b/frontend/src/lib/components/help/SupHelp.svelte
@@ -2,7 +2,11 @@
   import { Icon } from '$lib/icons';
   import type { HelpLink } from '.';
 
-  export let helpLink: HelpLink;
+  interface Props {
+    helpLink: HelpLink;
+  }
+
+  let { helpLink }: Props = $props();
 </script>
 
 <sup>

--- a/frontend/src/lib/components/modals/ConfirmDeleteModal.svelte
+++ b/frontend/src/lib/components/modals/ConfirmDeleteModal.svelte
@@ -1,4 +1,4 @@
-<script context="module" lang="ts">
+<script module lang="ts">
   export type DeleteModalI18nShape = {
     title: string;
     submit: string;
@@ -19,15 +19,19 @@
   import { TrashIcon } from '$lib/icons';
   import tt from '$lib/i18n';
 
-  export let i18nScope: I18nShapeKey<DeleteModalI18nShape>;
-  let name: string;
+  interface Props {
+    i18nScope: I18nShapeKey<DeleteModalI18nShape>;
+  }
+
+  let { i18nScope }: Props = $props();
+  let name: string = $state();
 
   export async function open(_name: string, onSubmit: FormSubmitCallback<Schema>): Promise<FormModalResult<Schema>> {
     name = _name;
     return await deletionFormModal.open(onSubmit);
   }
 
-  $: t = tTypeScoped<DeleteModalI18nShape>(i18nScope);
+  let t = $derived(tTypeScoped<DeleteModalI18nShape>(i18nScope));
 
   const verify = z.object({
     keyphrase: z.string().refine((value) => value.match(`^${$t('enter_to_delete.value')}$`), $tt('form.value_is_incorrect')),
@@ -35,32 +39,38 @@
 
   type Schema = typeof verify;
 
-  let deletionFormModal: FormModal<Schema>;
-  $: deletionForm = deletionFormModal?.form();
+  let deletionFormModal: FormModal<Schema> = $state();
+  let deletionForm = $derived(deletionFormModal?.form());
 </script>
 
 <div class="contents">
-  <FormModal bind:this={deletionFormModal} schema={verify} let:errors submitVariant="btn-error">
-    <span slot="title">{$t('title')}</span>
-    <Input
-      id="keyphrase"
-      type="text"
-      autofocus
-      label={$t(
-        'enter_to_delete.label',
-        /*
-        Compiler: https://github.com/cibernox/babel-plugin-precompile-intl/blob/1afecaa725f9d59d785666ebccc065a9c41d8b74/src/index.ts#L299
-        Formatter: https://github.com/cibernox/precompile-intl-runtime/blob/cdaee6ebaa7c2e690db4dff3b8545ebaa79704fc/src/stores/formatters.ts#L44
-        `name` is optional in the translation template, so its name must get `sort()`ed after `_value`
-        */
-        { _value: $t('enter_to_delete.value'), name }
-      )}
-      error={errors.keyphrase}
-      bind:value={$deletionForm.keyphrase}
-    />
-    <svelte:fragment slot="submitText">
-      {$t('submit')}
-      <TrashIcon />
-    </svelte:fragment>
+  <FormModal bind:this={deletionFormModal} schema={verify}  submitVariant="btn-error">
+    {#snippet title()}
+        <span >{$t('title')}</span>
+      {/snippet}
+    {#snippet children({ errors })}
+        <Input
+        id="keyphrase"
+        type="text"
+        autofocus
+        label={$t(
+          'enter_to_delete.label',
+          /*
+          Compiler: https://github.com/cibernox/babel-plugin-precompile-intl/blob/1afecaa725f9d59d785666ebccc065a9c41d8b74/src/index.ts#L299
+          Formatter: https://github.com/cibernox/precompile-intl-runtime/blob/cdaee6ebaa7c2e690db4dff3b8545ebaa79704fc/src/stores/formatters.ts#L44
+          `name` is optional in the translation template, so its name must get `sort()`ed after `_value`
+          */
+          { _value: $t('enter_to_delete.value'), name }
+        )}
+        error={errors.keyphrase}
+        bind:value={$deletionForm.keyphrase}
+      />
+      {/snippet}
+      {#snippet submitText()}
+      
+        {$t('submit')}
+        <TrashIcon />
+      
+      {/snippet}
   </FormModal>
 </div>

--- a/frontend/src/lib/components/modals/ConfirmDeleteModal.svelte
+++ b/frontend/src/lib/components/modals/ConfirmDeleteModal.svelte
@@ -24,7 +24,7 @@
   }
 
   let { i18nScope }: Props = $props();
-  let name: string = $state();
+  let name: string | undefined = $state();
 
   export async function open(_name: string, onSubmit: FormSubmitCallback<Schema>): Promise<FormModalResult<Schema>> {
     name = _name;
@@ -34,22 +34,24 @@
   let t = $derived(tTypeScoped<DeleteModalI18nShape>(i18nScope));
 
   const verify = z.object({
-    keyphrase: z.string().refine((value) => value.match(`^${$t('enter_to_delete.value')}$`), $tt('form.value_is_incorrect')),
+    keyphrase: z
+      .string()
+      .refine((value) => value.match(`^${$t('enter_to_delete.value')}$`), $tt('form.value_is_incorrect')),
   });
 
   type Schema = typeof verify;
 
-  let deletionFormModal: FormModal<Schema> = $state();
+  let deletionFormModal: FormModal<Schema> = $state()!;
   let deletionForm = $derived(deletionFormModal?.form());
 </script>
 
 <div class="contents">
-  <FormModal bind:this={deletionFormModal} schema={verify}  submitVariant="btn-error">
+  <FormModal bind:this={deletionFormModal} schema={verify} submitVariant="btn-error">
     {#snippet title()}
-        <span >{$t('title')}</span>
-      {/snippet}
+      <span>{$t('title')}</span>
+    {/snippet}
     {#snippet children({ errors })}
-        <Input
+      <Input
         id="keyphrase"
         type="text"
         autofocus
@@ -60,17 +62,15 @@
           Formatter: https://github.com/cibernox/precompile-intl-runtime/blob/cdaee6ebaa7c2e690db4dff3b8545ebaa79704fc/src/stores/formatters.ts#L44
           `name` is optional in the translation template, so its name must get `sort()`ed after `_value`
           */
-          { _value: $t('enter_to_delete.value'), name }
+          { _value: $t('enter_to_delete.value'), name: name ?? '' },
         )}
         error={errors.keyphrase}
         bind:value={$deletionForm.keyphrase}
       />
-      {/snippet}
-      {#snippet submitText()}
-      
-        {$t('submit')}
-        <TrashIcon />
-      
-      {/snippet}
+    {/snippet}
+    {#snippet submitText()}
+      {$t('submit')}
+      <TrashIcon />
+    {/snippet}
   </FormModal>
 </div>

--- a/frontend/src/lib/components/modals/ConfirmDeleteModal.svelte
+++ b/frontend/src/lib/components/modals/ConfirmDeleteModal.svelte
@@ -28,7 +28,7 @@
 
   export async function open(_name: string, onSubmit: FormSubmitCallback<Schema>): Promise<FormModalResult<Schema>> {
     name = _name;
-    return await deletionFormModal.open(onSubmit);
+    return await deletionFormModal!.open(onSubmit);
   }
 
   let t = $derived(tTypeScoped<DeleteModalI18nShape>(i18nScope));
@@ -41,7 +41,8 @@
 
   type Schema = typeof verify;
 
-  let deletionFormModal: FormModal<Schema> = $state()!;
+  // eslint-disable-next-line @typescript-eslint/no-redundant-type-constituents
+  let deletionFormModal: FormModal<Schema> | undefined = $state();
   let deletionForm = $derived(deletionFormModal?.form());
 </script>
 
@@ -65,7 +66,7 @@
           { _value: $t('enter_to_delete.value'), name: name ?? '' },
         )}
         error={errors.keyphrase}
-        bind:value={$deletionForm.keyphrase}
+        bind:value={$deletionForm!.keyphrase}
       />
     {/snippet}
     {#snippet submitText()}

--- a/frontend/src/lib/components/modals/ConfirmModal.svelte
+++ b/frontend/src/lib/components/modals/ConfirmModal.svelte
@@ -14,7 +14,7 @@
     hideActions?: boolean;
     doneText?: string;
     showDoneState?: boolean;
-    children?: Snippet<[unknown]>;
+    children?: Snippet<[{ done: boolean; error: ErrorMessage }]>;
   }
 
   let {

--- a/frontend/src/lib/components/modals/ConfirmModal.svelte
+++ b/frontend/src/lib/components/modals/ConfirmModal.svelte
@@ -48,7 +48,7 @@
     return true;
   }
 
-  let modal: Modal = $state();
+  let modal: Modal = $state()!;
   let error: ErrorMessage = $state(undefined);
 </script>
 
@@ -60,17 +60,17 @@
   <FormError {error} right />
   {#snippet actions({ submitting, close })}
     {#if !done}
-      <Button variant={submitVariant} loading={submitting} on:click={() => modal.submitModal()}>
+      <Button variant={submitVariant} loading={submitting} onclick={() => modal.submitModal()}>
         {submitText}
         {#if submitIcon}
           <Icon icon={submitIcon} />
         {/if}
       </Button>
-      <Button disabled={submitting} on:click={() => modal.cancelModal()}>
+      <Button disabled={submitting} onclick={() => modal.cancelModal()}>
         {cancelText}
       </Button>
     {:else}
-      <Button variant="btn-primary" on:click={close}>
+      <Button variant="btn-primary" onclick={close}>
         {doneText}
       </Button>
     {/if}

--- a/frontend/src/lib/components/modals/ConfirmModal.svelte
+++ b/frontend/src/lib/components/modals/ConfirmModal.svelte
@@ -1,7 +1,8 @@
-﻿<script lang="ts">
-  import {type IconString, Icon} from '$lib/icons';
-  import Modal, {DialogResponse} from './Modal.svelte';
-  import {Button, type ErrorMessage, FormError} from '$lib/forms';
+<script lang="ts">
+  import type { Snippet } from 'svelte';
+  import { type IconString, Icon } from '$lib/icons';
+  import Modal, { DialogResponse } from './Modal.svelte';
+  import { Button, type ErrorMessage, FormError } from '$lib/forms';
   import t from '$lib/i18n';
 
 
@@ -15,7 +16,7 @@
     hideActions?: boolean;
     doneText?: any;
     showDoneState?: boolean;
-    children?: import('svelte').Snippet<[any]>;
+    children?: Snippet<[any]>;
   }
 
   let {

--- a/frontend/src/lib/components/modals/ConfirmModal.svelte
+++ b/frontend/src/lib/components/modals/ConfirmModal.svelte
@@ -5,13 +5,11 @@
   import { Button, type ErrorMessage, FormError } from '$lib/forms';
   import t from '$lib/i18n';
 
-
-
   interface Props {
     title: string;
     submitText: string;
     submitIcon?: IconString | undefined;
-    submitVariant?: 'btn-primary' |  'btn-error';
+    submitVariant?: 'btn-primary' | 'btn-error';
     cancelText: string;
     hideActions?: boolean;
     doneText?: any;
@@ -28,7 +26,7 @@
     hideActions = false,
     doneText = $t('common.close'),
     showDoneState = false,
-    children
+    children,
   }: Props = $props();
 
   let done = $state(false);
@@ -54,30 +52,27 @@
   let error: ErrorMessage = $state(undefined);
 </script>
 
-
 <Modal bind:this={modal} showCloseButton={false} {hideActions}>
   <h2 class="text-xl mb-2">
     {title}
   </h2>
-  {@render children?.({ done, error, })}
-  <FormError {error} right/>
+  {@render children?.({ done, error })}
+  <FormError {error} right />
   {#snippet actions({ submitting, close })}
-  
-      {#if !done}
-        <Button variant={submitVariant} loading={submitting} on:click={() => modal.submitModal()}>
-          {submitText}
-          {#if submitIcon}
-            <Icon icon={submitIcon}/>
-          {/if}
-        </Button>
-        <Button disabled={submitting} on:click={() => modal.cancelModal()}>
-          {cancelText}
-        </Button>
-      {:else}
-        <Button variant="btn-primary" on:click={close}>
-          {doneText}
-        </Button>
-      {/if}
-    
+    {#if !done}
+      <Button variant={submitVariant} loading={submitting} on:click={() => modal.submitModal()}>
+        {submitText}
+        {#if submitIcon}
+          <Icon icon={submitIcon} />
+        {/if}
+      </Button>
+      <Button disabled={submitting} on:click={() => modal.cancelModal()}>
+        {cancelText}
+      </Button>
+    {:else}
+      <Button variant="btn-primary" on:click={close}>
+        {doneText}
+      </Button>
+    {/if}
   {/snippet}
 </Modal>

--- a/frontend/src/lib/components/modals/ConfirmModal.svelte
+++ b/frontend/src/lib/components/modals/ConfirmModal.svelte
@@ -4,18 +4,33 @@
   import {Button, type ErrorMessage, FormError} from '$lib/forms';
   import t from '$lib/i18n';
 
-  export let title: string;
-  export let submitText: string;
-  export let submitIcon: IconString | undefined = undefined;
-  export let submitVariant: 'btn-primary' |  'btn-error' = 'btn-primary';
 
-  export let cancelText: string;
-  export let hideActions: boolean = false;
 
-  export let doneText = $t('common.close');
-  export let showDoneState = false;
+  interface Props {
+    title: string;
+    submitText: string;
+    submitIcon?: IconString | undefined;
+    submitVariant?: 'btn-primary' |  'btn-error';
+    cancelText: string;
+    hideActions?: boolean;
+    doneText?: any;
+    showDoneState?: boolean;
+    children?: import('svelte').Snippet<[any]>;
+  }
 
-  let done = false;
+  let {
+    title,
+    submitText,
+    submitIcon = undefined,
+    submitVariant = 'btn-primary',
+    cancelText,
+    hideActions = false,
+    doneText = $t('common.close'),
+    showDoneState = false,
+    children
+  }: Props = $props();
+
+  let done = $state(false);
 
   export async function open(onSubmit: () => Promise<ErrorMessage>): Promise<boolean> {
     done = false;
@@ -34,8 +49,8 @@
     return true;
   }
 
-  let modal: Modal;
-  let error: ErrorMessage = undefined;
+  let modal: Modal = $state();
+  let error: ErrorMessage = $state(undefined);
 </script>
 
 
@@ -43,23 +58,25 @@
   <h2 class="text-xl mb-2">
     {title}
   </h2>
-  <slot {done} {error} />
+  {@render children?.({ done, error, })}
   <FormError {error} right/>
-  <svelte:fragment slot="actions" let:submitting let:close>
-    {#if !done}
-      <Button variant={submitVariant} loading={submitting} on:click={() => modal.submitModal()}>
-        {submitText}
-        {#if submitIcon}
-          <Icon icon={submitIcon}/>
-        {/if}
-      </Button>
-      <Button disabled={submitting} on:click={() => modal.cancelModal()}>
-        {cancelText}
-      </Button>
-    {:else}
-      <Button variant="btn-primary" on:click={close}>
-        {doneText}
-      </Button>
-    {/if}
-  </svelte:fragment>
+  {#snippet actions({ submitting, close })}
+  
+      {#if !done}
+        <Button variant={submitVariant} loading={submitting} on:click={() => modal.submitModal()}>
+          {submitText}
+          {#if submitIcon}
+            <Icon icon={submitIcon}/>
+          {/if}
+        </Button>
+        <Button disabled={submitting} on:click={() => modal.cancelModal()}>
+          {cancelText}
+        </Button>
+      {:else}
+        <Button variant="btn-primary" on:click={close}>
+          {doneText}
+        </Button>
+      {/if}
+    
+  {/snippet}
 </Modal>

--- a/frontend/src/lib/components/modals/ConfirmModal.svelte
+++ b/frontend/src/lib/components/modals/ConfirmModal.svelte
@@ -32,6 +32,7 @@
   let done = $state(false);
 
   export async function open(onSubmit: () => Promise<ErrorMessage>): Promise<boolean> {
+    if (!modal) return false;
     done = false;
     if ((await modal.openModal()) === DialogResponse.Cancel) {
       error = undefined;
@@ -48,7 +49,7 @@
     return true;
   }
 
-  let modal: Modal = $state()!;
+  let modal: Modal | undefined = $state();
   let error: ErrorMessage = $state(undefined);
 </script>
 
@@ -60,13 +61,13 @@
   <FormError {error} right />
   {#snippet actions({ submitting, close })}
     {#if !done}
-      <Button variant={submitVariant} loading={submitting} onclick={() => modal.submitModal()}>
+      <Button variant={submitVariant} loading={submitting} onclick={() => modal?.submitModal()}>
         {submitText}
         {#if submitIcon}
           <Icon icon={submitIcon} />
         {/if}
       </Button>
-      <Button disabled={submitting} onclick={() => modal.cancelModal()}>
+      <Button disabled={submitting} onclick={() => modal?.cancelModal()}>
         {cancelText}
       </Button>
     {:else}

--- a/frontend/src/lib/components/modals/ConfirmModal.svelte
+++ b/frontend/src/lib/components/modals/ConfirmModal.svelte
@@ -12,9 +12,9 @@
     submitVariant?: 'btn-primary' | 'btn-error';
     cancelText: string;
     hideActions?: boolean;
-    doneText?: any;
+    doneText?: string;
     showDoneState?: boolean;
-    children?: Snippet<[any]>;
+    children?: Snippet<[unknown]>;
   }
 
   let {

--- a/frontend/src/lib/components/modals/DeleteModal.svelte
+++ b/frontend/src/lib/components/modals/DeleteModal.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import type { Snippet } from 'svelte';
   import t from '$lib/i18n';
   import {type ErrorMessage} from '$lib/forms';
   import ConfirmModal from '$lib/components/modals/ConfirmModal.svelte';
@@ -6,7 +7,7 @@
   interface Props {
     entityName: string;
     isRemoveDialog?: boolean;
-    children?: import('svelte').Snippet;
+    children?: Snippet;
   }
 
   let { entityName, isRemoveDialog = false, children }: Props = $props();

--- a/frontend/src/lib/components/modals/DeleteModal.svelte
+++ b/frontend/src/lib/components/modals/DeleteModal.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import type { Snippet } from 'svelte';
   import t from '$lib/i18n';
-  import {type ErrorMessage} from '$lib/forms';
+  import { type ErrorMessage } from '$lib/forms';
   import ConfirmModal from '$lib/components/modals/ConfirmModal.svelte';
 
   interface Props {
@@ -17,11 +17,14 @@
     return await modal.open(deleteCallback);
   }
 </script>
-<ConfirmModal bind:this={modal}
-              title={isRemoveDialog ? $t('delete_modal.remove', { entityName }) : $t('delete_modal.delete', { entityName })}
-              submitText={isRemoveDialog ? $t('delete_modal.remove', { entityName }) : $t('delete_modal.delete', { entityName })}
-              submitIcon="i-mdi-trash-can"
-              submitVariant="btn-error"
-              cancelText={isRemoveDialog ? $t('delete_modal.dont_remove') : $t('delete_modal.dont_delete')}>
+
+<ConfirmModal
+  bind:this={modal}
+  title={isRemoveDialog ? $t('delete_modal.remove', { entityName }) : $t('delete_modal.delete', { entityName })}
+  submitText={isRemoveDialog ? $t('delete_modal.remove', { entityName }) : $t('delete_modal.delete', { entityName })}
+  submitIcon="i-mdi-trash-can"
+  submitVariant="btn-error"
+  cancelText={isRemoveDialog ? $t('delete_modal.dont_remove') : $t('delete_modal.dont_delete')}
+>
   {@render children?.()}
 </ConfirmModal>

--- a/frontend/src/lib/components/modals/DeleteModal.svelte
+++ b/frontend/src/lib/components/modals/DeleteModal.svelte
@@ -11,7 +11,7 @@
   }
 
   let { entityName, isRemoveDialog = false, children }: Props = $props();
-  let modal: ConfirmModal = $state();
+  let modal: ConfirmModal = $state()!;
 
   export async function prompt(deleteCallback: () => Promise<ErrorMessage>): Promise<boolean> {
     return await modal.open(deleteCallback);

--- a/frontend/src/lib/components/modals/DeleteModal.svelte
+++ b/frontend/src/lib/components/modals/DeleteModal.svelte
@@ -3,9 +3,14 @@
   import {type ErrorMessage} from '$lib/forms';
   import ConfirmModal from '$lib/components/modals/ConfirmModal.svelte';
 
-  export let entityName: string;
-  export let isRemoveDialog = false;
-  let modal: ConfirmModal;
+  interface Props {
+    entityName: string;
+    isRemoveDialog?: boolean;
+    children?: import('svelte').Snippet;
+  }
+
+  let { entityName, isRemoveDialog = false, children }: Props = $props();
+  let modal: ConfirmModal = $state();
 
   export async function prompt(deleteCallback: () => Promise<ErrorMessage>): Promise<boolean> {
     return await modal.open(deleteCallback);
@@ -17,5 +22,5 @@
               submitIcon="i-mdi-trash-can"
               submitVariant="btn-error"
               cancelText={isRemoveDialog ? $t('delete_modal.dont_remove') : $t('delete_modal.dont_delete')}>
-  <slot/>
+  {@render children?.()}
 </ConfirmModal>

--- a/frontend/src/lib/components/modals/DeleteModal.svelte
+++ b/frontend/src/lib/components/modals/DeleteModal.svelte
@@ -11,10 +11,10 @@
   }
 
   let { entityName, isRemoveDialog = false, children }: Props = $props();
-  let modal: ConfirmModal = $state()!;
+  let modal: ConfirmModal | undefined = $state();
 
   export async function prompt(deleteCallback: () => Promise<ErrorMessage>): Promise<boolean> {
-    return await modal.open(deleteCallback);
+    return (await modal?.open(deleteCallback)) ?? false;
   }
 </script>
 

--- a/frontend/src/lib/components/modals/FormModal.svelte
+++ b/frontend/src/lib/components/modals/FormModal.svelte
@@ -52,9 +52,9 @@
     doneText,
   }: Props = $props();
 
-  const superForm = lexSuperForm(schema, () => modal.submitModal());
+  const superForm = lexSuperForm(schema, () => modal?.submitModal() ?? Promise.resolve(undefined));
   const { form: _form, errors, reset, message, enhance, formState, tainted } = superForm;
-  let modal: Modal = $state()!;
+  let modal: Modal | undefined = $state();
   let done = $state(false);
 
   export async function open(
@@ -90,7 +90,7 @@
   }
 
   async function openModal(onSubmit: SubmitCallback): Promise<DialogResponse> {
-    const result = await modal.openModal();
+    const result = await modal!.openModal();
     if (result == DialogResponse.Cancel) return result;
 
     const error = await onSubmit($formState);

--- a/frontend/src/lib/components/modals/FormModal.svelte
+++ b/frontend/src/lib/components/modals/FormModal.svelte
@@ -1,4 +1,5 @@
 <script module lang="ts">
+  import type { Snippet } from 'svelte';
   import Modal, { DialogResponse } from '$lib/components/modals/Modal.svelte';
   import type { LexFormErrors, LexFormState } from '$lib/forms/superforms';
   import type { AnyZodObject, ZodObject, z } from 'zod';
@@ -28,11 +29,11 @@
     submitVariant?: SubmitVariant;
     hideActions?: boolean;
     showDoneState?: boolean;
-    title?: import('svelte').Snippet;
-    children?: import('svelte').Snippet<[any]>;
-    extraActions?: import('svelte').Snippet;
-    submitText?: import('svelte').Snippet;
-    doneText?: import('svelte').Snippet;
+    title?: Snippet;
+    children?: Snippet<[any]>;
+    extraActions?: Snippet;
+    submitText?: Snippet;
+    doneText?: Snippet;
   }
 
   let {

--- a/frontend/src/lib/components/modals/FormModal.svelte
+++ b/frontend/src/lib/components/modals/FormModal.svelte
@@ -11,8 +11,12 @@
     formState: LexFormState<S>;
   };
 
-  export type FormSubmitReturn<Schema extends ZodValidation<AnyZodObject>> = ErrorMessage | Partial<LexFormErrors<Schema>>;
-  export type FormSubmitCallback<Schema extends ZodValidation<AnyZodObject>> = (state: LexFormState<Schema>) => Promise<FormSubmitReturn<Schema>>;
+  export type FormSubmitReturn<Schema extends ZodValidation<AnyZodObject>> =
+    | ErrorMessage
+    | Partial<LexFormErrors<Schema>>;
+  export type FormSubmitCallback<Schema extends ZodValidation<AnyZodObject>> = (
+    state: LexFormState<Schema>,
+  ) => Promise<FormSubmitReturn<Schema>>;
 </script>
 
 <script lang="ts">
@@ -45,7 +49,7 @@
     children,
     extraActions,
     submitText,
-    doneText
+    doneText,
   }: Props = $props();
 
   const superForm = lexSuperForm(schema, () => modal.submitModal());
@@ -54,12 +58,12 @@
   let done = $state(false);
 
   export async function open(
-    value: Partial<FormType> | undefined,  //eslint-disable-line @typescript-eslint/no-redundant-type-constituents
+    value: Partial<FormType> | undefined, //eslint-disable-line @typescript-eslint/no-redundant-type-constituents
     onSubmit: SubmitCallback,
   ): Promise<FormModalResult<Schema>>;
   export async function open(onSubmit: SubmitCallback): Promise<FormModalResult<Schema>>;
   export async function open(
-    valueOrOnSubmit: Partial<FormType> | SubmitCallback | undefined,  //eslint-disable-line @typescript-eslint/no-redundant-type-constituents
+    valueOrOnSubmit: Partial<FormType> | SubmitCallback | undefined, //eslint-disable-line @typescript-eslint/no-redundant-type-constituents
     _onSubmit?: SubmitCallback,
   ): Promise<FormModalResult<Schema>> {
     done = false;
@@ -69,12 +73,11 @@
     reset();
 
     //need to use update otherwise some fields might be undefined since value can be a partial
-    if (value) _form.update(f => ({...f, ...value}), { taint: false });
+    if (value) _form.update((f) => ({ ...f, ...value }), { taint: false });
 
     const response = await openModal(onSubmit);
     const _formState = $formState; // we need to read the form state before the modal closes or it will be reset
-    if (response !== DialogResponse.Submit || !showDoneState)
-      modal?.close();
+    if (response !== DialogResponse.Submit || !showDoneState) modal?.close();
     return { response, formState: _formState };
   }
 
@@ -93,7 +96,7 @@
     const error = await onSubmit($formState);
     if (error) {
       if (typeof error === 'string') $message = error;
-      if (typeof error === 'object') $errors = {...$errors, ...error};
+      if (typeof error === 'object') $errors = { ...$errors, ...error };
       // again go back to the top and await a response from the modal.
       return await openModal(onSubmit);
     }
@@ -109,25 +112,21 @@
 <Modal bind:this={modal} on:close={() => reset()} bottom closeOnClickOutside={!$tainted} {hideActions}>
   <Form id="modalForm" {enhance}>
     <p class="mb-4 text-lg font-bold">{@render title?.()}</p>
-    {@render children?.({ errors: $errors, })}
+    {@render children?.({ errors: $errors })}
   </Form>
   <FormError error={$message} right />
   {#snippet extraActions()}
-  
-      {@render extraActions_render?.()}
-    
+    {@render extraActions_render?.()}
   {/snippet}
   {#snippet actions({ submitting, close })}
-  
-      {#if !done}
-        <SubmitButton form="modalForm" variant={submitVariant} loading={submitting}>
-          {@render submitText?.()}
-        </SubmitButton>
-      {:else}
-        <Button variant="btn-primary" on:click={close}>
-          {@render doneText?.()}
-        </Button>
-      {/if}
-    
+    {#if !done}
+      <SubmitButton form="modalForm" variant={submitVariant} loading={submitting}>
+        {@render submitText?.()}
+      </SubmitButton>
+    {:else}
+      <Button variant="btn-primary" on:click={close}>
+        {@render doneText?.()}
+      </Button>
+    {/if}
   {/snippet}
 </Modal>

--- a/frontend/src/lib/components/modals/FormModal.svelte
+++ b/frontend/src/lib/components/modals/FormModal.svelte
@@ -54,7 +54,7 @@
 
   const superForm = lexSuperForm(schema, () => modal.submitModal());
   const { form: _form, errors, reset, message, enhance, formState, tainted } = superForm;
-  let modal: Modal = $state();
+  let modal: Modal = $state()!;
   let done = $state(false);
 
   export async function open(
@@ -124,7 +124,7 @@
         {@render submitText?.()}
       </SubmitButton>
     {:else}
-      <Button variant="btn-primary" on:click={close}>
+      <Button variant="btn-primary" onclick={close}>
         {@render doneText?.()}
       </Button>
     {/if}

--- a/frontend/src/lib/components/modals/FormModal.svelte
+++ b/frontend/src/lib/components/modals/FormModal.svelte
@@ -34,7 +34,7 @@
     hideActions?: boolean;
     showDoneState?: boolean;
     title?: Snippet;
-    children?: Snippet<[any]>;
+    children?: Snippet<[unknown]>;
     extraActions?: Snippet;
     submitText?: Snippet;
     doneText?: Snippet;
@@ -106,7 +106,7 @@
     return result;
   }
 
-  const extraActions_render = $derived(extraActions);
+  const extraActionsRender = $derived(extraActions);
 </script>
 
 <Modal bind:this={modal} on:close={() => reset()} bottom closeOnClickOutside={!$tainted} {hideActions}>
@@ -116,7 +116,7 @@
   </Form>
   <FormError error={$message} right />
   {#snippet extraActions()}
-    {@render extraActions_render?.()}
+    {@render extraActionsRender?.()}
   {/snippet}
   {#snippet actions({ submitting, close })}
     {#if !done}

--- a/frontend/src/lib/components/modals/FormModal.svelte
+++ b/frontend/src/lib/components/modals/FormModal.svelte
@@ -3,7 +3,7 @@
   import Modal, { DialogResponse } from '$lib/components/modals/Modal.svelte';
   import type { LexFormErrors, LexFormState } from '$lib/forms/superforms';
   import type { AnyZodObject, ZodObject, z } from 'zod';
-  import type { ZodValidation } from 'sveltekit-superforms';
+  import type { UnwrapEffects, ValidationErrors, ZodValidation } from 'sveltekit-superforms';
   import type { ErrorMessage } from '$lib/forms';
 
   export type FormModalResult<S extends AnyZodObject> = {
@@ -34,7 +34,7 @@
     hideActions?: boolean;
     showDoneState?: boolean;
     title?: Snippet;
-    children?: Snippet<[unknown]>;
+    children?: Snippet<[{ errors: ValidationErrors<UnwrapEffects<Schema>> }]>;
     extraActions?: Snippet;
     submitText?: Snippet;
     doneText?: Snippet;

--- a/frontend/src/lib/components/modals/Modal.svelte
+++ b/frontend/src/lib/components/modals/Modal.svelte
@@ -23,7 +23,6 @@
   let dialogResponse = writable<DialogResponse | null>(null);
   let open = writable(false);
   let closing = $derived($dialogResponse !== null && $open);
-  // eslint-disable-next-line svelte/valid-compile
   let submitting = $derived($dialogResponse === DialogResponse.Submit && $open);
   interface Props {
     bottom?: boolean;
@@ -92,7 +91,6 @@
     $open = false;
   }
 
-  // eslint-disable-next-line svelte/valid-compile
   run(() => {
     if ($dialogResponse === DialogResponse.Submit) {
       dispatch('submit');

--- a/frontend/src/lib/components/modals/Modal.svelte
+++ b/frontend/src/lib/components/modals/Modal.svelte
@@ -6,6 +6,7 @@
 </script>
 
 <script lang="ts">
+  import type { Snippet } from 'svelte';
   import { run } from 'svelte/legacy';
 
   import t from '$lib/i18n';
@@ -29,9 +30,9 @@
     showCloseButton?: boolean;
     closeOnClickOutside?: boolean;
     hideActions?: boolean;
-    children?: import('svelte').Snippet<[any]>;
-    actions?: import('svelte').Snippet<[any]>;
-    extraActions?: import('svelte').Snippet;
+    children?: Snippet<[any]>;
+    actions?: Snippet<[any]>;
+    extraActions?: Snippet;
   }
 
   let {

--- a/frontend/src/lib/components/modals/Modal.svelte
+++ b/frontend/src/lib/components/modals/Modal.svelte
@@ -31,7 +31,7 @@
     closeOnClickOutside?: boolean;
     hideActions?: boolean;
     children?: Snippet<[unknown]>;
-    actions?: Snippet<[{ submitting: boolean; close: () => void }]>;
+    actions?: Snippet<[{ submitting: boolean; closing?: boolean; close: () => void }]>;
     extraActions?: Snippet;
   }
 

--- a/frontend/src/lib/components/modals/Modal.svelte
+++ b/frontend/src/lib/components/modals/Modal.svelte
@@ -42,7 +42,7 @@
     hideActions = false,
     children,
     actions,
-    extraActions
+    extraActions,
   }: Props = $props();
 
   export async function openModal(autoCloseOnCancel = true, autoCloseOnSubmit = false): Promise<DialogResponse> {
@@ -115,11 +115,6 @@
     }
   });
 </script>
-<style>
-  .modal-action {
-    justify-content: var(--justify-actions, space-between)
-  }
-</style>
 
 {#if $open}
   <!-- using DaisyUI modal https://daisyui.com/components/modal/ -->
@@ -138,14 +133,14 @@
           >✕
         </button>
       {/if}
-      {@render children?.({ closing, submitting, })}
+      {@render children?.({ closing, submitting })}
       {#if actions && !hideActions}
         <div class="modal-action">
           <div class="flex gap-4">
             {@render extraActions?.()}
           </div>
           <div class="flex gap-4">
-            {@render actions?.({ closing, submitting, close, })}
+            {@render actions?.({ closing, submitting, close })}
           </div>
         </div>
       {/if}
@@ -158,3 +153,9 @@
     <Notify />
   </dialog>
 {/if}
+
+<style>
+  .modal-action {
+    justify-content: var(--justify-actions, space-between);
+  }
+</style>

--- a/frontend/src/lib/components/modals/Modal.svelte
+++ b/frontend/src/lib/components/modals/Modal.svelte
@@ -30,8 +30,8 @@
     showCloseButton?: boolean;
     closeOnClickOutside?: boolean;
     hideActions?: boolean;
-    children?: Snippet<[any]>;
-    actions?: Snippet<[any]>;
+    children?: Snippet<[unknown]>;
+    actions?: Snippet<[unknown]>;
     extraActions?: Snippet;
   }
 

--- a/frontend/src/lib/components/modals/Modal.svelte
+++ b/frontend/src/lib/components/modals/Modal.svelte
@@ -31,7 +31,7 @@
     closeOnClickOutside?: boolean;
     hideActions?: boolean;
     children?: Snippet<[unknown]>;
-    actions?: Snippet<[unknown]>;
+    actions?: Snippet<[{ submitting: boolean; close: () => void }]>;
     extraActions?: Snippet;
   }
 

--- a/frontend/src/lib/email/ApproveProjectRequest.svelte
+++ b/frontend/src/lib/email/ApproveProjectRequest.svelte
@@ -3,9 +3,13 @@
   import type { CreateProjectInput } from '$lib/gql/types';
   import t from '$lib/i18n';
 
-  export let name: string;
-  export let baseUrl: string;
-  export let project: CreateProjectInput;
+  interface Props {
+    name: string;
+    baseUrl: string;
+    project: CreateProjectInput;
+  }
+
+  let { name, baseUrl, project }: Props = $props();
   let projectUrl = new URL(`/?projectSearch=${encodeURIComponent(project.code)}`, baseUrl);
   let projectName = project.name;
 </script>

--- a/frontend/src/lib/email/CreateAccountRequestOrg.svelte
+++ b/frontend/src/lib/email/CreateAccountRequestOrg.svelte
@@ -3,12 +3,21 @@
   import t from '$lib/i18n';
   import { toI18nKey } from '$lib/util/timespan';
 
-  export let verifyUrl: string;
-  export let orgName: string;
-  export let managerName: string;
-  export let lifetime: string;
+  interface Props {
+    verifyUrl: string;
+    orgName: string;
+    managerName: string;
+    lifetime: string;
+  }
 
-  $: [expirationText, expirationParam] = toI18nKey(lifetime);
+  let {
+    verifyUrl,
+    orgName,
+    managerName,
+    lifetime
+  }: Props = $props();
+
+  let [expirationText, expirationParam] = $derived(toI18nKey(lifetime));
 </script>
 
 <Email subject={$t('emails.create_account_request_email_org.subject', {orgName})} name="">

--- a/frontend/src/lib/email/CreateAccountRequestProject.svelte
+++ b/frontend/src/lib/email/CreateAccountRequestProject.svelte
@@ -3,12 +3,21 @@
   import t from '$lib/i18n';
   import { toI18nKey } from '$lib/util/timespan';
 
-  export let verifyUrl: string;
-  export let projectName: string;
-  export let managerName: string;
-  export let lifetime: string;
+  interface Props {
+    verifyUrl: string;
+    projectName: string;
+    managerName: string;
+    lifetime: string;
+  }
 
-  $: [expirationText, expirationParam] = toI18nKey(lifetime);
+  let {
+    verifyUrl,
+    projectName,
+    managerName,
+    lifetime
+  }: Props = $props();
+
+  let [expirationText, expirationParam] = $derived(toI18nKey(lifetime));
 </script>
 
 <Email subject={$t('emails.create_account_request_email_project.subject', {projectName})} name="">

--- a/frontend/src/lib/email/CreateProjectRequest.svelte
+++ b/frontend/src/lib/email/CreateProjectRequest.svelte
@@ -6,10 +6,19 @@
     import FormatRetentionPolicy from '$lib/components/FormatRetentionPolicy.svelte';
     import { toSearchParams } from '$lib/util/query-params';
 
-    export let name: string;
-    export let baseUrl: string;
-    export let project: CreateProjectInput;
-    export let user: { name: string; email: string };
+    interface Props {
+        name: string;
+        baseUrl: string;
+        project: CreateProjectInput;
+        user: { name: string; email: string };
+    }
+
+    let {
+        name,
+        baseUrl,
+        project,
+        user
+    }: Props = $props();
     let createUrl = new URL(`/project/create?${toSearchParams<CreateProjectInput>(project)}`, baseUrl);
 </script>
 

--- a/frontend/src/lib/email/Email.svelte
+++ b/frontend/src/lib/email/Email.svelte
@@ -1,11 +1,12 @@
 <script lang="ts">
+  import type { Snippet } from 'svelte';
   import Subject from '$lib/email/Subject.svelte';
   import t from '$lib/i18n';
   const lexboxLogo = 'https://lexbox.org/images/logo-dark.png';
   interface Props {
     subject: string;
     name: string;
-    children?: import('svelte').Snippet;
+    children?: Snippet;
   }
 
   let { subject, name, children }: Props = $props();

--- a/frontend/src/lib/email/Email.svelte
+++ b/frontend/src/lib/email/Email.svelte
@@ -42,11 +42,7 @@
       <mj-column>
         <mj-divider border-color="#6a737d" border-width="1px"></mj-divider>
         <mj-social font-size="15px" icon-size="40px" icon-padding="8px" align="left">
-          <mj-social-element
-            href="https://lexbox.org"
-            src={lexboxLogo}
-            alt="Lexbox Logo"
-            font-size="20px">
+          <mj-social-element href="https://lexbox.org" src={lexboxLogo} alt="Lexbox Logo" font-size="20px">
             {$t('appbar.app_name')}
           </mj-social-element>
         </mj-social>

--- a/frontend/src/lib/email/Email.svelte
+++ b/frontend/src/lib/email/Email.svelte
@@ -2,8 +2,13 @@
   import Subject from '$lib/email/Subject.svelte';
   import t from '$lib/i18n';
   const lexboxLogo = 'https://lexbox.org/images/logo-dark.png';
-  export let subject: string;
-  export let name: string;
+  interface Props {
+    subject: string;
+    name: string;
+    children?: import('svelte').Snippet;
+  }
+
+  let { subject, name, children }: Props = $props();
 </script>
 
 <Subject value={subject} />
@@ -28,13 +33,13 @@
             {$t('emails.shared.greeting_noname')}
           {/if}
         </mj-text>
-        <mj-divider border-color="black" />
-        <slot />
+        <mj-divider border-color="black"></mj-divider>
+        {@render children?.()}
       </mj-column>
     </mj-section>
     <mj-section padding-top="100px">
       <mj-column>
-        <mj-divider border-color="#6a737d" border-width="1px" />
+        <mj-divider border-color="#6a737d" border-width="1px"></mj-divider>
         <mj-social font-size="15px" icon-size="40px" icon-padding="8px" align="left">
           <mj-social-element
             href="https://lexbox.org"

--- a/frontend/src/lib/email/EmailVerificationStatus.svelte
+++ b/frontend/src/lib/email/EmailVerificationStatus.svelte
@@ -1,4 +1,4 @@
-<script lang="ts" context="module">
+<script lang="ts" module>
   import { writable, type Writable } from 'svelte/store';
   import { defineContext } from '$lib/util/context';
 
@@ -14,10 +14,14 @@
   import { Button } from '$lib/forms';
   import { onNavigate } from '$app/navigation';
 
-  export let user: LexAuthUser;
+  interface Props {
+    user: LexAuthUser;
+  }
 
-  let sendingVerificationEmail = false;
-  let sentVerificationEmail = false;
+  let { user }: Props = $props();
+
+  let sendingVerificationEmail = $state(false);
+  let sentVerificationEmail = $state(false);
 
   async function sendVerificationEmail(): Promise<void> {
     sendingVerificationEmail = true;
@@ -45,7 +49,7 @@
       <div>{$t('account_settings.verify_email.you_have_mail')}</div>
       <span>{$t('account_settings.verify_email.verify_to_change', { $requestedEmail })}</span>
     </div>
-    <span class="i-mdi-email-heart-outline" />
+    <span class="i-mdi-email-heart-outline"></span>
   </div>
 {:else if $emailResult}
   <div class="alert alert-success" transition:slide|local>
@@ -54,7 +58,7 @@
     {:else}
       <span>{$t('account_settings.verify_email.change_success')}</span>
     {/if}
-    <span class="i-mdi-check-circle-outline" />
+    <span class="i-mdi-check-circle-outline"></span>
     <a class="btn" href="/">{$t('account_settings.verify_email.go_to_projects')}</a>
   </div>
 {:else if !user?.emailVerified}
@@ -64,7 +68,7 @@
         <div>{$t('account_settings.verify_email.you_have_mail')}</div>
         <span>{$t('account_settings.verify_email.check_inbox')}</span>
       </div>
-      <span class="i-mdi-email-heart-outline" />
+      <span class="i-mdi-email-heart-outline"></span>
     </div>
   {:else if user.email}
     <div class="alert alert-warning" transition:slide|local>

--- a/frontend/src/lib/email/EmailVerificationStatus.svelte
+++ b/frontend/src/lib/email/EmailVerificationStatus.svelte
@@ -2,8 +2,12 @@
   import { writable, type Writable } from 'svelte/store';
   import { defineContext } from '$lib/util/context';
 
-  export const { use: useRequestedEmail, init: initRequestedEmail } = defineContext<Writable<string | null>>(() => writable());
-  export const { use: useEmailResult, init: initEmailResult } = defineContext<Writable<EmailResult | null>>(() => writable());
+  export const { use: useRequestedEmail, init: initRequestedEmail } = defineContext<Writable<string | null>>(() =>
+    writable(),
+  );
+  export const { use: useEmailResult, init: initEmailResult } = defineContext<Writable<EmailResult | null>>(() =>
+    writable(),
+  );
 </script>
 
 <script lang="ts">
@@ -73,7 +77,7 @@
   {:else if user.email}
     <div class="alert alert-warning" transition:slide|local>
       <span>{$t('account_settings.verify_email.please_verify')}</span>
-      <Button loading={sendingVerificationEmail} on:click={sendVerificationEmail}>
+      <Button loading={sendingVerificationEmail} onclick={sendVerificationEmail}>
         {$t('account_settings.verify_email.resend')}
       </Button>
     </div>

--- a/frontend/src/lib/email/ForgotPassword.svelte
+++ b/frontend/src/lib/email/ForgotPassword.svelte
@@ -3,11 +3,15 @@
   import t from '$lib/i18n';
   import { toI18nKey } from '$lib/util/timespan';
 
-  export let name: string;
-  export let resetUrl: string;
-  export let lifetime: string;
+  interface Props {
+    name: string;
+    resetUrl: string;
+    lifetime: string;
+  }
 
-  $: [expirationText, expirationParam] = toI18nKey(lifetime);
+  let { name, resetUrl, lifetime }: Props = $props();
+
+  let [expirationText, expirationParam] = $derived(toI18nKey(lifetime));
 </script>
 
 <Email subject={$t('emails.forgot_password.subject')} {name}>

--- a/frontend/src/lib/email/JoinProjectRequest.svelte
+++ b/frontend/src/lib/email/JoinProjectRequest.svelte
@@ -2,12 +2,23 @@
   import Email from '$lib/email/Email.svelte';
   import t from '$lib/i18n';
 
-  export let managerName: string;
-  export let requestingUserName: string;
-  export let requestingUserId: string;
-  export let projectCode: string;
-  export let projectName: string;
-  export let baseUrl: string;
+  interface Props {
+    managerName: string;
+    requestingUserName: string;
+    requestingUserId: string;
+    projectCode: string;
+    projectName: string;
+    baseUrl: string;
+  }
+
+  let {
+    managerName,
+    requestingUserName,
+    requestingUserId,
+    projectCode,
+    projectName,
+    baseUrl
+  }: Props = $props();
   let approveUrl = new URL(`/project/${projectCode}?addUserId=${requestingUserId}&addUserName=${requestingUserName}`, baseUrl);
 
 </script>

--- a/frontend/src/lib/email/NewAdmin.svelte
+++ b/frontend/src/lib/email/NewAdmin.svelte
@@ -2,9 +2,13 @@
   import Email from '$lib/email/Email.svelte';
   import t from '$lib/i18n';
 
-  export let name: string;
-  export let adminName: string;
-  export let adminEmail: string;
+  interface Props {
+    name: string;
+    adminName: string;
+    adminEmail: string;
+  }
+
+  let { name, adminName, adminEmail }: Props = $props();
 </script>
 
 <Email subject={$t('emails.new_admin.subject', {adminName})} {name}>

--- a/frontend/src/lib/email/PasswordChanged.svelte
+++ b/frontend/src/lib/email/PasswordChanged.svelte
@@ -2,7 +2,11 @@
   import Email from '$lib/email/Email.svelte';
   import t from '$lib/i18n';
 
-  export let name: string;
+  interface Props {
+    name: string;
+  }
+
+  let { name }: Props = $props();
 </script>
 
 <Email subject={$t('emails.password_changed.subject')} {name}>

--- a/frontend/src/lib/email/Subject.svelte
+++ b/frontend/src/lib/email/Subject.svelte
@@ -1,5 +1,9 @@
 <script lang="ts">
-  export let value = '';
+  interface Props {
+    value?: string;
+  }
+
+  let { value = '' }: Props = $props();
 </script>
 
 <svelte:head>

--- a/frontend/src/lib/email/UserAdded.svelte
+++ b/frontend/src/lib/email/UserAdded.svelte
@@ -2,10 +2,19 @@
   import Email from '$lib/email/Email.svelte';
   import t from '$lib/i18n';
 
-  export let name: string;
-  export let baseUrl: string;
-  export let projectName: string;
-  export let projectCode: string;
+  interface Props {
+    name: string;
+    baseUrl: string;
+    projectName: string;
+    projectCode: string;
+  }
+
+  let {
+    name,
+    baseUrl,
+    projectName,
+    projectCode
+  }: Props = $props();
   let projectUrl = new URL(`/?projectSearch=${encodeURIComponent(projectCode)}`, baseUrl);
 </script>
 

--- a/frontend/src/lib/email/VerifyEmailAddress.svelte
+++ b/frontend/src/lib/email/VerifyEmailAddress.svelte
@@ -3,12 +3,21 @@
   import t from '$lib/i18n';
   import { toI18nKey } from '$lib/util/timespan';
 
-  export let name: string;
-  export let verifyUrl: string;
-  export let newAddress: boolean;
-  export let lifetime: string;
+  interface Props {
+    name: string;
+    verifyUrl: string;
+    newAddress: boolean;
+    lifetime: string;
+  }
 
-  $: [expirationText, expirationParam] = toI18nKey(lifetime);
+  let {
+    name,
+    verifyUrl,
+    newAddress,
+    lifetime
+  }: Props = $props();
+
+  let [expirationText, expirationParam] = $derived(toI18nKey(lifetime));
 </script>
 
 <Email subject={$t('emails.verify_email.subject')} {name}>

--- a/frontend/src/lib/error/UnexpectedError.svelte
+++ b/frontend/src/lib/error/UnexpectedError.svelte
@@ -7,8 +7,8 @@
   import { onDestroy } from 'svelte';
   import { browser } from '$app/environment';
 
-  let alertMessageElem: HTMLElement = $state()!;
-  let traceIdElem: HTMLElement = $state()!;
+  let alertMessageElem: HTMLElement | undefined = $state();
+  let traceIdElem: HTMLElement | undefined = $state();
 
   const error = derived(useError(), (error) => {
     if (error) {
@@ -35,9 +35,12 @@
     error.subscribe((e) => {
       if (e) {
         alertMessageElem =
-          alertMessageElem ?? (browser ? document.querySelector('.error-message') : undefined) ?? undefined;
+          alertMessageElem ??
+          (browser ? (document.querySelector('.error-message') as HTMLElement) : undefined) ??
+          undefined;
         if (alertMessageElem) alertMessageElem.textContent = e.message;
-        traceIdElem = traceIdElem ?? (browser ? document.querySelector('.trace-id') : undefined) ?? undefined;
+        traceIdElem =
+          traceIdElem ?? (browser ? (document.querySelector('.trace-id') as HTMLElement) : undefined) ?? undefined;
         if (traceIdElem) traceIdElem.textContent = e.traceId;
       }
     }),
@@ -89,7 +92,8 @@
 
   <div>
     <span>{$t('errors.error_code')}:</span>
-    <!-- svelte-ignore a11y_no_static_element_interactions a11y_click_events_have_key_events -->
+    <!-- svelte-ignore a11y_no_static_element_interactions -->
+    <!-- svelte-ignore a11y_click_events_have_key_events -->
     <span onclick={onTraceIdClick} class="trace-id" bind:this={traceIdElem}>{$error?.traceId}</span>
   </div>
 </div>

--- a/frontend/src/lib/error/UnexpectedError.svelte
+++ b/frontend/src/lib/error/UnexpectedError.svelte
@@ -34,12 +34,13 @@
     // subscribe() is more durable than reactive syntax
     error.subscribe((e) => {
       if (e) {
-        alertMessageElem = alertMessageElem ?? (browser ? document.querySelector('.error-message') : undefined) ?? undefined;
+        alertMessageElem =
+          alertMessageElem ?? (browser ? document.querySelector('.error-message') : undefined) ?? undefined;
         if (alertMessageElem) alertMessageElem.textContent = e.message;
         traceIdElem = traceIdElem ?? (browser ? document.querySelector('.trace-id') : undefined) ?? undefined;
         if (traceIdElem) traceIdElem.textContent = e.traceId;
       }
-    })
+    }),
   );
 
   const TIME_RANGE_2024_TO_2040 = 'trace_start_ts=1704286862&trace_end_ts=2209042862';
@@ -72,7 +73,11 @@
     <span class="text-2xl">{$t('errors.apology')}</span>
   </div>
 
-  <div class="max-w-full whitespace-pre-wrap error-message" style="overflow-wrap: break-word" bind:this={alertMessageElem}>
+  <div
+    class="max-w-full whitespace-pre-wrap error-message"
+    style="overflow-wrap: break-word"
+    bind:this={alertMessageElem}
+  >
     {$error?.message}
   </div>
 

--- a/frontend/src/lib/error/UnexpectedError.svelte
+++ b/frontend/src/lib/error/UnexpectedError.svelte
@@ -7,8 +7,8 @@
   import { onDestroy } from 'svelte';
   import { browser } from '$app/environment';
 
-  let alertMessageElem: HTMLElement = $state();
-  let traceIdElem: HTMLElement = $state();
+  let alertMessageElem: HTMLElement = $state()!;
+  let traceIdElem: HTMLElement = $state()!;
 
   const error = derived(useError(), (error) => {
     if (error) {

--- a/frontend/src/lib/error/UnexpectedError.svelte
+++ b/frontend/src/lib/error/UnexpectedError.svelte
@@ -89,7 +89,7 @@
 
   <div>
     <span>{$t('errors.error_code')}:</span>
-    <!-- svelte-ignore a11y_no_static_element_interactions, a11y_click_events_have_key_events -->
+    <!-- svelte-ignore a11y_no_static_element_interactions a11y_click_events_have_key_events -->
     <span onclick={onTraceIdClick} class="trace-id" bind:this={traceIdElem}>{$error?.traceId}</span>
   </div>
 </div>

--- a/frontend/src/lib/error/UnexpectedError.svelte
+++ b/frontend/src/lib/error/UnexpectedError.svelte
@@ -7,8 +7,8 @@
   import { onDestroy } from 'svelte';
   import { browser } from '$app/environment';
 
-  let alertMessageElem: HTMLElement;
-  let traceIdElem: HTMLElement;
+  let alertMessageElem: HTMLElement = $state();
+  let traceIdElem: HTMLElement = $state();
 
   const error = derived(useError(), (error) => {
     if (error) {
@@ -68,7 +68,7 @@
 
 <div class="flex flex-col gap-4 items-start">
   <div class="flex gap-4">
-    <span class="i-mdi-alert-circle-outline text-3xl" />
+    <span class="i-mdi-alert-circle-outline text-3xl"></span>
     <span class="text-2xl">{$t('errors.apology')}</span>
   </div>
 
@@ -84,7 +84,7 @@
 
   <div>
     <span>{$t('errors.error_code')}:</span>
-    <!-- svelte-ignore a11y-no-static-element-interactions a11y-click-events-have-key-events -->
-    <span on:click={onTraceIdClick} class="trace-id" bind:this={traceIdElem}>{$error?.traceId}</span>
+    <!-- svelte-ignore a11y_no_static_element_interactions, a11y_click_events_have_key_events -->
+    <span onclick={onTraceIdClick} class="trace-id" bind:this={traceIdElem}>{$error?.traceId}</span>
   </div>
 </div>

--- a/frontend/src/lib/error/UnexpectedErrorAlert.svelte
+++ b/frontend/src/lib/error/UnexpectedErrorAlert.svelte
@@ -6,7 +6,7 @@
   import { onDestroy } from 'svelte';
   import { browser } from '$app/environment';
 
-  let dialog: HTMLDialogElement;
+  let dialog: HTMLDialogElement = $state();
   const error = useError();
   const dismiss = useDismiss();
   beforeNavigate(dismiss);
@@ -45,7 +45,7 @@
         {$t('errors.go_home')}
         <span class="i-mdi-home-outline text-xl"></span>
       </a>
-      <button on:click={dismissClick} class="btn btn-outline self-end">
+      <button onclick={dismissClick} class="btn btn-outline self-end">
         {$t('modal.dismiss')}
         <span class="i-mdi-close text-xl"></span>
       </button>

--- a/frontend/src/lib/error/UnexpectedErrorAlert.svelte
+++ b/frontend/src/lib/error/UnexpectedErrorAlert.svelte
@@ -6,7 +6,7 @@
   import { onDestroy } from 'svelte';
   import { browser } from '$app/environment';
 
-  let dialog: HTMLDialogElement = $state()!;
+  let dialog: HTMLDialogElement | undefined = $state();
   const error = useError();
   const dismiss = useDismiss();
   beforeNavigate(dismiss);
@@ -14,7 +14,8 @@
   onDestroy(
     // subscribe() is more durable than reactive syntax
     error.subscribe((e) => {
-      dialog = dialog ?? (browser ? document.querySelector('.error-alert') : undefined) ?? undefined;
+      dialog =
+        dialog ?? (browser ? (document.querySelector('.error-alert') as HTMLDialogElement) : undefined) ?? undefined;
       if (!dialog) return;
       // eslint-disable-next-line @typescript-eslint/no-unused-expressions
       e ? open() : close();
@@ -27,13 +28,13 @@
   }
 
   function open(): void {
-    dialog.showModal?.call(dialog);
-    dialog.classList.add('modal-open');
+    dialog?.showModal?.call(dialog);
+    dialog?.classList.add('modal-open');
   }
 
   function close(): void {
-    dialog.close?.call(dialog);
-    dialog.classList.remove('modal-open');
+    dialog?.close?.call(dialog);
+    dialog?.classList.remove('modal-open');
   }
 </script>
 

--- a/frontend/src/lib/error/UnexpectedErrorAlert.svelte
+++ b/frontend/src/lib/error/UnexpectedErrorAlert.svelte
@@ -1,12 +1,12 @@
 <script lang="ts">
   import { beforeNavigate } from '$app/navigation';
-  import {useDismiss, useError} from '.';
+  import { useDismiss, useError } from '.';
   import t from '$lib/i18n';
   import UnexpectedError from './UnexpectedError.svelte';
   import { onDestroy } from 'svelte';
   import { browser } from '$app/environment';
 
-  let dialog: HTMLDialogElement = $state();
+  let dialog: HTMLDialogElement = $state()!;
   const error = useError();
   const dismiss = useDismiss();
   beforeNavigate(dismiss);
@@ -18,7 +18,7 @@
       if (!dialog) return;
       // eslint-disable-next-line @typescript-eslint/no-unused-expressions
       e ? open() : close();
-    })
+    }),
   );
 
   function dismissClick(): void {

--- a/frontend/src/lib/forms/Button.svelte
+++ b/frontend/src/lib/forms/Button.svelte
@@ -15,7 +15,7 @@
     disabled?: boolean;
     customLoader?: boolean;
     children?: Snippet;
-    [key: string]: any;
+    [key: string]: unknown;
   }
 
   let {

--- a/frontend/src/lib/forms/Button.svelte
+++ b/frontend/src/lib/forms/Button.svelte
@@ -1,8 +1,5 @@
 <script lang="ts">
   import type { Snippet } from 'svelte';
-  import { createBubbler } from 'svelte/legacy';
-
-  const bubble = createBubbler();
   import Loader from '$lib/components/Loader.svelte';
 
   interface Props {

--- a/frontend/src/lib/forms/Button.svelte
+++ b/frontend/src/lib/forms/Button.svelte
@@ -15,7 +15,7 @@
     disabled?: boolean;
     customLoader?: boolean;
     children?: Snippet;
-    onclick: () => void;
+    onclick?: () => void;
     [key: string]: unknown;
   }
 

--- a/frontend/src/lib/forms/Button.svelte
+++ b/frontend/src/lib/forms/Button.svelte
@@ -1,24 +1,44 @@
 <script lang="ts">
+  import { createBubbler } from 'svelte/legacy';
+
+  const bubble = createBubbler();
   import Loader from '$lib/components/Loader.svelte';
 
-  export let loading = false;
-  export let active = false;
-  export let variant: 'btn-primary' | 'btn-success' | 'btn-error' | 'btn-ghost' | 'btn-warning' | 'btn-accent' | undefined = undefined;
-  export let outline = false;
-  export let type: undefined | 'submit' = undefined;
-  export let size: undefined | 'btn-sm' = undefined;
-  export let disabled = false;
-  export let customLoader = false;
+  interface Props {
+    loading?: boolean;
+    active?: boolean;
+    variant?: 'btn-primary' | 'btn-success' | 'btn-error' | 'btn-ghost' | 'btn-warning' | 'btn-accent' | undefined;
+    outline?: boolean;
+    type?: undefined | 'submit';
+    size?: undefined | 'btn-sm';
+    disabled?: boolean;
+    customLoader?: boolean;
+    children?: import('svelte').Snippet;
+    [key: string]: any
+  }
+
+  let {
+    loading = false,
+    active = false,
+    variant = undefined,
+    outline = false,
+    type = undefined,
+    size = undefined,
+    disabled = false,
+    customLoader = false,
+    children,
+    ...rest
+  }: Props = $props();
 </script>
 
 <!-- https://daisyui.com/components/button -->
-<button on:click {...$$restProps} class="btn whitespace-nowrap {variant ?? ''} {$$restProps.class ?? ''} {size ?? ''}" {type}
+<button onclick={bubble('click')} {...rest} class="btn whitespace-nowrap {variant ?? ''} {rest.class ?? ''} {size ?? ''}" {type}
   class:btn-outline={outline}
   class:btn-active={active}
   disabled={disabled && !loading}
-  class:pointer-events-none={loading || $$restProps.class?.includes('pointer-events-none')}>
+  class:pointer-events-none={loading || rest.class?.includes('pointer-events-none')}>
   {#if !customLoader}
     <Loader {loading} />
   {/if}
-  <slot />
+  {@render children?.()}
 </button>

--- a/frontend/src/lib/forms/Button.svelte
+++ b/frontend/src/lib/forms/Button.svelte
@@ -15,6 +15,7 @@
     disabled?: boolean;
     customLoader?: boolean;
     children?: Snippet;
+    onclick: () => void;
     [key: string]: unknown;
   }
 
@@ -28,20 +29,21 @@
     disabled = false,
     customLoader = false,
     children,
+    onclick,
     ...rest
   }: Props = $props();
 </script>
 
 <!-- https://daisyui.com/components/button -->
 <button
-  onclick={bubble('click')}
+  {onclick}
   {...rest}
   class="btn whitespace-nowrap {variant ?? ''} {rest.class ?? ''} {size ?? ''}"
   {type}
   class:btn-outline={outline}
   class:btn-active={active}
   disabled={disabled && !loading}
-  class:pointer-events-none={loading || rest.class?.includes('pointer-events-none')}
+  class:pointer-events-none={loading || (rest.class as string)?.includes('pointer-events-none')}
 >
   {#if !customLoader}
     <Loader {loading} />

--- a/frontend/src/lib/forms/Button.svelte
+++ b/frontend/src/lib/forms/Button.svelte
@@ -33,11 +33,16 @@
 </script>
 
 <!-- https://daisyui.com/components/button -->
-<button onclick={bubble('click')} {...rest} class="btn whitespace-nowrap {variant ?? ''} {rest.class ?? ''} {size ?? ''}" {type}
+<button
+  onclick={bubble('click')}
+  {...rest}
+  class="btn whitespace-nowrap {variant ?? ''} {rest.class ?? ''} {size ?? ''}"
+  {type}
   class:btn-outline={outline}
   class:btn-active={active}
   disabled={disabled && !loading}
-  class:pointer-events-none={loading || rest.class?.includes('pointer-events-none')}>
+  class:pointer-events-none={loading || rest.class?.includes('pointer-events-none')}
+>
   {#if !customLoader}
     <Loader {loading} />
   {/if}

--- a/frontend/src/lib/forms/Button.svelte
+++ b/frontend/src/lib/forms/Button.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import type { Snippet } from 'svelte';
   import { createBubbler } from 'svelte/legacy';
 
   const bubble = createBubbler();
@@ -13,8 +14,8 @@
     size?: undefined | 'btn-sm';
     disabled?: boolean;
     customLoader?: boolean;
-    children?: import('svelte').Snippet;
-    [key: string]: any
+    children?: Snippet;
+    [key: string]: any;
   }
 
   let {

--- a/frontend/src/lib/forms/Checkbox.svelte
+++ b/frontend/src/lib/forms/Checkbox.svelte
@@ -1,12 +1,12 @@
 <script lang="ts">
-  import {NewTabLinkMarkdown} from '$lib/components/Markdown';
+  import { NewTabLinkMarkdown } from '$lib/components/Markdown';
   import FormFieldError from './FormFieldError.svelte';
   import { randomFormId } from './utils';
 
   interface Props {
     label: string;
     value: boolean;
-    id?: any;
+    id?: string;
     error?: string | string[] | undefined;
     description?: string | undefined;
     variant?: 'checkbox-warning' | undefined;
@@ -20,7 +20,7 @@
     error = undefined,
     description = undefined,
     variant = undefined,
-    labelColor = undefined
+    labelColor = undefined,
   }: Props = $props();
 </script>
 

--- a/frontend/src/lib/forms/Checkbox.svelte
+++ b/frontend/src/lib/forms/Checkbox.svelte
@@ -3,13 +3,25 @@
   import FormFieldError from './FormFieldError.svelte';
   import { randomFormId } from './utils';
 
-  export let label: string;
-  export let value: boolean;
-  export let id = randomFormId();
-  export let error: string | string[] | undefined = undefined;
-  export let description: string | undefined = undefined;
-  export let variant: 'checkbox-warning' | undefined = undefined;
-  export let labelColor: 'text-warning' | undefined = undefined;
+  interface Props {
+    label: string;
+    value: boolean;
+    id?: any;
+    error?: string | string[] | undefined;
+    description?: string | undefined;
+    variant?: 'checkbox-warning' | undefined;
+    labelColor?: 'text-warning' | undefined;
+  }
+
+  let {
+    label,
+    value = $bindable(),
+    id = randomFormId(),
+    error = undefined,
+    description = undefined,
+    variant = undefined,
+    labelColor = undefined
+  }: Props = $props();
 </script>
 
 <div class="form-control w-full">

--- a/frontend/src/lib/forms/DisplayLanguageSelect.svelte
+++ b/frontend/src/lib/forms/DisplayLanguageSelect.svelte
@@ -2,7 +2,7 @@
   import t from '$lib/i18n';
   import { availableLocales } from '$locales';
 
-  import Select, { type Props as SelectProps } from './Select.svelte';
+  import Select, { type SelectProps } from './Select.svelte';
 
   interface Props extends SelectProps {
     id?: string;

--- a/frontend/src/lib/forms/DisplayLanguageSelect.svelte
+++ b/frontend/src/lib/forms/DisplayLanguageSelect.svelte
@@ -4,7 +4,7 @@
 
   import Select, { type SelectProps } from './Select.svelte';
 
-  interface Props extends SelectProps {
+  interface Props extends Omit<SelectProps, 'label'> {
     id?: string;
     value: string;
   }

--- a/frontend/src/lib/forms/DisplayLanguageSelect.svelte
+++ b/frontend/src/lib/forms/DisplayLanguageSelect.svelte
@@ -4,10 +4,14 @@
 
   import { Select } from '.';
 
-  export let id = 'display-language';
-  export let value: string;
+  interface Props {
+    id?: string;
+    value: string;
+  }
 
-  $: currentValueNotSupported = value && !availableLocales.includes(value);
+  let { id = 'display-language', value = $bindable() }: Props = $props();
+
+  let currentValueNotSupported = $derived(value && !availableLocales.includes(value));
   const localNames: Record<string, string> = {
     en: 'English',
     es: 'Español',

--- a/frontend/src/lib/forms/DisplayLanguageSelect.svelte
+++ b/frontend/src/lib/forms/DisplayLanguageSelect.svelte
@@ -2,14 +2,14 @@
   import t from '$lib/i18n';
   import { availableLocales } from '$locales';
 
-  import { Select } from '.';
+  import Select, { type Props as SelectProps } from './Select.svelte';
 
-  interface Props {
+  interface Props extends SelectProps {
     id?: string;
     value: string;
   }
 
-  let { id = 'display-language', value = $bindable() }: Props = $props();
+  let { id = 'display-language', value = $bindable(), ...rest }: Props = $props();
 
   let currentValueNotSupported = $derived(value && !availableLocales.includes(value));
   const localNames: Record<string, string> = {
@@ -20,7 +20,7 @@
   };
 </script>
 
-<Select {id} bind:value label={$t('account_settings.language.title')}>
+<Select {...rest} {id} bind:value label={$t('account_settings.language.title')}>
   {#if currentValueNotSupported}
     <!-- Make sure we don't overwrite persisted locales that we don't support yet -->
     <option {value}>{value} ({$t('account_settings.language.not_supported')})</option>

--- a/frontend/src/lib/forms/Form.svelte
+++ b/frontend/src/lib/forms/Form.svelte
@@ -1,8 +1,6 @@
 <script lang="ts">
   import type { Snippet } from 'svelte';
-  import { createBubbler, preventDefault } from 'svelte/legacy';
 
-  const bubble = createBubbler();
   import type { AnySuperForm } from './types';
 
   let formElem: HTMLFormElement | undefined = $state();
@@ -30,7 +28,7 @@
   {id}
   use:enhanceIfRequested
   method="post"
-  onsubmit={preventDefault(bubble('submit'))}
+  onsubmit={e => e.preventDefault()}
   class="flex flex-col"
 >
   {@render children?.()}

--- a/frontend/src/lib/forms/Form.svelte
+++ b/frontend/src/lib/forms/Form.svelte
@@ -1,10 +1,18 @@
 <script lang="ts">
+  import { createBubbler, preventDefault } from 'svelte/legacy';
+
+  const bubble = createBubbler();
   import type { AnySuperForm } from './types';
 
-  let formElem: HTMLFormElement;
-  export let id: string | undefined = undefined;
+  let formElem: HTMLFormElement = $state();
 
-  export let enhance: AnySuperForm['enhance'] | undefined = undefined;
+  interface Props {
+    id?: string | undefined;
+    enhance?: AnySuperForm['enhance'] | undefined;
+    children?: import('svelte').Snippet;
+  }
+
+  let { id = undefined, enhance = undefined, children }: Props = $props();
   function enhanceIfRequested(...args: Parameters<AnySuperForm['enhance']>): void {
     // eslint-disable-next-line @typescript-eslint/no-unused-expressions
     enhance && enhance(...args);
@@ -16,7 +24,7 @@
 </script>
 
 <!-- https://daisyui.com/components/input/#with-form-control-and-labels -->
-<form bind:this={formElem} {id} use:enhanceIfRequested method="post" on:submit|preventDefault class="flex flex-col">
-  <slot />
+<form bind:this={formElem} {id} use:enhanceIfRequested method="post" onsubmit={preventDefault(bubble('submit'))} class="flex flex-col">
+  {@render children?.()}
 </form>
 <!-- see frontend/src/app.postcss for global styles related to forms -->

--- a/frontend/src/lib/forms/Form.svelte
+++ b/frontend/src/lib/forms/Form.svelte
@@ -25,7 +25,14 @@
 </script>
 
 <!-- https://daisyui.com/components/input/#with-form-control-and-labels -->
-<form bind:this={formElem} {id} use:enhanceIfRequested method="post" onsubmit={preventDefault(bubble('submit'))} class="flex flex-col">
+<form
+  bind:this={formElem}
+  {id}
+  use:enhanceIfRequested
+  method="post"
+  onsubmit={preventDefault(bubble('submit'))}
+  class="flex flex-col"
+>
   {@render children?.()}
 </form>
 <!-- see frontend/src/app.postcss for global styles related to forms -->

--- a/frontend/src/lib/forms/Form.svelte
+++ b/frontend/src/lib/forms/Form.svelte
@@ -5,7 +5,7 @@
   const bubble = createBubbler();
   import type { AnySuperForm } from './types';
 
-  let formElem: HTMLFormElement = $state()!;
+  let formElem: HTMLFormElement | undefined = $state();
 
   interface Props {
     id?: string | undefined;
@@ -20,7 +20,7 @@
   }
 
   export function requestSubmit(): void {
-    formElem.requestSubmit();
+    formElem?.requestSubmit();
   }
 </script>
 

--- a/frontend/src/lib/forms/Form.svelte
+++ b/frontend/src/lib/forms/Form.svelte
@@ -5,7 +5,7 @@
   const bubble = createBubbler();
   import type { AnySuperForm } from './types';
 
-  let formElem: HTMLFormElement = $state();
+  let formElem: HTMLFormElement = $state()!;
 
   interface Props {
     id?: string | undefined;

--- a/frontend/src/lib/forms/Form.svelte
+++ b/frontend/src/lib/forms/Form.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import type { Snippet } from 'svelte';
   import { createBubbler, preventDefault } from 'svelte/legacy';
 
   const bubble = createBubbler();
@@ -9,7 +10,7 @@
   interface Props {
     id?: string | undefined;
     enhance?: AnySuperForm['enhance'] | undefined;
-    children?: import('svelte').Snippet;
+    children?: Snippet;
   }
 
   let { id = undefined, enhance = undefined, children }: Props = $props();

--- a/frontend/src/lib/forms/FormError.svelte
+++ b/frontend/src/lib/forms/FormError.svelte
@@ -2,9 +2,13 @@
   import {NewTabLinkMarkdown} from '$lib/components/Markdown';
   import type { ErrorMessage } from './types';
 
-  export let error: ErrorMessage = undefined;
-  export let markdown = false;
-  export let right = false; // when the form submit button is on the right
+  interface Props {
+    error?: ErrorMessage;
+    markdown?: boolean;
+    right?: boolean; // when the form submit button is on the right
+  }
+
+  let { error = undefined, markdown = false, right = false }: Props = $props();
 </script>
 
 {#if error}

--- a/frontend/src/lib/forms/FormField.svelte
+++ b/frontend/src/lib/forms/FormField.svelte
@@ -3,11 +3,10 @@
   import { onMount } from 'svelte';
   import FormFieldError from './FormFieldError.svelte';
   import { randomFormId } from './utils';
-  import {NewTabLinkMarkdown} from '$lib/components/Markdown';
+  import { NewTabLinkMarkdown } from '$lib/components/Markdown';
   import type { HelpLink } from '$lib/components/help';
   import SupHelp from '$lib/components/help/SupHelp.svelte';
 
-  
   interface Props {
     label: string;
     description?: string | undefined;
@@ -15,9 +14,9 @@
     id?: string;
     helpLink?: HelpLink | undefined;
     /**
-   * For login pages, EditableText, admin pages etc. auto focus is not a real accessibility problem.
-   * So we allow/support it and disable a11y-autofocus warnings in generic places.
-   */
+     * For login pages, EditableText, admin pages etc. auto focus is not a real accessibility problem.
+     * So we allow/support it and disable a11y-autofocus warnings in generic places.
+     */
     autofocus?: boolean;
     children?: Snippet;
   }
@@ -29,7 +28,7 @@
     id = randomFormId(),
     helpLink = undefined,
     autofocus = false,
-    children
+    children,
   }: Props = $props();
 
   let elem: HTMLDivElement = $state();

--- a/frontend/src/lib/forms/FormField.svelte
+++ b/frontend/src/lib/forms/FormField.svelte
@@ -31,13 +31,13 @@
     children,
   }: Props = $props();
 
-  let elem: HTMLDivElement = $state()!;
+  let elem: HTMLDivElement | undefined = $state();
 
   onMount(autofocusIfRequested);
 
   function autofocusIfRequested(): void {
     // eslint-disable-next-line @typescript-eslint/no-unused-expressions
-    autofocus && elem.querySelector<HTMLElement>('input, select, textarea')?.focus();
+    autofocus && elem?.querySelector<HTMLElement>('input, select, textarea')?.focus();
   }
 </script>
 

--- a/frontend/src/lib/forms/FormField.svelte
+++ b/frontend/src/lib/forms/FormField.svelte
@@ -31,7 +31,7 @@
     children,
   }: Props = $props();
 
-  let elem: HTMLDivElement = $state();
+  let elem: HTMLDivElement = $state()!;
 
   onMount(autofocusIfRequested);
 

--- a/frontend/src/lib/forms/FormField.svelte
+++ b/frontend/src/lib/forms/FormField.svelte
@@ -6,18 +6,32 @@
   import type { HelpLink } from '$lib/components/help';
   import SupHelp from '$lib/components/help/SupHelp.svelte';
 
-  export let label: string;
-  export let description: string | undefined = undefined;
-  export let error: string | string[] | undefined = undefined;
-  export let id: string = randomFormId();
-  export let helpLink: HelpLink | undefined = undefined;
-  /**
+  
+  interface Props {
+    label: string;
+    description?: string | undefined;
+    error?: string | string[] | undefined;
+    id?: string;
+    helpLink?: HelpLink | undefined;
+    /**
    * For login pages, EditableText, admin pages etc. auto focus is not a real accessibility problem.
    * So we allow/support it and disable a11y-autofocus warnings in generic places.
    */
-  export let autofocus = false;
+    autofocus?: boolean;
+    children?: import('svelte').Snippet;
+  }
 
-  let elem: HTMLDivElement;
+  let {
+    label,
+    description = undefined,
+    error = undefined,
+    id = randomFormId(),
+    helpLink = undefined,
+    autofocus = false,
+    children
+  }: Props = $props();
+
+  let elem: HTMLDivElement = $state();
 
   onMount(autofocusIfRequested);
 
@@ -36,7 +50,7 @@
       {/if}
     </span>
   </label>
-  <slot />
+  {@render children?.()}
   {#if description}
     <label for={id} class="label pb-0 underline-links">
       <span class="label-text-alt description">

--- a/frontend/src/lib/forms/FormField.svelte
+++ b/frontend/src/lib/forms/FormField.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import type { Snippet } from 'svelte';
   import { onMount } from 'svelte';
   import FormFieldError from './FormFieldError.svelte';
   import { randomFormId } from './utils';
@@ -18,7 +19,7 @@
    * So we allow/support it and disable a11y-autofocus warnings in generic places.
    */
     autofocus?: boolean;
-    children?: import('svelte').Snippet;
+    children?: Snippet;
   }
 
   let {

--- a/frontend/src/lib/forms/FormFieldError.svelte
+++ b/frontend/src/lib/forms/FormFieldError.svelte
@@ -1,6 +1,10 @@
 <script lang="ts">
-  export let error: string | string[] | undefined;
-  export let id: string;
+  interface Props {
+    error: string | string[] | undefined;
+    id: string;
+  }
+
+  let { error, id }: Props = $props();
 </script>
 
 {#if error}

--- a/frontend/src/lib/forms/Input.svelte
+++ b/frontend/src/lib/forms/Input.svelte
@@ -5,9 +5,9 @@
   import IconButton from '$lib/components/IconButton.svelte';
 
   // Despite the compatibility table, 'new-password' seems to work well in Chrome, Edge & Firefox
-  
+
   interface Props {
-    id?: any;
+    id?: string;
     label: string;
     description?: string | undefined;
     value?: string | undefined | null;
@@ -30,24 +30,40 @@
     readonly = false,
     error = undefined,
     placeholder = '',
-    autocomplete = undefined
+    autocomplete = undefined,
   }: Props = $props();
 
   let currentType = $state(type);
 
   function togglePasswordVisibility(): void {
     if (type == 'password') {
-      currentType = (currentType == 'password') ? 'text' : 'password';
+      currentType = currentType == 'password' ? 'text' : 'password';
     }
   }
-
 </script>
 
 <FormField {id} {error} {label} {autofocus} {description}>
-  {#if (type == 'password')}
+  {#if type == 'password'}
     <div class="relative">
-      <PlainInput {id} bind:value on:input type={currentType} {autofocus} {readonly} {error} {placeholder} {autocomplete} style="w-full" />
-      <span class="eye"><IconButton variant="btn-ghost" icon={currentType == 'password' ? 'i-mdi-eye' : 'i-mdi-eye-off'} on:click={togglePasswordVisibility} /></span>
+      <PlainInput
+        {id}
+        bind:value
+        on:input
+        type={currentType}
+        {autofocus}
+        {readonly}
+        {error}
+        {placeholder}
+        {autocomplete}
+        style="w-full"
+      />
+      <span class="eye"
+        ><IconButton
+          variant="btn-ghost"
+          icon={currentType == 'password' ? 'i-mdi-eye' : 'i-mdi-eye-off'}
+          on:click={togglePasswordVisibility}
+        /></span
+      >
     </div>
   {:else}
     <PlainInput {id} bind:value on:input {type} {autofocus} {readonly} {error} {placeholder} {autocomplete} />

--- a/frontend/src/lib/forms/Input.svelte
+++ b/frontend/src/lib/forms/Input.svelte
@@ -4,8 +4,6 @@
   import FormField from './FormField.svelte';
   import IconButton from '$lib/components/IconButton.svelte';
 
-  // Despite the compatibility table, 'new-password' seems to work well in Chrome, Edge & Firefox
-
   interface Props {
     id?: string;
     label: string;
@@ -16,6 +14,7 @@
     readonly?: boolean;
     error?: string | string[] | undefined;
     placeholder?: string;
+    // Despite the compatibility table, 'new-password' seems to work well in Chrome, Edge & Firefox
     // https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/autocomplete#browser_compatibility
     autocomplete?: 'new-password' | 'current-password' | undefined;
   }

--- a/frontend/src/lib/forms/Input.svelte
+++ b/frontend/src/lib/forms/Input.svelte
@@ -4,20 +4,36 @@
   import FormField from './FormField.svelte';
   import IconButton from '$lib/components/IconButton.svelte';
 
-  export let id = randomFormId();
-  export let label: string;
-  export let description: string | undefined = undefined;
-  export let value: string | undefined | null = undefined;
-  export let type: 'text' | 'email' | 'password' = 'text';
-  export let autofocus: true | undefined = undefined;
-  export let readonly = false;
-  export let error: string | string[] | undefined = undefined;
-  export let placeholder = '';
   // Despite the compatibility table, 'new-password' seems to work well in Chrome, Edge & Firefox
-  // https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/autocomplete#browser_compatibility
-  export let autocomplete: 'new-password' | 'current-password' | undefined = undefined;
+  
+  interface Props {
+    id?: any;
+    label: string;
+    description?: string | undefined;
+    value?: string | undefined | null;
+    type?: 'text' | 'email' | 'password';
+    autofocus?: true | undefined;
+    readonly?: boolean;
+    error?: string | string[] | undefined;
+    placeholder?: string;
+    // https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/autocomplete#browser_compatibility
+    autocomplete?: 'new-password' | 'current-password' | undefined;
+  }
 
-  let currentType = type;
+  let {
+    id = randomFormId(),
+    label,
+    description = undefined,
+    value = $bindable(undefined),
+    type = 'text',
+    autofocus = undefined,
+    readonly = false,
+    error = undefined,
+    placeholder = '',
+    autocomplete = undefined
+  }: Props = $props();
+
+  let currentType = $state(type);
 
   function togglePasswordVisibility(): void {
     if (type == 'password') {

--- a/frontend/src/lib/forms/Input.svelte
+++ b/frontend/src/lib/forms/Input.svelte
@@ -61,7 +61,7 @@
         ><IconButton
           variant="btn-ghost"
           icon={currentType == 'password' ? 'i-mdi-eye' : 'i-mdi-eye-off'}
-          on:click={togglePasswordVisibility}
+          onclick={togglePasswordVisibility}
         /></span
       >
     </div>

--- a/frontend/src/lib/forms/MaybeProtectedForm.svelte
+++ b/frontend/src/lib/forms/MaybeProtectedForm.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import type { Snippet } from 'svelte';
   import Form from './Form.svelte';
   import ProtectedForm from './ProtectedForm.svelte';
   import type { AnySuperForm } from './types';
@@ -7,7 +8,7 @@
     enhance?: AnySuperForm['enhance'] | undefined;
     turnstileToken?: string;
     skipTurnstile?: boolean;
-    children?: import('svelte').Snippet;
+    children?: Snippet;
   }
 
   let {

--- a/frontend/src/lib/forms/MaybeProtectedForm.svelte
+++ b/frontend/src/lib/forms/MaybeProtectedForm.svelte
@@ -11,20 +11,15 @@
     children?: Snippet;
   }
 
-  let {
-    enhance = undefined,
-    turnstileToken = $bindable(''),
-    skipTurnstile = false,
-    children
-  }: Props = $props();
+  let { enhance = undefined, turnstileToken = $bindable(''), skipTurnstile = false, children }: Props = $props();
 </script>
 
 {#if skipTurnstile}
-<Form {enhance} on:submit>
-  {@render children?.()}
-</Form>
+  <Form {enhance} on:submit>
+    {@render children?.()}
+  </Form>
 {:else}
-<ProtectedForm {enhance} on:submit bind:turnstileToken>
-  {@render children?.()}
-</ProtectedForm>
+  <ProtectedForm {enhance} on:submit bind:turnstileToken>
+    {@render children?.()}
+  </ProtectedForm>
 {/if}

--- a/frontend/src/lib/forms/MaybeProtectedForm.svelte
+++ b/frontend/src/lib/forms/MaybeProtectedForm.svelte
@@ -16,20 +16,15 @@
     turnstileToken = $bindable(''),
     skipTurnstile = false,
     children,
-    ...rest
   }: Props = $props();
 </script>
 
 {#if skipTurnstile}
-  <!-- TODO: This used to have an on:submit attribute to bubble up the submit event from HTML.
-       Let's check if the createBubbler() call in Form makes that unnecessary now. -->
-  <Form {enhance} {...rest}>
+  <Form {enhance}>
     {@render children?.()}
   </Form>
 {:else}
-  <!-- TODO: This used to have an on:submit attribute to bubble up the submit event from HTML.
-       Let's check if the createBubbler() call in Form makes that unnecessary now. -->
-  <ProtectedForm {enhance} bind:turnstileToken {...rest}>
+  <ProtectedForm {enhance} bind:turnstileToken>
     {@render children?.()}
   </ProtectedForm>
 {/if}

--- a/frontend/src/lib/forms/MaybeProtectedForm.svelte
+++ b/frontend/src/lib/forms/MaybeProtectedForm.svelte
@@ -11,19 +11,25 @@
     children?: Snippet;
   }
 
-  let { enhance = undefined, turnstileToken = $bindable(''), skipTurnstile = false, children }: Props = $props();
+  let {
+    enhance = undefined,
+    turnstileToken = $bindable(''),
+    skipTurnstile = false,
+    children,
+    ...rest
+  }: Props = $props();
 </script>
 
 {#if skipTurnstile}
   <!-- TODO: This used to have an on:submit attribute to bubble up the submit event from HTML.
        Let's check if the createBubbler() call in Form makes that unnecessary now. -->
-  <Form {enhance}>
+  <Form {enhance} {...rest}>
     {@render children?.()}
   </Form>
 {:else}
   <!-- TODO: This used to have an on:submit attribute to bubble up the submit event from HTML.
        Let's check if the createBubbler() call in Form makes that unnecessary now. -->
-  <ProtectedForm {enhance} bind:turnstileToken>
+  <ProtectedForm {enhance} bind:turnstileToken {...rest}>
     {@render children?.()}
   </ProtectedForm>
 {/if}

--- a/frontend/src/lib/forms/MaybeProtectedForm.svelte
+++ b/frontend/src/lib/forms/MaybeProtectedForm.svelte
@@ -3,17 +3,27 @@
   import ProtectedForm from './ProtectedForm.svelte';
   import type { AnySuperForm } from './types';
 
-  export let enhance: AnySuperForm['enhance'] | undefined = undefined;
-  export let turnstileToken = '';
-  export let skipTurnstile = false;
+  interface Props {
+    enhance?: AnySuperForm['enhance'] | undefined;
+    turnstileToken?: string;
+    skipTurnstile?: boolean;
+    children?: import('svelte').Snippet;
+  }
+
+  let {
+    enhance = undefined,
+    turnstileToken = $bindable(''),
+    skipTurnstile = false,
+    children
+  }: Props = $props();
 </script>
 
 {#if skipTurnstile}
 <Form {enhance} on:submit>
-  <slot />
+  {@render children?.()}
 </Form>
 {:else}
 <ProtectedForm {enhance} on:submit bind:turnstileToken>
-  <slot />
+  {@render children?.()}
 </ProtectedForm>
 {/if}

--- a/frontend/src/lib/forms/MaybeProtectedForm.svelte
+++ b/frontend/src/lib/forms/MaybeProtectedForm.svelte
@@ -15,11 +15,15 @@
 </script>
 
 {#if skipTurnstile}
-  <Form {enhance} on:submit>
+  <!-- TODO: This used to have an on:submit attribute to bubble up the submit event from HTML.
+       Let's check if the createBubbler() call in Form makes that unnecessary now. -->
+  <Form {enhance}>
     {@render children?.()}
   </Form>
 {:else}
-  <ProtectedForm {enhance} on:submit bind:turnstileToken>
+  <!-- TODO: This used to have an on:submit attribute to bubble up the submit event from HTML.
+       Let's check if the createBubbler() call in Form makes that unnecessary now. -->
+  <ProtectedForm {enhance} bind:turnstileToken>
     {@render children?.()}
   </ProtectedForm>
 {/if}

--- a/frontend/src/lib/forms/OrgRoleSelect.svelte
+++ b/frontend/src/lib/forms/OrgRoleSelect.svelte
@@ -9,12 +9,12 @@
     error?: string | string[] | undefined;
   }
 
-  let { id = 'role', value = $bindable(), error = undefined }: Props = $props();
+  let { id = 'role', value = $bindable(), error = undefined, ...rest }: Props = $props();
 </script>
 
 <!-- TODO: This used to have an on:change attribute to bubble up the submit event from HTML.
      Let's check if the createBubbler() call in Form makes that unnecessary now. -->
-<Select {id} bind:value label={$t('org_role.label')} {error}>
+<Select {id} bind:value label={$t('org_role.label')} {error} {...rest}>
   <option value={OrgRole.User}>
     {$t('org_role.user_description')}
   </option>

--- a/frontend/src/lib/forms/OrgRoleSelect.svelte
+++ b/frontend/src/lib/forms/OrgRoleSelect.svelte
@@ -3,7 +3,7 @@
   import t from '$lib/i18n';
   import Select, { type SelectProps } from './Select.svelte';
 
-  interface Props extends SelectProps {
+  interface Props extends Omit<SelectProps, 'label'> {
     id?: string;
     value: OrgRole;
   }

--- a/frontend/src/lib/forms/OrgRoleSelect.svelte
+++ b/frontend/src/lib/forms/OrgRoleSelect.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import { OrgRole } from '$lib/gql/types';
   import t from '$lib/i18n';
-  import Select, { type Props as SelectProps } from './Select.svelte';
+  import Select, { type SelectProps } from './Select.svelte';
 
   interface Props extends SelectProps {
     id?: string;

--- a/frontend/src/lib/forms/OrgRoleSelect.svelte
+++ b/frontend/src/lib/forms/OrgRoleSelect.svelte
@@ -12,7 +12,9 @@
   let { id = 'role', value = $bindable(), error = undefined }: Props = $props();
 </script>
 
-<Select {id} bind:value label={$t('org_role.label')} {error} on:change>
+<!-- TODO: This used to have an on:change attribute to bubble up the submit event from HTML.
+     Let's check if the createBubbler() call in Form makes that unnecessary now. -->
+<Select {id} bind:value label={$t('org_role.label')} {error}>
   <option value={OrgRole.User}>
     {$t('org_role.user_description')}
   </option>

--- a/frontend/src/lib/forms/OrgRoleSelect.svelte
+++ b/frontend/src/lib/forms/OrgRoleSelect.svelte
@@ -3,9 +3,13 @@
   import t from '$lib/i18n';
   import Select from './Select.svelte';
 
-  export let id = 'role';
-  export let value: OrgRole;
-  export let error: string | string[] | undefined = undefined;
+  interface Props {
+    id?: string;
+    value: OrgRole;
+    error?: string | string[] | undefined;
+  }
+
+  let { id = 'role', value = $bindable(), error = undefined }: Props = $props();
 </script>
 
 <Select {id} bind:value label={$t('org_role.label')} {error} on:change>

--- a/frontend/src/lib/forms/OrgRoleSelect.svelte
+++ b/frontend/src/lib/forms/OrgRoleSelect.svelte
@@ -1,18 +1,17 @@
 <script lang="ts">
   import { OrgRole } from '$lib/gql/types';
   import t from '$lib/i18n';
-  import Select from './Select.svelte';
+  import Select, { type Props as SelectProps } from './Select.svelte';
 
-  interface Props {
+  interface Props extends SelectProps {
     id?: string;
     value: OrgRole;
-    error?: string | string[] | undefined;
   }
 
-  let { id = 'role', value = $bindable(), error = undefined, ...rest }: Props = $props();
+  let { id = 'role', value = $bindable(), ...rest }: Props = $props();
 </script>
 
-<Select {id} bind:value label={$t('org_role.label')} {error} {...rest}>
+<Select {...rest} {id} bind:value label={$t('org_role.label')}>
   <option value={OrgRole.User}>
     {$t('org_role.user_description')}
   </option>

--- a/frontend/src/lib/forms/OrgRoleSelect.svelte
+++ b/frontend/src/lib/forms/OrgRoleSelect.svelte
@@ -12,8 +12,6 @@
   let { id = 'role', value = $bindable(), error = undefined, ...rest }: Props = $props();
 </script>
 
-<!-- TODO: This used to have an on:change attribute to bubble up the submit event from HTML.
-     Let's check if the createBubbler() call in Form makes that unnecessary now. -->
 <Select {id} bind:value label={$t('org_role.label')} {error} {...rest}>
   <option value={OrgRole.User}>
     {$t('org_role.user_description')}

--- a/frontend/src/lib/forms/PlainInput.svelte
+++ b/frontend/src/lib/forms/PlainInput.svelte
@@ -11,8 +11,6 @@
 
   let input: HTMLInputElement | undefined = $state();
 
-  // Despite the compatibility table, 'new-password' seems to work well in Chrome, Edge & Firefox
-
   export function clear(): void {
     debouncer.clear();
     if (input) input.value = ''; // if we cancel the debounce the input and the component can get out of sync
@@ -31,6 +29,7 @@
     readonly?: boolean;
     error?: string | string[] | undefined;
     placeholder?: string;
+    // Despite the compatibility table, 'new-password' seems to work well in Chrome, Edge & Firefox
     // https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/autocomplete#browser_compatibility
     autocomplete?: 'new-password' | 'current-password' | 'off' | undefined;
     debounce?: number | boolean;

--- a/frontend/src/lib/forms/PlainInput.svelte
+++ b/frontend/src/lib/forms/PlainInput.svelte
@@ -9,18 +9,18 @@
     input: string | undefined;
   }>();
 
-  let input: HTMLInputElement = $state()!;
+  let input: HTMLInputElement | undefined = $state();
 
   // Despite the compatibility table, 'new-password' seems to work well in Chrome, Edge & Firefox
 
   export function clear(): void {
     debouncer.clear();
-    input.value = ''; // if we cancel the debounce the input and the component can get out of sync
+    if (input) input.value = ''; // if we cancel the debounce the input and the component can get out of sync
     undebouncedValue = value = undefined;
   }
 
   export function focus(): void {
-    input.focus();
+    input?.focus();
   }
 
   interface Props {

--- a/frontend/src/lib/forms/PlainInput.svelte
+++ b/frontend/src/lib/forms/PlainInput.svelte
@@ -9,7 +9,7 @@
     input: string | undefined;
   }>();
 
-  let input: HTMLInputElement = $state();
+  let input: HTMLInputElement = $state()!;
 
   // Despite the compatibility table, 'new-password' seems to work well in Chrome, Edge & Firefox
 
@@ -64,7 +64,7 @@
     const currValue = (event.target as HTMLInputElement).value;
     undebouncedValue = currValue;
     debouncer.debounce(currValue);
-    handlingInputEventTimeout = setTimeout(() => handlingInputEvent = false);
+    handlingInputEventTimeout = setTimeout(() => (handlingInputEvent = false));
   }
   let debouncer = $derived(makeDebouncer((newValue: string | undefined) => (value = newValue), debounce));
   run(() => {

--- a/frontend/src/lib/forms/PlainInput.svelte
+++ b/frontend/src/lib/forms/PlainInput.svelte
@@ -12,8 +12,6 @@
   let input: HTMLInputElement = $state();
 
   // Despite the compatibility table, 'new-password' seems to work well in Chrome, Edge & Firefox
-  
-
 
   export function clear(): void {
     debouncer.clear();
@@ -53,11 +51,10 @@
     autocomplete = undefined,
     debounce = false,
     debouncing = $bindable(false),
-    undebouncedValue = $bindable(undefined),
+    undebouncedValue = $bindable(),
     style = undefined,
-    keydownHandler = undefined
+    keydownHandler = undefined,
   }: Props = $props();
-
 
   let handlingInputEvent = $state(false);
   let handlingInputEventTimeout: ReturnType<typeof setTimeout>;

--- a/frontend/src/lib/forms/PlainInput.svelte
+++ b/frontend/src/lib/forms/PlainInput.svelte
@@ -24,7 +24,7 @@
   }
 
   interface Props {
-    id?: any;
+    id?: string;
     value?: string | undefined | null;
     type?: 'text' | 'email' | 'password';
     autofocus?: true | undefined;

--- a/frontend/src/lib/forms/PlainInput.svelte
+++ b/frontend/src/lib/forms/PlainInput.svelte
@@ -49,7 +49,7 @@
     error = undefined,
     placeholder = '',
     autocomplete = undefined,
-    debounce = false,
+    debounce = $bindable(false),
     debouncing = $bindable(false),
     undebouncedValue = $bindable(),
     style = undefined,

--- a/frontend/src/lib/forms/ProjectRoleSelect.svelte
+++ b/frontend/src/lib/forms/ProjectRoleSelect.svelte
@@ -4,7 +4,7 @@
 
   import Select, { type SelectProps } from './Select.svelte';
 
-  interface Props extends SelectProps {
+  interface Props extends Omit<SelectProps, 'label'> {
     id?: string;
     value: ProjectRole;
   }

--- a/frontend/src/lib/forms/ProjectRoleSelect.svelte
+++ b/frontend/src/lib/forms/ProjectRoleSelect.svelte
@@ -2,18 +2,17 @@
   import { ProjectRole } from '$lib/gql/types';
   import t from '$lib/i18n';
 
-  import { Select } from '.';
+  import Select, { type Props as SelectProps } from './Select.svelte';
 
-  interface Props {
+  interface Props extends SelectProps {
     id?: string;
     value: ProjectRole;
-    error: string[] | undefined;
   }
 
-  let { id = 'role', value = $bindable(), error }: Props = $props();
+  let { id = 'role', value = $bindable(), ...rest }: Props = $props();
 </script>
 
-<Select {id} bind:value label={$t('project_role.label')} {error}>
+<Select {...rest} {id} bind:value label={$t('project_role.label')}>
   <option value={ProjectRole.Editor}>
     {$t('project_role.editor_description')}
   </option>

--- a/frontend/src/lib/forms/ProjectRoleSelect.svelte
+++ b/frontend/src/lib/forms/ProjectRoleSelect.svelte
@@ -2,7 +2,7 @@
   import { ProjectRole } from '$lib/gql/types';
   import t from '$lib/i18n';
 
-  import Select, { type Props as SelectProps } from './Select.svelte';
+  import Select, { type SelectProps } from './Select.svelte';
 
   interface Props extends SelectProps {
     id?: string;

--- a/frontend/src/lib/forms/ProjectRoleSelect.svelte
+++ b/frontend/src/lib/forms/ProjectRoleSelect.svelte
@@ -4,9 +4,13 @@
 
   import { Select } from '.';
 
-  export let id = 'role';
-  export let value: ProjectRole;
-  export let error: string[] | undefined;
+  interface Props {
+    id?: string;
+    value: ProjectRole;
+    error: string[] | undefined;
+  }
+
+  let { id = 'role', value = $bindable(), error }: Props = $props();
 </script>
 
 <Select {id} bind:value label={$t('project_role.label')} {error}>

--- a/frontend/src/lib/forms/ProjectTypeSelect.svelte
+++ b/frontend/src/lib/forms/ProjectTypeSelect.svelte
@@ -4,10 +4,19 @@
   import t from '$lib/i18n';
   import Select from './Select.svelte';
 
-  export let value: ProjectType | undefined;
-  export let error: string | string[] | undefined = undefined;
-  export let undefinedOptionLabel: string | undefined = undefined;
-  export let includeUnknown = false;
+  interface Props {
+    value: ProjectType | undefined;
+    error?: string | string[] | undefined;
+    undefinedOptionLabel?: string | undefined;
+    includeUnknown?: boolean;
+  }
+
+  let {
+    value = $bindable(),
+    error = undefined,
+    undefinedOptionLabel = undefined,
+    includeUnknown = false
+  }: Props = $props();
   const types = [
     ProjectType.FlEx,
     ProjectType.WeSay,

--- a/frontend/src/lib/forms/ProjectTypeSelect.svelte
+++ b/frontend/src/lib/forms/ProjectTypeSelect.svelte
@@ -2,7 +2,7 @@
   import { FormatProjectType, ProjectTypeIcon } from '$lib/components/ProjectType';
   import { ProjectType } from '$lib/gql/types';
   import t from '$lib/i18n';
-  import Select, { type Props as SelectProps } from './Select.svelte';
+  import Select, { type SelectProps } from './Select.svelte';
 
   interface Props extends SelectProps {
     value: ProjectType | undefined;

--- a/frontend/src/lib/forms/ProjectTypeSelect.svelte
+++ b/frontend/src/lib/forms/ProjectTypeSelect.svelte
@@ -16,6 +16,7 @@
     error = undefined,
     undefinedOptionLabel = undefined,
     includeUnknown = false,
+    ...rest
   }: Props = $props();
   const types = [
     ProjectType.FlEx,
@@ -29,7 +30,7 @@
 <div class="relative">
   <!-- TODO: This used to have an on:change attribute to bubble up the submit event from HTML.
        Let's check if the createBubbler() call in Form makes that unnecessary now. -->
-  <Select id="type" label={$t('project_type.type')} bind:value {error}>
+  <Select id="type" label={$t('project_type.type')} bind:value {error} {...rest}>
     {#if undefinedOptionLabel}
       <option value={undefined}>{undefinedOptionLabel}</option>
     {/if}

--- a/frontend/src/lib/forms/ProjectTypeSelect.svelte
+++ b/frontend/src/lib/forms/ProjectTypeSelect.svelte
@@ -4,7 +4,7 @@
   import t from '$lib/i18n';
   import Select, { type SelectProps } from './Select.svelte';
 
-  interface Props extends SelectProps {
+  interface Props extends Omit<SelectProps, 'label'> {
     value: ProjectType | undefined;
     undefinedOptionLabel?: string | undefined;
     includeUnknown?: boolean;

--- a/frontend/src/lib/forms/ProjectTypeSelect.svelte
+++ b/frontend/src/lib/forms/ProjectTypeSelect.svelte
@@ -2,18 +2,16 @@
   import { FormatProjectType, ProjectTypeIcon } from '$lib/components/ProjectType';
   import { ProjectType } from '$lib/gql/types';
   import t from '$lib/i18n';
-  import Select from './Select.svelte';
+  import Select, { type Props as SelectProps } from './Select.svelte';
 
-  interface Props {
+  interface Props extends SelectProps {
     value: ProjectType | undefined;
-    error?: string | string[] | undefined;
     undefinedOptionLabel?: string | undefined;
     includeUnknown?: boolean;
   }
 
   let {
     value = $bindable(),
-    error = undefined,
     undefinedOptionLabel = undefined,
     includeUnknown = false,
     ...rest
@@ -28,7 +26,7 @@
 </script>
 
 <div class="relative">
-  <Select id="type" label={$t('project_type.type')} bind:value {error} {...rest}>
+  <Select {...rest} id="type" label={$t('project_type.type')} bind:value>
     {#if undefinedOptionLabel}
       <option value={undefined}>{undefinedOptionLabel}</option>
     {/if}

--- a/frontend/src/lib/forms/ProjectTypeSelect.svelte
+++ b/frontend/src/lib/forms/ProjectTypeSelect.svelte
@@ -28,8 +28,6 @@
 </script>
 
 <div class="relative">
-  <!-- TODO: This used to have an on:change attribute to bubble up the submit event from HTML.
-       Let's check if the createBubbler() call in Form makes that unnecessary now. -->
   <Select id="type" label={$t('project_type.type')} bind:value {error} {...rest}>
     {#if undefinedOptionLabel}
       <option value={undefined}>{undefinedOptionLabel}</option>

--- a/frontend/src/lib/forms/ProjectTypeSelect.svelte
+++ b/frontend/src/lib/forms/ProjectTypeSelect.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import {FormatProjectType, ProjectTypeIcon} from '$lib/components/ProjectType';
+  import { FormatProjectType, ProjectTypeIcon } from '$lib/components/ProjectType';
   import { ProjectType } from '$lib/gql/types';
   import t from '$lib/i18n';
   import Select from './Select.svelte';
@@ -15,26 +15,29 @@
     value = $bindable(),
     error = undefined,
     undefinedOptionLabel = undefined,
-    includeUnknown = false
+    includeUnknown = false,
   }: Props = $props();
   const types = [
     ProjectType.FlEx,
     ProjectType.WeSay,
     ProjectType.OneStoryEditor,
     ProjectType.OurWord,
-    ProjectType.AdaptIt
+    ProjectType.AdaptIt,
   ];
 </script>
+
 <div class="relative">
-  <Select id="type" label={$t('project_type.type')} bind:value {error} on:change>
+  <!-- TODO: This used to have an on:change attribute to bubble up the submit event from HTML.
+       Let's check if the createBubbler() call in Form makes that unnecessary now. -->
+  <Select id="type" label={$t('project_type.type')} bind:value {error}>
     {#if undefinedOptionLabel}
       <option value={undefined}>{undefinedOptionLabel}</option>
     {/if}
     {#each types as type}
-      <option value={type}><FormatProjectType {type}/></option>
+      <option value={type}><FormatProjectType {type} /></option>
     {/each}
     {#if includeUnknown}
-      <option value={ProjectType.Unknown}><FormatProjectType type={ProjectType.Unknown}/></option>
+      <option value={ProjectType.Unknown}><FormatProjectType type={ProjectType.Unknown} /></option>
     {/if}
   </Select>
   <span class="absolute right-10 top-[3.75rem] -translate-y-1/2 pointer-events-none leading-0">

--- a/frontend/src/lib/forms/ProtectedForm.svelte
+++ b/frontend/src/lib/forms/ProtectedForm.svelte
@@ -1,4 +1,4 @@
-<script context="module" lang="ts">
+<script module lang="ts">
   export type Token = {
     token: string;
   };
@@ -10,10 +10,15 @@
   import Form from './Form.svelte';
   import type { AnySuperForm } from './types';
 
-  export let enhance: AnySuperForm['enhance'] | undefined = undefined;
 
   const siteKey = env.PUBLIC_TURNSTILE_SITE_KEY;
-  export let turnstileToken = '';
+  interface Props {
+    enhance?: AnySuperForm['enhance'] | undefined;
+    turnstileToken?: string;
+    children?: import('svelte').Snippet;
+  }
+
+  let { enhance = undefined, turnstileToken = $bindable(''), children }: Props = $props();
 
   function deliverToken({ detail: { token } }: CustomEvent<Token>): void {
     turnstileToken = token;
@@ -21,7 +26,7 @@
 </script>
 
 <Form {enhance} on:submit>
-  <slot />
+  {@render children?.()}
 </Form>
 
 <section class="mt-8 flex justify-center md:justify-end">

--- a/frontend/src/lib/forms/ProtectedForm.svelte
+++ b/frontend/src/lib/forms/ProtectedForm.svelte
@@ -18,16 +18,14 @@
     children?: Snippet;
   }
 
-  let { enhance = undefined, turnstileToken = $bindable(''), children, ...rest }: Props = $props();
+  let { enhance = undefined, turnstileToken = $bindable(''), children }: Props = $props();
 
   function deliverToken({ detail: { token } }: CustomEvent<Token>): void {
     turnstileToken = token;
   }
 </script>
 
-<!-- TODO: This used to have an on:submit attribute to bubble up the submit event from HTML.
-     Let's check if the createBubbler() call in Form makes that unnecessary now. -->
-<Form {enhance} {...rest}>
+<Form {enhance}>
   {@render children?.()}
 </Form>
 

--- a/frontend/src/lib/forms/ProtectedForm.svelte
+++ b/frontend/src/lib/forms/ProtectedForm.svelte
@@ -18,7 +18,7 @@
     children?: Snippet;
   }
 
-  let { enhance = undefined, turnstileToken = $bindable(''), children }: Props = $props();
+  let { enhance = undefined, turnstileToken = $bindable(''), children, ...rest }: Props = $props();
 
   function deliverToken({ detail: { token } }: CustomEvent<Token>): void {
     turnstileToken = token;
@@ -27,7 +27,7 @@
 
 <!-- TODO: This used to have an on:submit attribute to bubble up the submit event from HTML.
      Let's check if the createBubbler() call in Form makes that unnecessary now. -->
-<Form {enhance}>
+<Form {enhance} {...rest}>
   {@render children?.()}
 </Form>
 

--- a/frontend/src/lib/forms/ProtectedForm.svelte
+++ b/frontend/src/lib/forms/ProtectedForm.svelte
@@ -5,17 +5,17 @@
 </script>
 
 <script lang="ts">
+  import type { Snippet } from 'svelte';
   import { env } from '$env/dynamic/public';
   import { Turnstile } from 'svelte-turnstile';
   import Form from './Form.svelte';
   import type { AnySuperForm } from './types';
 
-
   const siteKey = env.PUBLIC_TURNSTILE_SITE_KEY;
   interface Props {
     enhance?: AnySuperForm['enhance'] | undefined;
     turnstileToken?: string;
-    children?: import('svelte').Snippet;
+    children?: Snippet;
   }
 
   let { enhance = undefined, turnstileToken = $bindable(''), children }: Props = $props();

--- a/frontend/src/lib/forms/ProtectedForm.svelte
+++ b/frontend/src/lib/forms/ProtectedForm.svelte
@@ -25,7 +25,9 @@
   }
 </script>
 
-<Form {enhance} on:submit>
+<!-- TODO: This used to have an on:submit attribute to bubble up the submit event from HTML.
+     Let's check if the createBubbler() call in Form makes that unnecessary now. -->
+<Form {enhance}>
   {@render children?.()}
 </Form>
 

--- a/frontend/src/lib/forms/RadioButtonGroup.svelte
+++ b/frontend/src/lib/forms/RadioButtonGroup.svelte
@@ -1,4 +1,4 @@
-<script lang="ts" context="module">
+<script lang="ts" module>
   export type SingleRadioButton = {
     label: string
     value: string
@@ -10,15 +10,29 @@
   import FormFieldError from './FormFieldError.svelte';
   import { randomFormId } from './utils';
 
-  export let buttons: SingleRadioButton[];
-  export let label: string; // This is for the group as a whole
-  export let value: string = ''; // Should be used with `bind:value={localVariable}`
-  export let id = randomFormId();
-  export let error: string | string[] | undefined = undefined;
-  export let description: string | undefined = undefined;
-  export let variant: 'radio-warning' | undefined = undefined;
-  export let labelColor: 'text-warning' | undefined = undefined;
-  export let divClass: string | undefined = undefined;
+  interface Props {
+    buttons: SingleRadioButton[];
+    label: string; // This is for the group as a whole
+    value?: string; // Should be used with `bind:value={localVariable}`
+    id?: any;
+    error?: string | string[] | undefined;
+    description?: string | undefined;
+    variant?: 'radio-warning' | undefined;
+    labelColor?: 'text-warning' | undefined;
+    divClass?: string | undefined;
+  }
+
+  let {
+    buttons,
+    label,
+    value = $bindable(''),
+    id = randomFormId(),
+    error = undefined,
+    description = undefined,
+    variant = undefined,
+    labelColor = undefined,
+    divClass = undefined
+  }: Props = $props();
 </script>
 
 <div

--- a/frontend/src/lib/forms/RadioButtonGroup.svelte
+++ b/frontend/src/lib/forms/RadioButtonGroup.svelte
@@ -1,12 +1,12 @@
 <script lang="ts" module>
   export type SingleRadioButton = {
-    label: string
-    value: string
-  }
+    label: string;
+    value: string;
+  };
 </script>
 
 <script lang="ts">
-  import {NewTabLinkMarkdown} from '$lib/components/Markdown';
+  import { NewTabLinkMarkdown } from '$lib/components/Markdown';
   import FormFieldError from './FormFieldError.svelte';
   import { randomFormId } from './utils';
 
@@ -14,7 +14,7 @@
     buttons: SingleRadioButton[];
     label: string; // This is for the group as a whole
     value?: string; // Should be used with `bind:value={localVariable}`
-    id?: any;
+    id?: string;
     error?: string | string[] | undefined;
     description?: string | undefined;
     variant?: 'radio-warning' | undefined;
@@ -31,28 +31,23 @@
     description = undefined,
     variant = undefined,
     labelColor = undefined,
-    divClass = undefined
+    divClass = undefined,
   }: Props = $props();
 </script>
 
-<div
-  role="radiogroup"
-  class={divClass ?? ''}
-  aria-labelledby={`label-${id}`}
-  id={`group-${id}`}
-  >
+<div role="radiogroup" class={divClass ?? ''} aria-labelledby={`label-${id}`} id={`group-${id}`}>
   <div class="legend" id={`label-${id}`}>
     {label}
   </div>
   {#each buttons as button}
-  <div class="form-control w-full">
-    <label class="label cursor-pointer justify-normal pb-0">
-      <input {id} type="radio" bind:group={value} value={button.value} class="radio mr-2 {variant ?? ''}" />
-      <span class="label-text inline-flex items-center gap-2 {labelColor ?? ''}">
-        {button.label}
-      </span>
-    </label>
-  </div>
+    <div class="form-control w-full">
+      <label class="label cursor-pointer justify-normal pb-0">
+        <input {id} type="radio" bind:group={value} value={button.value} class="radio mr-2 {variant ?? ''}" />
+        <span class="label-text inline-flex items-center gap-2 {labelColor ?? ''}">
+          {button.label}
+        </span>
+      </label>
+    </div>
   {/each}
   {#if description}
     <label for={id} class="label pb-0">

--- a/frontend/src/lib/forms/Select.svelte
+++ b/frontend/src/lib/forms/Select.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import type { Snippet } from 'svelte';
   import { createBubbler } from 'svelte/legacy';
 
   const bubble = createBubbler();
@@ -14,7 +15,7 @@
     error?: string | string[] | undefined;
     disabled?: boolean;
     helpLink?: HelpLink | undefined;
-    children?: import('svelte').Snippet;
+    children?: Snippet;
   }
 
   let {

--- a/frontend/src/lib/forms/Select.svelte
+++ b/frontend/src/lib/forms/Select.svelte
@@ -1,20 +1,37 @@
 <script lang="ts">
+  import { createBubbler } from 'svelte/legacy';
+
+  const bubble = createBubbler();
   import type { HelpLink } from '$lib/components/help';
   import FormField from './FormField.svelte';
   import { randomFormId } from './utils';
 
-  export let label: string;
-  export let value: string | undefined;
-  export let id = randomFormId();
-  export let autofocus = false;
-  export let error: string | string[] | undefined = undefined;
-  export let disabled = false;
-  export let helpLink: HelpLink | undefined = undefined;
+  interface Props {
+    label: string;
+    value: string | undefined;
+    id?: any;
+    autofocus?: boolean;
+    error?: string | string[] | undefined;
+    disabled?: boolean;
+    helpLink?: HelpLink | undefined;
+    children?: import('svelte').Snippet;
+  }
+
+  let {
+    label,
+    value = $bindable(),
+    id = randomFormId(),
+    autofocus = false,
+    error = undefined,
+    disabled = false,
+    helpLink = undefined,
+    children
+  }: Props = $props();
 </script>
 
 <FormField {id} {label} {error} {autofocus} {helpLink}>
-  <!-- svelte-ignore a11y-autofocus -->
-  <select {disabled} bind:value {id} class="select select-bordered" {autofocus} on:change>
-    <slot />
+  <!-- svelte-ignore a11y_autofocus -->
+  <select {disabled} bind:value {id} class="select select-bordered" {autofocus} onchange={bubble('change')}>
+    {@render children?.()}
   </select>
 </FormField>

--- a/frontend/src/lib/forms/Select.svelte
+++ b/frontend/src/lib/forms/Select.svelte
@@ -26,7 +26,7 @@
     error = undefined,
     disabled = false,
     helpLink = undefined,
-    children
+    children,
   }: Props = $props();
 </script>
 

--- a/frontend/src/lib/forms/Select.svelte
+++ b/frontend/src/lib/forms/Select.svelte
@@ -1,8 +1,5 @@
 <script lang="ts">
   import type { Snippet } from 'svelte';
-  import { createBubbler } from 'svelte/legacy';
-
-  const bubble = createBubbler();
   import type { HelpLink } from '$lib/components/help';
   import FormField from './FormField.svelte';
   import { randomFormId } from './utils';
@@ -32,7 +29,7 @@
 
 <FormField {id} {label} {error} {autofocus} {helpLink}>
   <!-- svelte-ignore a11y_autofocus -->
-  <select {disabled} bind:value {id} class="select select-bordered" {autofocus} onchange={bubble('change')}>
+  <select {disabled} bind:value {id} class="select select-bordered" {autofocus}>
     {@render children?.()}
   </select>
 </FormField>

--- a/frontend/src/lib/forms/Select.svelte
+++ b/frontend/src/lib/forms/Select.svelte
@@ -10,7 +10,7 @@
   interface Props {
     label: string;
     value: string | undefined;
-    id?: any;
+    id?: string;
     autofocus?: boolean;
     error?: string | string[] | undefined;
     disabled?: boolean;

--- a/frontend/src/lib/forms/Select.svelte
+++ b/frontend/src/lib/forms/Select.svelte
@@ -4,7 +4,7 @@
   import FormField from './FormField.svelte';
   import { randomFormId } from './utils';
 
-  interface Props {
+  export interface Props {
     label: string;
     value: string | undefined;
     id?: string;

--- a/frontend/src/lib/forms/Select.svelte
+++ b/frontend/src/lib/forms/Select.svelte
@@ -4,7 +4,7 @@
   import FormField from './FormField.svelte';
   import { randomFormId } from './utils';
 
-  export interface Props {
+  export interface SelectProps {
     label: string;
     value: string | undefined;
     id?: string;
@@ -24,7 +24,7 @@
     disabled = false,
     helpLink = undefined,
     children,
-  }: Props = $props();
+  }: SelectProps = $props();
 </script>
 
 <FormField {id} {label} {error} {autofocus} {helpLink}>

--- a/frontend/src/lib/forms/SubmitButton.svelte
+++ b/frontend/src/lib/forms/SubmitButton.svelte
@@ -10,7 +10,7 @@
     loading?: boolean;
     form?: string | undefined;
     variant?: SubmitVariant;
-    onclick: () => void;
+    onclick?: () => void;
     children?: Snippet;
   }
 

--- a/frontend/src/lib/forms/SubmitButton.svelte
+++ b/frontend/src/lib/forms/SubmitButton.svelte
@@ -3,13 +3,14 @@
 </script>
 
 <script lang="ts">
+  import type { Snippet } from 'svelte';
   import Button from './Button.svelte';
 
   interface Props {
     loading?: boolean;
     form?: string | undefined;
     variant?: SubmitVariant;
-    children?: import('svelte').Snippet;
+    children?: Snippet;
   }
 
   let {

--- a/frontend/src/lib/forms/SubmitButton.svelte
+++ b/frontend/src/lib/forms/SubmitButton.svelte
@@ -13,12 +13,7 @@
     children?: Snippet;
   }
 
-  let {
-    loading = false,
-    form = undefined,
-    variant = 'btn-primary',
-    children
-  }: Props = $props();
+  let { loading = false, form = undefined, variant = 'btn-primary', children }: Props = $props();
 </script>
 
 <!-- https://daisyui.com/components/button -->

--- a/frontend/src/lib/forms/SubmitButton.svelte
+++ b/frontend/src/lib/forms/SubmitButton.svelte
@@ -1,16 +1,26 @@
-<script context="module" lang="ts">
+<script module lang="ts">
   export type SubmitVariant = 'btn-primary' | 'btn-warning' | 'btn-accent' | 'btn-error';
 </script>
 
 <script lang="ts">
   import Button from './Button.svelte';
 
-  export let loading = false;
-  export let form: string | undefined = undefined;
-  export let variant: SubmitVariant = 'btn-primary';
+  interface Props {
+    loading?: boolean;
+    form?: string | undefined;
+    variant?: SubmitVariant;
+    children?: import('svelte').Snippet;
+  }
+
+  let {
+    loading = false,
+    form = undefined,
+    variant = 'btn-primary',
+    children
+  }: Props = $props();
 </script>
 
 <!-- https://daisyui.com/components/button -->
 <Button type="submit" on:click {variant} {loading} {form}>
-  <slot />
+  {@render children?.()}
 </Button>

--- a/frontend/src/lib/forms/SubmitButton.svelte
+++ b/frontend/src/lib/forms/SubmitButton.svelte
@@ -10,13 +10,14 @@
     loading?: boolean;
     form?: string | undefined;
     variant?: SubmitVariant;
+    onclick: () => void;
     children?: Snippet;
   }
 
-  let { loading = false, form = undefined, variant = 'btn-primary', children }: Props = $props();
+  let { loading = false, form = undefined, variant = 'btn-primary', onclick, children }: Props = $props();
 </script>
 
 <!-- https://daisyui.com/components/button -->
-<Button type="submit" on:click {variant} {loading} {form}>
+<Button type="submit" {onclick} {variant} {loading} {form}>
   {@render children?.()}
 </Button>

--- a/frontend/src/lib/forms/SubmitButton.svelte
+++ b/frontend/src/lib/forms/SubmitButton.svelte
@@ -14,10 +14,10 @@
     children?: Snippet;
   }
 
-  let { loading = false, form = undefined, variant = 'btn-primary', onclick, children }: Props = $props();
+  let { loading = false, form = undefined, variant = 'btn-primary', onclick, children, ...rest }: Props = $props();
 </script>
 
 <!-- https://daisyui.com/components/button -->
-<Button type="submit" {onclick} {variant} {loading} {form}>
+<Button type="submit" {onclick} {variant} {loading} {form} {...rest}>
   {@render children?.()}
 </Button>

--- a/frontend/src/lib/forms/SubmitButton.svelte
+++ b/frontend/src/lib/forms/SubmitButton.svelte
@@ -14,10 +14,10 @@
     children?: Snippet;
   }
 
-  let { loading = false, form = undefined, variant = 'btn-primary', onclick, children, ...rest }: Props = $props();
+  let { loading = false, form = undefined, variant = 'btn-primary', onclick, children }: Props = $props();
 </script>
 
 <!-- https://daisyui.com/components/button -->
-<Button type="submit" {onclick} {variant} {loading} {form} {...rest}>
+<Button type="submit" {onclick} {variant} {loading} {form}>
   {@render children?.()}
 </Button>

--- a/frontend/src/lib/forms/SystemRoleSelect.svelte
+++ b/frontend/src/lib/forms/SystemRoleSelect.svelte
@@ -4,10 +4,19 @@
 
   import { Select } from '.';
 
-  export let id = 'role';
-  export let value: UserRole;
-  export let error: string[] | undefined;
-  export let disabled = false;
+  interface Props {
+    id?: string;
+    value: UserRole;
+    error: string[] | undefined;
+    disabled?: boolean;
+  }
+
+  let {
+    id = 'role',
+    value = $bindable(),
+    error,
+    disabled = false
+  }: Props = $props();
 </script>
 
 <div class="contents" class:text-accent={value === UserRole.Admin}>

--- a/frontend/src/lib/forms/SystemRoleSelect.svelte
+++ b/frontend/src/lib/forms/SystemRoleSelect.svelte
@@ -4,7 +4,7 @@
 
   import Select, { type SelectProps } from './Select.svelte';
 
-  interface Props extends SelectProps {
+  interface Props extends Omit<SelectProps, 'label'> {
     id?: string;
     value: UserRole;
   }

--- a/frontend/src/lib/forms/SystemRoleSelect.svelte
+++ b/frontend/src/lib/forms/SystemRoleSelect.svelte
@@ -2,7 +2,7 @@
   import { UserRole } from '$lib/gql/types';
   import t from '$lib/i18n';
 
-  import Select, { type Props as SelectProps } from './Select.svelte';
+  import Select, { type SelectProps } from './Select.svelte';
 
   interface Props extends SelectProps {
     id?: string;

--- a/frontend/src/lib/forms/SystemRoleSelect.svelte
+++ b/frontend/src/lib/forms/SystemRoleSelect.svelte
@@ -2,25 +2,22 @@
   import { UserRole } from '$lib/gql/types';
   import t from '$lib/i18n';
 
-  import { Select } from '.';
+  import Select, { type Props as SelectProps } from './Select.svelte';
 
-  interface Props {
+  interface Props extends SelectProps {
     id?: string;
     value: UserRole;
-    error: string[] | undefined;
-    disabled?: boolean;
   }
 
   let {
     id = 'role',
     value = $bindable(),
-    error,
-    disabled = false
+    ...rest
   }: Props = $props();
 </script>
 
 <div class="contents" class:text-accent={value === UserRole.Admin}>
-  <Select {id} bind:value label={$t('system_role.label')} {error} {disabled}>
+  <Select {...rest} {id} bind:value label={$t('system_role.label')} >
     <option value={UserRole.User} class="text-base-content">
       {$t('system_role.user_description')}
     </option>

--- a/frontend/src/lib/forms/TextArea.svelte
+++ b/frontend/src/lib/forms/TextArea.svelte
@@ -2,19 +2,32 @@
   import { randomFormId } from './utils';
   import FormField from './FormField.svelte';
 
-  export let label: string;
-  export let description: string | undefined = undefined;
-  export let value: string | undefined = undefined;
-  export let id = randomFormId();
-  export let autofocus = false;
-  export let readonly = false;
-  export let error: string | string[] | undefined = undefined;
-  export let placeholder = '';
+  interface Props {
+    label: string;
+    description?: string | undefined;
+    value?: string | undefined;
+    id?: any;
+    autofocus?: boolean;
+    readonly?: boolean;
+    error?: string | string[] | undefined;
+    placeholder?: string;
+  }
+
+  let {
+    label,
+    description = undefined,
+    value = $bindable(undefined),
+    id = randomFormId(),
+    autofocus = false,
+    readonly = false,
+    error = undefined,
+    placeholder = ''
+  }: Props = $props();
 </script>
 
 <!-- https://daisyui.com/components/input -->
 <FormField {id} {error} {label} {autofocus} {description}>
-  <!-- svelte-ignore a11y-autofocus -->
+  <!-- svelte-ignore a11y_autofocus -->
   <textarea
     {id}
     bind:value
@@ -23,5 +36,5 @@
     {placeholder}
     {readonly}
     {autofocus}
-  />
+></textarea>
 </FormField>

--- a/frontend/src/lib/forms/TextArea.svelte
+++ b/frontend/src/lib/forms/TextArea.svelte
@@ -6,7 +6,7 @@
     label: string;
     description?: string | undefined;
     value?: string | undefined;
-    id?: any;
+    id?: string;
     autofocus?: boolean;
     readonly?: boolean;
     error?: string | string[] | undefined;
@@ -21,7 +21,7 @@
     autofocus = false,
     readonly = false,
     error = undefined,
-    placeholder = ''
+    placeholder = '',
   }: Props = $props();
 </script>
 
@@ -36,5 +36,5 @@
     {placeholder}
     {readonly}
     {autofocus}
-></textarea>
+  ></textarea>
 </FormField>

--- a/frontend/src/lib/forms/UserTypeSelect.svelte
+++ b/frontend/src/lib/forms/UserTypeSelect.svelte
@@ -8,7 +8,7 @@
     undefinedOptionLabel?: string | undefined;
   }
 
-  let { value = $bindable(), undefinedOptionLabel = undefined }: Props = $props();
+  let { value = $bindable(), undefinedOptionLabel = undefined, ...rest }: Props = $props();
 
   const options: Record<Exclude<UserType, undefined>, I18nKey> = {
     admin: 'admin_dashboard.user_filter.user_type.admin',
@@ -20,7 +20,7 @@
 <div class="relative">
   <!-- TODO: This used to have an on:change attribute to bubble up the submit event from HTML.
        Let's check if the createBubbler() call in Form makes that unnecessary now. -->
-  <Select id="type" label={$t('admin_dashboard.user_filter.user_type.label')} bind:value>
+  <Select id="type" label={$t('admin_dashboard.user_filter.user_type.label')} bind:value {...rest}>
     {#if undefinedOptionLabel}
       <option value={undefined}>{undefinedOptionLabel}</option>
     {/if}

--- a/frontend/src/lib/forms/UserTypeSelect.svelte
+++ b/frontend/src/lib/forms/UserTypeSelect.svelte
@@ -18,8 +18,6 @@
 </script>
 
 <div class="relative">
-  <!-- TODO: This used to have an on:change attribute to bubble up the submit event from HTML.
-       Let's check if the createBubbler() call in Form makes that unnecessary now. -->
   <Select id="type" label={$t('admin_dashboard.user_filter.user_type.label')} bind:value {...rest}>
     {#if undefinedOptionLabel}
       <option value={undefined}>{undefinedOptionLabel}</option>

--- a/frontend/src/lib/forms/UserTypeSelect.svelte
+++ b/frontend/src/lib/forms/UserTypeSelect.svelte
@@ -3,7 +3,7 @@
   import Select, { type SelectProps } from './Select.svelte';
   import type { UserType } from '$lib/components/Users';
 
-  interface Props extends SelectProps {
+  interface Props extends Omit<SelectProps, 'label'> {
     value: UserType;
     undefinedOptionLabel?: string | undefined;
   }
@@ -18,7 +18,6 @@
 </script>
 
 <div class="relative">
-  <!-- Note: important that ...rest be at the start of the attributes list so that `label={$t(...)}` will not be overridden by the `label` prop in ...rest -->
   <Select {...rest} id="type" label={$t('admin_dashboard.user_filter.user_type.label')} bind:value>
     {#if undefinedOptionLabel}
       <option value={undefined}>{undefinedOptionLabel}</option>

--- a/frontend/src/lib/forms/UserTypeSelect.svelte
+++ b/frontend/src/lib/forms/UserTypeSelect.svelte
@@ -3,8 +3,12 @@
   import Select from './Select.svelte';
   import type { UserType } from '$lib/components/Users';
 
-  export let value: UserType;
-  export let undefinedOptionLabel: string | undefined = undefined;
+  interface Props {
+    value: UserType;
+    undefinedOptionLabel?: string | undefined;
+  }
+
+  let { value = $bindable(), undefinedOptionLabel = undefined }: Props = $props();
 
   const options: Record<Exclude<UserType, undefined>, I18nKey> = {
     admin: 'admin_dashboard.user_filter.user_type.admin',

--- a/frontend/src/lib/forms/UserTypeSelect.svelte
+++ b/frontend/src/lib/forms/UserTypeSelect.svelte
@@ -13,17 +13,19 @@
   const options: Record<Exclude<UserType, undefined>, I18nKey> = {
     admin: 'admin_dashboard.user_filter.user_type.admin',
     nonAdmin: 'admin_dashboard.user_filter.user_type.nonAdmin',
-    guest: 'admin_dashboard.user_filter.user_type.guest'
+    guest: 'admin_dashboard.user_filter.user_type.guest',
   };
 </script>
 
 <div class="relative">
-  <Select id="type" label={$t('admin_dashboard.user_filter.user_type.label')} bind:value on:change>
+  <!-- TODO: This used to have an on:change attribute to bubble up the submit event from HTML.
+       Let's check if the createBubbler() call in Form makes that unnecessary now. -->
+  <Select id="type" label={$t('admin_dashboard.user_filter.user_type.label')} bind:value>
     {#if undefinedOptionLabel}
       <option value={undefined}>{undefinedOptionLabel}</option>
     {/if}
     {#each Object.entries(options) as [value, label]}
-      <option value={value}>{$t(label)}</option>
+      <option {value}>{$t(label)}</option>
     {/each}
   </Select>
 </div>

--- a/frontend/src/lib/forms/UserTypeSelect.svelte
+++ b/frontend/src/lib/forms/UserTypeSelect.svelte
@@ -1,9 +1,9 @@
 <script lang="ts">
   import t, { type I18nKey } from '$lib/i18n';
-  import Select from './Select.svelte';
+  import Select, { type Props as SelectProps } from './Select.svelte';
   import type { UserType } from '$lib/components/Users';
 
-  interface Props {
+  interface Props extends SelectProps {
     value: UserType;
     undefinedOptionLabel?: string | undefined;
   }
@@ -18,7 +18,8 @@
 </script>
 
 <div class="relative">
-  <Select id="type" label={$t('admin_dashboard.user_filter.user_type.label')} bind:value {...rest}>
+  <!-- Note: important that ...rest be at the start of the attributes list so that `label={$t(...)}` will not be overridden by the `label` prop in ...rest -->
+  <Select {...rest} id="type" label={$t('admin_dashboard.user_filter.user_type.label')} bind:value>
     {#if undefinedOptionLabel}
       <option value={undefined}>{undefinedOptionLabel}</option>
     {/if}

--- a/frontend/src/lib/forms/UserTypeSelect.svelte
+++ b/frontend/src/lib/forms/UserTypeSelect.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import t, { type I18nKey } from '$lib/i18n';
-  import Select, { type Props as SelectProps } from './Select.svelte';
+  import Select, { type SelectProps } from './Select.svelte';
   import type { UserType } from '$lib/components/Users';
 
   interface Props extends SelectProps {

--- a/frontend/src/lib/forms/UserTypeahead.svelte
+++ b/frontend/src/lib/forms/UserTypeahead.svelte
@@ -1,4 +1,6 @@
 <script lang="ts">
+  import { run } from 'svelte/legacy';
+
   import { FormField, PlainInput, randomFormId } from '$lib/forms';
   import { _userTypeaheadSearch, _usersTypeaheadSearch, type SingleUserTypeaheadResult, type SingleUserICanSeeTypeaheadResult } from '$lib/gql/typeahead-queries';
   import { overlay } from '$lib/overlay';
@@ -8,14 +10,27 @@
 
   type UserTypeaheadResult = SingleUserTypeaheadResult | SingleUserICanSeeTypeaheadResult;
 
-  export let label: string;
-  export let error: string | string[] | undefined = undefined;
-  export let id: string = randomFormId();
-  export let autofocus: true | undefined = undefined;
-  export let value: string;
-  export let debounceMs = 200;
-  export let isAdmin: boolean = false;
-  export let exclude: string[] = [];
+  interface Props {
+    label: string;
+    error?: string | string[] | undefined;
+    id?: string;
+    autofocus?: true | undefined;
+    value: string;
+    debounceMs?: number;
+    isAdmin?: boolean;
+    exclude?: string[];
+  }
+
+  let {
+    label,
+    error = undefined,
+    id = randomFormId(),
+    autofocus = undefined,
+    value = $bindable(),
+    debounceMs = 200,
+    isAdmin = false,
+    exclude = []
+  }: Props = $props();
 
   function typeaheadSearch(): Promise<UserTypeaheadResult[]> {
     return isAdmin ? _userTypeaheadSearch(value) : _usersTypeaheadSearch(value);
@@ -30,8 +45,6 @@
     [],
     debounceMs);
 
-  $: typeaheadResults = $_typeaheadResults;
-  $: filteredResults = typeaheadResults.filter(user => !exclude.includes(user.id));
 
   const dispatch = createEventDispatcher<{
       selectedUserChange: UserTypeaheadResult | null;
@@ -45,10 +58,6 @@
     value = getInputValue(user);
   }
 
-  $: if ($selectedUser && value !== getInputValue($selectedUser)) {
-    $selectedUser = null;
-    dispatch('selectedUserChange', $selectedUser);
-  }
 
   function formatResult(user: UserTypeaheadResult): string {
     const extra = 'username' in user && user.username && 'email' in user && user.email ? ` (${user.username}, ${user.email})`
@@ -65,15 +74,8 @@
     return '';
   }
 
-  let highlightIdx: number | undefined = undefined;
-  let typeaheadOpen = false;
-  $: {
-    if (typeaheadOpen) {
-      highlightIdx ??= filteredResults.length ? 0 : undefined;
-    } else {
-      highlightIdx = undefined;
-    }
-  }
+  let highlightIdx: number | undefined = $state(undefined);
+  let typeaheadOpen = $state(false);
   function keydownHandler(event: KeyboardEvent): void
   {
     if (!typeaheadOpen) return;
@@ -105,11 +107,26 @@
       typeaheadResults = []; // prevent old results showing when opening next time
     }
   }
+  let typeaheadResults = $derived($_typeaheadResults);
+  let filteredResults = $derived(typeaheadResults.filter(user => !exclude.includes(user.id)));
+  run(() => {
+    if ($selectedUser && value !== getInputValue($selectedUser)) {
+      $selectedUser = null;
+      dispatch('selectedUserChange', $selectedUser);
+    }
+  });
+  run(() => {
+    if (typeaheadOpen) {
+      highlightIdx ??= filteredResults.length ? 0 : undefined;
+    } else {
+      highlightIdx = undefined;
+    }
+  });
 </script>
 
 <FormField {id} {label} {error} {autofocus}>
   <div use:overlay={{ closeClickSelector: '.menu li'}}
-    on:overlayOpen={onOverlayOpen}>
+    onoverlayOpen={onOverlayOpen}>
     <PlainInput
       style="w-full"
       bind:value {id}
@@ -122,7 +139,7 @@
     <div class="overlay-content">
       <ul class="menu p-0">
       {#each filteredResults as user, idx}
-        <li class={(highlightIdx == idx) ? 'p-0 bg-primary text-white' : 'p-0'}><button class="whitespace-nowrap" on:click={() => {
+        <li class={(highlightIdx == idx) ? 'p-0 bg-primary text-white' : 'p-0'}><button class="whitespace-nowrap" onclick={() => {
           setTimeout(() => selectUser(user));
         }}>{formatResult(user)}</button></li>
       {/each}

--- a/frontend/src/lib/forms/UserTypeahead.svelte
+++ b/frontend/src/lib/forms/UserTypeahead.svelte
@@ -103,7 +103,6 @@
   function onOverlayOpen(e: CustomEvent): void {
     typeaheadOpen = e.detail;
     if (!typeaheadOpen) {
-      // eslint-disable-next-line svelte/no-reactive-reassign
       typeaheadResults = []; // prevent old results showing when opening next time
     }
   }

--- a/frontend/src/lib/forms/UserTypeahead.svelte
+++ b/frontend/src/lib/forms/UserTypeahead.svelte
@@ -100,8 +100,8 @@
     }
   }
 
-  function onOverlayOpen(e: CustomEvent): void {
-    typeaheadOpen = e.detail;
+  function onOverlayOpen(open: boolean): void {
+    typeaheadOpen = open;
     if (!typeaheadOpen) {
       typeaheadResults = []; // prevent old results showing when opening next time
     }
@@ -124,8 +124,7 @@
 </script>
 
 <FormField {id} {label} {error} {autofocus}>
-  <div use:overlay={{ closeClickSelector: '.menu li'}}
-    onoverlayOpen={onOverlayOpen}>
+  <div use:overlay={{ closeClickSelector: '.menu li', onOverlayOpen}}>
     <PlainInput
       style="w-full"
       bind:value {id}

--- a/frontend/src/lib/icons/AdminIcon.svelte
+++ b/frontend/src/lib/icons/AdminIcon.svelte
@@ -1,5 +1,9 @@
 <script lang="ts">
-  export let size: 'text-2xl' | 'text-xl' = 'text-2xl';
+  interface Props {
+    size?: 'text-2xl' | 'text-xl';
+  }
+
+  let { size = 'text-2xl' }: Props = $props();
 </script>
 
-<span class="i-mdi-security {size}" />
+<span class="i-mdi-security {size}"></span>

--- a/frontend/src/lib/icons/AppLogo.svelte
+++ b/frontend/src/lib/icons/AppLogo.svelte
@@ -1,11 +1,15 @@
-﻿<script>
+﻿<script lang="ts">
   import logoDark from '$lib/assets/logo-dark.svg';
   import logoLight from '$lib/assets/logo-light.svg';
   import logoMono from '$lib/assets/logo-mono.svg?raw';
-  let className = '';
-  export {className as class};
+  
 
-  export let mono = false;
+  interface Props {
+    class?: string;
+    mono?: boolean;
+  }
+
+  let { class: className = '', mono = false }: Props = $props();
 </script>
 
 {#if mono}

--- a/frontend/src/lib/icons/AuthenticatedUserIcon.svelte
+++ b/frontend/src/lib/icons/AuthenticatedUserIcon.svelte
@@ -1,7 +1,11 @@
 <script lang="ts">
     type IconSize = 'text-4xl' | 'text-2xl';
-    export let size: IconSize = 'text-2xl';
+    interface Props {
+        size?: IconSize;
+    }
+
+    let { size = 'text-2xl' }: Props = $props();
 </script>
 
 <!-- https://icon-sets.iconify.design/healthicons/ui-user-profile/ -->
-<span class="i-mdi-account-circle {size}" />
+<span class="i-mdi-account-circle {size}"></span>

--- a/frontend/src/lib/icons/CircleArrowIcon.svelte
+++ b/frontend/src/lib/icons/CircleArrowIcon.svelte
@@ -1,1 +1,1 @@
-<span class="i-mdi-replay text-2xl" />
+<span class="i-mdi-replay text-2xl"></span>

--- a/frontend/src/lib/icons/HomeIcon.svelte
+++ b/frontend/src/lib/icons/HomeIcon.svelte
@@ -1,5 +1,9 @@
 <script lang="ts">
-  export let size: 'text-2xl' | 'text-xl' = 'text-2xl';
+  interface Props {
+    size?: 'text-2xl' | 'text-xl';
+  }
+
+  let { size = 'text-2xl' }: Props = $props();
 </script>
 
-<span class="i-mdi-home-outline {size}" />
+<span class="i-mdi-home-outline {size}"></span>

--- a/frontend/src/lib/icons/Icon.svelte
+++ b/frontend/src/lib/icons/Icon.svelte
@@ -1,4 +1,4 @@
-<script lang="ts" context="module">
+<script lang="ts" module>
   // Add more as necessary. Should be as limited as possible to maximize consistency. https://daisyui.com/components/badge/
   export type IconSize = 'text-md' | 'text-lg' | 'text-xl' | 'text-2xl' | 'text-5xl';
 </script>
@@ -6,16 +6,29 @@
 <script lang="ts">
   import type { IconString } from '$lib/icons';
 
-  export let icon: IconString | undefined = undefined;
-  export let size: IconSize = 'text-lg';
-  export let color: `text-${string}` | undefined = undefined;
-  export let pale = false;
-  export let spin = false;
-  export let spinReverse = false;
-  // For pixel perfect text alignment, because the svgs often contain vertical white-space
-  export let y: string | undefined = undefined;
+  
+  interface Props {
+    icon?: IconString | undefined;
+    size?: IconSize;
+    color?: `text-${string}` | undefined;
+    pale?: boolean;
+    spin?: boolean;
+    spinReverse?: boolean;
+    // For pixel perfect text alignment, because the svgs often contain vertical white-space
+    y?: string | undefined;
+  }
 
-  $: transform = y ? `translateY(${y})` : '';
+  let {
+    icon = undefined,
+    size = 'text-lg',
+    color = undefined,
+    pale = false,
+    spin = false,
+    spinReverse = false,
+    y = undefined
+  }: Props = $props();
+
+  let transform = $derived(y ? `translateY(${y})` : '');
 </script>
 
 {#if icon}

--- a/frontend/src/lib/icons/LogoutIcon.svelte
+++ b/frontend/src/lib/icons/LogoutIcon.svelte
@@ -1,2 +1,2 @@
 <!-- https://icon-sets.iconify.design/mdi/logout/ -->
-<span class="i-mdi-logout text-2xl" />
+<span class="i-mdi-logout text-2xl"></span>

--- a/frontend/src/lib/icons/PencilIcon.svelte
+++ b/frontend/src/lib/icons/PencilIcon.svelte
@@ -1,1 +1,1 @@
-<span class="i-mdi-pencil-outline text-2xl" />
+<span class="i-mdi-pencil-outline text-2xl"></span>

--- a/frontend/src/lib/icons/TrashIcon.svelte
+++ b/frontend/src/lib/icons/TrashIcon.svelte
@@ -1,8 +1,12 @@
 <script lang="ts">
   import Icon from './Icon.svelte';
 
-  export let pale = false;
-  export let color: 'text-error' | undefined = undefined;
+  interface Props {
+    pale?: boolean;
+    color?: 'text-error' | undefined;
+  }
+
+  let { pale = false, color = undefined }: Props = $props();
 </script>
 
 <Icon icon="i-mdi-trash-can" size="text-2xl" {color} {pale} />

--- a/frontend/src/lib/icons/UserAddOutline.svelte
+++ b/frontend/src/lib/icons/UserAddOutline.svelte
@@ -1,3 +1,3 @@
 <!-- https://icon-sets.iconify.design/mdi/user-add-outline/ -->
 <!-- <svg xmlns="http://www.w3.org/2000/svg" width="36" height="36" viewBox="0 0 24 24"><path fill="currentColor" d="M15 4a4 4 0 0 0-4 4a4 4 0 0 0 4 4a4 4 0 0 0 4-4a4 4 0 0 0-4-4m0 1.9a2.1 2.1 0 1 1 0 4.2A2.1 2.1 0 0 1 12.9 8A2.1 2.1 0 0 1 15 5.9M4 7v3H1v2h3v3h2v-3h3v-2H6V7H4m11 6c-2.67 0-8 1.33-8 4v3h16v-3c0-2.67-5.33-4-8-4m0 1.9c2.97 0 6.1 1.46 6.1 2.1v1.1H8.9V17c0-.64 3.1-2.1 6.1-2.1Z"/></svg> -->
-<span class="i-mdi-account-plus text-3xl" />
+<span class="i-mdi-account-plus text-3xl"></span>

--- a/frontend/src/lib/layout/AdminContent.svelte
+++ b/frontend/src/lib/layout/AdminContent.svelte
@@ -10,5 +10,5 @@
 
 <!-- eslint-disable-next-line @typescript-eslint/no-unsafe-argument -->
 {#if page.data.user?.isAdmin}
-    {@render children?.()}
+  {@render children?.()}
 {/if}

--- a/frontend/src/lib/layout/AdminContent.svelte
+++ b/frontend/src/lib/layout/AdminContent.svelte
@@ -1,11 +1,13 @@
 <script lang="ts">
-  import { page } from '$app/state'
+  import type { Snippet } from 'svelte';
+  import { page } from '$app/state';
   interface Props {
-    children?: import('svelte').Snippet;
+    children?: Snippet;
   }
 
   let { children }: Props = $props();
 </script>
+
 <!-- eslint-disable-next-line @typescript-eslint/no-unsafe-argument -->
 {#if page.data.user?.isAdmin}
     {@render children?.()}

--- a/frontend/src/lib/layout/AdminContent.svelte
+++ b/frontend/src/lib/layout/AdminContent.svelte
@@ -1,7 +1,12 @@
-<script>
-  import { page } from '$app/stores'
+<script lang="ts">
+  import { page } from '$app/state'
+  interface Props {
+    children?: import('svelte').Snippet;
+  }
+
+  let { children }: Props = $props();
 </script>
 <!-- eslint-disable-next-line @typescript-eslint/no-unsafe-argument -->
-{#if $page.data.user?.isAdmin}
-    <slot />
+{#if page.data.user?.isAdmin}
+    {@render children?.()}
 {/if}

--- a/frontend/src/lib/layout/AppBar.svelte
+++ b/frontend/src/lib/layout/AppBar.svelte
@@ -4,7 +4,7 @@
   import { AuthenticatedUserIcon, UserAddOutline } from '$lib/icons';
   import { onMount } from 'svelte';
   import type { LexAuthUser } from '$lib/user';
-  import { page } from '$app/stores';
+  import { page } from '$app/state';
   import AppLogo from '$lib/icons/AppLogo.svelte';
 
   onMount(() => {
@@ -47,14 +47,14 @@
           <AuthenticatedUserIcon size="text-4xl" />
         </label>
       {:else}
-        {#if $page.url.pathname !== '/login'}
+        {#if page.url.pathname !== '/login'}
           <a href="/login" class="btn btn-primary">
             {$t('login.button_login')}
           <span class="i-mdi-logout text-3xl"></span>
           </a>
         {/if}
 
-        {#if $page.url.pathname !== '/register'}
+        {#if page.url.pathname !== '/register'}
           <a href="/register" class="btn btn-primary">
             {$t('register.button_register')}
             <UserAddOutline/>

--- a/frontend/src/lib/layout/AppBar.svelte
+++ b/frontend/src/lib/layout/AppBar.svelte
@@ -12,9 +12,13 @@
     if (isPlaywright) environmentName = 'playwright';
   });
   let isPlaywright = false;
-  let environmentName = env.PUBLIC_ENV_NAME?.toLowerCase();
-  export let user: LexAuthUser | null;
-  $: loggedIn = !!user;
+  let environmentName = $state(env.PUBLIC_ENV_NAME?.toLowerCase());
+  interface Props {
+    user: LexAuthUser | null;
+  }
+
+  let { user }: Props = $props();
+  let loggedIn = $derived(!!user);
 </script>
 
 <!-- https://daisyui.com/components/navbar -->
@@ -22,7 +26,7 @@
   {#if environmentName !== 'production'}
     <a href="https://lexbox.org" class="flex gap-2 justify-center items-center bg-warning text-warning-content p-2 underline">
       {$t('environment_warning', { environmentName })}
-      <span class="i-mdi-open-in-new text-xl shrink-0" />
+      <span class="i-mdi-open-in-new text-xl shrink-0"></span>
     </a>
   {/if}
   <div class="navbar justify-between bg-primary text-primary-content md:pl-3 md:pr-6">
@@ -46,7 +50,7 @@
         {#if $page.url.pathname !== '/login'}
           <a href="/login" class="btn btn-primary">
             {$t('login.button_login')}
-          <span class="i-mdi-logout text-3xl"/>
+          <span class="i-mdi-logout text-3xl"></span>
           </a>
         {/if}
 

--- a/frontend/src/lib/layout/AppMenu.svelte
+++ b/frontend/src/lib/layout/AppMenu.svelte
@@ -8,9 +8,13 @@
   import Icon from '$lib/icons/Icon.svelte';
   import { helpLinks } from '$lib/components/help';
 
-  export let serverVersion: string;
-  export let apiVersion: string | null;
-  export let user: LexAuthUser;
+  interface Props {
+    serverVersion: string;
+    apiVersion: string | null;
+    user: LexAuthUser;
+  }
+
+  let { serverVersion, apiVersion, user }: Props = $props();
 </script>
 
 <!-- https://daisyui.com/components/menu  -->
@@ -27,7 +31,7 @@
     </a>
   </li>
 
-  <div class="divider" />
+  <div class="divider"></div>
 
   <AdminContent>
     <li>
@@ -66,8 +70,8 @@
     </a>
   </li>
 
-  <div class="divider" />
-  <div class="grow" />
+  <div class="divider"></div>
+  <div class="grow"></div>
   <div class="flex flex-col items-end gap-1">
     <Badge>Client Version: {APP_VERSION}</Badge>
     <Badge>Server Version: {serverVersion}</Badge>

--- a/frontend/src/lib/layout/Breadcrumbs/PageBreadcrumb.svelte
+++ b/frontend/src/lib/layout/Breadcrumbs/PageBreadcrumb.svelte
@@ -5,8 +5,13 @@
   import {page} from '$app/stores';
   import type {Action} from 'svelte/action';
 
-  export let href: string | undefined = undefined;
-  $: isCurrentPath = $page.url.pathname === href;
+  interface Props {
+    href?: string | undefined;
+    children?: import('svelte').Snippet;
+  }
+
+  let { href = undefined, children }: Props = $props();
+  let isCurrentPath = $derived($page.url.pathname === href);
 
   let crumbs: Writable<Element[]> = getContext('breadcrumb-store');
 
@@ -32,10 +37,10 @@
   <span use:makeBreadCrumb>
     {#if href && !isCurrentPath}
       <a {href} class="hover:border-b">
-        <slot/>
+        {@render children?.()}
       </a>
     {:else}
-        <slot/>
+        {@render children?.()}
     {/if}
   </span>
 </div>

--- a/frontend/src/lib/layout/Breadcrumbs/PageBreadcrumb.svelte
+++ b/frontend/src/lib/layout/Breadcrumbs/PageBreadcrumb.svelte
@@ -20,7 +20,9 @@
 
   function makeBreadCrumb(element: Element): ReturnType<Action> {
     if (setup) {
-      console.error('BreadCrumb already setup, this will mess up the order in which the crumbs are rendered. Probably caused by changing a prop after the component is mounted.');
+      console.error(
+        'BreadCrumb already setup, this will mess up the order in which the crumbs are rendered. Probably caused by changing a prop after the component is mounted.',
+      );
       return;
     }
     element.remove();
@@ -41,7 +43,7 @@
         {@render children?.()}
       </a>
     {:else}
-        {@render children?.()}
+      {@render children?.()}
     {/if}
   </span>
 </div>

--- a/frontend/src/lib/layout/Breadcrumbs/PageBreadcrumb.svelte
+++ b/frontend/src/lib/layout/Breadcrumbs/PageBreadcrumb.svelte
@@ -1,13 +1,14 @@
-﻿<script lang="ts">
+<script lang="ts">
+  import type { Snippet } from 'svelte';
 
-  import type {Writable} from 'svelte/store';
-  import {getContext} from 'svelte';
-  import {page} from '$app/state';
-  import type {Action} from 'svelte/action';
+  import type { Writable } from 'svelte/store';
+  import { getContext } from 'svelte';
+  import { page } from '$app/state';
+  import type { Action } from 'svelte/action';
 
   interface Props {
     href?: string | undefined;
-    children?: import('svelte').Snippet;
+    children?: Snippet;
   }
 
   let { href = undefined, children }: Props = $props();

--- a/frontend/src/lib/layout/Breadcrumbs/PageBreadcrumb.svelte
+++ b/frontend/src/lib/layout/Breadcrumbs/PageBreadcrumb.svelte
@@ -2,7 +2,7 @@
 
   import type {Writable} from 'svelte/store';
   import {getContext} from 'svelte';
-  import {page} from '$app/stores';
+  import {page} from '$app/state';
   import type {Action} from 'svelte/action';
 
   interface Props {
@@ -11,7 +11,7 @@
   }
 
   let { href = undefined, children }: Props = $props();
-  let isCurrentPath = $derived($page.url.pathname === href);
+  let isCurrentPath = $derived(page.url.pathname === href);
 
   let crumbs: Writable<Element[]> = getContext('breadcrumb-store');
 

--- a/frontend/src/lib/layout/Breadcrumbs/RenderElement.svelte
+++ b/frontend/src/lib/layout/Breadcrumbs/RenderElement.svelte
@@ -1,11 +1,17 @@
 ﻿<script lang="ts">
-  export let el: Element;
-  export let tag = 'div';
-  let target: Element;
-  $: {
+  import { run } from 'svelte/legacy';
+
+  interface Props {
+    el: Element;
+    tag?: string;
+  }
+
+  let { el, tag = 'div' }: Props = $props();
+  let target: Element = $state();
+  run(() => {
     if (target && el)
       // eslint-disable-next-line svelte/no-dom-manipulating
       target.replaceChildren(el);
-  }
+  });
 </script>
 <svelte:element this={tag} bind:this={target}/>

--- a/frontend/src/lib/layout/Breadcrumbs/RenderElement.svelte
+++ b/frontend/src/lib/layout/Breadcrumbs/RenderElement.svelte
@@ -1,4 +1,4 @@
-﻿<script lang="ts">
+<script lang="ts">
   import { run } from 'svelte/legacy';
 
   interface Props {
@@ -7,11 +7,12 @@
   }
 
   let { el, tag = 'div' }: Props = $props();
-  let target: Element = $state();
+  let target: Element = $state()!;
   run(() => {
     if (target && el)
       // eslint-disable-next-line svelte/no-dom-manipulating
       target.replaceChildren(el);
   });
 </script>
-<svelte:element this={tag} bind:this={target}/>
+
+<svelte:element this={tag} bind:this={target} />

--- a/frontend/src/lib/layout/Breadcrumbs/RenderElement.svelte
+++ b/frontend/src/lib/layout/Breadcrumbs/RenderElement.svelte
@@ -7,7 +7,7 @@
   }
 
   let { el, tag = 'div' }: Props = $props();
-  let target: Element = $state()!;
+  let target: Element | undefined = $state();
   run(() => {
     if (target && el)
       // eslint-disable-next-line svelte/no-dom-manipulating

--- a/frontend/src/lib/layout/Content.svelte
+++ b/frontend/src/lib/layout/Content.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
+  import type { Snippet } from 'svelte';
   interface Props {
-    children?: import('svelte').Snippet;
+    children?: Snippet;
   }
 
   let { children }: Props = $props();

--- a/frontend/src/lib/layout/Content.svelte
+++ b/frontend/src/lib/layout/Content.svelte
@@ -1,3 +1,11 @@
+<script lang="ts">
+  interface Props {
+    children?: import('svelte').Snippet;
+  }
+
+  let { children }: Props = $props();
+</script>
+
 <main class="max-w-none px-2 md:px-6 py-8 flex-grow flex flex-col">
-  <slot />
+  {@render children?.()}
 </main>

--- a/frontend/src/lib/layout/DetailItem.svelte
+++ b/frontend/src/lib/layout/DetailItem.svelte
@@ -2,11 +2,25 @@
   import CopyToClipboardButton from '$lib/components/CopyToClipboardButton.svelte';
   import Loader from '$lib/components/Loader.svelte';
 
-  export let title: string;
-  export let text: string | null | undefined = undefined;
-  export let copyToClipboard = false;
-  export let loading = false;
-  export let wrap = false;
+  interface Props {
+    title: string;
+    text?: string | null | undefined;
+    copyToClipboard?: boolean;
+    loading?: boolean;
+    wrap?: boolean;
+    children?: import('svelte').Snippet;
+    extras?: import('svelte').Snippet;
+  }
+
+  let {
+    title,
+    text = undefined,
+    copyToClipboard = false,
+    loading = false,
+    wrap = false,
+    children,
+    extras
+  }: Props = $props();
 </script>
 
 <div class="text-lg flex items-center gap-2 detail-item whitespace-nowrap" class:flex-wrap={wrap}>
@@ -16,12 +30,12 @@
   {:else if text}
     <span class="text-secondary x-ellipsis">{text}</span>
   {:else}
-    <slot/>
+    {@render children?.()}
   {/if}
   {#if copyToClipboard}
     <CopyToClipboardButton textToCopy={text ?? ''} size="btn-sm" outline={false} />
   {/if}
-  {#if $$slots.extras}
-    <slot name="extras" />
+  {#if extras}
+    {@render extras?.()}
   {/if}
 </div>

--- a/frontend/src/lib/layout/DetailItem.svelte
+++ b/frontend/src/lib/layout/DetailItem.svelte
@@ -20,7 +20,7 @@
     loading = false,
     wrap = false,
     children,
-    extras
+    extras,
   }: Props = $props();
 </script>
 

--- a/frontend/src/lib/layout/DetailItem.svelte
+++ b/frontend/src/lib/layout/DetailItem.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import type { Snippet } from 'svelte';
   import CopyToClipboardButton from '$lib/components/CopyToClipboardButton.svelte';
   import Loader from '$lib/components/Loader.svelte';
 
@@ -8,8 +9,8 @@
     copyToClipboard?: boolean;
     loading?: boolean;
     wrap?: boolean;
-    children?: import('svelte').Snippet;
-    extras?: import('svelte').Snippet;
+    children?: Snippet;
+    extras?: Snippet;
   }
 
   let {

--- a/frontend/src/lib/layout/DetailsPage.svelte
+++ b/frontend/src/lib/layout/DetailsPage.svelte
@@ -30,21 +30,22 @@
     children,
   }: Props = $props();
 
-  const banner_render = $derived(banner);
-  const actions_render = $derived(actions);
-  const title_render = $derived(title);
-  const headerContent_render = $derived(headerContent);
+  // TODO: Can probably simplify this and get rid of the fooRender varaibles, I suspect. 2025-05 RM
+  const bannerRender = $derived(banner);
+  const actionsRender = $derived(actions);
+  const titleRender = $derived(title);
+  const headerContentRender = $derived(headerContent);
 </script>
 
 <HeaderPage {wide} {titleText} {setBreadcrumb}>
   {#snippet banner()}
-    {@render banner_render?.()}
+    {@render bannerRender?.()}
   {/snippet}
   {#snippet actions()}
-    {@render actions_render?.()}
+    {@render actionsRender?.()}
   {/snippet}
   {#snippet title()}
-    {@render title_render?.()}
+    {@render titleRender?.()}
   {/snippet}
   {#snippet headerContent()}
     {#if badges}
@@ -52,7 +53,7 @@
         {@render badges?.()}
       </BadgeList>
     {/if}
-    {@render headerContent_render?.()}
+    {@render headerContentRender?.()}
   {/snippet}
   {#if details}
     <div class="my-4 space-y-2 details">

--- a/frontend/src/lib/layout/DetailsPage.svelte
+++ b/frontend/src/lib/layout/DetailsPage.svelte
@@ -16,6 +16,8 @@
     children,
     ...rest
   }: Props = $props();
+
+  const headerContentRender = $derived(headerContent);
 </script>
 
 <HeaderPage {...rest}>
@@ -25,7 +27,7 @@
         {@render badges?.()}
       </BadgeList>
     {/if}
-    {@render headerContent?.()}
+    {@render headerContentRender?.()}
   {/snippet}
   {#if details}
     <div class="my-4 space-y-2 details">

--- a/frontend/src/lib/layout/DetailsPage.svelte
+++ b/frontend/src/lib/layout/DetailsPage.svelte
@@ -3,28 +3,63 @@
   import t from '$lib/i18n';
   import HeaderPage from './HeaderPage.svelte';
 
-  export let titleText: string;
-  export let wide = false;
-  export let setBreadcrumb = true;
+  interface Props {
+    titleText: string;
+    wide?: boolean;
+    setBreadcrumb?: boolean;
+    banner?: import('svelte').Snippet;
+    actions?: import('svelte').Snippet;
+    title?: import('svelte').Snippet;
+    badges?: import('svelte').Snippet;
+    headerContent?: import('svelte').Snippet;
+    details?: import('svelte').Snippet;
+    children?: import('svelte').Snippet;
+  }
+
+  let {
+    titleText,
+    wide = false,
+    setBreadcrumb = true,
+    banner,
+    actions,
+    title,
+    badges,
+    headerContent,
+    details,
+    children
+  }: Props = $props();
+
+  const banner_render = $derived(banner);
+  const actions_render = $derived(actions);
+  const title_render = $derived(title);
+  const headerContent_render = $derived(headerContent);
 </script>
 
 <HeaderPage {wide} titleText={titleText} {setBreadcrumb}>
-  <svelte:fragment slot="banner"><slot name="banner"></slot></svelte:fragment>
-  <svelte:fragment slot="actions"><slot name="actions"></slot></svelte:fragment>
-  <svelte:fragment slot="title"><slot name="title"></slot></svelte:fragment>
-  <svelte:fragment slot="headerContent">
-    {#if $$slots.badges}
-      <BadgeList>
-        <slot name="badges" />
-      </BadgeList>
-    {/if}
-    <slot name="headerContent" />
-  </svelte:fragment>
-  {#if $$slots.details}
+  {#snippet banner()}
+    {@render banner_render?.()}
+  {/snippet}
+  {#snippet actions()}
+    {@render actions_render?.()}
+  {/snippet}
+  {#snippet title()}
+    {@render title_render?.()}
+  {/snippet}
+  {#snippet headerContent()}
+  
+      {#if badges}
+        <BadgeList>
+          {@render badges?.()}
+        </BadgeList>
+      {/if}
+      {@render headerContent_render?.()}
+    
+  {/snippet}
+  {#if details}
     <div class="my-4 space-y-2 details">
       <p class="text-2xl mb-4">{$t('project_page.summary')}</p>
-      <slot name="details" />
+      {@render details?.()}
     </div>
   {/if}
-  <slot />
+  {@render children?.()}
 </HeaderPage>

--- a/frontend/src/lib/layout/DetailsPage.svelte
+++ b/frontend/src/lib/layout/DetailsPage.svelte
@@ -5,15 +5,8 @@
   import HeaderPage, { type Props as HeaderPageProps } from './HeaderPage.svelte';
 
   interface Props extends HeaderPageProps {
-    wide?: boolean;
-    setBreadcrumb?: boolean;
-    banner?: Snippet;
-    actions?: Snippet;
-    title?: Snippet;
     badges?: Snippet;
-    headerContent?: Snippet;
     details?: Snippet;
-    children?: Snippet;
   }
 
   let {

--- a/frontend/src/lib/layout/DetailsPage.svelte
+++ b/frontend/src/lib/layout/DetailsPage.svelte
@@ -27,7 +27,7 @@
     badges,
     headerContent,
     details,
-    children
+    children,
   }: Props = $props();
 
   const banner_render = $derived(banner);
@@ -36,7 +36,7 @@
   const headerContent_render = $derived(headerContent);
 </script>
 
-<HeaderPage {wide} titleText={titleText} {setBreadcrumb}>
+<HeaderPage {wide} {titleText} {setBreadcrumb}>
   {#snippet banner()}
     {@render banner_render?.()}
   {/snippet}
@@ -47,14 +47,12 @@
     {@render title_render?.()}
   {/snippet}
   {#snippet headerContent()}
-  
-      {#if badges}
-        <BadgeList>
-          {@render badges?.()}
-        </BadgeList>
-      {/if}
-      {@render headerContent_render?.()}
-    
+    {#if badges}
+      <BadgeList>
+        {@render badges?.()}
+      </BadgeList>
+    {/if}
+    {@render headerContent_render?.()}
   {/snippet}
   {#if details}
     <div class="my-4 space-y-2 details">

--- a/frontend/src/lib/layout/DetailsPage.svelte
+++ b/frontend/src/lib/layout/DetailsPage.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import type { Snippet } from 'svelte';
   import BadgeList from '$lib/components/Badges/BadgeList.svelte';
   import t from '$lib/i18n';
   import HeaderPage from './HeaderPage.svelte';
@@ -7,13 +8,13 @@
     titleText: string;
     wide?: boolean;
     setBreadcrumb?: boolean;
-    banner?: import('svelte').Snippet;
-    actions?: import('svelte').Snippet;
-    title?: import('svelte').Snippet;
-    badges?: import('svelte').Snippet;
-    headerContent?: import('svelte').Snippet;
-    details?: import('svelte').Snippet;
-    children?: import('svelte').Snippet;
+    banner?: Snippet;
+    actions?: Snippet;
+    title?: Snippet;
+    badges?: Snippet;
+    headerContent?: Snippet;
+    details?: Snippet;
+    children?: Snippet;
   }
 
   let {

--- a/frontend/src/lib/layout/DetailsPage.svelte
+++ b/frontend/src/lib/layout/DetailsPage.svelte
@@ -2,10 +2,9 @@
   import type { Snippet } from 'svelte';
   import BadgeList from '$lib/components/Badges/BadgeList.svelte';
   import t from '$lib/i18n';
-  import HeaderPage from './HeaderPage.svelte';
+  import HeaderPage, { type Props as HeaderPageProps } from './HeaderPage.svelte';
 
-  interface Props {
-    titleText: string;
+  interface Props extends HeaderPageProps {
     wide?: boolean;
     setBreadcrumb?: boolean;
     banner?: Snippet;
@@ -18,42 +17,22 @@
   }
 
   let {
-    titleText,
-    wide = false,
-    setBreadcrumb = true,
-    banner,
-    actions,
-    title,
-    badges,
-    headerContent,
     details,
+    headerContent,
+    badges,
     children,
+    ...rest
   }: Props = $props();
-
-  // TODO: Can probably simplify this and get rid of the fooRender varaibles, I suspect. 2025-05 RM
-  const bannerRender = $derived(banner);
-  const actionsRender = $derived(actions);
-  const titleRender = $derived(title);
-  const headerContentRender = $derived(headerContent);
 </script>
 
-<HeaderPage {wide} {titleText} {setBreadcrumb}>
-  {#snippet banner()}
-    {@render bannerRender?.()}
-  {/snippet}
-  {#snippet actions()}
-    {@render actionsRender?.()}
-  {/snippet}
-  {#snippet title()}
-    {@render titleRender?.()}
-  {/snippet}
+<HeaderPage {...rest}>
   {#snippet headerContent()}
     {#if badges}
       <BadgeList>
         {@render badges?.()}
       </BadgeList>
     {/if}
-    {@render headerContentRender?.()}
+    {@render headerContent?.()}
   {/snippet}
   {#if details}
     <div class="my-4 space-y-2 details">

--- a/frontend/src/lib/layout/DevContent.svelte
+++ b/frontend/src/lib/layout/DevContent.svelte
@@ -1,12 +1,4 @@
-<script lang="ts">
-  interface Props {
-    children?: import('svelte').Snippet;
-  }
-
-  let { children }: Props = $props();
-</script>
-
-﻿<script module lang="ts">
+<script module lang="ts">
   import { writable } from 'svelte/store';
   import { browser } from '$app/environment';
 
@@ -22,6 +14,15 @@
     };
     isDev.set(localStorage.getItem('devMode') === 'true');
   }
+</script>
+
+<script lang="ts">
+  import type { Snippet } from 'svelte';
+  interface Props {
+    children?: Snippet;
+  }
+
+  let { children }: Props = $props();
 </script>
 
 {#if $isDev}

--- a/frontend/src/lib/layout/DevContent.svelte
+++ b/frontend/src/lib/layout/DevContent.svelte
@@ -1,4 +1,12 @@
-﻿<script context="module" lang="ts">
+<script lang="ts">
+  interface Props {
+    children?: import('svelte').Snippet;
+  }
+
+  let { children }: Props = $props();
+</script>
+
+﻿<script module lang="ts">
   import { writable } from 'svelte/store';
   import { browser } from '$app/environment';
 
@@ -17,5 +25,5 @@
 </script>
 
 {#if $isDev}
-  <slot />
+  {@render children?.()}
 {/if}

--- a/frontend/src/lib/layout/EditableDetailItem.svelte
+++ b/frontend/src/lib/layout/EditableDetailItem.svelte
@@ -2,13 +2,24 @@
   import EditableText from '$lib/components/EditableText.svelte';
   import type { ErrorMessage } from '$lib/forms';
 
-  export let title: string;
-  export let value: string | null | undefined;
 
-  export let disabled = false;
-  export let saveHandler: (newValue: string) => Promise<ErrorMessage>;
-  export let placeholder: string | undefined = undefined;
-  export let multiline = false;
+  interface Props {
+    title: string;
+    value: string | null | undefined;
+    disabled?: boolean;
+    saveHandler: (newValue: string) => Promise<ErrorMessage>;
+    placeholder?: string | undefined;
+    multiline?: boolean;
+  }
+
+  let {
+    title,
+    value,
+    disabled = false,
+    saveHandler,
+    placeholder = undefined,
+    multiline = false
+  }: Props = $props();
 </script>
 
 <div>

--- a/frontend/src/lib/layout/FeatureFlagContent.svelte
+++ b/frontend/src/lib/layout/FeatureFlagContent.svelte
@@ -1,5 +1,5 @@
 ﻿<script lang="ts">
-  import {page} from '$app/stores'
+  import {page} from '$app/state'
   import type {FeatureFlag} from '$lib/gql/types';
   import {hasFeatureFlag} from '$lib/user';
 
@@ -11,6 +11,6 @@
   let { flag, children }: Props = $props();
 </script>
 <!-- eslint-disable-next-line @typescript-eslint/no-unsafe-argument -->
-{#if hasFeatureFlag($page.data.user, flag)}
+{#if hasFeatureFlag(page.data.user, flag)}
     {@render children?.()}
 {/if}

--- a/frontend/src/lib/layout/FeatureFlagContent.svelte
+++ b/frontend/src/lib/layout/FeatureFlagContent.svelte
@@ -3,9 +3,14 @@
   import type {FeatureFlag} from '$lib/gql/types';
   import {hasFeatureFlag} from '$lib/user';
 
-  export let flag: FeatureFlag | keyof typeof FeatureFlag;
+  interface Props {
+    flag: FeatureFlag | keyof typeof FeatureFlag;
+    children?: import('svelte').Snippet;
+  }
+
+  let { flag, children }: Props = $props();
 </script>
 <!-- eslint-disable-next-line @typescript-eslint/no-unsafe-argument -->
 {#if hasFeatureFlag($page.data.user, flag)}
-    <slot />
+    {@render children?.()}
 {/if}

--- a/frontend/src/lib/layout/FeatureFlagContent.svelte
+++ b/frontend/src/lib/layout/FeatureFlagContent.svelte
@@ -14,5 +14,5 @@
 
 <!-- eslint-disable-next-line @typescript-eslint/no-unsafe-argument -->
 {#if hasFeatureFlag(page.data.user, flag)}
-    {@render children?.()}
+  {@render children?.()}
 {/if}

--- a/frontend/src/lib/layout/FeatureFlagContent.svelte
+++ b/frontend/src/lib/layout/FeatureFlagContent.svelte
@@ -1,15 +1,17 @@
-﻿<script lang="ts">
-  import {page} from '$app/state'
-  import type {FeatureFlag} from '$lib/gql/types';
-  import {hasFeatureFlag} from '$lib/user';
+<script lang="ts">
+  import type { Snippet } from 'svelte';
+  import { page } from '$app/state';
+  import type { FeatureFlag } from '$lib/gql/types';
+  import { hasFeatureFlag } from '$lib/user';
 
   interface Props {
     flag: FeatureFlag | keyof typeof FeatureFlag;
-    children?: import('svelte').Snippet;
+    children?: Snippet;
   }
 
   let { flag, children }: Props = $props();
 </script>
+
 <!-- eslint-disable-next-line @typescript-eslint/no-unsafe-argument -->
 {#if hasFeatureFlag(page.data.user, flag)}
     {@render children?.()}

--- a/frontend/src/lib/layout/HeaderPage.svelte
+++ b/frontend/src/lib/layout/HeaderPage.svelte
@@ -1,31 +1,27 @@
 <script lang="ts">
   import type { Snippet } from 'svelte';
-  import Page from './Page.svelte';
+  import Page, { type Props as PageProps } from './Page.svelte';
 
-  interface Props {
-    titleText: string;
-    wide?: boolean;
-    setBreadcrumb?: boolean;
+  export interface Props extends PageProps {
+    titleText?: string;
     banner?: Snippet;
     actions?: Snippet;
-    title?: Snippet;
     headerContent?: Snippet;
-    children?: Snippet;
   }
 
   let {
-    titleText,
     wide = false,
     setBreadcrumb = true,
     banner,
     actions,
     title,
+    titleText,
     headerContent,
     children,
   }: Props = $props();
 </script>
 
-<Page title={titleText} {wide} {setBreadcrumb}>
+<Page title={titleText ?? title} {wide} {setBreadcrumb}>
   {#snippet header()}
     {@render banner?.()}
     <div class="flex flex-row-reverse flex-wrap justify-between mb-4 gap-y-2 gap-x-4">
@@ -33,9 +29,11 @@
         {@render actions?.()}
       </div>
       <h1 class="text-3xl text-left grow max-w-full flex gap-4 items-end flex-wrap">
-        {#if title}
+        {#if title && typeof(title) === 'function'}
           {@render title?.()}
-        {:else}
+        {:else if title}
+          {title}
+        {:else if titleText}
           {titleText}
         {/if}
       </h1>

--- a/frontend/src/lib/layout/HeaderPage.svelte
+++ b/frontend/src/lib/layout/HeaderPage.svelte
@@ -2,26 +2,26 @@
   import type { Snippet } from 'svelte';
   import Page, { type Props as PageProps } from './Page.svelte';
 
-  export interface Props extends PageProps {
-    titleText?: string;
+  export interface Props extends Omit<PageProps, 'title'> {
+    titleText: string;
     banner?: Snippet;
     actions?: Snippet;
+    title?: Snippet;
     headerContent?: Snippet;
   }
 
   let {
-    wide = false,
-    setBreadcrumb = true,
+    titleText,
     banner,
     actions,
     title,
-    titleText,
     headerContent,
     children,
+    ...rest
   }: Props = $props();
 </script>
 
-<Page title={titleText ?? title} {wide} {setBreadcrumb}>
+<Page {...rest} title={titleText}>
   {#snippet header()}
     {@render banner?.()}
     <div class="flex flex-row-reverse flex-wrap justify-between mb-4 gap-y-2 gap-x-4">
@@ -29,11 +29,9 @@
         {@render actions?.()}
       </div>
       <h1 class="text-3xl text-left grow max-w-full flex gap-4 items-end flex-wrap">
-        {#if title && typeof(title) === 'function'}
+        {#if title}
           {@render title?.()}
-        {:else if title}
-          {title}
-        {:else if titleText}
+        {:else}
           {titleText}
         {/if}
       </h1>

--- a/frontend/src/lib/layout/HeaderPage.svelte
+++ b/frontend/src/lib/layout/HeaderPage.svelte
@@ -1,15 +1,16 @@
 <script lang="ts">
+  import type { Snippet } from 'svelte';
   import Page from './Page.svelte';
 
   interface Props {
     titleText: string;
     wide?: boolean;
     setBreadcrumb?: boolean;
-    banner?: import('svelte').Snippet;
-    actions?: import('svelte').Snippet;
-    title?: import('svelte').Snippet;
-    headerContent?: import('svelte').Snippet;
-    children?: import('svelte').Snippet;
+    banner?: Snippet;
+    actions?: Snippet;
+    title?: Snippet;
+    headerContent?: Snippet;
+    children?: Snippet;
   }
 
   let {

--- a/frontend/src/lib/layout/HeaderPage.svelte
+++ b/frontend/src/lib/layout/HeaderPage.svelte
@@ -21,28 +21,26 @@
     actions,
     title,
     headerContent,
-    children
+    children,
   }: Props = $props();
 </script>
 
 <Page title={titleText} {wide} {setBreadcrumb}>
   {#snippet header()}
-  
-      {@render banner?.()}
-      <div class="flex flex-row-reverse flex-wrap justify-between mb-4 gap-y-2 gap-x-4">
-        <div class="inline-flex flex-wrap header-actions gap-2 justify-end">
-          {@render actions?.()}
-        </div>
-        <h1 class="text-3xl text-left grow max-w-full flex gap-4 items-end flex-wrap">
-          {#if title}
-            {@render title?.()}
-          {:else}
-            {titleText}
-          {/if}
-        </h1>
+    {@render banner?.()}
+    <div class="flex flex-row-reverse flex-wrap justify-between mb-4 gap-y-2 gap-x-4">
+      <div class="inline-flex flex-wrap header-actions gap-2 justify-end">
+        {@render actions?.()}
       </div>
-      {@render headerContent?.()}
-    
+      <h1 class="text-3xl text-left grow max-w-full flex gap-4 items-end flex-wrap">
+        {#if title}
+          {@render title?.()}
+        {:else}
+          {titleText}
+        {/if}
+      </h1>
+    </div>
+    {@render headerContent?.()}
   {/snippet}
   <div class="divider"></div>
   <div class="pb-6">

--- a/frontend/src/lib/layout/HeaderPage.svelte
+++ b/frontend/src/lib/layout/HeaderPage.svelte
@@ -1,30 +1,50 @@
 <script lang="ts">
   import Page from './Page.svelte';
 
-  export let titleText: string;
-  export let wide = false;
-  export let setBreadcrumb = true;
+  interface Props {
+    titleText: string;
+    wide?: boolean;
+    setBreadcrumb?: boolean;
+    banner?: import('svelte').Snippet;
+    actions?: import('svelte').Snippet;
+    title?: import('svelte').Snippet;
+    headerContent?: import('svelte').Snippet;
+    children?: import('svelte').Snippet;
+  }
+
+  let {
+    titleText,
+    wide = false,
+    setBreadcrumb = true,
+    banner,
+    actions,
+    title,
+    headerContent,
+    children
+  }: Props = $props();
 </script>
 
 <Page title={titleText} {wide} {setBreadcrumb}>
-  <svelte:fragment slot="header">
-    <slot name="banner" />
-    <div class="flex flex-row-reverse flex-wrap justify-between mb-4 gap-y-2 gap-x-4">
-      <div class="inline-flex flex-wrap header-actions gap-2 justify-end">
-        <slot name="actions" />
+  {#snippet header()}
+  
+      {@render banner?.()}
+      <div class="flex flex-row-reverse flex-wrap justify-between mb-4 gap-y-2 gap-x-4">
+        <div class="inline-flex flex-wrap header-actions gap-2 justify-end">
+          {@render actions?.()}
+        </div>
+        <h1 class="text-3xl text-left grow max-w-full flex gap-4 items-end flex-wrap">
+          {#if title}
+            {@render title?.()}
+          {:else}
+            {titleText}
+          {/if}
+        </h1>
       </div>
-      <h1 class="text-3xl text-left grow max-w-full flex gap-4 items-end flex-wrap">
-        {#if $$slots.title}
-          <slot name="title" />
-        {:else}
-          {titleText}
-        {/if}
-      </h1>
-    </div>
-    <slot name="headerContent" />
-  </svelte:fragment>
-  <div class="divider" />
+      {@render headerContent?.()}
+    
+  {/snippet}
+  <div class="divider"></div>
   <div class="pb-6">
-    <slot />
+    {@render children?.()}
   </div>
 </Page>

--- a/frontend/src/lib/layout/Layout.svelte
+++ b/frontend/src/lib/layout/Layout.svelte
@@ -11,11 +11,16 @@
   import DevContent from './DevContent.svelte';
   import { helpLinks } from '$lib/components/help';
 
-  export let hideToolbar = false;
+  interface Props {
+    hideToolbar?: boolean;
+    children?: import('svelte').Snippet;
+  }
 
-  let menuToggle = false;
-  $: data = $page.data as LayoutData;
-  $: user = data.user;
+  let { hideToolbar = false, children }: Props = $props();
+
+  let menuToggle = $state(false);
+  let data = $derived($page.data as LayoutData);
+  let user = $derived(data.user);
 
   function close(): void {
     menuToggle = false;
@@ -33,7 +38,7 @@
   initEmailResult();
 </script>
 
-<svelte:window on:keydown={closeOnEscape} />
+<svelte:window onkeydown={closeOnEscape} />
 
 {#if user?.audience === 'LexboxApi' || user?.scope?.includes('lexboxapi')}
   <div class="drawer drawer-end grow">
@@ -84,12 +89,12 @@
       </div>
 
       <Content>
-        <slot />
+        {@render children?.()}
       </Content>
     </div>
     <div class="drawer-side z-10">
       <!-- using a label means it works before hydration is complete -->
-      <label for="drawer-toggle" class="drawer-overlay" />
+      <label for="drawer-toggle" class="drawer-overlay"></label>
       <AppMenu {user} serverVersion={data.serverVersion} apiVersion={data.apiVersion} />
     </div>
   </div>
@@ -99,7 +104,7 @@
   <AppBar {user} />
 
   <Content>
-    <slot />
+    {@render children?.()}
   </Content>
 {/if}
 

--- a/frontend/src/lib/layout/Layout.svelte
+++ b/frontend/src/lib/layout/Layout.svelte
@@ -59,8 +59,12 @@
                 <Icon size="text-2xl" icon="i-mdi-package-variant" />
               </a>
             </DevContent>
-            <a href={helpLinks.helpList} target="_blank" rel="external"
-              class="btn btn-sm btn-info btn-outline hidden lg:flex">
+            <a
+              href={helpLinks.helpList}
+              target="_blank"
+              rel="external"
+              class="btn btn-sm btn-info btn-outline hidden lg:flex"
+            >
               {$t('appmenu.help')}
               <Icon icon="i-mdi-open-in-new" size="text-lg" />
             </a>

--- a/frontend/src/lib/layout/Layout.svelte
+++ b/frontend/src/lib/layout/Layout.svelte
@@ -6,7 +6,7 @@
   import { onMount } from 'svelte';
   import { ensureClientMatchesUser } from '$lib/gql';
   import { beforeNavigate } from '$app/navigation';
-  import { page } from '$app/stores';
+  import { page } from '$app/state';
   import type { LayoutData } from '../../routes/$types';
   import DevContent from './DevContent.svelte';
   import { helpLinks } from '$lib/components/help';
@@ -19,7 +19,7 @@
   let { hideToolbar = false, children }: Props = $props();
 
   let menuToggle = $state(false);
-  let data = $derived($page.data as LayoutData);
+  let data = $derived(page.data as LayoutData);
   let user = $derived(data.user);
 
   function close(): void {

--- a/frontend/src/lib/layout/Layout.svelte
+++ b/frontend/src/lib/layout/Layout.svelte
@@ -1,5 +1,9 @@
 <script lang="ts">
-  import EmailVerificationStatus, { initEmailResult, initRequestedEmail } from '$lib/email/EmailVerificationStatus.svelte';
+  import type { Snippet } from 'svelte';
+  import EmailVerificationStatus, {
+    initEmailResult,
+    initRequestedEmail,
+  } from '$lib/email/EmailVerificationStatus.svelte';
   import t from '$lib/i18n';
   import { AdminIcon, HomeIcon, Icon } from '$lib/icons';
   import { AdminContent, AppBar, AppMenu, Breadcrumbs, Content } from '$lib/layout';
@@ -13,7 +17,7 @@
 
   interface Props {
     hideToolbar?: boolean;
-    children?: import('svelte').Snippet;
+    children?: Snippet;
   }
 
   let { hideToolbar = false, children }: Props = $props();

--- a/frontend/src/lib/layout/Page.svelte
+++ b/frontend/src/lib/layout/Page.svelte
@@ -4,7 +4,7 @@
   import { PageBreadcrumb } from '$lib/layout';
 
   export interface Props {
-    title?: string | Snippet | undefined;
+    title?: string;
     wide?: boolean;
     setBreadcrumb?: boolean;
     header?: Snippet;
@@ -16,7 +16,7 @@
   let maxWidth = $derived(wide ? 'md:max-w-4xl' : 'md:max-w-2xl');
 </script>
 
-{#if title && typeof(title) === 'string'}
+{#if title}
   <SetTitle {title} />
   {#if setBreadcrumb}
     <PageBreadcrumb>{title}</PageBreadcrumb>

--- a/frontend/src/lib/layout/Page.svelte
+++ b/frontend/src/lib/layout/Page.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import type { Snippet } from 'svelte';
   import SetTitle from './SetTitle.svelte';
   import { PageBreadcrumb } from '$lib/layout';
 
@@ -6,8 +7,8 @@
     title?: string | undefined;
     wide?: boolean;
     setBreadcrumb?: boolean;
-    header?: import('svelte').Snippet;
-    children?: import('svelte').Snippet;
+    header?: Snippet;
+    children?: Snippet;
   }
 
   let {

--- a/frontend/src/lib/layout/Page.svelte
+++ b/frontend/src/lib/layout/Page.svelte
@@ -3,8 +3,8 @@
   import SetTitle from './SetTitle.svelte';
   import { PageBreadcrumb } from '$lib/layout';
 
-  interface Props {
-    title?: string | undefined;
+  export interface Props {
+    title?: string | Snippet | undefined;
     wide?: boolean;
     setBreadcrumb?: boolean;
     header?: Snippet;
@@ -16,7 +16,7 @@
   let maxWidth = $derived(wide ? 'md:max-w-4xl' : 'md:max-w-2xl');
 </script>
 
-{#if title}
+{#if title && typeof(title) === 'string'}
   <SetTitle {title} />
   {#if setBreadcrumb}
     <PageBreadcrumb>{title}</PageBreadcrumb>

--- a/frontend/src/lib/layout/Page.svelte
+++ b/frontend/src/lib/layout/Page.svelte
@@ -2,11 +2,23 @@
   import SetTitle from './SetTitle.svelte';
   import { PageBreadcrumb } from '$lib/layout';
 
-  export let title: string | undefined = undefined;
-  export let wide = false;
-  export let setBreadcrumb = true;
+  interface Props {
+    title?: string | undefined;
+    wide?: boolean;
+    setBreadcrumb?: boolean;
+    header?: import('svelte').Snippet;
+    children?: import('svelte').Snippet;
+  }
 
-  $: maxWidth = wide ? 'md:max-w-4xl' : 'md:max-w-2xl';
+  let {
+    title = undefined,
+    wide = false,
+    setBreadcrumb = true,
+    header,
+    children
+  }: Props = $props();
+
+  let maxWidth = $derived(wide ? 'md:max-w-4xl' : 'md:max-w-2xl');
 </script>
 
 {#if title}
@@ -17,10 +29,10 @@
 {/if}
 
 <div class="md:px-8 md:mx-auto {maxWidth} w-full">
-  {#if $$slots.header}
-    <slot name="header" />
+  {#if header}
+    {@render header?.()}
   {/if}
   <main>
-    <slot />
+    {@render children?.()}
   </main>
 </div>

--- a/frontend/src/lib/layout/Page.svelte
+++ b/frontend/src/lib/layout/Page.svelte
@@ -11,22 +11,16 @@
     children?: Snippet;
   }
 
-  let {
-    title = undefined,
-    wide = false,
-    setBreadcrumb = true,
-    header,
-    children
-  }: Props = $props();
+  let { title = undefined, wide = false, setBreadcrumb = true, header, children }: Props = $props();
 
   let maxWidth = $derived(wide ? 'md:max-w-4xl' : 'md:max-w-2xl');
 </script>
 
 {#if title}
-  <SetTitle {title}/>
-    {#if setBreadcrumb}
-      <PageBreadcrumb>{title}</PageBreadcrumb>
-    {/if}
+  <SetTitle {title} />
+  {#if setBreadcrumb}
+    <PageBreadcrumb>{title}</PageBreadcrumb>
+  {/if}
 {/if}
 
 <div class="md:px-8 md:mx-auto {maxWidth} w-full">

--- a/frontend/src/lib/layout/PageTitle.svelte
+++ b/frontend/src/lib/layout/PageTitle.svelte
@@ -1,7 +1,11 @@
 <script lang="ts">
   import SetTitle from './SetTitle.svelte';
 
-  export let title: string;
+  interface Props {
+    title: string;
+  }
+
+  let { title }: Props = $props();
 </script>
 
 <SetTitle {title} />

--- a/frontend/src/lib/layout/SetTitle.svelte
+++ b/frontend/src/lib/layout/SetTitle.svelte
@@ -1,5 +1,9 @@
 <script lang="ts">
-  export let title: string;
+  interface Props {
+    title: string;
+  }
+
+  let { title }: Props = $props();
 </script>
 
 <svelte:head>

--- a/frontend/src/lib/layout/TitlePage.svelte
+++ b/frontend/src/lib/layout/TitlePage.svelte
@@ -2,14 +2,21 @@
   import Page from './Page.svelte';
   import PageTitle from './PageTitle.svelte';
 
-  export let title: string;
+  interface Props {
+    title: string;
+    children?: import('svelte').Snippet;
+  }
+
+  let { title, children }: Props = $props();
 </script>
 
 <Page {title}>
-  <svelte:fragment slot="header">
-    <PageTitle {title} />
-  </svelte:fragment>
+  {#snippet header()}
+  
+      <PageTitle {title} />
+    
+  {/snippet}
   <div class="py-6">
-    <slot />
+    {@render children?.()}
   </div>
 </Page>

--- a/frontend/src/lib/layout/TitlePage.svelte
+++ b/frontend/src/lib/layout/TitlePage.svelte
@@ -1,10 +1,11 @@
 <script lang="ts">
+  import type { Snippet } from 'svelte';
   import Page from './Page.svelte';
   import PageTitle from './PageTitle.svelte';
 
   interface Props {
     title: string;
-    children?: import('svelte').Snippet;
+    children?: Snippet;
   }
 
   let { title, children }: Props = $props();

--- a/frontend/src/lib/layout/TitlePage.svelte
+++ b/frontend/src/lib/layout/TitlePage.svelte
@@ -13,9 +13,7 @@
 
 <Page {title}>
   {#snippet header()}
-  
-      <PageTitle {title} />
-    
+    <PageTitle {title} />
   {/snippet}
   <div class="py-6">
     {@render children?.()}

--- a/frontend/src/lib/notify/Notify.svelte
+++ b/frontend/src/lib/notify/Notify.svelte
@@ -17,7 +17,7 @@
     {#each $notifications as note (note)}
       <div class="alert {note.category ?? ''}" in:slide out:blur>
         {note.message}
-        <button on:click={() => removeNotification(note)} class="btn btn-circle btn-sm btn-ghost">✕</button>
+        <button onclick={() => removeNotification(note)} class="btn btn-circle btn-sm btn-ghost">✕</button>
       </div>
     {/each}
   </div>

--- a/frontend/src/lib/notify/Notify.svelte
+++ b/frontend/src/lib/notify/Notify.svelte
@@ -11,7 +11,7 @@
   <div class="toast toast-center prose z-20">
     {#if $notifications.length > 1}
       <div class="flex justify-end" in:slide out:blur>
-        <BadgeButton on:click={removeAllNotifications}>{$t('notify.close_all')}<span class="ml-2">✕</span></BadgeButton>
+        <BadgeButton onclick={removeAllNotifications}>{$t('notify.close_all')}<span class="ml-2">✕</span></BadgeButton>
       </div>
     {/if}
     {#each $notifications as note (note)}

--- a/frontend/src/lib/overlay/OverlayContainer.svelte
+++ b/frontend/src/lib/overlay/OverlayContainer.svelte
@@ -2,4 +2,4 @@
   import { overlayContainer } from '.';
 </script>
 
-<div use:overlayContainer class="bg-base-200 shadow rounded-box z-[2] absolute" />
+<div use:overlayContainer class="bg-base-200 shadow rounded-box z-[2] absolute"></div>

--- a/frontend/src/lib/user.test.ts
+++ b/frontend/src/lib/user.test.ts
@@ -1,4 +1,4 @@
-﻿import {describe, expect, it} from 'vitest';
+import {describe, expect, it} from 'vitest';
 
 import {FeatureFlag, type AuthUserOrg} from '$lib/gql/generated/graphql';
 import {jwtToUser} from '$lib/user';

--- a/frontend/src/routes/(authenticated)/+layout.svelte
+++ b/frontend/src/routes/(authenticated)/+layout.svelte
@@ -1,9 +1,14 @@
-<script>
+<script lang="ts">
   import { Layout } from '$lib/layout';
   import { HomeBreadcrumb } from '$lib/layout';
+  interface Props {
+    children?: import('svelte').Snippet;
+  }
+
+  let { children }: Props = $props();
 </script>
 
 <HomeBreadcrumb />
 <Layout>
-  <slot />
+  {@render children?.()}
 </Layout>

--- a/frontend/src/routes/(authenticated)/+layout.svelte
+++ b/frontend/src/routes/(authenticated)/+layout.svelte
@@ -1,8 +1,9 @@
 <script lang="ts">
+  import type { Snippet } from 'svelte';
   import { Layout } from '$lib/layout';
   import { HomeBreadcrumb } from '$lib/layout';
   interface Props {
-    children?: import('svelte').Snippet;
+    children?: Snippet;
   }
 
   let { children }: Props = $props();

--- a/frontend/src/routes/(authenticated)/+page.svelte
+++ b/frontend/src/routes/(authenticated)/+page.svelte
@@ -78,7 +78,7 @@
   }
 </script>
 
-<HeaderPage wide titleText={$t('user_dashboard.title')}>
+<HeaderPage wide title={$t('user_dashboard.title')}>
   {#snippet headerContent()}
     <div class="flex gap-4 w-full">
       <div class="grow">

--- a/frontend/src/routes/(authenticated)/+page.svelte
+++ b/frontend/src/routes/(authenticated)/+page.svelte
@@ -57,6 +57,7 @@
   // looks like it could be simplified, perhaps by turning it into a single $derived.by
   let initializedMode = $state(false);
   let defaultMode = $derived(allProjects.length < 10 ? ViewMode.Grid : ViewMode.Table);
+  // svelte-ignore state_referenced_locally
   let mode: ViewMode = $state(defaultMode); // Only captures initial value, but that's okay; rest is captured in run() block
 
   run(() => {

--- a/frontend/src/routes/(authenticated)/+page.svelte
+++ b/frontend/src/routes/(authenticated)/+page.svelte
@@ -90,12 +90,12 @@
         />
       </div>
       <div class="join">
-        <IconButton icon="i-mdi-grid" join active={mode === ViewMode.Grid} on:click={() => selectMode(ViewMode.Grid)} />
+        <IconButton icon="i-mdi-grid" join active={mode === ViewMode.Grid} onclick={() => selectMode(ViewMode.Grid)} />
         <IconButton
           icon="i-mdi-land-rows-horizontal"
           join
           active={mode === ViewMode.Table}
-          on:click={() => selectMode(ViewMode.Table)}
+          onclick={() => selectMode(ViewMode.Table)}
         />
       </div>
     </div>
@@ -126,7 +126,7 @@
     {/if}
 
     {#if shownProjects.length < filteredProjects.length}
-      <Button class="float-right mt-2" on:click={() => (limitResults = false)}>
+      <Button class="float-right mt-2" onclick={() => (limitResults = false)}>
         {$t('paging.load_more')}
       </Button>
     {/if}

--- a/frontend/src/routes/(authenticated)/+page.svelte
+++ b/frontend/src/routes/(authenticated)/+page.svelte
@@ -78,7 +78,7 @@
   }
 </script>
 
-<HeaderPage wide title={$t('user_dashboard.title')}>
+<HeaderPage wide titleText={$t('user_dashboard.title')}>
   {#snippet headerContent()}
     <div class="flex gap-4 w-full">
       <div class="grow">

--- a/frontend/src/routes/(authenticated)/+page.svelte
+++ b/frontend/src/routes/(authenticated)/+page.svelte
@@ -7,12 +7,17 @@
   import { HeaderPage } from '$lib/layout';
   import { getSearchParams, queryParam } from '$lib/util/query-params';
   import type { ProjectType } from '$lib/gql/types';
-  import { ProjectFilter, filterProjects, type ProjectFilters, type ProjectItemWithDraftStatus } from '$lib/components/Projects';
+  import {
+    ProjectFilter,
+    filterProjects,
+    type ProjectFilters,
+    type ProjectItemWithDraftStatus,
+  } from '$lib/components/Projects';
   import ProjectTable from '$lib/components/Projects/ProjectTable.svelte';
   import { Button } from '$lib/forms';
   import { limit } from '$lib/components/Paging';
   import IconButton from '$lib/components/IconButton.svelte';
-  import Cookies from 'js-cookie'
+  import Cookies from 'js-cookie';
   import { STORAGE_VIEW_MODE_KEY, ViewMode } from './shared';
 
   interface Props {
@@ -35,11 +40,12 @@
   let limitResults = $state(true);
   run(() => {
     allProjects = [
-      ...$draftProjects.map(p => ({
-        ...p, isDraft: true as const,
-        createUrl: ''
+      ...$draftProjects.map((p) => ({
+        ...p,
+        isDraft: true as const,
+        createUrl: '',
       })),
-      ...$projects.map(p => ({ ...p, isDraft: false as const })),
+      ...$projects.map((p) => ({ ...p, isDraft: false as const })),
     ];
   });
   run(() => {
@@ -47,9 +53,11 @@
   });
   let shownProjects = $derived(limitResults ? limit(filteredProjects) : filteredProjects);
 
+  // TODO: This whole thing with initializedMode, defaultMode, and mode *and* the run() block below
+  // looks like it could be simplified, perhaps by turning it into a single $derived.by
   let initializedMode = $state(false);
-  let mode: ViewMode = $state();
   let defaultMode = $derived(allProjects.length < 10 ? ViewMode.Grid : ViewMode.Table);
+  let mode: ViewMode = $state(defaultMode); // Only captures initial value, but that's okay; rest is captured in run() block
 
   run(() => {
     if (!initializedMode) {
@@ -71,40 +79,33 @@
 
 <HeaderPage wide titleText={$t('user_dashboard.title')}>
   {#snippet headerContent()}
-  
-      <div class="flex gap-4 w-full">
-        <div class="grow">
-          <ProjectFilter
-            {filters}
-            filterDefaults={defaultFilterValues}
-            on:change={() => (limitResults = true)}
-            filterKeys={['projectSearch', 'projectType', 'confidential']}
-          />
-        </div>
-        <div class="join">
-          <IconButton
-            icon="i-mdi-grid"
-            join
-            active={mode === ViewMode.Grid}
-            on:click={() => selectMode(ViewMode.Grid)} />
-          <IconButton
-            icon="i-mdi-land-rows-horizontal"
-            join
-            active={mode === ViewMode.Table}
-            on:click={() => selectMode(ViewMode.Table)} />
-        </div>
+    <div class="flex gap-4 w-full">
+      <div class="grow">
+        <ProjectFilter
+          {filters}
+          filterDefaults={defaultFilterValues}
+          on:change={() => (limitResults = true)}
+          filterKeys={['projectSearch', 'projectType', 'confidential']}
+        />
       </div>
-    
+      <div class="join">
+        <IconButton icon="i-mdi-grid" join active={mode === ViewMode.Grid} on:click={() => selectMode(ViewMode.Grid)} />
+        <IconButton
+          icon="i-mdi-land-rows-horizontal"
+          join
+          active={mode === ViewMode.Table}
+          on:click={() => selectMode(ViewMode.Table)}
+        />
+      </div>
+    </div>
   {/snippet}
   {#snippet actions()}
-  
-      {#if data.user.emailVerified && !data.user.createdByAdmin}
-        <a href="/project/create" class="btn btn-success">
-          {$t('project.create.title')}
-          <span class="i-mdi-plus text-2xl"></span>
-        </a>
-      {/if}
-    
+    {#if data.user.emailVerified && !data.user.createdByAdmin}
+      <a href="/project/create" class="btn btn-success">
+        {$t('project.create.title')}
+        <span class="i-mdi-plus text-2xl"></span>
+      </a>
+    {/if}
   {/snippet}
 
   {#if !allProjects.length}

--- a/frontend/src/routes/(authenticated)/admin/+page.svelte
+++ b/frontend/src/routes/(authenticated)/admin/+page.svelte
@@ -12,7 +12,7 @@
   import { type AdminSearchParams, type User } from './+page';
   import { getSearchParams, queryParam } from '$lib/util/query-params';
   import type { ProjectType } from '$lib/gql/types';
-  import { derived } from 'svelte/store';
+  import { derived as derivedStore } from 'svelte/store';
   import AdminProjects from './AdminProjects.svelte';
   import UserModal from '$lib/components/Users/UserModal.svelte';
   import { PageBreadcrumb } from '$lib/layout';
@@ -51,7 +51,7 @@
   const { queryParamValues, defaultQueryParamValues } = queryParams;
   $: tab = $queryParamValues.tab;
 
-  const loadingUsers = derived(navigating, (nav) => {
+  const loadingUsers = derivedStore(navigating, (nav) => {
     if (!nav?.to?.route.id?.endsWith('/admin')) return false;
     const fromUrl = nav?.from?.url;
     return fromUrl && userFilterKeys.some((key) =>

--- a/frontend/src/routes/(authenticated)/admin/+page.svelte
+++ b/frontend/src/routes/(authenticated)/admin/+page.svelte
@@ -86,12 +86,13 @@
     $queryParamValues.tab = 'projects';
   }
 
-  let userModal: UserModal = $state()!;
-  let createUserModal: CreateUserModal = $state()!;
-  let deleteUserModal: DeleteUserModal = $state()!;
-  let formModal: EditUserAccount = $state()!;
+  let userModal: UserModal | undefined = $state();
+  let createUserModal: CreateUserModal | undefined = $state();
+  let deleteUserModal: DeleteUserModal | undefined = $state();
+  let formModal: EditUserAccount | undefined = $state();
 
   async function deleteUser(user: User): Promise<void> {
+    if (!formModal || !deleteUserModal) return;
     formModal.close();
     const { response } = await deleteUserModal.open(user);
     if (response == DialogResponse.Submit) {
@@ -100,6 +101,7 @@
   }
 
   async function openModal(user: User): Promise<void> {
+    if (!formModal) return;
     const { response, formState } = await formModal.openModal(user);
     if (response == DialogResponse.Submit) {
       if (formState.name.tainted || formState.password.tainted || formState.role.tainted) {
@@ -152,7 +154,7 @@
           <svelte:element
             this={browser ? 'button' : 'div'}
             class="btn btn-sm btn-success max-xs:btn-square"
-            onclick={() => createUserModal.open()}
+            onclick={() => createUserModal?.open()}
           >
             <span class="admin-tabs:hidden">
               {$t('admin_dashboard.create_user_modal.create_user')}
@@ -175,7 +177,7 @@
       <div class="overflow-x-visible @container scroll-shadow">
         <UserTable
           {shownUsers}
-          on:openUserModal={(event) => userModal.open(event.detail)}
+          on:openUserModal={(event) => userModal?.open(event.detail)}
           on:editUser={(event) => openModal(event.detail)}
           on:filterProjectsByUser={(event) => filterProjectsByUser(event.detail)}
         />

--- a/frontend/src/routes/(authenticated)/admin/+page.svelte
+++ b/frontend/src/routes/(authenticated)/admin/+page.svelte
@@ -60,8 +60,12 @@
   const loadingUsers = derivedStore(navigating, (nav) => {
     if (!nav?.to?.route.id?.endsWith('/admin')) return false;
     const fromUrl = nav?.from?.url;
-    return fromUrl && userFilterKeys.some((key) =>
-      (fromUrl.searchParams.get(key) ?? defaultQueryParamValues[key])?.toString() !== $queryParamValues[key]);
+    return (
+      fromUrl &&
+      userFilterKeys.some(
+        (key) => (fromUrl.searchParams.get(key) ?? defaultQueryParamValues[key])?.toString() !== $queryParamValues[key],
+      )
+    );
   });
 
   let hasActiveFilter = $state(false);
@@ -82,10 +86,10 @@
     $queryParamValues.tab = 'projects';
   }
 
-  let userModal: UserModal = $state();
-  let createUserModal: CreateUserModal = $state();
-  let deleteUserModal: DeleteUserModal = $state();
-  let formModal: EditUserAccount = $state();
+  let userModal: UserModal = $state()!;
+  let createUserModal: CreateUserModal = $state()!;
+  let deleteUserModal: DeleteUserModal = $state()!;
+  let formModal: EditUserAccount = $state()!;
 
   async function deleteUser(user: User): Promise<void> {
     formModal.close();
@@ -130,7 +134,7 @@
     </div>
 
     <div class:admin-tabs:hidden={tab !== 'users'}>
-      <AdminTabs activeTab="users" on:clickTab={(event) => $queryParamValues.tab = event.detail}>
+      <AdminTabs activeTab="users" on:clickTab={(event) => ($queryParamValues.tab = event.detail)}>
         <div class="flex gap-4 justify-between grow">
           <div class="flex gap-4 items-center">
             {$t('admin_dashboard.user_table_title')}
@@ -145,8 +149,11 @@
             </div>
           </div>
           <!-- svelte-ignore a11y_no_static_element_interactions -->
-          <svelte:element this={browser ? 'button' : 'div'} class="btn btn-sm btn-success max-xs:btn-square"
-            onclick={() => createUserModal.open()}>
+          <svelte:element
+            this={browser ? 'button' : 'div'}
+            class="btn btn-sm btn-success max-xs:btn-square"
+            onclick={() => createUserModal.open()}
+          >
             <span class="admin-tabs:hidden">
               {$t('admin_dashboard.create_user_modal.create_user')}
             </span>
@@ -179,6 +186,10 @@
 
   <EditUserAccount bind:this={formModal} {deleteUser} currUser={data.user} />
   <DeleteUserModal bind:this={deleteUserModal} i18nScope="admin_dashboard.form_modal.delete_user" />
-  <UserModal bind:this={userModal}/>
-  <CreateUserModal handleSubmit={createGuestUserByAdmin} on:submitted={(e) => onUserCreated(e.detail)} bind:this={createUserModal}/>
+  <UserModal bind:this={userModal} />
+  <CreateUserModal
+    handleSubmit={createGuestUserByAdmin}
+    on:submitted={(e) => onUserCreated(e.detail)}
+    bind:this={createUserModal}
+  />
 </main>

--- a/frontend/src/routes/(authenticated)/admin/AdminProjects.svelte
+++ b/frontend/src/routes/(authenticated)/admin/AdminProjects.svelte
@@ -77,8 +77,9 @@
     limitResults ? limit(filteredProjects, lastLoadUsedActiveFilter ? DEFAULT_PAGE_SIZE : 10) : filteredProjects,
   );
 
-  let deleteProjectModal: ConfirmDeleteModal = $state()!;
+  let deleteProjectModal: ConfirmDeleteModal | undefined = $state();
   async function deleteProjectOrDraft(project: ProjectItemWithDraftStatus): Promise<void> {
+    if (!deleteProjectModal) return;
     const deleteFn = project.isDraft ? _deleteDraftProject : _deleteProject;
     const result = await deleteProjectModal.open(project.name, async () => {
       const { error } = await deleteFn(project.id);

--- a/frontend/src/routes/(authenticated)/admin/AdminProjects.svelte
+++ b/frontend/src/routes/(authenticated)/admin/AdminProjects.svelte
@@ -20,7 +20,7 @@
   import {TrashIcon} from '$lib/icons';
   import {useNotifications} from '$lib/notify';
   import {type QueryParams, toSearchParams} from '$lib/util/query-params';
-  import {derived} from 'svelte/store';
+  import {derived as derivedStore} from 'svelte/store';
   import type {AdminSearchParams, DraftProject} from './+page';
   import AdminTabs from './AdminTabs.svelte';
   import type {CreateProjectInput} from '$lib/gql/types';
@@ -36,7 +36,7 @@
 
   const serverSideProjectFilterKeys = (['showDeletedProjects'] as const satisfies Readonly<(keyof ProjectFilters)[]>);
 
-  const loading = derived(navigating, (nav) => {
+  const loading = derivedStore(navigating, (nav) => {
     const fromUrl = nav?.from?.url;
     return fromUrl && serverSideProjectFilterKeys.some((key) =>
       (fromUrl.searchParams.get(key) ?? filterDefaults?.[key])?.toString() !== $filters?.[key]?.toString());

--- a/frontend/src/routes/(authenticated)/admin/AdminProjects.svelte
+++ b/frontend/src/routes/(authenticated)/admin/AdminProjects.svelte
@@ -1,31 +1,31 @@
 <script lang="ts">
   import { run } from 'svelte/legacy';
 
-  import {navigating} from '$app/stores';
-  import {Badge} from '$lib/components/Badges';
+  import { navigating } from '$app/stores';
+  import { Badge } from '$lib/components/Badges';
   import Dropdown from '$lib/components/Dropdown.svelte';
-  import {DEFAULT_PAGE_SIZE, limit} from '$lib/components/Paging';
+  import { DEFAULT_PAGE_SIZE, limit } from '$lib/components/Paging';
   import {
     filterProjects,
     ProjectFilter,
     type ProjectFilters,
     type ProjectItem,
     type ProjectItemWithDraftStatus,
-    ProjectTable
+    ProjectTable,
   } from '$lib/components/Projects';
-  import {RefineFilterMessage} from '$lib/components/Table';
-  import {DialogResponse} from '$lib/components/modals';
+  import { RefineFilterMessage } from '$lib/components/Table';
+  import { DialogResponse } from '$lib/components/modals';
   import ConfirmDeleteModal from '$lib/components/modals/ConfirmDeleteModal.svelte';
-  import {Button} from '$lib/forms';
-  import {_deleteProject, _deleteDraftProject} from '$lib/gql/mutations';
-  import t, {number} from '$lib/i18n';
-  import {TrashIcon} from '$lib/icons';
-  import {useNotifications} from '$lib/notify';
-  import {type QueryParams, toSearchParams} from '$lib/util/query-params';
-  import {derived as derivedStore} from 'svelte/store';
-  import type {AdminSearchParams, DraftProject} from './+page';
+  import { Button } from '$lib/forms';
+  import { _deleteProject, _deleteDraftProject } from '$lib/gql/mutations';
+  import t, { number } from '$lib/i18n';
+  import { TrashIcon } from '$lib/icons';
+  import { useNotifications } from '$lib/notify';
+  import { type QueryParams, toSearchParams } from '$lib/util/query-params';
+  import { derived as derivedStore } from 'svelte/store';
+  import type { AdminSearchParams, DraftProject } from './+page';
   import AdminTabs from './AdminTabs.svelte';
-  import type {CreateProjectInput} from '$lib/gql/types';
+  import type { CreateProjectInput } from '$lib/gql/types';
 
   interface Props {
     projects: ProjectItem[];
@@ -40,12 +40,16 @@
 
   const { notifyWarning } = useNotifications();
 
-  const serverSideProjectFilterKeys = (['showDeletedProjects'] as const satisfies Readonly<(keyof ProjectFilters)[]>);
+  const serverSideProjectFilterKeys = ['showDeletedProjects'] as const satisfies Readonly<(keyof ProjectFilters)[]>;
 
   const loading = derivedStore(navigating, (nav) => {
     const fromUrl = nav?.from?.url;
-    return fromUrl && serverSideProjectFilterKeys.some((key) =>
-      (fromUrl.searchParams.get(key) ?? filterDefaults?.[key])?.toString() !== $filters?.[key]?.toString());
+    return (
+      fromUrl &&
+      serverSideProjectFilterKeys.some(
+        (key) => (fromUrl.searchParams.get(key) ?? filterDefaults?.[key])?.toString() !== $filters?.[key]?.toString(),
+      )
+    );
   });
 
   let allProjects: ProjectItemWithDraftStatus[] = $state([]);
@@ -58,19 +62,22 @@
   });
   run(() => {
     allProjects = [
-      ...draftProjects.map(p => ({
-        ...p, isDraft: true as const,
-        createUrl: `/project/create?${toSearchParams<CreateProjectInput>(p as CreateProjectInput)}` /* TODO #737 - Remove unnecessary cast */
+      ...draftProjects.map((p) => ({
+        ...p,
+        isDraft: true as const,
+        createUrl: `/project/create?${toSearchParams<CreateProjectInput>(p as CreateProjectInput)}` /* TODO #737 - Remove unnecessary cast */,
       })),
-      ...projects.map(p => ({ ...p, isDraft: false as const })),
+      ...projects.map((p) => ({ ...p, isDraft: false as const })),
     ];
   });
   run(() => {
     filteredProjects = filterProjects(allProjects, $filters);
   });
-  let shownProjects = $derived(limitResults ? limit(filteredProjects, lastLoadUsedActiveFilter ? DEFAULT_PAGE_SIZE : 10) : filteredProjects);
+  let shownProjects = $derived(
+    limitResults ? limit(filteredProjects, lastLoadUsedActiveFilter ? DEFAULT_PAGE_SIZE : 10) : filteredProjects,
+  );
 
-  let deleteProjectModal: ConfirmDeleteModal = $state();
+  let deleteProjectModal: ConfirmDeleteModal = $state()!;
   async function deleteProjectOrDraft(project: ProjectItemWithDraftStatus): Promise<void> {
     const deleteFn = project.isDraft ? _deleteDraftProject : _deleteProject;
     const result = await deleteProjectModal.open(project.name, async () => {
@@ -85,7 +92,7 @@
 
 <ConfirmDeleteModal bind:this={deleteProjectModal} i18nScope="delete_project_modal" />
 <div>
-  <AdminTabs activeTab="projects" on:clickTab={(event) => $queryParamValues.tab = event.detail}>
+  <AdminTabs activeTab="projects" on:clickTab={(event) => ($queryParamValues.tab = event.detail)}>
     <div class="flex gap-4 justify-between grow">
       <div class="flex gap-4 items-center">
         {$t('admin_dashboard.project_table_title')}
@@ -99,8 +106,7 @@
           </Badge>
         </div>
       </div>
-      <a class="btn btn-sm btn-success max-xs:btn-square"
-        href="/project/create">
+      <a class="btn btn-sm btn-success max-xs:btn-square" href="/project/create">
         <span class="admin-tabs:hidden">
           {$t('project.create.title')}
         </span>
@@ -123,14 +129,14 @@
 
   <ProjectTable projects={shownProjects}>
     {#snippet actions({ project })}
-        <td class="p-0"  >
+      <td class="p-0">
         {#if project.isDraft || !project.deletedDate}
           <Dropdown>
             <button class="btn btn-ghost btn-square" aria-label={$t('common.actions')}>
               <span class="i-mdi-dots-vertical text-lg"></span>
             </button>
             {#snippet content()}
-                    <ul  class="menu">
+              <ul class="menu">
                 <li>
                   <button class="text-error whitespace-nowrap" onclick={() => deleteProjectOrDraft(project)}>
                     <TrashIcon />
@@ -138,16 +144,16 @@
                   </button>
                 </li>
               </ul>
-                  {/snippet}
+            {/snippet}
           </Dropdown>
         {/if}
       </td>
-      {/snippet}
+    {/snippet}
   </ProjectTable>
 
   {#if shownProjects.length < filteredProjects.length}
     {#if lastLoadUsedActiveFilter}
-      <Button class="float-right mt-2" on:click={() => (limitResults = false)}>
+      <Button class="float-right mt-2" onclick={() => (limitResults = false)}>
         {$t('paging.load_more')}
       </Button>
     {:else}

--- a/frontend/src/routes/(authenticated)/admin/AdminTabs.svelte
+++ b/frontend/src/routes/(authenticated)/admin/AdminTabs.svelte
@@ -15,7 +15,7 @@
   import { createEventDispatcher } from 'svelte';
 
   const dispatch = createEventDispatcher<{
-    clickTab: AdminTabId
+    clickTab: AdminTabId;
   }>();
 
   interface Props {
@@ -30,7 +30,12 @@
   <div class="tab tab-divider"></div>
   {#each adminTabs as tab}
     {@const isActiveTab = activeTab === tab}
-    <button onclick={() => dispatch('clickTab', tab)} role="tab" class:tab-active={isActiveTab} class="tab grow flex-1 basis-1/2">
+    <button
+      onclick={() => dispatch('clickTab', tab)}
+      role="tab"
+      class:tab-active={isActiveTab}
+      class="tab grow flex-1 basis-1/2"
+    >
       <h2 class="text-lg flex gap-4 items-center">
         {#if isActiveTab}
           {#if children}{@render children()}{:else}

--- a/frontend/src/routes/(authenticated)/admin/AdminTabs.svelte
+++ b/frontend/src/routes/(authenticated)/admin/AdminTabs.svelte
@@ -1,4 +1,4 @@
-<script lang="ts" context="module">
+<script lang="ts" module>
   import type { I18nKey } from '$lib/i18n';
 
   export const adminTabs = ['projects', 'users'] as const;
@@ -17,30 +17,35 @@
     clickTab: AdminTabId
   }>();
 
-  export let activeTab: AdminTabId = 'projects';
+  interface Props {
+    activeTab?: AdminTabId;
+    children?: import('svelte').Snippet;
+  }
+
+  let { activeTab = 'projects', children }: Props = $props();
 </script>
 
 <div role="tablist" class="hidden admin-tabs:flex tabs tabs-lifted tabs-lg overflow-x-auto">
-  <div class="tab tab-divider" />
+  <div class="tab tab-divider"></div>
   {#each adminTabs as tab}
     {@const isActiveTab = activeTab === tab}
-    <button on:click={() => dispatch('clickTab', tab)} role="tab" class:tab-active={isActiveTab} class="tab grow flex-1 basis-1/2">
+    <button onclick={() => dispatch('clickTab', tab)} role="tab" class:tab-active={isActiveTab} class="tab grow flex-1 basis-1/2">
       <h2 class="text-lg flex gap-4 items-center">
         {#if isActiveTab}
-          <slot>
+          {#if children}{@render children()}{:else}
             {$t(DEFAULT_TAB_I18N[tab])}
-          </slot>
+          {/if}
         {:else}
           {$t(DEFAULT_TAB_I18N[tab])}
         {/if}
       </h2>
     </button>
-    <div class="tab tab-divider" />
+    <div class="tab tab-divider"></div>
   {/each}
 </div>
 
 <h2 class="admin-tabs:hidden text-2xl flex gap-4">
-  <slot>
+  {#if children}{@render children()}{:else}
     {$t(DEFAULT_TAB_I18N[activeTab])}
-  </slot>
+  {/if}
 </h2>

--- a/frontend/src/routes/(authenticated)/admin/AdminTabs.svelte
+++ b/frontend/src/routes/(authenticated)/admin/AdminTabs.svelte
@@ -1,4 +1,5 @@
 <script lang="ts" module>
+  import type { Snippet } from 'svelte';
   import type { I18nKey } from '$lib/i18n';
 
   export const adminTabs = ['projects', 'users'] as const;
@@ -19,7 +20,7 @@
 
   interface Props {
     activeTab?: AdminTabId;
-    children?: import('svelte').Snippet;
+    children?: Snippet;
   }
 
   let { activeTab = 'projects', children }: Props = $props();

--- a/frontend/src/routes/(authenticated)/admin/EditUserAccount.svelte
+++ b/frontend/src/routes/(authenticated)/admin/EditUserAccount.svelte
@@ -166,7 +166,12 @@
         autocomplete="new-password"
         error={errors.password}
       />
-      <PasswordStrengthMeter bind:score={$form!.score} password={$form!.password} />
+      <PasswordStrengthMeter
+        onScoreUpdated={(score) => {
+          if ($form) $form.score = score;
+        }}
+        password={$form!.password}
+      />
     </div>
     <FormError error={lockUserError} />
   {/snippet}

--- a/frontend/src/routes/(authenticated)/authorize/+layout@.svelte
+++ b/frontend/src/routes/(authenticated)/authorize/+layout@.svelte
@@ -1,7 +1,12 @@
-<script>
+<script lang="ts">
   import { Layout } from '$lib/layout';
+  interface Props {
+    children?: import('svelte').Snippet;
+  }
+
+  let { children }: Props = $props();
 </script>
 
 <Layout hideToolbar>
-  <slot />
+  {@render children?.()}
 </Layout>

--- a/frontend/src/routes/(authenticated)/authorize/+layout@.svelte
+++ b/frontend/src/routes/(authenticated)/authorize/+layout@.svelte
@@ -1,7 +1,8 @@
 <script lang="ts">
+  import type { Snippet } from 'svelte';
   import { Layout } from '$lib/layout';
   interface Props {
-    children?: import('svelte').Snippet;
+    children?: Snippet;
   }
 
   let { children }: Props = $props();

--- a/frontend/src/routes/(authenticated)/authorize/+page.svelte
+++ b/frontend/src/routes/(authenticated)/authorize/+page.svelte
@@ -6,7 +6,11 @@
   import Icon from '$lib/icons/Icon.svelte';
   import type { PageData } from './$types';
 
-  export let data: PageData;
+  interface Props {
+    data: PageData;
+  }
+
+  let { data }: Props = $props();
 </script>
 
 <div class="flex flex-col items-center grow">

--- a/frontend/src/routes/(authenticated)/authorize/+page.ts
+++ b/frontend/src/routes/(authenticated)/authorize/+page.ts
@@ -1,4 +1,4 @@
-﻿import type { PageLoadEvent } from './$types';
+import type { PageLoadEvent } from './$types';
 
 export function load(event: PageLoadEvent) {
   return {

--- a/frontend/src/routes/(authenticated)/org/[org_id]/+page.svelte
+++ b/frontend/src/routes/(authenticated)/org/[org_id]/+page.svelte
@@ -71,30 +71,31 @@
     notifySuccess($t('org_page.notifications.rename_org', { name: newName }));
   }
 
-  let userModal: UserModal = $state()!;
+  let userModal: UserModal | undefined = $state();
   async function openUserModal(user: User): Promise<void> {
     const queryUser = await _orgMemberById(org.id as UUID, user.id as UUID);
-    return userModal.open(queryUser);
+    return userModal?.open(queryUser);
   }
 
-  let addOrgMemberModal: AddOrgMemberModal = $state()!;
+  let addOrgMemberModal: AddOrgMemberModal | undefined = $state();
   async function openAddOrgMemberModal(): Promise<void> {
-    await addOrgMemberModal.openModal();
+    await addOrgMemberModal?.openModal();
   }
 
-  let bulkAddMembersModal: BulkAddOrgMembers = $state()!;
+  let bulkAddMembersModal: BulkAddOrgMembers | undefined = $state();
 
-  let changeMemberRoleModal: ChangeOrgMemberRoleModal = $state()!;
+  let changeMemberRoleModal: ChangeOrgMemberRoleModal | undefined = $state();
   async function openChangeMemberRoleModal(member: OrgUser): Promise<void> {
-    await changeMemberRoleModal.open({
+    await changeMemberRoleModal?.open({
       userId: member.user.id,
       name: member.user.name,
       role: member.role,
     });
   }
 
-  let deleteOrgModal: ConfirmDeleteModal = $state()!;
+  let deleteOrgModal: ConfirmDeleteModal | undefined = $state();
   async function confirmDeleteOrg(): Promise<void> {
+    if (!deleteOrgModal) return;
     const result = await deleteOrgModal.open(org.name, async () => {
       const { error } = await _deleteOrg(org.id);
       return error?.message;
@@ -105,9 +106,10 @@
     }
   }
 
-  let removeProjectFromOrgModal: DeleteModal = $state()!;
+  let removeProjectFromOrgModal: DeleteModal | undefined = $state();
   let projectToRemove: string = $state('');
   async function removeProjectFromOrg(projectId: string, projectName: string): Promise<void> {
+    if (!removeProjectFromOrgModal) return;
     projectToRemove = projectName;
     const removed = await removeProjectFromOrgModal.prompt(async () => {
       const { error } = await _removeProjectFromOrg(projectId, org.id);
@@ -118,9 +120,10 @@
     }
   }
 
-  let leaveModal: ConfirmModal = $state()!;
+  let leaveModal: ConfirmModal | undefined = $state();
 
   async function leaveOrg(): Promise<void> {
+    if (!leaveModal) return;
     const left = await leaveModal.open(async () => {
       const result = await _leaveOrg(org.id);
       if (result.error?.byType('LastMemberCantLeaveError')) {
@@ -146,7 +149,7 @@
     return createGuestUserByAdmin(password, passwordStrength, name, email, locale, _turnstileToken, org.id);
   }
 
-  let createUserModal: CreateUserModal = $state()!;
+  let createUserModal: CreateUserModal | undefined = $state();
   function onUserCreated(user: LexAuthUser): void {
     notifySuccess($t('admin_dashboard.notifications.user_created', { name: user.name }), Duration.Long);
   }
@@ -170,13 +173,13 @@
           {#snippet content()}
             <ul class="menu">
               <li>
-                <button class="whitespace-nowrap" onclick={() => bulkAddMembersModal.open()}>
+                <button class="whitespace-nowrap" onclick={() => bulkAddMembersModal?.open()}>
                   {$t('org_page.bulk_add_members.add_button')}
                   <Icon icon="i-mdi-account-multiple-plus-outline" />
                 </button>
               </li>
               <li>
-                <button class="whitespace-nowrap" onclick={() => createUserModal.open()}>
+                <button class="whitespace-nowrap" onclick={() => createUserModal?.open()}>
                   {$t('admin_dashboard.create_user_modal.create_user')}
                   <Icon icon="i-mdi-plus" />
                 </button>

--- a/frontend/src/routes/(authenticated)/org/[org_id]/+page.svelte
+++ b/frontend/src/routes/(authenticated)/org/[org_id]/+page.svelte
@@ -8,7 +8,16 @@
   import type { PageData } from './$types';
   import { OrgRole } from '$lib/gql/types';
   import { useNotifications } from '$lib/notify';
-  import { _changeOrgName, _deleteOrg, _orgMemberById, type OrgSearchParams, type User, type OrgUser, _removeProjectFromOrg, _leaveOrg } from './+page';
+  import {
+    _changeOrgName,
+    _deleteOrg,
+    _orgMemberById,
+    type OrgSearchParams,
+    type User,
+    type OrgUser,
+    _removeProjectFromOrg,
+    _leaveOrg,
+  } from './+page';
   import OrgTabs, { type OrgTabId } from './OrgTabs.svelte';
   import { getSearchParams, queryParam } from '$lib/util/query-params';
   import { Icon, TrashIcon } from '$lib/icons';
@@ -26,8 +35,8 @@
   import Dropdown from '$lib/components/Dropdown.svelte';
   import AddMyProjectsToOrgModal from './AddMyProjectsToOrgModal.svelte';
   import CreateUserModal from '$lib/components/Users/CreateUserModal.svelte';
-  import {createGuestUserByAdmin, type LexAuthUser} from '$lib/user';
-  import {Duration} from '$lib/util/time';
+  import { createGuestUserByAdmin, type LexAuthUser } from '$lib/user';
+  import { Duration } from '$lib/util/time';
   import IconButton from '$lib/components/IconButton.svelte';
 
   interface Props {
@@ -44,9 +53,11 @@
   });
   const { queryParamValues } = queryParams;
 
-  let canManage = $derived(user.isAdmin || !!org.members.find(m => m.user.id === user.id && m.role === OrgRole.Admin))
-  let isMember = $derived(!!org.members.find(m => m.user.id === user.id))
-  let canSeeSettings = $derived(user.isAdmin || isMember)
+  let canManage = $derived(
+    user.isAdmin || !!org.members.find((m) => m.user.id === user.id && m.role === OrgRole.Admin),
+  );
+  let isMember = $derived(!!org.members.find((m) => m.user.id === user.id));
+  let canSeeSettings = $derived(user.isAdmin || isMember);
 
   const { notifySuccess, notifyWarning } = useNotifications();
 
@@ -60,29 +71,29 @@
     notifySuccess($t('org_page.notifications.rename_org', { name: newName }));
   }
 
-  let userModal: UserModal = $state();
+  let userModal: UserModal = $state()!;
   async function openUserModal(user: User): Promise<void> {
     const queryUser = await _orgMemberById(org.id as UUID, user.id as UUID);
     return userModal.open(queryUser);
   }
 
-  let addOrgMemberModal: AddOrgMemberModal = $state();
+  let addOrgMemberModal: AddOrgMemberModal = $state()!;
   async function openAddOrgMemberModal(): Promise<void> {
     await addOrgMemberModal.openModal();
   }
 
-  let bulkAddMembersModal: BulkAddOrgMembers = $state();
+  let bulkAddMembersModal: BulkAddOrgMembers = $state()!;
 
-  let changeMemberRoleModal: ChangeOrgMemberRoleModal = $state();
+  let changeMemberRoleModal: ChangeOrgMemberRoleModal = $state()!;
   async function openChangeMemberRoleModal(member: OrgUser): Promise<void> {
     await changeMemberRoleModal.open({
       userId: member.user.id,
       name: member.user.name,
-      role: member.role
+      role: member.role,
     });
   }
 
-  let deleteOrgModal: ConfirmDeleteModal = $state();
+  let deleteOrgModal: ConfirmDeleteModal = $state()!;
   async function confirmDeleteOrg(): Promise<void> {
     const result = await deleteOrgModal.open(org.name, async () => {
       const { error } = await _deleteOrg(org.id);
@@ -94,8 +105,8 @@
     }
   }
 
-  let removeProjectFromOrgModal: DeleteModal = $state();
-  let projectToRemove: string = $state();
+  let removeProjectFromOrgModal: DeleteModal = $state()!;
+  let projectToRemove: string = $state('');
   async function removeProjectFromOrg(projectId: string, projectName: string): Promise<void> {
     projectToRemove = projectName;
     const removed = await removeProjectFromOrgModal.prompt(async () => {
@@ -103,11 +114,11 @@
       return error?.message;
     });
     if (removed) {
-      notifyWarning($t('org_page.notifications.remove_project_from_org', {projectName: projectToRemove}));
+      notifyWarning($t('org_page.notifications.remove_project_from_org', { projectName: projectToRemove }));
     }
   }
 
-  let leaveModal: ConfirmModal = $state();
+  let leaveModal: ConfirmModal = $state()!;
 
   async function leaveOrg(): Promise<void> {
     const left = await leaveModal.open(async () => {
@@ -124,11 +135,18 @@
     }
   }
 
-  function createGuestUser(password: string, passwordStrength: number, name: string, email: string, locale: string, _turnstileToken: string): ReturnType<typeof createGuestUserByAdmin> {
+  function createGuestUser(
+    password: string,
+    passwordStrength: number,
+    name: string,
+    email: string,
+    locale: string,
+    _turnstileToken: string,
+  ): ReturnType<typeof createGuestUserByAdmin> {
     return createGuestUserByAdmin(password, passwordStrength, name, email, locale, _turnstileToken, org.id);
   }
 
-  let createUserModal: CreateUserModal = $state();
+  let createUserModal: CreateUserModal = $state()!;
   function onUserCreated(user: LexAuthUser): void {
     notifySuccess($t('admin_dashboard.notifications.user_created', { name: user.name }), Duration.Long);
   }
@@ -138,21 +156,19 @@
 
 <DetailsPage wide titleText={org.name}>
   {#snippet actions()}
-  
-      {#if isMember}
-        <AddMyProjectsToOrgModal {user} {org} />
-      {/if}
-      {#if canManage}
+    {#if isMember}
+      <AddMyProjectsToOrgModal {user} {org} />
+    {/if}
+    {#if canManage}
       <div class="join gap-x-0.5">
-        <Button variant="btn-success" class="join-item"
-          on:click={openAddOrgMemberModal}>
+        <Button variant="btn-success" class="join-item" onclick={openAddOrgMemberModal}>
           {$t('org_page.add_user.add_button')}
           <span class="i-mdi-account-plus-outline text-2xl"></span>
         </Button>
         <Dropdown>
           <IconButton icon="i-mdi-menu-down" variant="btn-success" join outline={false} />
           {#snippet content()}
-                    <ul  class="menu">
+            <ul class="menu">
               <li>
                 <button class="whitespace-nowrap" onclick={() => bulkAddMembersModal.open()}>
                   {$t('org_page.bulk_add_members.add_button')}
@@ -166,17 +182,20 @@
                 </button>
               </li>
             </ul>
-                  {/snippet}
+          {/snippet}
         </Dropdown>
       </div>
-      <CreateUserModal handleSubmit={createGuestUser} on:submitted={(e) => onUserCreated(e.detail)} bind:this={createUserModal}/>
+      <CreateUserModal
+        handleSubmit={createGuestUser}
+        on:submitted={(e) => onUserCreated(e.detail)}
+        bind:this={createUserModal}
+      />
       <AddOrgMemberModal bind:this={addOrgMemberModal} {org} />
       <BulkAddOrgMembers bind:this={bulkAddMembersModal} orgId={org.id} />
-      {/if}
-    
+    {/if}
   {/snippet}
   {#snippet title()}
-    <div  class="max-w-full flex items-baseline flex-wrap">
+    <div class="max-w-full flex items-baseline flex-wrap">
       <span class="mr-2">{$t('org_page.organization')}:</span>
       <span class="text-primary max-w-full">
         <EditableText
@@ -189,23 +208,25 @@
     </div>
   {/snippet}
   <div class="mt-6">
-    <OrgTabs bind:activeTab={$queryParamValues.tab} hideSettingsTab={!canSeeSettings} memberCount={org.members.length} projectCount={org.projects.length} />
+    <OrgTabs
+      bind:activeTab={$queryParamValues.tab}
+      hideSettingsTab={!canSeeSettings}
+      memberCount={org.members.length}
+      projectCount={org.projects.length}
+    />
   </div>
   <div class="py-6 px-2">
     {#if $queryParamValues.tab === 'projects'}
-      <ProjectTable
-        columns={['name', 'code', 'users', 'type']}
-        projects={org.projects}
-      >
+      <ProjectTable columns={['name', 'code', 'users', 'type']} projects={org.projects}>
         {#snippet actions({ project })}
-                <td class="p-0"  >
+          <td class="p-0">
             {#if canManage}
               <Dropdown>
                 <button class="btn btn-ghost btn-square" aria-label={$t('common.actions')}>
                   <span class="i-mdi-dots-vertical text-lg"></span>
                 </button>
                 {#snippet content()}
-                            <ul  class="menu">
+                  <ul class="menu">
                     <li>
                       <button class="text-error" onclick={() => removeProjectFromOrg(project.id, project.name)}>
                         <TrashIcon />
@@ -213,18 +234,18 @@
                       </button>
                     </li>
                   </ul>
-                          {/snippet}
+                {/snippet}
               </Dropdown>
             {/if}
           </td>
-              {/snippet}
+        {/snippet}
       </ProjectTable>
       <DeleteModal
         bind:this={removeProjectFromOrgModal}
         entityName={$t('org_page.remove_project_from_org_title')}
         isRemoveDialog
       >
-        {$t('org_page.confirm_remove_project_from_org', {projectName: projectToRemove, orgName: org.name})}
+        {$t('org_page.confirm_remove_project_from_org', { projectName: projectToRemove, orgName: org.name })}
       </DeleteModal>
     {:else if $queryParamValues.tab === 'members'}
       <OrgMemberTable
@@ -243,16 +264,18 @@
     {:else if $queryParamValues.tab === 'settings'}
       {#if isMember}
         <div class="flex justify-end">
-          <Button outline variant="btn-error" on:click={leaveOrg}>
+          <Button outline variant="btn-error" onclick={leaveOrg}>
             {$t('org_page.leave.leave_org')}
-            <Icon icon="i-mdi-exit-run"/>
+            <Icon icon="i-mdi-exit-run" />
           </Button>
-          <ConfirmModal bind:this={leaveModal}
-                        title={$t('org_page.leave.confirm_title')}
-                        submitText={$t('org_page.leave.leave_action')}
-                        submitIcon="i-mdi-exit-run"
-                        submitVariant="btn-error"
-                        cancelText={$t('org_page.leave.dont_leave')}>
+          <ConfirmModal
+            bind:this={leaveModal}
+            title={$t('org_page.leave.confirm_title')}
+            submitText={$t('org_page.leave.leave_action')}
+            submitIcon="i-mdi-exit-run"
+            submitVariant="btn-error"
+            cancelText={$t('org_page.leave.dont_leave')}
+          >
             <p>{$t('org_page.leave.confirm_leave')}</p>
           </ConfirmModal>
         </div>
@@ -260,9 +283,9 @@
       <AdminContent>
         <div class="divider"></div>
         <div class="flex justify-end">
-          <Button variant="btn-error" on:click={confirmDeleteOrg}>
+          <Button variant="btn-error" onclick={confirmDeleteOrg}>
             {$t('org_page.delete_modal.submit')}
-            <TrashIcon/>
+            <TrashIcon />
           </Button>
         </div>
       </AdminContent>

--- a/frontend/src/routes/(authenticated)/org/[org_id]/AddMyProjectsToOrgModal.svelte
+++ b/frontend/src/routes/(authenticated)/org/[org_id]/AddMyProjectsToOrgModal.svelte
@@ -10,17 +10,21 @@
   import {useNotifications} from '$lib/notify';
   import {type UUID} from 'crypto';
 
-  export let user: LexAuthUser;
-  export let org: Org;
+  interface Props {
+    user: LexAuthUser;
+    org: Org;
+  }
+
+  let { user, org }: Props = $props();
 
   const {notifySuccess} = useNotifications();
 
   const schema = z.object({});
 
-  let formModal: FormModal<typeof schema>;
-  let newProjects: Project[] = [];
-  let alreadyAddedProjects: number = 0;
-  let selectedProjects: string[] = [];
+  let formModal: FormModal<typeof schema> = $state();
+  let newProjects: Project[] = $state([]);
+  let alreadyAddedProjects: number = $state(0);
+  let selectedProjects: string[] = $state([]);
 
   async function openModal(): Promise<void> {
     const projectsIManage = await _getProjectsIManage(user);
@@ -54,13 +58,15 @@
 
 <Button variant="btn-success" on:click={openModal}>
   {$t('org_page.add_my_projects.open_button')}
-  <span class="i-mdi-plus text-2xl" />
+  <span class="i-mdi-plus text-2xl"></span>
 </Button>
 
 <FormModal bind:this={formModal} {schema} hideActions={!newProjects.length}>
-  <span slot="title">
-    {$t('org_page.add_my_projects.title')}
-  </span>
+  {#snippet title()}
+    <span >
+      {$t('org_page.add_my_projects.title')}
+    </span>
+  {/snippet}
   {#if newProjects.length}
     <UserProjects projects={newProjects} bind:selectedProjects hideRoleColumn />
   {:else if alreadyAddedProjects}
@@ -72,5 +78,7 @@
       {$t('org_page.add_my_projects.no_projects_managed')}
     </span>
   {/if}
-  <span slot="submitText">{$t('org_page.add_my_projects.submit_button')}</span>
+  {#snippet submitText()}
+    <span >{$t('org_page.add_my_projects.submit_button')}</span>
+  {/snippet}
 </FormModal>

--- a/frontend/src/routes/(authenticated)/org/[org_id]/AddMyProjectsToOrgModal.svelte
+++ b/frontend/src/routes/(authenticated)/org/[org_id]/AddMyProjectsToOrgModal.svelte
@@ -1,14 +1,14 @@
 <script lang="ts">
-  import {DialogResponse, FormModal} from '$lib/components/modals';
-  import UserProjects, {type Project} from '$lib/components/Users/UserProjects.svelte';
+  import { DialogResponse, FormModal } from '$lib/components/modals';
+  import UserProjects, { type Project } from '$lib/components/Users/UserProjects.svelte';
   import Button from '$lib/forms/Button.svelte';
   import t from '$lib/i18n';
-  import {type LexAuthUser} from '$lib/user';
-  import {z} from 'zod';
-  import {_addProjectsToOrg, _getProjectsIManage, type Org} from './+page';
-  import {ProjectRole} from '$lib/gql/types';
-  import {useNotifications} from '$lib/notify';
-  import {type UUID} from 'crypto';
+  import { type LexAuthUser } from '$lib/user';
+  import { z } from 'zod';
+  import { _addProjectsToOrg, _getProjectsIManage, type Org } from './+page';
+  import { ProjectRole } from '$lib/gql/types';
+  import { useNotifications } from '$lib/notify';
+  import { type UUID } from 'crypto';
 
   interface Props {
     user: LexAuthUser;
@@ -17,11 +17,11 @@
 
   let { user, org }: Props = $props();
 
-  const {notifySuccess} = useNotifications();
+  const { notifySuccess } = useNotifications();
 
   const schema = z.object({});
 
-  let formModal: FormModal<typeof schema> = $state();
+  let formModal: FormModal<typeof schema> = $state()!;
   let newProjects: Project[] = $state([]);
   let alreadyAddedProjects: number = $state(0);
   let selectedProjects: string[] = $state([]);
@@ -31,8 +31,8 @@
 
     newProjects = [];
     alreadyAddedProjects = 0;
-    projectsIManage.forEach(proj => {
-      if (org.projects.find(p => p.id === proj.id)) {
+    projectsIManage.forEach((proj) => {
+      if (org.projects.find((p) => p.id === proj.id)) {
         alreadyAddedProjects++;
       } else {
         newProjects.push({
@@ -56,14 +56,14 @@
   }
 </script>
 
-<Button variant="btn-success" on:click={openModal}>
+<Button variant="btn-success" onclick={openModal}>
   {$t('org_page.add_my_projects.open_button')}
   <span class="i-mdi-plus text-2xl"></span>
 </Button>
 
 <FormModal bind:this={formModal} {schema} hideActions={!newProjects.length}>
   {#snippet title()}
-    <span >
+    <span>
       {$t('org_page.add_my_projects.title')}
     </span>
   {/snippet}
@@ -79,6 +79,6 @@
     </span>
   {/if}
   {#snippet submitText()}
-    <span >{$t('org_page.add_my_projects.submit_button')}</span>
+    <span>{$t('org_page.add_my_projects.submit_button')}</span>
   {/snippet}
 </FormModal>

--- a/frontend/src/routes/(authenticated)/org/[org_id]/AddMyProjectsToOrgModal.svelte
+++ b/frontend/src/routes/(authenticated)/org/[org_id]/AddMyProjectsToOrgModal.svelte
@@ -21,7 +21,8 @@
 
   const schema = z.object({});
 
-  let formModal: FormModal<typeof schema> = $state()!;
+  // eslint-disable-next-line @typescript-eslint/no-redundant-type-constituents
+  let formModal: FormModal<typeof schema> | undefined = $state();
   let newProjects: Project[] = $state([]);
   let alreadyAddedProjects: number = $state(0);
   let selectedProjects: string[] = $state([]);
@@ -42,7 +43,7 @@
       }
     });
 
-    const { response } = await formModal.open(undefined, async () => {
+    const { response } = await formModal!.open(undefined, async () => {
       if (!selectedProjects.length) {
         return $t('org_page.add_my_projects.no_projects_selected');
       }

--- a/frontend/src/routes/(authenticated)/org/[org_id]/AddOrgMemberModal.svelte
+++ b/frontend/src/routes/(authenticated)/org/[org_id]/AddOrgMemberModal.svelte
@@ -13,7 +13,11 @@
   import type { SingleUserICanSeeTypeaheadResult, SingleUserTypeaheadResult } from '$lib/gql/typeahead-queries';
   import UserProjects, { type Project } from '$lib/components/Users/UserProjects.svelte';
 
-  export let org: Org;
+  interface Props {
+    org: Org;
+  }
+
+  let { org }: Props = $props();
 
   const schema = z.object({
     usernameOrEmail: z.string().trim()
@@ -22,14 +26,14 @@
     role: z.enum([OrgRole.User, OrgRole.Admin]).default(OrgRole.User),
     canInvite: z.boolean().default(false),
   });
-  let formModal: FormModal<typeof schema>;
-  $: form = formModal?.form();
+  let formModal: FormModal<typeof schema> = $state();
+  let form = $derived(formModal?.form());
 
   const { notifySuccess } = useNotifications();
 
-  let newProjects: Project[] = [];
-  let alreadyAddedProjects: Project[] = [];
-  let selectedProjects: string[] = [];
+  let newProjects: Project[] = $state([]);
+  let alreadyAddedProjects: Project[] = $state([]);
+  let selectedProjects: string[] = $state([]);
 
   function resetProjects(): void {
     newProjects = [];
@@ -93,60 +97,68 @@
   }
 </script>
 
-<FormModal bind:this={formModal} {schema} let:errors --justify-actions="end">
-  <span slot="title">
-    {$t('org_page.add_user.modal_title')}
-    <SupHelp helpLink={helpLinks.addOrgMember} />
-    <!-- TODO: helpLinks.addOrgMember currently points to Add_Project_Member scribe. Create a scribe with Add_Org_Member help. -->
-  </span>
-  {#if $page.data.user?.isAdmin}
-    <UserTypeahead
-      id="usernameOrEmail"
-      label={$t('login.label_email')}
-      isAdmin={$page.data.user?.isAdmin}
-      bind:value={$form.usernameOrEmail}
-      error={errors.usernameOrEmail}
-      on:selectedUserChange={(event) => populateUserProjects(event.detail)}
-      autofocus
-      exclude={org.members.map(m => m.user.id)}
+<FormModal bind:this={formModal} {schema}  --justify-actions="end">
+  {#snippet title()}
+    <span >
+      {$t('org_page.add_user.modal_title')}
+      <SupHelp helpLink={helpLinks.addOrgMember} />
+      <!-- TODO: helpLinks.addOrgMember currently points to Add_Project_Member scribe. Create a scribe with Add_Org_Member help. -->
+    </span>
+  {/snippet}
+  {#snippet children({ errors })}
+    {#if $page.data.user?.isAdmin}
+      <UserTypeahead
+        id="usernameOrEmail"
+        label={$t('login.label_email')}
+        isAdmin={$page.data.user?.isAdmin}
+        bind:value={$form.usernameOrEmail}
+        error={errors.usernameOrEmail}
+        on:selectedUserChange={(event) => populateUserProjects(event.detail)}
+        autofocus
+        exclude={org.members.map(m => m.user.id)}
+        />
+    {:else}
+      <Input
+        id="usernameOrEmail"
+        type="text"
+        label={$t('login.label_email')}
+        bind:value={$form.usernameOrEmail}
+        error={errors.usernameOrEmail}
+        autofocus
       />
-  {:else}
-    <Input
-      id="usernameOrEmail"
-      type="text"
-      label={$t('login.label_email')}
-      bind:value={$form.usernameOrEmail}
-      error={errors.usernameOrEmail}
-      autofocus
-    />
-  {/if}
-  <OrgRoleSelect bind:value={$form.role} error={errors.role} />
-  {#if newProjects.length || alreadyAddedProjects.length}
-    <div class="label label-text">
-      {$t('org_page.add_user.also_add_projects')}
-    </div>
-    {#if newProjects.length}
-      <UserProjects projects={newProjects} bind:selectedProjects />
-    {:else}
-      <span class="text-secondary px-1">
-        {$t('org_page.add_user.all_projects_already_added', { count: alreadyAddedProjects.length })}
-      </span>
     {/if}
-  {/if}
-  <svelte:fragment slot="extraActions">
-    <Checkbox
-      id="invite"
-      label={$t('org_page.add_user.invite')}
-      variant="checkbox-warning"
-      labelColor="text-warning"
-      bind:value={$form.canInvite}
-    />
-  </svelte:fragment>
-  <span slot="submitText">
-    {#if $form.canInvite && $form.usernameOrEmail.includes('@')}
-      {$t('org_page.add_user.submit_button_email')}
-    {:else}
-      {$t('org_page.add_user.submit_button')}
+    <OrgRoleSelect bind:value={$form.role} error={errors.role} />
+    {#if newProjects.length || alreadyAddedProjects.length}
+      <div class="label label-text">
+        {$t('org_page.add_user.also_add_projects')}
+      </div>
+      {#if newProjects.length}
+        <UserProjects projects={newProjects} bind:selectedProjects />
+      {:else}
+        <span class="text-secondary px-1">
+          {$t('org_page.add_user.all_projects_already_added', { count: alreadyAddedProjects.length })}
+        </span>
+      {/if}
     {/if}
-  </span>
+    {/snippet}
+  {#snippet extraActions()}
+  
+      <Checkbox
+        id="invite"
+        label={$t('org_page.add_user.invite')}
+        variant="checkbox-warning"
+        labelColor="text-warning"
+        bind:value={$form.canInvite}
+      />
+    
+  {/snippet}
+  {#snippet submitText()}
+    <span >
+      {#if $form.canInvite && $form.usernameOrEmail.includes('@')}
+        {$t('org_page.add_user.submit_button_email')}
+      {:else}
+        {$t('org_page.add_user.submit_button')}
+      {/if}
+    </span>
+  {/snippet}
 </FormModal>

--- a/frontend/src/routes/(authenticated)/org/[org_id]/AddOrgMemberModal.svelte
+++ b/frontend/src/routes/(authenticated)/org/[org_id]/AddOrgMemberModal.svelte
@@ -5,7 +5,7 @@
   import t from '$lib/i18n';
   import { z } from 'zod';
   import { useNotifications } from '$lib/notify';
-  import { page } from '$app/stores'
+  import { page } from '$app/stores';
   import UserTypeahead from '$lib/forms/UserTypeahead.svelte';
   import { SupHelp, helpLinks } from '$lib/components/help';
   import type { UUID } from 'crypto';
@@ -20,13 +20,15 @@
   let { org }: Props = $props();
 
   const schema = z.object({
-    usernameOrEmail: z.string().trim()
+    usernameOrEmail: z
+      .string()
+      .trim()
       .min(1, $t('org_page.add_user.empty_user_field'))
       .refine((value) => !value.includes('@') || isEmail(value), { message: $t('form.invalid_email') }),
     role: z.enum([OrgRole.User, OrgRole.Admin]).default(OrgRole.User),
     canInvite: z.boolean().default(false),
   });
-  let formModal: FormModal<typeof schema> = $state();
+  let formModal: FormModal<typeof schema> = $state()!;
   let form = $derived(formModal?.form());
 
   const { notifySuccess } = useNotifications();
@@ -44,9 +46,16 @@
   function populateUserProjects(user: SingleUserTypeaheadResult | SingleUserICanSeeTypeaheadResult | null): void {
     resetProjects();
     if (user && 'projects' in user) {
-      const userProjects = [...user.projects.map(p => ({memberRole: p.role, id: p.project.id, code: p.project.code, name: p.project.name}))];
-      userProjects.forEach(proj => {
-        if (org.projects.find(p => p.id === proj.id)) {
+      const userProjects = [
+        ...user.projects.map((p) => ({
+          memberRole: p.role,
+          id: p.project.id,
+          code: p.project.code,
+          name: p.project.name,
+        })),
+      ];
+      userProjects.forEach((proj) => {
+        if (org.projects.find((p) => p.id === proj.id)) {
           alreadyAddedProjects.push(proj);
         } else {
           newProjects.push(proj);
@@ -97,9 +106,9 @@
   }
 </script>
 
-<FormModal bind:this={formModal} {schema}  --justify-actions="end">
+<FormModal bind:this={formModal} {schema} --justify-actions="end">
   {#snippet title()}
-    <span >
+    <span>
       {$t('org_page.add_user.modal_title')}
       <SupHelp helpLink={helpLinks.addOrgMember} />
       <!-- TODO: helpLinks.addOrgMember currently points to Add_Project_Member scribe. Create a scribe with Add_Org_Member help. -->
@@ -115,8 +124,8 @@
         error={errors.usernameOrEmail}
         on:selectedUserChange={(event) => populateUserProjects(event.detail)}
         autofocus
-        exclude={org.members.map(m => m.user.id)}
-        />
+        exclude={org.members.map((m) => m.user.id)}
+      />
     {:else}
       <Input
         id="usernameOrEmail"
@@ -140,20 +149,18 @@
         </span>
       {/if}
     {/if}
-    {/snippet}
+  {/snippet}
   {#snippet extraActions()}
-  
-      <Checkbox
-        id="invite"
-        label={$t('org_page.add_user.invite')}
-        variant="checkbox-warning"
-        labelColor="text-warning"
-        bind:value={$form.canInvite}
-      />
-    
+    <Checkbox
+      id="invite"
+      label={$t('org_page.add_user.invite')}
+      variant="checkbox-warning"
+      labelColor="text-warning"
+      bind:value={$form.canInvite}
+    />
   {/snippet}
   {#snippet submitText()}
-    <span >
+    <span>
       {#if $form.canInvite && $form.usernameOrEmail.includes('@')}
         {$t('org_page.add_user.submit_button_email')}
       {:else}

--- a/frontend/src/routes/(authenticated)/org/[org_id]/AddOrgMemberModal.svelte
+++ b/frontend/src/routes/(authenticated)/org/[org_id]/AddOrgMemberModal.svelte
@@ -28,7 +28,8 @@
     role: z.enum([OrgRole.User, OrgRole.Admin]).default(OrgRole.User),
     canInvite: z.boolean().default(false),
   });
-  let formModal: FormModal<typeof schema> = $state()!;
+  // eslint-disable-next-line @typescript-eslint/no-redundant-type-constituents
+  let formModal: FormModal<typeof schema> | undefined = $state();
   let form = $derived(formModal?.form());
 
   const { notifySuccess } = useNotifications();
@@ -65,6 +66,7 @@
   }
 
   export async function openModal(): Promise<void> {
+    if (!formModal || !$form) return;
     resetProjects();
     let userInvited = false;
     const { response, formState } = await formModal.open(async () => {
@@ -120,7 +122,7 @@
         id="usernameOrEmail"
         label={$t('login.label_email')}
         isAdmin={$page.data.user?.isAdmin}
-        bind:value={$form.usernameOrEmail}
+        bind:value={$form!.usernameOrEmail}
         error={errors.usernameOrEmail}
         on:selectedUserChange={(event) => populateUserProjects(event.detail)}
         autofocus
@@ -131,12 +133,12 @@
         id="usernameOrEmail"
         type="text"
         label={$t('login.label_email')}
-        bind:value={$form.usernameOrEmail}
+        bind:value={$form!.usernameOrEmail}
         error={errors.usernameOrEmail}
         autofocus
       />
     {/if}
-    <OrgRoleSelect bind:value={$form.role} error={errors.role} />
+    <OrgRoleSelect bind:value={$form!.role} error={errors.role} />
     {#if newProjects.length || alreadyAddedProjects.length}
       <div class="label label-text">
         {$t('org_page.add_user.also_add_projects')}
@@ -156,12 +158,12 @@
       label={$t('org_page.add_user.invite')}
       variant="checkbox-warning"
       labelColor="text-warning"
-      bind:value={$form.canInvite}
+      bind:value={$form!.canInvite}
     />
   {/snippet}
   {#snippet submitText()}
     <span>
-      {#if $form.canInvite && $form.usernameOrEmail.includes('@')}
+      {#if $form!.canInvite && $form!.usernameOrEmail.includes('@')}
         {$t('org_page.add_user.submit_button_email')}
       {:else}
         {$t('org_page.add_user.submit_button')}

--- a/frontend/src/routes/(authenticated)/org/[org_id]/BulkAddOrgMembers.svelte
+++ b/frontend/src/routes/(authenticated)/org/[org_id]/BulkAddOrgMembers.svelte
@@ -30,7 +30,7 @@
     usernamesText: z.string().trim().min(1, $t('org_page.bulk_add_members.empty_user_field')),
   });
 
-  let formModal: FormModal<typeof schema> = $state();
+  let formModal: FormModal<typeof schema> = $state()!;
   let form = $derived(formModal?.form());
 
   let addedMembers: BulkAddOrgMembersResult['addedMembers'] = $state([]);
@@ -42,7 +42,8 @@
 
     for (const username of usernames) {
       if (username.includes('@')) {
-        if (!isEmail(username)) return { usernamesText: [$t('org_page.bulk_add_members.invalid_email_address', { email: username })] };
+        if (!isEmail(username))
+          return { usernamesText: [$t('org_page.bulk_add_members.invalid_email_address', { email: username })] };
       } else if (!usernameRe.test(username)) {
         return { usernamesText: [$t('org_page.bulk_add_members.invalid_username', { username })] };
       }
@@ -55,19 +56,15 @@
       const usernames = state.usernamesText.currentValue
         .split('\n')
         // Remove whitespace
-        .map(s => s.trim())
+        .map((s) => s.trim())
         // Remove empty lines before validating, otherwise final newline would count as invalid because empty string
-        .filter(s => s)
+        .filter((s) => s)
         .filter(distinct);
 
       const bulkErrors = validateBulkAddInput(usernames);
       if (bulkErrors) return bulkErrors;
 
-      const { error, data } = await _bulkAddOrgMembers(
-        orgId as UUID,
-        usernames,
-        OrgRole.User,
-      );
+      const { error, data } = await _bulkAddOrgMembers(orgId as UUID, usernames, OrgRole.User);
 
       addedMembers = data?.bulkAddOrgMembers.bulkAddOrgMembersResult?.addedMembers ?? [];
       notFoundMembers = data?.bulkAddOrgMembers.bulkAddOrgMembersResult?.notFoundMembers ?? [];
@@ -82,80 +79,80 @@
   }
 </script>
 
-<FormModal bind:this={formModal} {schema}  showDoneState>
-    {#snippet title()}
-    <span >
-        {$t('org_page.bulk_add_members.modal_title')}
-        <SupHelp helpLink={helpLinks.bulkAddCreate} />
-      </span>
+<FormModal bind:this={formModal} {schema} showDoneState>
+  {#snippet title()}
+    <span>
+      {$t('org_page.bulk_add_members.modal_title')}
+      <SupHelp helpLink={helpLinks.bulkAddCreate} />
+    </span>
   {/snippet}
-    {#snippet children({ errors })}
+  {#snippet children({ errors })}
     {#if currentStep == BulkAddSteps.Add}
-        <p class="mb-2">{$t('org_page.bulk_add_members.explanation')}</p>
-        <div class="contents usernames">
-          <TextArea
-            id="usernamesText"
-            label={$t('org_page.bulk_add_members.usernames')}
-            description={$t('org_page.bulk_add_members.usernames_description')}
-            bind:value={$form.usernamesText}
-            error={errors.usernamesText}
-          />
-        </div>
-      {:else if currentStep == BulkAddSteps.Results}
-        <div class="mb-4">
-          <p class="flex gap-1 items-center">
-            <Icon icon="i-mdi-plus" color="text-success" />
-            {$t('org_page.bulk_add_members.members_added', {addedCount: addedMembers.length})}
-          </p>
-          {#if addedMembers.length > 0}
-            <div class="mt-2">
-              <BadgeList>
-                {#each addedMembers as user}
-                <OrgMemberBadge member={{ name: user.username, role: user.role }} />
-                {/each}
-              </BadgeList>
-            </div>
-          {/if}
-        </div>
-        <div class="mb-4">
-          <p class="flex gap-1 items-center">
-            <Icon icon="i-mdi-account-off" color="text-info" />
-            {$t('org_page.bulk_add_members.accounts_not_found', {notFoundCount: notFoundMembers.length})}
-          </p>
-          {#if notFoundMembers.length > 0}
-            <div class="mt-2">
-              <BadgeList>
-                {#each notFoundMembers as user}
-                  <OrgMemberBadge member={{ name: user.username, role: user.role }} />
-                {/each}
-              </BadgeList>
-            </div>
-          {/if}
-        </div>
-        {#if existingMembers.length > 0}
-          <p class="flex gap-1 items-center">
-            <Icon icon="i-mdi-account-outline" color="text-info" />
-            {$t('org_page.bulk_add_members.already_members', {count: existingMembers.length})}
-          </p>
+      <p class="mb-2">{$t('org_page.bulk_add_members.explanation')}</p>
+      <div class="contents usernames">
+        <TextArea
+          id="usernamesText"
+          label={$t('org_page.bulk_add_members.usernames')}
+          description={$t('org_page.bulk_add_members.usernames_description')}
+          bind:value={$form.usernamesText}
+          error={errors.usernamesText}
+        />
+      </div>
+    {:else if currentStep == BulkAddSteps.Results}
+      <div class="mb-4">
+        <p class="flex gap-1 items-center">
+          <Icon icon="i-mdi-plus" color="text-success" />
+          {$t('org_page.bulk_add_members.members_added', { addedCount: addedMembers.length })}
+        </p>
+        {#if addedMembers.length > 0}
           <div class="mt-2">
             <BadgeList>
-              {#each existingMembers as user}
+              {#each addedMembers as user}
                 <OrgMemberBadge member={{ name: user.username, role: user.role }} />
               {/each}
             </BadgeList>
           </div>
         {/if}
-      {:else}
-        <p>Internal error: unknown step {currentStep}</p>
+      </div>
+      <div class="mb-4">
+        <p class="flex gap-1 items-center">
+          <Icon icon="i-mdi-account-off" color="text-info" />
+          {$t('org_page.bulk_add_members.accounts_not_found', { notFoundCount: notFoundMembers.length })}
+        </p>
+        {#if notFoundMembers.length > 0}
+          <div class="mt-2">
+            <BadgeList>
+              {#each notFoundMembers as user}
+                <OrgMemberBadge member={{ name: user.username, role: user.role }} />
+              {/each}
+            </BadgeList>
+          </div>
+        {/if}
+      </div>
+      {#if existingMembers.length > 0}
+        <p class="flex gap-1 items-center">
+          <Icon icon="i-mdi-account-outline" color="text-info" />
+          {$t('org_page.bulk_add_members.already_members', { count: existingMembers.length })}
+        </p>
+        <div class="mt-2">
+          <BadgeList>
+            {#each existingMembers as user}
+              <OrgMemberBadge member={{ name: user.username, role: user.role }} />
+            {/each}
+          </BadgeList>
+        </div>
       {/if}
-      {/snippet}
+    {:else}
+      <p>Internal error: unknown step {currentStep}</p>
+    {/if}
+  {/snippet}
   {#snippet submitText()}
-    <span >{$t('org_page.bulk_add_members.submit_button')}</span>
+    <span>{$t('org_page.bulk_add_members.submit_button')}</span>
   {/snippet}
-    {#snippet doneText()}
-    <span >{$t('org_page.bulk_add_members.finish_button')}</span>
+  {#snippet doneText()}
+    <span>{$t('org_page.bulk_add_members.finish_button')}</span>
   {/snippet}
-  </FormModal>
+</FormModal>
 
 <style lang="postcss">
   .usernames :global(.description) {

--- a/frontend/src/routes/(authenticated)/org/[org_id]/BulkAddOrgMembers.svelte
+++ b/frontend/src/routes/(authenticated)/org/[org_id]/BulkAddOrgMembers.svelte
@@ -14,6 +14,7 @@
   import type { UUID } from 'crypto';
   import { invalidate } from '$app/navigation';
 
+  // svelte-ignore non_reactive_update
   enum BulkAddSteps {
     Add,
     Results,
@@ -30,7 +31,8 @@
     usernamesText: z.string().trim().min(1, $t('org_page.bulk_add_members.empty_user_field')),
   });
 
-  let formModal: FormModal<typeof schema> = $state()!;
+  // eslint-disable-next-line @typescript-eslint/no-redundant-type-constituents
+  let formModal: FormModal<typeof schema> | undefined = $state();
   let form = $derived(formModal?.form());
 
   let addedMembers: BulkAddOrgMembersResult['addedMembers'] = $state([]);
@@ -51,6 +53,7 @@
   }
 
   export async function open(): Promise<void> {
+    if (!formModal) return;
     currentStep = BulkAddSteps.Add;
     const { response } = await formModal.open(undefined, async (state) => {
       const usernames = state.usernamesText.currentValue
@@ -94,7 +97,7 @@
           id="usernamesText"
           label={$t('org_page.bulk_add_members.usernames')}
           description={$t('org_page.bulk_add_members.usernames_description')}
-          bind:value={$form.usernamesText}
+          bind:value={$form!.usernamesText}
           error={errors.usernamesText}
         />
       </div>

--- a/frontend/src/routes/(authenticated)/org/[org_id]/ChangeOrgMemberRoleModal.svelte
+++ b/frontend/src/routes/(authenticated)/org/[org_id]/ChangeOrgMemberRoleModal.svelte
@@ -6,16 +6,20 @@
   import { z } from 'zod';
   import { _changeOrgMemberRole } from './+page';
 
-  export let orgId: string;
+  interface Props {
+    orgId: string;
+  }
+
+  let { orgId }: Props = $props();
 
   const schema = z.object({
     role: z.enum([OrgRole.User, OrgRole.Admin])
   });
   type Schema = typeof schema;
-  let formModal: FormModal<Schema>;
-  $: form = formModal?.form();
+  let formModal: FormModal<Schema> = $state();
+  let form = $derived(formModal?.form());
 
-  let name: string;
+  let name: string = $state();
 
   export async function open(member: { userId: string; name: string; role: OrgRole }): Promise<FormModalResult<Schema>> {
     name = member.name;
@@ -36,8 +40,14 @@
   }
 </script>
 
-<FormModal bind:this={formModal} {schema} let:errors>
-  <span slot="title">{$t('org_page.change_role_modal.title', { name })}</span>
-  <OrgRoleSelect bind:value={$form.role} error={errors.role} />
-  <span slot="submitText">{$t('org_page.change_role_modal.button_label')}</span>
+<FormModal bind:this={formModal} {schema} >
+  {#snippet title()}
+    <span >{$t('org_page.change_role_modal.title', { name })}</span>
+  {/snippet}
+  {#snippet children({ errors })}
+    <OrgRoleSelect bind:value={$form.role} error={errors.role} />
+    {/snippet}
+  {#snippet submitText()}
+    <span >{$t('org_page.change_role_modal.button_label')}</span>
+  {/snippet}
 </FormModal>

--- a/frontend/src/routes/(authenticated)/org/[org_id]/ChangeOrgMemberRoleModal.svelte
+++ b/frontend/src/routes/(authenticated)/org/[org_id]/ChangeOrgMemberRoleModal.svelte
@@ -13,22 +13,22 @@
   let { orgId }: Props = $props();
 
   const schema = z.object({
-    role: z.enum([OrgRole.User, OrgRole.Admin])
+    role: z.enum([OrgRole.User, OrgRole.Admin]),
   });
   type Schema = typeof schema;
-  let formModal: FormModal<Schema> = $state();
+  let formModal: FormModal<Schema> = $state()!;
   let form = $derived(formModal?.form());
 
-  let name: string = $state();
+  let name: string = $state('');
 
-  export async function open(member: { userId: string; name: string; role: OrgRole }): Promise<FormModalResult<Schema>> {
+  export async function open(member: {
+    userId: string;
+    name: string;
+    role: OrgRole;
+  }): Promise<FormModalResult<Schema>> {
     name = member.name;
     return await formModal.open(tryParse(schema, member), async () => {
-      const result = await _changeOrgMemberRole(
-        orgId,
-        member.userId,
-        $form.role,
-      );
+      const result = await _changeOrgMemberRole(orgId, member.userId, $form.role);
       if (result.error?.byType('OrgMembersMustBeVerified')) {
         return { role: [$t('org_page.add_user.user_must_be_verified')] };
       }
@@ -40,14 +40,14 @@
   }
 </script>
 
-<FormModal bind:this={formModal} {schema} >
+<FormModal bind:this={formModal} {schema}>
   {#snippet title()}
-    <span >{$t('org_page.change_role_modal.title', { name })}</span>
+    <span>{$t('org_page.change_role_modal.title', { name })}</span>
   {/snippet}
   {#snippet children({ errors })}
     <OrgRoleSelect bind:value={$form.role} error={errors.role} />
-    {/snippet}
+  {/snippet}
   {#snippet submitText()}
-    <span >{$t('org_page.change_role_modal.button_label')}</span>
+    <span>{$t('org_page.change_role_modal.button_label')}</span>
   {/snippet}
 </FormModal>

--- a/frontend/src/routes/(authenticated)/org/[org_id]/ChangeOrgMemberRoleModal.svelte
+++ b/frontend/src/routes/(authenticated)/org/[org_id]/ChangeOrgMemberRoleModal.svelte
@@ -16,7 +16,8 @@
     role: z.enum([OrgRole.User, OrgRole.Admin]),
   });
   type Schema = typeof schema;
-  let formModal: FormModal<Schema> = $state()!;
+  // eslint-disable-next-line @typescript-eslint/no-redundant-type-constituents
+  let formModal: FormModal<Schema> | undefined = $state();
   let form = $derived(formModal?.form());
 
   let name: string = $state('');
@@ -27,8 +28,8 @@
     role: OrgRole;
   }): Promise<FormModalResult<Schema>> {
     name = member.name;
-    return await formModal.open(tryParse(schema, member), async () => {
-      const result = await _changeOrgMemberRole(orgId, member.userId, $form.role);
+    return await formModal!.open(tryParse(schema, member), async () => {
+      const result = await _changeOrgMemberRole(orgId, member.userId, $form!.role);
       if (result.error?.byType('OrgMembersMustBeVerified')) {
         return { role: [$t('org_page.add_user.user_must_be_verified')] };
       }
@@ -45,7 +46,7 @@
     <span>{$t('org_page.change_role_modal.title', { name })}</span>
   {/snippet}
   {#snippet children({ errors })}
-    <OrgRoleSelect bind:value={$form.role} error={errors.role} />
+    <OrgRoleSelect bind:value={$form!.role} error={errors.role} />
   {/snippet}
   {#snippet submitText()}
     <span>{$t('org_page.change_role_modal.button_label')}</span>

--- a/frontend/src/routes/(authenticated)/org/[org_id]/OrgMemberTable.svelte
+++ b/frontend/src/routes/(authenticated)/org/[org_id]/OrgMemberTable.svelte
@@ -27,10 +27,11 @@
     changeMemberRole: OrgUser;
   }>();
 
-  let removeMemberModal: DeleteModal = $state()!;
+  let removeMemberModal: DeleteModal | undefined = $state();
   let memberToRemove: string = $state('');
 
   async function removeMember(member: User): Promise<void> {
+    if (!removeMemberModal) return;
     memberToRemove = member.name;
     const removed = await removeMemberModal.prompt(async () => {
       const { error } = await _deleteOrgUser(org.id, member.id);
@@ -72,7 +73,7 @@
                   variant="btn-ghost"
                   size="btn-sm"
                   class="max-w-full"
-                  on:click={() => dispatch('openUserModal', memberUser)}
+                  onclick={() => dispatch('openUserModal', memberUser)}
                 >
                   <span class="x-ellipsis" title={memberUser.name}>
                     {memberUser.name}

--- a/frontend/src/routes/(authenticated)/org/[org_id]/OrgMemberTable.svelte
+++ b/frontend/src/routes/(authenticated)/org/[org_id]/OrgMemberTable.svelte
@@ -7,9 +7,9 @@
   import Dropdown from '$lib/components/Dropdown.svelte';
   import { _deleteOrgUser, type Org, type OrgUser, type User } from './+page';
   import DeleteModal from '$lib/components/modals/DeleteModal.svelte';
-  import {useNotifications} from '$lib/notify';
-  import type {LexAuthUser} from '$lib/user';
-  import {OrgRole} from '$lib/gql/types';
+  import { useNotifications } from '$lib/notify';
+  import type { LexAuthUser } from '$lib/user';
+  import { OrgRole } from '$lib/gql/types';
 
   interface Props {
     org: Org;
@@ -18,22 +18,17 @@
     canManage: boolean;
   }
 
-  let {
-    org,
-    user,
-    shownUsers,
-    canManage
-  }: Props = $props();
+  let { org, user, shownUsers, canManage }: Props = $props();
 
   const { notifyWarning } = useNotifications();
 
   const dispatch = createEventDispatcher<{
-    openUserModal: User,
-    changeMemberRole: OrgUser,
+    openUserModal: User;
+    changeMemberRole: OrgUser;
   }>();
 
-  let removeMemberModal: DeleteModal = $state();
-  let memberToRemove: string = $state();
+  let removeMemberModal: DeleteModal = $state()!;
+  let memberToRemove: string = $state('');
 
   async function removeMember(member: User): Promise<void> {
     memberToRemove = member.name;
@@ -57,24 +52,28 @@
           <span class="i-mdi-sort-ascending text-xl align-[-5px] ml-2"></span>
         </th>
         {#if canManage}
-        <th>{$t('admin_dashboard.column_email_or_login')}</th>
+          <th>{$t('admin_dashboard.column_email_or_login')}</th>
         {/if}
         <th class="@2xl:table-cell">
           {$t('admin_dashboard.column_role')}
         </th>
-        <th>
-        </th>
+        <th> </th>
       </tr>
     </thead>
     <tbody>
       {#each shownUsers as member}
-      {@const memberUser = member.user}
-      {@const isOrgAdmin = member.role === OrgRole.Admin}
+        {@const memberUser = member.user}
+        {@const isOrgAdmin = member.role === OrgRole.Admin}
         <tr>
           <td>
             <div class="flex items-center gap-2 max-w-40 @xl:max-w-52">
               {#if canManage}
-                <Button variant="btn-ghost" size="btn-sm" class="max-w-full" on:click={() => dispatch('openUserModal', memberUser)}>
+                <Button
+                  variant="btn-ghost"
+                  size="btn-sm"
+                  class="max-w-full"
+                  on:click={() => dispatch('openUserModal', memberUser)}
+                >
                   <span class="x-ellipsis" title={memberUser.name}>
                     {memberUser.name}
                   </span>
@@ -88,41 +87,46 @@
             </div>
           </td>
           {#if canManage}
-          <td>
-            <span class="inline-flex items-center gap-2 text-left max-w-40">
-              <span class="x-ellipsis" title={memberUser.email ?? memberUser.username}>
-                {memberUser.email ?? memberUser.username}
+            <td>
+              <span class="inline-flex items-center gap-2 text-left max-w-40">
+                <span class="x-ellipsis" title={memberUser.email ?? memberUser.username}>
+                  {memberUser.email ?? memberUser.username}
+                </span>
               </span>
-            </span>
-          </td>
+            </td>
           {/if}
-          <td class="@2xl:table-cell" class:text-primary={isOrgAdmin} class:font-bold={isOrgAdmin} class:dark:brightness-150={isOrgAdmin}>
+          <td
+            class="@2xl:table-cell"
+            class:text-primary={isOrgAdmin}
+            class:font-bold={isOrgAdmin}
+            class:dark:brightness-150={isOrgAdmin}
+          >
             <FormatUserOrgRole role={member.role} />
           </td>
           {#if user.isAdmin || (canManage && memberUser.id !== user.id)}
-          <td class="p-0">
-            <Dropdown>
-              <button class="btn btn-ghost btn-square" aria-label={$t('common.actions')}>
-                <span class="i-mdi-dots-vertical text-lg"></span>
-              </button>
-              {#snippet content()}
-                                <ul  class="menu">
-                  <li>
-                    <button class="whitespace-nowrap" onclick={() => dispatch('changeMemberRole', member)}>
-                      <Icon icon="i-mdi-pencil-outline" />
-                      {$t('org_page.edit_member_role')}
-                    </button>
-                  </li>
-                  <li>
-                    <button class="whitespace-nowrap text-error" onclick={() => removeMember(memberUser)}>
-                      <Icon icon="i-mdi-account-remove" />
-                      {$t('org_page.remove_member.remove')}
-                    </button>
-                  </li>
-                </ul>
-                              {/snippet}
-            </Dropdown>
-          </td>
+            <td class="p-0">
+              <Dropdown>
+                <button class="btn btn-ghost btn-square" aria-label={$t('common.actions')}>
+                  <span class="i-mdi-dots-vertical text-lg"></span>
+                </button>
+                {#snippet content()}
+                  <ul class="menu">
+                    <li>
+                      <button class="whitespace-nowrap" onclick={() => dispatch('changeMemberRole', member)}>
+                        <Icon icon="i-mdi-pencil-outline" />
+                        {$t('org_page.edit_member_role')}
+                      </button>
+                    </li>
+                    <li>
+                      <button class="whitespace-nowrap text-error" onclick={() => removeMember(memberUser)}>
+                        <Icon icon="i-mdi-account-remove" />
+                        {$t('org_page.remove_member.remove')}
+                      </button>
+                    </li>
+                  </ul>
+                {/snippet}
+              </Dropdown>
+            </td>
           {/if}
         </tr>
       {/each}
@@ -130,10 +134,6 @@
   </table>
 </div>
 
-<DeleteModal
-  bind:this={removeMemberModal}
-  entityName={$t('org_page.remove_member.member')}
-  isRemoveDialog
-  >
-  {$t('org_page.remove_member.confirm_message', {memberName: memberToRemove})}
+<DeleteModal bind:this={removeMemberModal} entityName={$t('org_page.remove_member.member')} isRemoveDialog>
+  {$t('org_page.remove_member.confirm_message', { memberName: memberToRemove })}
 </DeleteModal>

--- a/frontend/src/routes/(authenticated)/org/[org_id]/OrgMemberTable.svelte
+++ b/frontend/src/routes/(authenticated)/org/[org_id]/OrgMemberTable.svelte
@@ -11,10 +11,19 @@
   import type {LexAuthUser} from '$lib/user';
   import {OrgRole} from '$lib/gql/types';
 
-  export let org: Org;
-  export let user: LexAuthUser;
-  export let shownUsers: OrgUser[];
-  export let canManage: boolean;
+  interface Props {
+    org: Org;
+    user: LexAuthUser;
+    shownUsers: OrgUser[];
+    canManage: boolean;
+  }
+
+  let {
+    org,
+    user,
+    shownUsers,
+    canManage
+  }: Props = $props();
 
   const { notifyWarning } = useNotifications();
 
@@ -23,8 +32,8 @@
     changeMemberRole: OrgUser,
   }>();
 
-  let removeMemberModal: DeleteModal;
-  let memberToRemove: string;
+  let removeMemberModal: DeleteModal = $state();
+  let memberToRemove: string = $state();
 
   async function removeMember(member: User): Promise<void> {
     memberToRemove = member.name;
@@ -45,7 +54,7 @@
       <tr class="bg-base-200">
         <th>
           {$t('admin_dashboard.column_name')}
-          <span class="i-mdi-sort-ascending text-xl align-[-5px] ml-2" />
+          <span class="i-mdi-sort-ascending text-xl align-[-5px] ml-2"></span>
         </th>
         {#if canManage}
         <th>{$t('admin_dashboard.column_email_or_login')}</th>
@@ -94,22 +103,24 @@
           <td class="p-0">
             <Dropdown>
               <button class="btn btn-ghost btn-square" aria-label={$t('common.actions')}>
-                <span class="i-mdi-dots-vertical text-lg" />
+                <span class="i-mdi-dots-vertical text-lg"></span>
               </button>
-              <ul slot="content" class="menu">
-                <li>
-                  <button class="whitespace-nowrap" on:click={() => dispatch('changeMemberRole', member)}>
-                    <Icon icon="i-mdi-pencil-outline" />
-                    {$t('org_page.edit_member_role')}
-                  </button>
-                </li>
-                <li>
-                  <button class="whitespace-nowrap text-error" on:click={() => removeMember(memberUser)}>
-                    <Icon icon="i-mdi-account-remove" />
-                    {$t('org_page.remove_member.remove')}
-                  </button>
-                </li>
-              </ul>
+              {#snippet content()}
+                                <ul  class="menu">
+                  <li>
+                    <button class="whitespace-nowrap" onclick={() => dispatch('changeMemberRole', member)}>
+                      <Icon icon="i-mdi-pencil-outline" />
+                      {$t('org_page.edit_member_role')}
+                    </button>
+                  </li>
+                  <li>
+                    <button class="whitespace-nowrap text-error" onclick={() => removeMember(memberUser)}>
+                      <Icon icon="i-mdi-account-remove" />
+                      {$t('org_page.remove_member.remove')}
+                    </button>
+                  </li>
+                </ul>
+                              {/snippet}
             </Dropdown>
           </td>
           {/if}

--- a/frontend/src/routes/(authenticated)/org/[org_id]/OrgTabs.svelte
+++ b/frontend/src/routes/(authenticated)/org/[org_id]/OrgTabs.svelte
@@ -1,4 +1,4 @@
-<script lang="ts" context="module">
+<script lang="ts" module>
   import { Badge } from '$lib/components/Badges';
   import type { I18nKey } from '$lib/i18n';
 
@@ -20,11 +20,19 @@
     clickTab: OrgTabId
   }>();
 
-  export let hideSettingsTab: boolean = false;
-  $: visibleTabs = hideSettingsTab ? orgTabs.filter(t => t !== 'settings') : orgTabs;
-  export let activeTab: OrgTabId = 'projects';
-  export let projectCount: number;
-  export let memberCount: number;
+  interface Props {
+    hideSettingsTab?: boolean;
+    activeTab?: OrgTabId;
+    projectCount: number;
+    memberCount: number;
+  }
+
+  let {
+    hideSettingsTab = false,
+    activeTab = $bindable('projects'),
+    projectCount,
+    memberCount
+  }: Props = $props();
 
   function handleTabChange(tab: OrgTabId): void {
     const proceed = dispatch('clickTab', tab);
@@ -32,13 +40,14 @@
       activeTab = tab;
     }
   }
+  let visibleTabs = $derived(hideSettingsTab ? orgTabs.filter(t => t !== 'settings') : orgTabs);
 </script>
 
 <div role="tablist" class="flex tabs tabs-lifted tabs-lg overflow-x-auto">
-  <div class="tab tab-divider" />
+  <div class="tab tab-divider"></div>
   {#each visibleTabs as tab}
     {@const isActiveTab = activeTab === tab}
-    <button on:click={() => handleTabChange(tab)} role="tab" class:tab-active={isActiveTab} class="tab grow flex-1 basis-1/2">
+    <button onclick={() => handleTabChange(tab)} role="tab" class:tab-active={isActiveTab} class="tab grow flex-1 basis-1/2">
       <h2 class="text-lg flex gap-4 items-center">
         {$t(DEFAULT_TAB_I18N[tab])}
         {#if tab === 'projects'}
@@ -48,6 +57,6 @@
         {/if}
       </h2>
     </button>
-    <div class="tab tab-divider" />
+    <div class="tab tab-divider"></div>
   {/each}
 </div>

--- a/frontend/src/routes/(authenticated)/org/create/+page.ts
+++ b/frontend/src/routes/(authenticated)/org/create/+page.ts
@@ -1,4 +1,4 @@
-﻿import {getClient, graphql} from '$lib/gql';
+import {getClient, graphql} from '$lib/gql';
 import type {CreateOrganizationInput, CreateOrgMutation} from '$lib/gql/generated/graphql';
 import type {$OpResult} from '$lib/gql/types';
 

--- a/frontend/src/routes/(authenticated)/org/list/+page.svelte
+++ b/frontend/src/routes/(authenticated)/org/list/+page.svelte
@@ -1,4 +1,6 @@
 <script lang="ts">
+  import { run } from 'svelte/legacy';
+
   import { FilterBar } from '$lib/components/FilterBar';
   import type { OrgListPageQuery } from '$lib/gql/types';
   import t, { date, number } from '$lib/i18n';
@@ -10,9 +12,13 @@
   import type { OrgListSearchParams } from './+page';
   import orderBy from 'just-order-by';
 
-  export let data: PageData;
-  $: orgs = data.orgs;
-  $: myOrgsMap = data.myOrgsMap;
+  interface Props {
+    data: PageData;
+  }
+
+  let { data }: Props = $props();
+  let orgs = $derived(data.orgs);
+  let myOrgsMap = $derived(data.myOrgsMap);
 
   const queryParams = getSearchParams<OrgListSearchParams>({
     search: queryParam.string<string>(''),
@@ -23,9 +29,9 @@
   type Org = OrgList[number];
 
   type Column = keyof Pick<Org, 'name' | 'memberCount' | 'createdDate'>;
-  let sortColumn: Column = 'name';
+  let sortColumn: Column = $state('name');
   type Dir = 'asc' | 'desc';
-  let sortDir: Dir = 'asc';
+  let sortDir: Dir = $state('asc');
 
   function swapSortDir(): void {
     sortDir = sortDir === 'asc' ? 'desc' : 'asc';
@@ -58,13 +64,13 @@
     ]);
   }
 
-  $: filteredOrgs = $orgs ? filterOrgs($orgs, $queryParamValues.search) : [];
-  $: displayOrgs = sortOrgs(filteredOrgs, sortColumn, sortDir);
-  $: filtering = filteredOrgs.length !== $orgs.length;
+  let filteredOrgs = $derived($orgs ? filterOrgs($orgs, $queryParamValues.search) : []);
+  let displayOrgs = $derived(sortOrgs(filteredOrgs, sortColumn, sortDir));
+  let filtering = $derived(filteredOrgs.length !== $orgs.length);
 
-  let myOrgs: OrgList = [];
-  let otherOrgs: OrgList = [];
-  $: {
+  let myOrgs: OrgList = $state([]);
+  let otherOrgs: OrgList = $state([]);
+  run(() => {
     myOrgs = [];
     otherOrgs = [];
     displayOrgs.forEach(org => {
@@ -74,7 +80,7 @@
         otherOrgs.push(org);
       }
     });
-  }
+  });
 </script>
 
 <!--
@@ -85,41 +91,47 @@ TODO:
 -->
 
 <HeaderPage wide titleText={$t('org.table.title')}>
-  <svelte:fragment slot="actions">
-    <AdminContent>
-      <a href="/org/create" class="btn btn-success">
-        {$t('org.create.title')}
-        <span class="i-mdi-plus text-2xl" />
-      </a>
-    </AdminContent>
-  </svelte:fragment>
-  <svelte:fragment slot="title">
-    {$t('org.table.title')}
-    <Icon icon="i-mdi-account-group-outline" size="text-5xl" y="10%" />
-  </svelte:fragment>
-  <svelte:fragment slot="headerContent">
-    <FilterBar
-      searchKey="search"
-      filterKeys={['search']}
-      filters={queryParamValues}
-      filterDefaults={defaultQueryParamValues}
-    />
-  </svelte:fragment>
+  {#snippet actions()}
+  
+      <AdminContent>
+        <a href="/org/create" class="btn btn-success">
+          {$t('org.create.title')}
+          <span class="i-mdi-plus text-2xl"></span>
+        </a>
+      </AdminContent>
+    
+  {/snippet}
+  {#snippet title()}
+  
+      {$t('org.table.title')}
+      <Icon icon="i-mdi-account-group-outline" size="text-5xl" y="10%" />
+    
+  {/snippet}
+  {#snippet headerContent()}
+  
+      <FilterBar
+        searchKey="search"
+        filterKeys={['search']}
+        filters={queryParamValues}
+        filterDefaults={defaultQueryParamValues}
+      />
+    
+  {/snippet}
   <div class="overflow-x-auto @container scroll-shadow">
     <table class="table table-lg">
       <thead>
         <tr class="bg-base-200">
-          <th on:click={() => handleSortClick('name')} class="cursor-pointer hover:bg-base-300">
+          <th onclick={() => handleSortClick('name')} class="cursor-pointer hover:bg-base-300">
             {$t('org.table.name')}
-            <span class:invisible={sortColumn !== 'name'}  class="{`i-mdi-sort-${sortDir}ending`} text-xl align-[-5px] ml-2" />
+            <span class:invisible={sortColumn !== 'name'}  class="{`i-mdi-sort-${sortDir}ending`} text-xl align-[-5px] ml-2"></span>
           </th>
-          <th on:click={() => handleSortClick('memberCount')} class="cursor-pointer hover:bg-base-300 hidden @md:table-cell">
+          <th onclick={() => handleSortClick('memberCount')} class="cursor-pointer hover:bg-base-300 hidden @md:table-cell">
             {$t('org.table.members')}
-            <span class:invisible={sortColumn !== 'memberCount'} class="{`i-mdi-sort-${sortDir}ending`} text-xl align-[-5px] ml-2" />
+            <span class:invisible={sortColumn !== 'memberCount'} class="{`i-mdi-sort-${sortDir}ending`} text-xl align-[-5px] ml-2"></span>
           </th>
-          <th on:click={() => handleSortClick('createdDate')} class="cursor-pointer hover:bg-base-300 hidden @xl:table-cell">
+          <th onclick={() => handleSortClick('createdDate')} class="cursor-pointer hover:bg-base-300 hidden @xl:table-cell">
             {$t('org.table.created_at')}
-            <span class:invisible={sortColumn !== 'createdDate'}  class="{`i-mdi-sort-${sortDir}ending`} text-xl align-[-5px] ml-2" />
+            <span class:invisible={sortColumn !== 'createdDate'}  class="{`i-mdi-sort-${sortDir}ending`} text-xl align-[-5px] ml-2"></span>
           </th>
         </tr>
       </thead>

--- a/frontend/src/routes/(authenticated)/project/[project_code]/+page.svelte
+++ b/frontend/src/routes/(authenticated)/project/[project_code]/+page.svelte
@@ -26,22 +26,22 @@
   import BulkAddProjectMembers from './BulkAddProjectMembers.svelte';
   import { CircleArrowIcon, TrashIcon } from '$lib/icons';
   import { useNotifications } from '$lib/notify';
-  import {DialogResponse, Modal} from '$lib/components/modals';
+  import { DialogResponse, Modal } from '$lib/components/modals';
   import { Button, type ErrorMessage } from '$lib/forms';
   import ResetProjectModal from './ResetProjectModal.svelte';
   import Dropdown from '$lib/components/Dropdown.svelte';
   import ConfirmDeleteModal from '$lib/components/modals/ConfirmDeleteModal.svelte';
-  import {_deleteProject} from '$lib/gql/mutations';
+  import { _deleteProject } from '$lib/gql/mutations';
   import { goto } from '$app/navigation';
   import MoreSettings from '$lib/components/MoreSettings.svelte';
-  import {AdminContent, FeatureFlagContent, PageBreadcrumb} from '$lib/layout';
+  import { AdminContent, FeatureFlagContent, PageBreadcrumb } from '$lib/layout';
   import Markdown from 'svelte-exmarkdown';
   import { OrgRole, ProjectRole, ProjectType, ResetStatus, RetentionPolicy } from '$lib/gql/generated/graphql';
   import Icon from '$lib/icons/Icon.svelte';
   import OpenInFlexModal from './OpenInFlexModal.svelte';
   import OpenInFlexButton from './OpenInFlexButton.svelte';
   import SendReceiveUrlField from './SendReceiveUrlField.svelte';
-  import {isDev} from '$lib/layout/DevContent.svelte';
+  import { isDev } from '$lib/layout/DevContent.svelte';
   import UserModal from '$lib/components/Users/UserModal.svelte';
   import IconButton from '$lib/components/IconButton.svelte';
   import ConfirmModal from '$lib/components/modals/ConfirmModal.svelte';
@@ -58,8 +58,8 @@
   import { getSearchParamValues } from '$lib/util/query-params';
   import FlexModelVersionText from '$lib/components/Projects/FlexModelVersionText.svelte';
   import CrdtSyncButton from './CrdtSyncButton.svelte';
-  import {_askToJoinProject} from '../create/+page'; // TODO: Should we duplicate this function in the project_code/+page.ts file, rather than importing it from elsewhere?
-  import {Duration} from '$lib/util/time';
+  import { _askToJoinProject } from '../create/+page'; // TODO: Should we duplicate this function in the project_code/+page.ts file, rather than importing it from elsewhere?
+  import { Duration } from '$lib/util/time';
 
   interface Props {
     data: PageData;
@@ -76,14 +76,16 @@
   });
   // TODO: Once we've stabilized the lastCommit issue with project reset, get rid of the next line
   run(() => {
-    if (! $changesetStore.fetching) isEmpty = $changesetStore.changesets.length === 0;
+    if (!$changesetStore.fetching) isEmpty = $changesetStore.changesets.length === 0;
   });
-  let members = $derived(project.users.sort((a, b) => {
-    if (a.role !== b.role) {
-      return a.role === ProjectRole.Manager ? -1 : 1;
-    }
-    return a.user.name.localeCompare(b.user.name);
-  }));
+  let members = $derived(
+    project.users.sort((a, b) => {
+      if (a.role !== b.role) {
+        return a.role === ProjectRole.Manager ? -1 : 1;
+      }
+      return a.user.name.localeCompare(b.user.name);
+    }),
+  );
 
   let lexEntryCount = $derived(project.flexProjectMetadata?.lexEntryCount);
   let flexModelVersion = $derived(project.flexProjectMetadata?.flexModelVersion);
@@ -97,7 +99,8 @@
     addUserName: string;
   };
 
-  onMount(() => { // query params not available during SSR
+  onMount(() => {
+    // query params not available during SSR
     const urlValues = getSearchParamValues<ProjectPageQueryParams>();
     if (urlValues.addUserId && urlValues.addUserName && addProjectMember) {
       void addProjectMember.openModal(urlValues.addUserId, urlValues.addUserName);
@@ -108,9 +111,9 @@
     }
   });
 
-  let addProjectMember: AddProjectMember = $state();
+  let addProjectMember: AddProjectMember = $state()!;
 
-  let userModal: UserModal = $state();
+  let userModal: UserModal = $state()!;
 
   let loadingRepoSize = $state(false);
   async function updateRepoSize(): Promise<void> {
@@ -120,7 +123,7 @@
   }
 
   function sizeStrInMb(sizeInKb: number): string {
-    return `${$number(sizeInKb / 1024, {maximumFractionDigits: 1})} MB`;
+    return `${$number(sizeInKb / 1024, { maximumFractionDigits: 1 })} MB`;
   }
 
   let loadingEntryCount = $state(false);
@@ -144,28 +147,28 @@
     loadingLanguageList = false;
   }
 
-  let orgRoles = $derived(project.organizations
-    ?.map((o) => user.orgs?.find((org) => org.orgId === o.id)?.role)
-    .filter(r => !!r) ?? []);
+  let orgRoles = $derived(
+    project.organizations?.map((o) => user.orgs?.find((org) => org.orgId === o.id)?.role).filter((r) => !!r) ?? [],
+  );
   let projectRole = $derived(project?.users.find((u) => u.user.id == user.id)?.role);
 
   // Mirrors PermissionService.CanViewProjectMembers() in C#
-  let canViewOtherMembers = $derived(user.isAdmin
-    || projectRole == ProjectRole.Manager
-    || projectRole && !project.isConfidential // public by default for members (non-members shouldn't even be here)
-    || orgRoles.some(role => role === OrgRole.Admin));
+  let canViewOtherMembers = $derived(
+    user.isAdmin ||
+      projectRole == ProjectRole.Manager ||
+      (projectRole && !project.isConfidential) || // public by default for members (non-members shouldn't even be here)
+      orgRoles.some((role) => role === OrgRole.Admin),
+  );
 
   // Almost mirrors PermissionService.CanAskToJoinProject() in C#, but admins won't be shown the "ask to join" button
-  let canAskToJoinProject = $derived(!user.isAdmin
-    && !projectRole
-    && orgRoles.some((_) => true));
+  let canAskToJoinProject = $derived(!user.isAdmin && !projectRole && orgRoles.some((_) => true));
 
-  let resetProjectModal: ResetProjectModal = $state();
+  let resetProjectModal: ResetProjectModal = $state()!;
   async function resetProject(): Promise<void> {
     await resetProjectModal.open(project.code, project.resetStatus);
   }
 
-  let removeUserModal: DeleteModal = $state();
+  let removeUserModal: DeleteModal = $state()!;
   let userToDelete: ProjectUser | undefined = $state();
   async function deleteProjectUser(projectUser: ProjectUser): Promise<void> {
     userToDelete = projectUser;
@@ -178,8 +181,8 @@
     }
   }
 
-  let removeProjectFromOrgModal: DeleteModal = $state();
-  let orgToRemove: string = $state();
+  let removeProjectFromOrgModal: DeleteModal = $state()!;
+  let orgToRemove: string = $state('');
   async function removeProjectFromOrg(orgId: string, orgName: string): Promise<void> {
     orgToRemove = orgName;
     const removed = await removeProjectFromOrgModal.prompt(async () => {
@@ -187,7 +190,7 @@
       return error?.message;
     });
     if (removed) {
-      notifyWarning($t('project_page.notifications.remove_project_from_org', {orgName: orgToRemove}));
+      notifyWarning($t('project_page.notifications.remove_project_from_org', { orgName: orgToRemove }));
     }
   }
 
@@ -211,12 +214,16 @@
   }
 
   let userId = $derived(user.id);
-  let orgsManagedByUser = $derived(user.orgs.filter(o => o.role === OrgRole.Admin).map(o => o.orgId));
-  let canManage = $derived(user.isAdmin || project?.users.find((u) => u.user.id == userId)?.role == ProjectRole.Manager || !!project?.organizations?.find((o) => orgsManagedByUser.includes(o.id)));
+  let orgsManagedByUser = $derived(user.orgs.filter((o) => o.role === OrgRole.Admin).map((o) => o.orgId));
+  let canManage = $derived(
+    user.isAdmin ||
+      project?.users.find((u) => u.user.id == userId)?.role == ProjectRole.Manager ||
+      !!project?.organizations?.find((o) => orgsManagedByUser.includes(o.id)),
+  );
 
   const projectNameValidation = z.string().trim().min(1, $t('project_page.project_name_empty_error'));
 
-  let deleteProjectModal: ConfirmDeleteModal = $state();
+  let deleteProjectModal: ConfirmDeleteModal = $state()!;
 
   async function softDeleteProject(): Promise<void> {
     projectStore.pause();
@@ -264,17 +271,17 @@
     let done = false;
     let value;
     while (!done) {
-      ({done, value} = await reader.read());
+      ({ done, value } = await reader.read());
       // The {stream: true} is important here; without it, in theory the output could be
       // broken in the middle of a UTF-8 byte sequence and get garbled. But with stream: true,
       // TextDecoder() will know to expect more output, so if the stream returns a partial
       // UTF-8 sequence, TextDecoder() will return everything except that sequence and wait
       // for more bytes before decoding that sequence.
-      if (value) hgCommandResponse += decoder.decode(value, {stream: true});
+      if (value) hgCommandResponse += decoder.decode(value, { stream: true });
     }
   }
 
-  async function hgCommand(execute: ()=> Promise<Response>): Promise<void> {
+  async function hgCommand(execute: () => Promise<Response>): Promise<void> {
     hgCommandResponse = '';
     void hgCommandResultModal.openModal(true, true);
     let response = await execute();
@@ -317,7 +324,7 @@
         }
       });
       if (left) {
-        notifySuccess($t('project_page.leave.leave_success', {projectName: project.name}))
+        notifySuccess($t('project_page.leave.leave_success', { projectName: project.name }));
         await goto(data.home);
       }
     } finally {
@@ -335,242 +342,247 @@
 {#if project}
   <DetailsPage wide titleText={project.name}>
     {#snippet actions()}
-      
-        {#if project.isLanguageForgeProject}
-          <a href="./{project.code}/viewer" target="_blank"
-             class="btn btn-neutral text-[#DCA54C] flex items-center gap-2">
-            {$t('project_page.open_with_viewer')}
-            <span class="i-mdi-dictionary text-2xl"></span>
-          </a>
-        {/if}
-        {#if project.type === ProjectType.FlEx}
-          <FeatureFlagContent flag="FwLiteBeta">
-            <CrdtSyncButton {project} {isEmpty} />
-          </FeatureFlagContent>
-        {/if}
-        {#if project.type === ProjectType.FlEx && $isDev && !isEmpty}
-          <OpenInFlexModal bind:this={openInFlexModal} {project}/>
-          <OpenInFlexButton projectId={project.id} on:click={openInFlexModal.open}/>
-        {:else if canAskToJoinProject}
-          <Button
-            variant="btn-primary"
-            loading={askLoading}
-            on:click={() => askToJoinProject(project.id, project.name)}
-          >
-            {#if !askLoading}
-              <span class="i-mdi-email text-2xl"></span>
-            {/if}
-            {$t('project_page.join_project.label')}
-          </Button>
-        {:else}
-          <Dropdown>
-            <button class="btn btn-primary">
-              {$t('project_page.get_project.label', {isEmpty: isEmpty.toString()})}
-              <span class="i-mdi-dots-vertical text-2xl"></span>
-            </button>
-            {#snippet content()}
-                        <div  class="card w-[calc(100vw-1rem)] sm:max-w-[35rem]">
-                <div class="card-body max-sm:p-4">
-                  <div class="prose">
-                    <h3>{$t('project_page.get_project.instructions_header', {type: project.type, mode: 'normal', isEmpty: isEmpty.toString()})}</h3>
-                    {#if project.type === ProjectType.WeSay}
-                      {#if isEmpty}
-                        <Markdown
-                            md={$t('project_page.get_project.instructions_wesay_empty', {
-                            code: project.code,
-                            login: encodeURIComponent(user.emailOrUsername),
-                            name: project.name,
-                          })}
-                        />
-                      {:else}
-                        <Markdown
-                            md={$t('project_page.get_project.instructions_wesay', {
-                            code: project.code,
-                            login: encodeURIComponent(user.emailOrUsername),
-                            name: project.name,
-                          })}
-                        />
-                      {/if}
+      {#if project.isLanguageForgeProject}
+        <a
+          href="./{project.code}/viewer"
+          target="_blank"
+          class="btn btn-neutral text-[#DCA54C] flex items-center gap-2"
+        >
+          {$t('project_page.open_with_viewer')}
+          <span class="i-mdi-dictionary text-2xl"></span>
+        </a>
+      {/if}
+      {#if project.type === ProjectType.FlEx}
+        <FeatureFlagContent flag="FwLiteBeta">
+          <CrdtSyncButton {project} {isEmpty} />
+        </FeatureFlagContent>
+      {/if}
+      {#if project.type === ProjectType.FlEx && $isDev && !isEmpty}
+        <OpenInFlexModal bind:this={openInFlexModal} {project} />
+        <OpenInFlexButton projectId={project.id} on:click={openInFlexModal.open} />
+      {:else if canAskToJoinProject}
+        <Button variant="btn-primary" loading={askLoading} on:click={() => askToJoinProject(project.id, project.name)}>
+          {#if !askLoading}
+            <span class="i-mdi-email text-2xl"></span>
+          {/if}
+          {$t('project_page.join_project.label')}
+        </Button>
+      {:else}
+        <Dropdown>
+          <button class="btn btn-primary">
+            {$t('project_page.get_project.label', { isEmpty: isEmpty.toString() })}
+            <span class="i-mdi-dots-vertical text-2xl"></span>
+          </button>
+          {#snippet content()}
+            <div class="card w-[calc(100vw-1rem)] sm:max-w-[35rem]">
+              <div class="card-body max-sm:p-4">
+                <div class="prose">
+                  <h3>
+                    {$t('project_page.get_project.instructions_header', {
+                      type: project.type,
+                      mode: 'normal',
+                      isEmpty: isEmpty.toString(),
+                    })}
+                  </h3>
+                  {#if project.type === ProjectType.WeSay}
+                    {#if isEmpty}
+                      <Markdown
+                        md={$t('project_page.get_project.instructions_wesay_empty', {
+                          code: project.code,
+                          login: encodeURIComponent(user.emailOrUsername),
+                          name: project.name,
+                        })}
+                      />
                     {:else}
-                      {#if isEmpty}
                       <Markdown
-                        md={$t('project_page.get_project.instructions_flex_empty', {
-                        code: project.code,
-                        login: user.emailOrUsername,
-                        name: project.name,
-                      })}
+                        md={$t('project_page.get_project.instructions_wesay', {
+                          code: project.code,
+                          login: encodeURIComponent(user.emailOrUsername),
+                          name: project.name,
+                        })}
                       />
-                      {:else}
-                      <Markdown
-                        md={$t('project_page.get_project.instructions_flex', {
-                        code: project.code,
-                        login: user.emailOrUsername,
-                        name: project.name,
-                      })}
-                      />
-                      {/if}
                     {/if}
-                  </div>
-                  <SendReceiveUrlField projectCode={project.code} />
+                  {:else if isEmpty}
+                    <Markdown
+                      md={$t('project_page.get_project.instructions_flex_empty', {
+                        code: project.code,
+                        login: user.emailOrUsername,
+                        name: project.name,
+                      })}
+                    />
+                  {:else}
+                    <Markdown
+                      md={$t('project_page.get_project.instructions_flex', {
+                        code: project.code,
+                        login: user.emailOrUsername,
+                        name: project.name,
+                      })}
+                    />
+                  {/if}
                 </div>
+                <SendReceiveUrlField projectCode={project.code} />
               </div>
-                      {/snippet}
-          </Dropdown>
-        {/if}
-      
-      {/snippet}
+            </div>
+          {/snippet}
+        </Dropdown>
+      {/if}
+    {/snippet}
     {#snippet title()}
-      
-        <div class="max-w-full flex items-baseline flex-wrap">
-          <span class="mr-2">{$t('project_page.project')}:</span>
-          <span class="text-primary max-w-full">
-            <EditableText
-              disabled={!canManage}
-              value={project.name}
-              validation={projectNameValidation}
-              saveHandler={updateProjectName}
-            />
-          </span>
-        </div>
-      
-      {/snippet}
-    {#snippet headerContent()}
-      
-        <BadgeList>
-          <ProjectConfidentialityBadge on:click={projectConfidentialityModal.openModal} {canManage} isConfidential={project.isConfidential ?? undefined} />
-          <ProjectTypeBadge type={project.type} />
-          {#if project.retentionPolicy === RetentionPolicy.Unknown}
-            {#if canManage}
-              <AddPurpose projectId={project.id} />
-            {/if}
-          {:else}
-            <Badge>
-              <FormatRetentionPolicy policy={project.retentionPolicy} />
-            </Badge>
-          {/if}
-          {#if project.resetStatus === ResetStatus.InProgress}
-            <button
-              class:tooltip={user.isAdmin}
-              data-tip={$t('project_page.reset_project_modal.click_to_continue')}
-              disabled={!user.isAdmin}
-              onclick={resetProject}
-            >
-              <Badge variant="badge-warning">
-                {$t('project_page.reset_project_modal.reset_in_progress')}
-                <span class="i-mdi-warning text-xl mb-[-2px]"></span>
-              </Badge>
-            </button>
-          {/if}
-          {#if project.hasHarmonyCommits}
-            <Badge>
-              {$t('project_page.using_fw_lite')}
-            </Badge>
-          {/if}
-        </BadgeList>
-        <ProjectConfidentialityModal bind:this={projectConfidentialityModal} projectId={project.id} isConfidential={project.isConfidential ?? undefined} />
-      
-      {/snippet}
-    {#snippet details()}
-      
-        <DetailItem title={$t('project_page.project_code')} text={project.code} copyToClipboard={true} />
-        <DetailItem title={$t('project_page.created_at')} text={$date(project.createdDate)} />
-        <DetailItem title={$t('project_page.last_commit')} text={$date(project.lastCommit)} />
-        <DetailItem title={$t('project_page.repo_size')} loading={loadingRepoSize} text={sizeStrInMb(project.repoSizeInKb ?? 0)} />
-        {#if project.type === ProjectType.FlEx || project.type === ProjectType.WeSay}
-          <DetailItem title={$t('project_page.num_entries')} text={$number(lexEntryCount)}>
-            {#snippet extras()}
-                    <AdminContent >
-                <IconButton
-                  loading={loadingEntryCount}
-                  icon="i-mdi-refresh"
-                  size="btn-sm"
-                  variant="btn-ghost"
-                  outline={false}
-                  on:click={updateEntryCount}
-                />
-              </AdminContent>
-                  {/snippet}
-          </DetailItem>
-        {/if}
-        {#if project.type === ProjectType.FlEx}
-          <DetailItem title={$t('project_page.model_version')}>
-            <FlexModelVersionText modelVersion={flexModelVersion ?? 0} />
-            {#snippet extras()}
-                    <AdminContent >
-                <IconButton
-                  loading={loadingModelVersion}
-                  icon="i-mdi-refresh"
-                  size="btn-sm"
-                  variant="btn-ghost"
-                  outline={false}
-                  on:click={updateModelVersion}
-                />
-              </AdminContent>
-                  {/snippet}
-          </DetailItem>
-        {/if}
-        {#if project.type === ProjectType.FlEx}
-          <div class="space-y-2">
-            <DetailItem title={$t('project_page.vernacular_langs')} wrap>
-              <AdminContent>
-                <IconButton
-                  loading={loadingLanguageList}
-                  icon="i-mdi-refresh"
-                  size="btn-sm"
-                  variant="btn-ghost"
-                  outline={false}
-                  on:click={updateLanguageList}
-                />
-              </AdminContent>
-              <WritingSystemList writingSystems={vernacularLangTags} />
-            </DetailItem>
-            <DetailItem title={$t('project_page.analysis_langs')} wrap>
-              <AdminContent>
-                <IconButton
-                  loading={loadingLanguageList}
-                  icon="i-mdi-refresh"
-                  size="btn-sm"
-                  variant="btn-ghost"
-                  outline={false}
-                  on:click={updateLanguageList}
-                />
-              </AdminContent>
-              <WritingSystemList writingSystems={analysisLangTags} />
-            </DetailItem>
-          </div>
-        {/if}
-        <div>
-          <EditableDetailItem
-            title={$t('project_page.description')}
-            value={project.description}
+      <div class="max-w-full flex items-baseline flex-wrap">
+        <span class="mr-2">{$t('project_page.project')}:</span>
+        <span class="text-primary max-w-full">
+          <EditableText
             disabled={!canManage}
-            saveHandler={updateProjectDescription}
-            placeholder={$t('project_page.add_description')}
-            multiline
+            value={project.name}
+            validation={projectNameValidation}
+            saveHandler={updateProjectName}
           />
+        </span>
+      </div>
+    {/snippet}
+    {#snippet headerContent()}
+      <BadgeList>
+        <ProjectConfidentialityBadge
+          on:click={projectConfidentialityModal.openModal}
+          {canManage}
+          isConfidential={project.isConfidential ?? undefined}
+        />
+        <ProjectTypeBadge type={project.type} />
+        {#if project.retentionPolicy === RetentionPolicy.Unknown}
+          {#if canManage}
+            <AddPurpose projectId={project.id} />
+          {/if}
+        {:else}
+          <Badge>
+            <FormatRetentionPolicy policy={project.retentionPolicy} />
+          </Badge>
+        {/if}
+        {#if project.resetStatus === ResetStatus.InProgress}
+          <button
+            class:tooltip={user.isAdmin}
+            data-tip={$t('project_page.reset_project_modal.click_to_continue')}
+            disabled={!user.isAdmin}
+            onclick={resetProject}
+          >
+            <Badge variant="badge-warning">
+              {$t('project_page.reset_project_modal.reset_in_progress')}
+              <span class="i-mdi-warning text-xl mb-[-2px]"></span>
+            </Badge>
+          </button>
+        {/if}
+        {#if project.hasHarmonyCommits}
+          <Badge>
+            {$t('project_page.using_fw_lite')}
+          </Badge>
+        {/if}
+      </BadgeList>
+      <ProjectConfidentialityModal
+        bind:this={projectConfidentialityModal}
+        projectId={project.id}
+        isConfidential={project.isConfidential ?? undefined}
+      />
+    {/snippet}
+    {#snippet details()}
+      <DetailItem title={$t('project_page.project_code')} text={project.code} copyToClipboard={true} />
+      <DetailItem title={$t('project_page.created_at')} text={$date(project.createdDate)} />
+      <DetailItem title={$t('project_page.last_commit')} text={$date(project.lastCommit)} />
+      <DetailItem
+        title={$t('project_page.repo_size')}
+        loading={loadingRepoSize}
+        text={sizeStrInMb(project.repoSizeInKb ?? 0)}
+      />
+      {#if project.type === ProjectType.FlEx || project.type === ProjectType.WeSay}
+        <DetailItem title={$t('project_page.num_entries')} text={$number(lexEntryCount)}>
+          {#snippet extras()}
+            <AdminContent>
+              <IconButton
+                loading={loadingEntryCount}
+                icon="i-mdi-refresh"
+                size="btn-sm"
+                variant="btn-ghost"
+                outline={false}
+                on:click={updateEntryCount}
+              />
+            </AdminContent>
+          {/snippet}
+        </DetailItem>
+      {/if}
+      {#if project.type === ProjectType.FlEx}
+        <DetailItem title={$t('project_page.model_version')}>
+          <FlexModelVersionText modelVersion={flexModelVersion ?? 0} />
+          {#snippet extras()}
+            <AdminContent>
+              <IconButton
+                loading={loadingModelVersion}
+                icon="i-mdi-refresh"
+                size="btn-sm"
+                variant="btn-ghost"
+                outline={false}
+                on:click={updateModelVersion}
+              />
+            </AdminContent>
+          {/snippet}
+        </DetailItem>
+      {/if}
+      {#if project.type === ProjectType.FlEx}
+        <div class="space-y-2">
+          <DetailItem title={$t('project_page.vernacular_langs')} wrap>
+            <AdminContent>
+              <IconButton
+                loading={loadingLanguageList}
+                icon="i-mdi-refresh"
+                size="btn-sm"
+                variant="btn-ghost"
+                outline={false}
+                on:click={updateLanguageList}
+              />
+            </AdminContent>
+            <WritingSystemList writingSystems={vernacularLangTags} />
+          </DetailItem>
+          <DetailItem title={$t('project_page.analysis_langs')} wrap>
+            <AdminContent>
+              <IconButton
+                loading={loadingLanguageList}
+                icon="i-mdi-refresh"
+                size="btn-sm"
+                variant="btn-ghost"
+                outline={false}
+                on:click={updateLanguageList}
+              />
+            </AdminContent>
+            <WritingSystemList writingSystems={analysisLangTags} />
+          </DetailItem>
         </div>
-      
-      {/snippet}
+      {/if}
+      <div>
+        <EditableDetailItem
+          title={$t('project_page.description')}
+          value={project.description}
+          disabled={!canManage}
+          saveHandler={updateProjectDescription}
+          placeholder={$t('project_page.add_description')}
+          multiline
+        />
+      </div>
+    {/snippet}
 
     <div class="space-y-4">
       <OrgList
-        canManage={canManage}
+        {canManage}
         organizations={project.organizations}
         on:removeProjectFromOrg={(event) => removeProjectFromOrg(event.detail.orgId, event.detail.orgName)}
       >
         {#snippet extraButtons()}
-              
-            {#if canManage}
-              <AddOrganization projectId={project.id} userIsAdmin={user.isAdmin} />
-            {/if}
-          
-              {/snippet}
+          {#if canManage}
+            <AddOrganization projectId={project.id} userIsAdmin={user.isAdmin} />
+          {/if}
+        {/snippet}
         <DeleteModal
-            bind:this={removeProjectFromOrgModal}
-            entityName={$t('project_page.remove_project_from_org_title')}
-            isRemoveDialog
-          >
-          {$t('project_page.confirm_remove_org', {orgName: orgToRemove})}
+          bind:this={removeProjectFromOrgModal}
+          entityName={$t('project_page.remove_project_from_org_title')}
+          isRemoveDialog
+        >
+          {$t('project_page.confirm_remove_org', { orgName: orgToRemove })}
         </DeleteModal>
       </OrgList>
       <MembersList
@@ -581,28 +593,30 @@
         {canViewOtherMembers}
         on:openUserModal={(event) => userModal.open(event.detail.user)}
         on:deleteProjectUser={(event) => deleteProjectUser(event.detail)}
-        >
-          {#snippet extraButtons()}
-              
-              <BadgeButton variant="badge-success" icon="i-mdi-account-plus-outline" on:click={() => addProjectMember.openModal(undefined, undefined)}>
-                {$t('project_page.add_user.add_button')}
-              </BadgeButton>
-
-              <AddProjectMember bind:this={addProjectMember} {project} />
-              <BulkAddProjectMembers projectId={project.id} />
-            
-              {/snippet}
-          <UserModal bind:this={userModal}/>
-
-          <DeleteModal
-            bind:this={removeUserModal}
-            entityName={$t('project_page.remove_project_user_title')}
-            isRemoveDialog
+      >
+        {#snippet extraButtons()}
+          <BadgeButton
+            variant="badge-success"
+            icon="i-mdi-account-plus-outline"
+            on:click={() => addProjectMember.openModal(undefined, undefined)}
           >
-            {$t('project_page.confirm_remove', {
-              userName: userToDelete?.user.name ?? '',
-            })}
-          </DeleteModal>
+            {$t('project_page.add_user.add_button')}
+          </BadgeButton>
+
+          <AddProjectMember bind:this={addProjectMember} {project} />
+          <BulkAddProjectMembers projectId={project.id} />
+        {/snippet}
+        <UserModal bind:this={userModal} />
+
+        <DeleteModal
+          bind:this={removeUserModal}
+          entityName={$t('project_page.remove_project_user_title')}
+          isRemoveDialog
+        >
+          {$t('project_page.confirm_remove', {
+            userName: userToDelete?.user.name ?? '',
+          })}
+        </DeleteModal>
       </MembersList>
       <div class="divider"></div>
       <div class="space-y-2">
@@ -614,7 +628,11 @@
         </p>
 
         <div class="max-h-[75vh] overflow-auto border-b border-base-200">
-          <HgLogView logEntries={$changesetStore.changesets} loading={$changesetStore.fetching} projectCode={project.code} />
+          <HgLogView
+            logEntries={$changesetStore.changesets}
+            loading={$changesetStore.fetching}
+            projectCode={project.code}
+          />
         </div>
       </div>
 
@@ -625,23 +643,25 @@
           {#if canManage}
             <button class="btn btn-error" onclick={softDeleteProject}>
               {$t('delete_project_modal.submit')}
-              <TrashIcon/>
+              <TrashIcon />
             </button>
             <Button outline variant="btn-warning" on:click={projectConfidentialityModal.openModal}>
               {$t('project.confidential.set_confidentiality')}
-              <Icon icon="i-mdi-shield-lock-outline"/>
+              <Icon icon="i-mdi-shield-lock-outline" />
             </Button>
-            {/if}
+          {/if}
           <Button outline variant="btn-error" on:click={leaveProject}>
             {$t('project_page.leave.leave_project')}
-            <Icon icon="i-mdi-exit-run"/>
+            <Icon icon="i-mdi-exit-run" />
           </Button>
-          <ConfirmModal bind:this={leaveModal}
-                        title={$t('project_page.leave.confirm_title')}
-                        submitText={$t('project_page.leave.leave_action')}
-                        submitIcon="i-mdi-exit-run"
-                        submitVariant="btn-error"
-                        cancelText={$t('project_page.leave.dont_leave')}>
+          <ConfirmModal
+            bind:this={leaveModal}
+            title={$t('project_page.leave.confirm_title')}
+            submitText={$t('project_page.leave.leave_action')}
+            submitIcon="i-mdi-exit-run"
+            submitVariant="btn-error"
+            cancelText={$t('project_page.leave.dont_leave')}
+          >
             <p>{$t('project_page.leave.confirm_leave')}</p>
           </ConfirmModal>
         </div>
@@ -650,9 +670,9 @@
           <div class="flex gap-4 max-sm:flex-col-reverse">
             <button class="btn btn-accent" onclick={resetProject}>
               {$t('project_page.reset_project_modal.submit')}
-              <CircleArrowIcon/>
+              <CircleArrowIcon />
             </button>
-            <ResetProjectModal bind:this={resetProjectModal}/>
+            <ResetProjectModal bind:this={resetProjectModal} />
             <Modal bind:this={hgCommandResultModal} closeOnClickOutside={false}>
               <div class="card">
                 <div class="card-body overflow-auto">
@@ -667,13 +687,12 @@
                 </div>
               </div>
             </Modal>
-            <Button on:click={recover}>HG Recover</Button>
-            <Button on:click={verify}>HG Verify</Button>
+            <Button onclick={recover}>HG Recover</Button>
+            <Button onclick={verify}>HG Verify</Button>
           </div>
         </AdminContent>
-        <ConfirmDeleteModal bind:this={deleteProjectModal} i18nScope="delete_project_modal"/>
+        <ConfirmDeleteModal bind:this={deleteProjectModal} i18nScope="delete_project_modal" />
       </MoreSettings>
-
     </div>
   </DetailsPage>
 {/if}

--- a/frontend/src/routes/(authenticated)/project/[project_code]/+page.svelte
+++ b/frontend/src/routes/(authenticated)/project/[project_code]/+page.svelte
@@ -111,9 +111,9 @@
     }
   });
 
-  let addProjectMember: AddProjectMember = $state()!;
+  let addProjectMember: AddProjectMember | undefined = $state();
 
-  let userModal: UserModal = $state()!;
+  let userModal: UserModal | undefined = $state();
 
   let loadingRepoSize = $state(false);
   async function updateRepoSize(): Promise<void> {
@@ -163,14 +163,15 @@
   // Almost mirrors PermissionService.CanAskToJoinProject() in C#, but admins won't be shown the "ask to join" button
   let canAskToJoinProject = $derived(!user.isAdmin && !projectRole && orgRoles.some((_) => true));
 
-  let resetProjectModal: ResetProjectModal = $state()!;
+  let resetProjectModal: ResetProjectModal | undefined = $state();
   async function resetProject(): Promise<void> {
-    await resetProjectModal.open(project.code, project.resetStatus);
+    await resetProjectModal?.open(project.code, project.resetStatus);
   }
 
-  let removeUserModal: DeleteModal = $state()!;
+  let removeUserModal: DeleteModal | undefined = $state();
   let userToDelete: ProjectUser | undefined = $state();
   async function deleteProjectUser(projectUser: ProjectUser): Promise<void> {
+    if (!removeUserModal) return;
     userToDelete = projectUser;
     const deleted = await removeUserModal.prompt(async () => {
       const { error } = await _deleteProjectUser(project.id, projectUser.user.id);
@@ -181,9 +182,10 @@
     }
   }
 
-  let removeProjectFromOrgModal: DeleteModal = $state()!;
+  let removeProjectFromOrgModal: DeleteModal | undefined = $state();
   let orgToRemove: string = $state('');
   async function removeProjectFromOrg(orgId: string, orgName: string): Promise<void> {
+    if (!removeProjectFromOrgModal) return;
     orgToRemove = orgName;
     const removed = await removeProjectFromOrgModal.prompt(async () => {
       const { error } = await _removeProjectFromOrg(project.id, orgId);
@@ -223,9 +225,10 @@
 
   const projectNameValidation = z.string().trim().min(1, $t('project_page.project_name_empty_error'));
 
-  let deleteProjectModal: ConfirmDeleteModal = $state()!;
+  let deleteProjectModal: ConfirmDeleteModal | undefined = $state();
 
   async function softDeleteProject(): Promise<void> {
+    if (!deleteProjectModal) return;
     projectStore.pause();
     changesetStore.pause();
     let deleted = false;
@@ -247,7 +250,7 @@
     }
   }
 
-  let hgCommandResultModal: Modal = $state()!;
+  let hgCommandResultModal: Modal | undefined = $state();
   let hgCommandResponse = $state('');
   let hgCommandRunning = $state(false);
 
@@ -282,6 +285,7 @@
   }
 
   async function hgCommand(execute: () => Promise<Response>): Promise<void> {
+    if (!hgCommandResultModal) return;
     hgCommandResponse = '';
     void hgCommandResultModal.openModal(true, true);
     let response = await execute();
@@ -308,11 +312,12 @@
     }
   }
 
-  let projectConfidentialityModal: ProjectConfidentialityModal = $state()!;
-  let openInFlexModal: OpenInFlexModal = $state()!;
-  let leaveModal: ConfirmModal = $state()!;
+  let projectConfidentialityModal: ProjectConfidentialityModal | undefined = $state();
+  let openInFlexModal: OpenInFlexModal | undefined = $state();
+  let leaveModal: ConfirmModal | undefined = $state();
 
   async function leaveProject(): Promise<void> {
+    if (!leaveModal) return;
     projectStore.pause();
     changesetStore.pause();
     let left = false;
@@ -443,7 +448,7 @@
     {#snippet headerContent()}
       <BadgeList>
         <ProjectConfidentialityBadge
-          on:click={projectConfidentialityModal.openModal}
+          on:click={projectConfidentialityModal!.openModal}
           {canManage}
           isConfidential={project.isConfidential ?? undefined}
         />
@@ -591,14 +596,14 @@
         canManageMember={(member) => canManage && (member.user?.id !== userId || user.isAdmin)}
         canManageList={canManage}
         {canViewOtherMembers}
-        on:openUserModal={(event) => userModal.open(event.detail.user)}
+        on:openUserModal={(event) => userModal?.open(event.detail.user)}
         on:deleteProjectUser={(event) => deleteProjectUser(event.detail)}
       >
         {#snippet extraButtons()}
           <BadgeButton
             variant="badge-success"
             icon="i-mdi-account-plus-outline"
-            onclick={() => addProjectMember.openModal(undefined, undefined)}
+            onclick={() => addProjectMember?.openModal(undefined, undefined)}
           >
             {$t('project_page.add_user.add_button')}
           </BadgeButton>
@@ -645,7 +650,7 @@
               {$t('delete_project_modal.submit')}
               <TrashIcon />
             </button>
-            <Button outline variant="btn-warning" onclick={projectConfidentialityModal.openModal}>
+            <Button outline variant="btn-warning" onclick={projectConfidentialityModal!.openModal}>
               {$t('project.confidential.set_confidentiality')}
               <Icon icon="i-mdi-shield-lock-outline" />
             </Button>

--- a/frontend/src/routes/(authenticated)/project/[project_code]/+page.svelte
+++ b/frontend/src/routes/(authenticated)/project/[project_code]/+page.svelte
@@ -449,7 +449,7 @@
     {#snippet headerContent()}
       <BadgeList>
         <ProjectConfidentialityBadge
-          onclick={projectConfidentialityModal!.openModal}
+          onclick={projectConfidentialityModal?.openModal}
           {canManage}
           isConfidential={project.isConfidential ?? undefined}
         />
@@ -651,7 +651,7 @@
               {$t('delete_project_modal.submit')}
               <TrashIcon />
             </button>
-            <Button outline variant="btn-warning" onclick={projectConfidentialityModal!.openModal}>
+            <Button outline variant="btn-warning" onclick={projectConfidentialityModal?.openModal}>
               {$t('project.confidential.set_confidentiality')}
               <Icon icon="i-mdi-shield-lock-outline" />
             </Button>

--- a/frontend/src/routes/(authenticated)/project/[project_code]/+page.svelte
+++ b/frontend/src/routes/(authenticated)/project/[project_code]/+page.svelte
@@ -364,6 +364,7 @@
       {/if}
       {#if project.type === ProjectType.FlEx && $isDev && !isEmpty}
         <OpenInFlexModal bind:this={openInFlexModal} {project} />
+        <!-- TODO: Figure out how bubble('click') works in new Svelte 5 world, where `on:click` is now a type error: "Argument of type '"click"' is not assignable to parameter of type 'never'" -->
         <OpenInFlexButton projectId={project.id} on:click={openInFlexModal.open} />
       {:else if canAskToJoinProject}
         <Button variant="btn-primary" loading={askLoading} onclick={() => askToJoinProject(project.id, project.name)}>
@@ -448,7 +449,7 @@
     {#snippet headerContent()}
       <BadgeList>
         <ProjectConfidentialityBadge
-          on:click={projectConfidentialityModal!.openModal}
+          onclick={projectConfidentialityModal!.openModal}
           {canManage}
           isConfidential={project.isConfidential ?? undefined}
         />

--- a/frontend/src/routes/(authenticated)/project/[project_code]/+page.svelte
+++ b/frontend/src/routes/(authenticated)/project/[project_code]/+page.svelte
@@ -365,7 +365,7 @@
       {#if project.type === ProjectType.FlEx && $isDev && !isEmpty}
         <OpenInFlexModal bind:this={openInFlexModal} {project} />
         <!-- TODO: Figure out how bubble('click') works in new Svelte 5 world, where `on:click` is now a type error: "Argument of type '"click"' is not assignable to parameter of type 'never'" -->
-        <OpenInFlexButton projectId={project.id} on:click={openInFlexModal.open} />
+        <OpenInFlexButton projectId={project.id} onclick={openInFlexModal.open} />
       {:else if canAskToJoinProject}
         <Button variant="btn-primary" loading={askLoading} onclick={() => askToJoinProject(project.id, project.name)}>
           {#if !askLoading}

--- a/frontend/src/routes/(authenticated)/project/[project_code]/+page.svelte
+++ b/frontend/src/routes/(authenticated)/project/[project_code]/+page.svelte
@@ -247,7 +247,7 @@
     }
   }
 
-  let hgCommandResultModal: Modal = $state();
+  let hgCommandResultModal: Modal = $state()!;
   let hgCommandResponse = $state('');
   let hgCommandRunning = $state(false);
 
@@ -308,9 +308,9 @@
     }
   }
 
-  let projectConfidentialityModal: ProjectConfidentialityModal = $state();
-  let openInFlexModal: OpenInFlexModal = $state();
-  let leaveModal: ConfirmModal = $state();
+  let projectConfidentialityModal: ProjectConfidentialityModal = $state()!;
+  let openInFlexModal: OpenInFlexModal = $state()!;
+  let leaveModal: ConfirmModal = $state()!;
 
   async function leaveProject(): Promise<void> {
     projectStore.pause();
@@ -361,7 +361,7 @@
         <OpenInFlexModal bind:this={openInFlexModal} {project} />
         <OpenInFlexButton projectId={project.id} on:click={openInFlexModal.open} />
       {:else if canAskToJoinProject}
-        <Button variant="btn-primary" loading={askLoading} on:click={() => askToJoinProject(project.id, project.name)}>
+        <Button variant="btn-primary" loading={askLoading} onclick={() => askToJoinProject(project.id, project.name)}>
           {#if !askLoading}
             <span class="i-mdi-email text-2xl"></span>
           {/if}
@@ -501,7 +501,7 @@
                 size="btn-sm"
                 variant="btn-ghost"
                 outline={false}
-                on:click={updateEntryCount}
+                onclick={updateEntryCount}
               />
             </AdminContent>
           {/snippet}
@@ -518,7 +518,7 @@
                 size="btn-sm"
                 variant="btn-ghost"
                 outline={false}
-                on:click={updateModelVersion}
+                onclick={updateModelVersion}
               />
             </AdminContent>
           {/snippet}
@@ -534,7 +534,7 @@
                 size="btn-sm"
                 variant="btn-ghost"
                 outline={false}
-                on:click={updateLanguageList}
+                onclick={updateLanguageList}
               />
             </AdminContent>
             <WritingSystemList writingSystems={vernacularLangTags} />
@@ -547,7 +547,7 @@
                 size="btn-sm"
                 variant="btn-ghost"
                 outline={false}
-                on:click={updateLanguageList}
+                onclick={updateLanguageList}
               />
             </AdminContent>
             <WritingSystemList writingSystems={analysisLangTags} />
@@ -598,7 +598,7 @@
           <BadgeButton
             variant="badge-success"
             icon="i-mdi-account-plus-outline"
-            on:click={() => addProjectMember.openModal(undefined, undefined)}
+            onclick={() => addProjectMember.openModal(undefined, undefined)}
           >
             {$t('project_page.add_user.add_button')}
           </BadgeButton>
@@ -645,12 +645,12 @@
               {$t('delete_project_modal.submit')}
               <TrashIcon />
             </button>
-            <Button outline variant="btn-warning" on:click={projectConfidentialityModal.openModal}>
+            <Button outline variant="btn-warning" onclick={projectConfidentialityModal.openModal}>
               {$t('project.confidential.set_confidentiality')}
               <Icon icon="i-mdi-shield-lock-outline" />
             </Button>
           {/if}
-          <Button outline variant="btn-error" on:click={leaveProject}>
+          <Button outline variant="btn-error" onclick={leaveProject}>
             {$t('project_page.leave.leave_project')}
             <Icon icon="i-mdi-exit-run" />
           </Button>

--- a/frontend/src/routes/(authenticated)/project/[project_code]/AddOrganization.svelte
+++ b/frontend/src/routes/(authenticated)/project/[project_code]/AddOrganization.svelte
@@ -17,11 +17,11 @@
   let orgList: Org[] = $state([]);
 
   const schema = z.object({
-    orgId: z.string().trim()
+    orgId: z.string().trim(),
   });
 
   type Schema = typeof schema;
-  let formModal: FormModal<Schema> = $state();
+  let formModal: FormModal<Schema> = $state()!;
   let form = $derived(formModal?.form());
 
   async function openModal(): Promise<void> {
@@ -32,37 +32,31 @@
       const { error } = await _addProjectToOrg({
         projectId,
         orgId: $form.orgId,
-      })
+      });
       if (error?.byType('NotFoundError')) {
         if (error.message === 'Organization not found') return $t('project_page.add_org.org_not_found');
         if (error.message === 'Project not found') return $t('project_page.add_org.project_not_found');
       }
     });
   }
-
 </script>
 
-<BadgeButton variant="badge-success" icon="i-mdi-account-plus-outline" on:click={openModal}>
+<BadgeButton variant="badge-success" icon="i-mdi-account-plus-outline" onclick={openModal}>
   {$t('project_page.add_org.add_button')}
 </BadgeButton>
 
-<FormModal bind:this={formModal} {schema} >
+<FormModal bind:this={formModal} {schema}>
   {#snippet title()}
-    <span >{$t('project_page.add_org.modal_title')}</span>
+    <span>{$t('project_page.add_org.modal_title')}</span>
   {/snippet}
   {#snippet children({ errors })}
-    <Select
-      id="org"
-      label={$t('project_page.organization.title')}
-      bind:value={$form.orgId}
-      error={errors.orgId}
-    >
+    <Select id="org" label={$t('project_page.organization.title')} bind:value={$form.orgId} error={errors.orgId}>
       {#each orgList as org}
         <option value={org.id}>{org.name}</option>
       {/each}
     </Select>
-    {/snippet}
+  {/snippet}
   {#snippet submitText()}
-    <span >{$t('project_page.add_org.submit_button')}</span>
+    <span>{$t('project_page.add_org.submit_button')}</span>
   {/snippet}
 </FormModal>

--- a/frontend/src/routes/(authenticated)/project/[project_code]/AddOrganization.svelte
+++ b/frontend/src/routes/(authenticated)/project/[project_code]/AddOrganization.svelte
@@ -21,10 +21,12 @@
   });
 
   type Schema = typeof schema;
-  let formModal: FormModal<Schema> = $state()!;
+  // eslint-disable-next-line @typescript-eslint/no-redundant-type-constituents
+  let formModal: FormModal<Schema> | undefined = $state();
   let form = $derived(formModal?.form());
 
   async function openModal(): Promise<void> {
+    if (!formModal || !$form) return;
     orgList = await _getOrgs(userIsAdmin);
     const selected = orgList.length > 0 && orgList.length < 6 ? { orgId: orgList[0].id } : {};
 
@@ -50,7 +52,7 @@
     <span>{$t('project_page.add_org.modal_title')}</span>
   {/snippet}
   {#snippet children({ errors })}
-    <Select id="org" label={$t('project_page.organization.title')} bind:value={$form.orgId} error={errors.orgId}>
+    <Select id="org" label={$t('project_page.organization.title')} bind:value={$form!.orgId} error={errors.orgId}>
       {#each orgList as org}
         <option value={org.id}>{org.name}</option>
       {/each}

--- a/frontend/src/routes/(authenticated)/project/[project_code]/AddOrganization.svelte
+++ b/frontend/src/routes/(authenticated)/project/[project_code]/AddOrganization.svelte
@@ -8,17 +8,21 @@
   import { BadgeButton } from '$lib/components/Badges';
 
   type Org = Pick<Organization, 'id' | 'name'>;
-  export let projectId: string;
-  export let userIsAdmin: boolean;
-  let orgList: Org[] = [];
+  interface Props {
+    projectId: string;
+    userIsAdmin: boolean;
+  }
+
+  let { projectId, userIsAdmin }: Props = $props();
+  let orgList: Org[] = $state([]);
 
   const schema = z.object({
     orgId: z.string().trim()
   });
 
   type Schema = typeof schema;
-  let formModal: FormModal<Schema>;
-  $: form = formModal?.form();
+  let formModal: FormModal<Schema> = $state();
+  let form = $derived(formModal?.form());
 
   async function openModal(): Promise<void> {
     orgList = await _getOrgs(userIsAdmin);
@@ -42,17 +46,23 @@
   {$t('project_page.add_org.add_button')}
 </BadgeButton>
 
-<FormModal bind:this={formModal} {schema} let:errors>
-  <span slot="title">{$t('project_page.add_org.modal_title')}</span>
-  <Select
-    id="org"
-    label={$t('project_page.organization.title')}
-    bind:value={$form.orgId}
-    error={errors.orgId}
-  >
-    {#each orgList as org}
-      <option value={org.id}>{org.name}</option>
-    {/each}
-  </Select>
-  <span slot="submitText">{$t('project_page.add_org.submit_button')}</span>
+<FormModal bind:this={formModal} {schema} >
+  {#snippet title()}
+    <span >{$t('project_page.add_org.modal_title')}</span>
+  {/snippet}
+  {#snippet children({ errors })}
+    <Select
+      id="org"
+      label={$t('project_page.organization.title')}
+      bind:value={$form.orgId}
+      error={errors.orgId}
+    >
+      {#each orgList as org}
+        <option value={org.id}>{org.name}</option>
+      {/each}
+    </Select>
+    {/snippet}
+  {#snippet submitText()}
+    <span >{$t('project_page.add_org.submit_button')}</span>
+  {/snippet}
 </FormModal>

--- a/frontend/src/routes/(authenticated)/project/[project_code]/AddProjectMember.svelte
+++ b/frontend/src/routes/(authenticated)/project/[project_code]/AddProjectMember.svelte
@@ -11,7 +11,11 @@
   import { SupHelp, helpLinks } from '$lib/components/help';
   import Checkbox from '$lib/forms/Checkbox.svelte';
 
-  export let project: Project;
+  interface Props {
+    project: Project;
+  }
+
+  let { project }: Props = $props();
   const schema = z.object({
     usernameOrEmail: z.string().trim()
       .min(1, $t('project_page.add_user.empty_user_field'))
@@ -19,9 +23,9 @@
     role: z.enum([ProjectRole.Editor, ProjectRole.Manager]).default(ProjectRole.Editor),
     canInvite: z.boolean().default(false),
   });
-  let formModal: FormModal<typeof schema>;
-  $: form = formModal?.form();
-  let selectedUserId: string | undefined = undefined;
+  let formModal: FormModal<typeof schema> = $state();
+  let form = $derived(formModal?.form());
+  let selectedUserId: string | undefined = $state(undefined);
 
   const { notifySuccess } = useNotifications();
 
@@ -71,38 +75,46 @@
   }
 </script>
 
-<FormModal bind:this={formModal} {schema} let:errors --justify-actions="end">
-  <span slot="title">
-    {$t('project_page.add_user.modal_title')}
-    <SupHelp helpLink={helpLinks.addProjectMember} />
-  </span>
-  <UserTypeahead
-    id="usernameOrEmail"
-    isAdmin={$page.data.user?.isAdmin}
-    label={$t('login.label_email')}
-    bind:value={$form.usernameOrEmail}
-    error={errors.usernameOrEmail}
-    autofocus
-    on:selectedUserChange={({ detail }) => {
-        selectedUserId = detail?.id;
-    }}
-    exclude={project.users.map(m => m.user.id)}
-  />
-  <ProjectRoleSelect bind:value={$form.role} error={errors.role} />
-  <svelte:fragment slot="extraActions">
-    <Checkbox
-      id="invite"
-      label={$t('project_page.add_user.invite_checkbox')}
-      variant="checkbox-warning"
-      labelColor="text-warning"
-      bind:value={$form.canInvite}
+<FormModal bind:this={formModal} {schema}  --justify-actions="end">
+  {#snippet title()}
+    <span >
+      {$t('project_page.add_user.modal_title')}
+      <SupHelp helpLink={helpLinks.addProjectMember} />
+    </span>
+  {/snippet}
+  {#snippet children({ errors })}
+    <UserTypeahead
+      id="usernameOrEmail"
+      isAdmin={$page.data.user?.isAdmin}
+      label={$t('login.label_email')}
+      bind:value={$form.usernameOrEmail}
+      error={errors.usernameOrEmail}
+      autofocus
+      on:selectedUserChange={({ detail }) => {
+          selectedUserId = detail?.id;
+      }}
+      exclude={project.users.map(m => m.user.id)}
     />
-  </svelte:fragment>
-  <span slot="submitText">
-    {#if $form.canInvite && $form.usernameOrEmail.includes('@')}
-      {$t('project_page.add_user.submit_button_invite')}
-    {:else}
-      {$t('project_page.add_user.submit_button')}
-    {/if}
-  </span>
+    <ProjectRoleSelect bind:value={$form.role} error={errors.role} />
+    {/snippet}
+  {#snippet extraActions()}
+  
+      <Checkbox
+        id="invite"
+        label={$t('project_page.add_user.invite_checkbox')}
+        variant="checkbox-warning"
+        labelColor="text-warning"
+        bind:value={$form.canInvite}
+      />
+    
+  {/snippet}
+  {#snippet submitText()}
+    <span >
+      {#if $form.canInvite && $form.usernameOrEmail.includes('@')}
+        {$t('project_page.add_user.submit_button_invite')}
+      {:else}
+        {$t('project_page.add_user.submit_button')}
+      {/if}
+    </span>
+  {/snippet}
 </FormModal>

--- a/frontend/src/routes/(authenticated)/project/[project_code]/AddProjectMember.svelte
+++ b/frontend/src/routes/(authenticated)/project/[project_code]/AddProjectMember.svelte
@@ -25,13 +25,15 @@
     role: z.enum([ProjectRole.Editor, ProjectRole.Manager]).default(ProjectRole.Editor),
     canInvite: z.boolean().default(false),
   });
-  let formModal: FormModal<typeof schema> = $state()!;
+  // eslint-disable-next-line @typescript-eslint/no-redundant-type-constituents
+  let formModal: FormModal<typeof schema> | undefined = $state();
   let form = $derived(formModal?.form());
   let selectedUserId: string | undefined = $state(undefined);
 
   const { notifySuccess } = useNotifications();
 
   export async function openModal(initialUserId?: string, initialUserName?: string): Promise<void> {
+    if (!formModal || !$form) return;
     let userInvited = false;
     const initialValue = initialUserName ? { usernameOrEmail: initialUserName } : undefined;
     if (initialUserId) selectedUserId = initialUserId;
@@ -89,7 +91,7 @@
       id="usernameOrEmail"
       isAdmin={$page.data.user?.isAdmin}
       label={$t('login.label_email')}
-      bind:value={$form.usernameOrEmail}
+      bind:value={$form!.usernameOrEmail}
       error={errors.usernameOrEmail}
       autofocus
       on:selectedUserChange={({ detail }) => {
@@ -97,7 +99,7 @@
       }}
       exclude={project.users.map((m) => m.user.id)}
     />
-    <ProjectRoleSelect bind:value={$form.role} error={errors.role} />
+    <ProjectRoleSelect bind:value={$form!.role} error={errors.role} />
   {/snippet}
   {#snippet extraActions()}
     <Checkbox
@@ -105,12 +107,12 @@
       label={$t('project_page.add_user.invite_checkbox')}
       variant="checkbox-warning"
       labelColor="text-warning"
-      bind:value={$form.canInvite}
+      bind:value={$form!.canInvite}
     />
   {/snippet}
   {#snippet submitText()}
     <span>
-      {#if $form.canInvite && $form.usernameOrEmail.includes('@')}
+      {#if $form!.canInvite && $form!.usernameOrEmail.includes('@')}
         {$t('project_page.add_user.submit_button_invite')}
       {:else}
         {$t('project_page.add_user.submit_button')}

--- a/frontend/src/routes/(authenticated)/project/[project_code]/AddProjectMember.svelte
+++ b/frontend/src/routes/(authenticated)/project/[project_code]/AddProjectMember.svelte
@@ -6,7 +6,7 @@
   import { z } from 'zod';
   import { _addProjectMember, type Project } from './+page';
   import { useNotifications } from '$lib/notify';
-  import { page } from '$app/stores'
+  import { page } from '$app/stores';
   import UserTypeahead from '$lib/forms/UserTypeahead.svelte';
   import { SupHelp, helpLinks } from '$lib/components/help';
   import Checkbox from '$lib/forms/Checkbox.svelte';
@@ -17,13 +17,15 @@
 
   let { project }: Props = $props();
   const schema = z.object({
-    usernameOrEmail: z.string().trim()
+    usernameOrEmail: z
+      .string()
+      .trim()
       .min(1, $t('project_page.add_user.empty_user_field'))
       .refine((value) => !value.includes('@') || isEmail(value), { message: $t('form.invalid_email') }),
     role: z.enum([ProjectRole.Editor, ProjectRole.Manager]).default(ProjectRole.Editor),
     canInvite: z.boolean().default(false),
   });
-  let formModal: FormModal<typeof schema> = $state();
+  let formModal: FormModal<typeof schema> = $state()!;
   let form = $derived(formModal?.form());
   let selectedUserId: string | undefined = $state(undefined);
 
@@ -75,9 +77,9 @@
   }
 </script>
 
-<FormModal bind:this={formModal} {schema}  --justify-actions="end">
+<FormModal bind:this={formModal} {schema} --justify-actions="end">
   {#snippet title()}
-    <span >
+    <span>
       {$t('project_page.add_user.modal_title')}
       <SupHelp helpLink={helpLinks.addProjectMember} />
     </span>
@@ -91,25 +93,23 @@
       error={errors.usernameOrEmail}
       autofocus
       on:selectedUserChange={({ detail }) => {
-          selectedUserId = detail?.id;
+        selectedUserId = detail?.id;
       }}
-      exclude={project.users.map(m => m.user.id)}
+      exclude={project.users.map((m) => m.user.id)}
     />
     <ProjectRoleSelect bind:value={$form.role} error={errors.role} />
-    {/snippet}
+  {/snippet}
   {#snippet extraActions()}
-  
-      <Checkbox
-        id="invite"
-        label={$t('project_page.add_user.invite_checkbox')}
-        variant="checkbox-warning"
-        labelColor="text-warning"
-        bind:value={$form.canInvite}
-      />
-    
+    <Checkbox
+      id="invite"
+      label={$t('project_page.add_user.invite_checkbox')}
+      variant="checkbox-warning"
+      labelColor="text-warning"
+      bind:value={$form.canInvite}
+    />
   {/snippet}
   {#snippet submitText()}
-    <span >
+    <span>
       {#if $form.canInvite && $form.usernameOrEmail.includes('@')}
         {$t('project_page.add_user.submit_button_invite')}
       {:else}

--- a/frontend/src/routes/(authenticated)/project/[project_code]/AddPurpose.svelte
+++ b/frontend/src/routes/(authenticated)/project/[project_code]/AddPurpose.svelte
@@ -9,15 +9,19 @@
   import { _setRetentionPolicy } from './+page';
   import { DialogResponse, FormModal } from '$lib/components/modals';
 
-  export let projectId: string;
+  interface Props {
+    projectId: string;
+  }
+
+  let { projectId }: Props = $props();
 
   const schema = z.object({
     retentionPolicy: z.nativeEnum(RetentionPolicy).default(RetentionPolicy.Training)
   });
 
   type Schema = typeof schema;
-  let formModal: FormModal<Schema>;
-  $: form = formModal?.form();
+  let formModal: FormModal<Schema> = $state();
+  let form = $derived(formModal?.form());
 
   const { notifySuccess } = useNotifications();
 
@@ -42,20 +46,26 @@
   {$t('project_page.add_purpose.add_button')}
 </BadgeButton>
 
-<FormModal bind:this={formModal} {schema} let:errors>
-  <span slot="title">{$t('project_page.add_purpose.modal_title')}</span>
-  <Select
-    id="policy"
-    label={$t('project.create.retention_policy')}
-    bind:value={$form.retentionPolicy}
-    error={errors.retentionPolicy}
-  >
-    <option value={RetentionPolicy.Verified}>{$t('retention_policy.language_project')}</option>
-    <option value={RetentionPolicy.Training}>{$t('retention_policy.training')}</option>
-    <option value={RetentionPolicy.Test}>{$t('retention_policy.test')}</option>
-    <AdminContent>
-      <option value={RetentionPolicy.Dev}>{$t('retention_policy.dev')}</option>
-    </AdminContent>
-  </Select>
-  <span slot="submitText">{'Add Purpose'}</span>
+<FormModal bind:this={formModal} {schema} >
+  {#snippet title()}
+    <span >{$t('project_page.add_purpose.modal_title')}</span>
+  {/snippet}
+  {#snippet children({ errors })}
+    <Select
+      id="policy"
+      label={$t('project.create.retention_policy')}
+      bind:value={$form.retentionPolicy}
+      error={errors.retentionPolicy}
+    >
+      <option value={RetentionPolicy.Verified}>{$t('retention_policy.language_project')}</option>
+      <option value={RetentionPolicy.Training}>{$t('retention_policy.training')}</option>
+      <option value={RetentionPolicy.Test}>{$t('retention_policy.test')}</option>
+      <AdminContent>
+        <option value={RetentionPolicy.Dev}>{$t('retention_policy.dev')}</option>
+      </AdminContent>
+    </Select>
+    {/snippet}
+  {#snippet submitText()}
+    <span >{'Add Purpose'}</span>
+  {/snippet}
 </FormModal>

--- a/frontend/src/routes/(authenticated)/project/[project_code]/AddPurpose.svelte
+++ b/frontend/src/routes/(authenticated)/project/[project_code]/AddPurpose.svelte
@@ -16,11 +16,11 @@
   let { projectId }: Props = $props();
 
   const schema = z.object({
-    retentionPolicy: z.nativeEnum(RetentionPolicy).default(RetentionPolicy.Training)
+    retentionPolicy: z.nativeEnum(RetentionPolicy).default(RetentionPolicy.Training),
   });
 
   type Schema = typeof schema;
-  let formModal: FormModal<Schema> = $state();
+  let formModal: FormModal<Schema> = $state()!;
   let form = $derived(formModal?.form());
 
   const { notifySuccess } = useNotifications();
@@ -30,25 +30,25 @@
       const { error } = await _setRetentionPolicy({
         projectId,
         retentionPolicy: $form.retentionPolicy,
-      })
+      });
       if (error?.byType('NotFoundError')) {
         if (error.message === 'Project not found') return $t('project_page.add_org.project_not_found');
       }
     });
 
     if (response === DialogResponse.Submit && formState.retentionPolicy.currentValue) {
-        notifySuccess($t('project_page.add_purpose.notify_success'));
+      notifySuccess($t('project_page.add_purpose.notify_success'));
     }
   }
 </script>
 
-<BadgeButton variant="badge-success" icon="i-mdi-plus" on:click={openModal}>
+<BadgeButton variant="badge-success" icon="i-mdi-plus" onclick={openModal}>
   {$t('project_page.add_purpose.add_button')}
 </BadgeButton>
 
-<FormModal bind:this={formModal} {schema} >
+<FormModal bind:this={formModal} {schema}>
   {#snippet title()}
-    <span >{$t('project_page.add_purpose.modal_title')}</span>
+    <span>{$t('project_page.add_purpose.modal_title')}</span>
   {/snippet}
   {#snippet children({ errors })}
     <Select
@@ -64,8 +64,8 @@
         <option value={RetentionPolicy.Dev}>{$t('retention_policy.dev')}</option>
       </AdminContent>
     </Select>
-    {/snippet}
+  {/snippet}
   {#snippet submitText()}
-    <span >{'Add Purpose'}</span>
+    <span>{'Add Purpose'}</span>
   {/snippet}
 </FormModal>

--- a/frontend/src/routes/(authenticated)/project/[project_code]/AddPurpose.svelte
+++ b/frontend/src/routes/(authenticated)/project/[project_code]/AddPurpose.svelte
@@ -20,12 +20,14 @@
   });
 
   type Schema = typeof schema;
-  let formModal: FormModal<Schema> = $state()!;
+  // eslint-disable-next-line @typescript-eslint/no-redundant-type-constituents
+  let formModal: FormModal<Schema> | undefined = $state();
   let form = $derived(formModal?.form());
 
   const { notifySuccess } = useNotifications();
 
   async function openModal(): Promise<void> {
+    if (!formModal || !$form) return;
     const { response, formState } = await formModal.open(async () => {
       const { error } = await _setRetentionPolicy({
         projectId,
@@ -54,7 +56,7 @@
     <Select
       id="policy"
       label={$t('project.create.retention_policy')}
-      bind:value={$form.retentionPolicy}
+      bind:value={$form!.retentionPolicy}
       error={errors.retentionPolicy}
     >
       <option value={RetentionPolicy.Verified}>{$t('retention_policy.language_project')}</option>

--- a/frontend/src/routes/(authenticated)/project/[project_code]/BulkAddProjectMembers.svelte
+++ b/frontend/src/routes/(authenticated)/project/[project_code]/BulkAddProjectMembers.svelte
@@ -15,6 +15,7 @@
   import { SupHelp, helpLinks } from '$lib/components/help';
   import { usernameRe } from '$lib/user';
 
+  // svelte-ignore non_reactive_update
   enum BulkAddSteps {
     Add,
     Results,
@@ -32,7 +33,8 @@
     password: passwordFormRules($t),
   });
 
-  let formModal: FormModal<typeof schema> = $state()!;
+  // eslint-disable-next-line @typescript-eslint/no-redundant-type-constituents
+  let formModal: FormModal<typeof schema> | undefined = $state();
   let form = $derived(formModal?.form());
 
   let addedMembers: BulkAddProjectMembersResult['addedMembers'] = $state([]);
@@ -54,6 +56,7 @@
   }
 
   async function openModal(): Promise<void> {
+    if (!formModal) return;
     currentStep = BulkAddSteps.Add;
     const { response } = await formModal.open(undefined, async (state) => {
       const passwordHash = await hash(state.password.currentValue);
@@ -114,16 +117,16 @@
           autocomplete="new-password"
           label={$t('project_page.bulk_add_members.shared_password')}
           description={$t('project_page.bulk_add_members.shared_password_description')}
-          bind:value={$form.password}
+          bind:value={$form!.password}
           error={errors.password}
         />
-        <PasswordStrengthMeter score={0} password={$form.password} />
+        <PasswordStrengthMeter score={0} password={$form!.password} />
         <div class="contents usernames">
           <TextArea
             id="usernamesText"
             label={$t('project_page.bulk_add_members.usernames')}
             description={$t('project_page.bulk_add_members.usernames_description')}
-            bind:value={$form.usernamesText}
+            bind:value={$form!.usernamesText}
             error={errors.usernamesText}
           />
         </div>

--- a/frontend/src/routes/(authenticated)/project/[project_code]/BulkAddProjectMembers.svelte
+++ b/frontend/src/routes/(authenticated)/project/[project_code]/BulkAddProjectMembers.svelte
@@ -120,7 +120,7 @@
           bind:value={$form!.password}
           error={errors.password}
         />
-        <PasswordStrengthMeter score={0} password={$form!.password} />
+        <PasswordStrengthMeter password={$form!.password} />
         <div class="contents usernames">
           <TextArea
             id="usernamesText"

--- a/frontend/src/routes/(authenticated)/project/[project_code]/BulkAddProjectMembers.svelte
+++ b/frontend/src/routes/(authenticated)/project/[project_code]/BulkAddProjectMembers.svelte
@@ -32,7 +32,7 @@
     password: passwordFormRules($t),
   });
 
-  let formModal: FormModal<typeof schema> = $state();
+  let formModal: FormModal<typeof schema> = $state()!;
   let form = $derived(formModal?.form());
 
   let addedMembers: BulkAddProjectMembersResult['addedMembers'] = $state([]);
@@ -45,7 +45,8 @@
 
     for (const username of usernames) {
       if (username.includes('@')) {
-        if (!isEmail(username)) return { usernamesText: [$t('project_page.bulk_add_members.invalid_email_address', { email: username })] };
+        if (!isEmail(username))
+          return { usernamesText: [$t('project_page.bulk_add_members.invalid_email_address', { email: username })] };
       } else if (!usernameRe.test(username)) {
         return { usernamesText: [$t('project_page.bulk_add_members.invalid_username', { username })] };
       }
@@ -59,9 +60,9 @@
       const usernames = state.usernamesText.currentValue
         .split('\n')
         // Remove whitespace
-        .map(s => s.trim())
+        .map((s) => s.trim())
         // Remove empty lines before validating, otherwise final newline would count as invalid because empty string
-        .filter(s => s)
+        .filter((s) => s)
         .filter(distinct);
 
       const bulkErrors = validateBulkAddInput(usernames);
@@ -77,7 +78,7 @@
       const invalidEmailError = error?.byType('InvalidEmailError');
       if (invalidEmailError) {
         const email = invalidEmailError[0].address!;
-        return { usernamesText: [$t('project_page.bulk_add_members.invalid_email_address', {email})] };
+        return { usernamesText: [$t('project_page.bulk_add_members.invalid_email_address', { email })] };
       }
 
       addedMembers = data?.bulkAddProjectMembers.bulkAddProjectMembersResult?.addedMembers ?? [];
@@ -93,19 +94,19 @@
 </script>
 
 <AdminContent>
-  <BadgeButton variant="badge-success" icon="i-mdi-account-multiple-plus-outline" on:click={openModal}>
+  <BadgeButton variant="badge-success" icon="i-mdi-account-multiple-plus-outline" onclick={openModal}>
     {$t('project_page.bulk_add_members.add_button')}
   </BadgeButton>
 
-  <FormModal bind:this={formModal} {schema}  showDoneState>
+  <FormModal bind:this={formModal} {schema} showDoneState>
     {#snippet title()}
-        <span >
+      <span>
         {$t('project_page.bulk_add_members.modal_title')}
         <SupHelp helpLink={helpLinks.bulkAddCreate} />
       </span>
-      {/snippet}
+    {/snippet}
     {#snippet children({ errors })}
-        {#if currentStep == BulkAddSteps.Add}
+      {#if currentStep == BulkAddSteps.Add}
         <p class="mb-2">{$t('project_page.bulk_add_members.explanation')}</p>
         <Input
           id="shared_password"
@@ -129,12 +130,12 @@
       {:else if currentStep == BulkAddSteps.Results}
         <p class="flex gap-1 items-center mb-4">
           <Icon icon="i-mdi-plus" color="text-success" />
-          {$t('project_page.bulk_add_members.members_added', {addedCount})}
+          {$t('project_page.bulk_add_members.members_added', { addedCount })}
         </p>
         <div class="mb-4 ml-8">
           <p class="flex gap-1 items-center">
             <Icon icon="i-mdi-account-outline" color="text-success" />
-            {$t('project_page.bulk_add_members.existing_added_members', {existedCount: addedMembers.length})}
+            {$t('project_page.bulk_add_members.existing_added_members', { existedCount: addedMembers.length })}
           </p>
           {#if addedMembers.length > 0}
             <div class="mt-2">
@@ -149,7 +150,7 @@
         <div class="mb-4 ml-8">
           <p class="flex gap-1 items-center">
             <Icon icon="i-mdi-creation-outline" color="text-success" />
-            {$t('project_page.bulk_add_members.accounts_created', {createdCount: createdMembers.length})}
+            {$t('project_page.bulk_add_members.accounts_created', { createdCount: createdMembers.length })}
           </p>
           {#if createdMembers.length > 0}
             <div class="mt-2">
@@ -164,7 +165,7 @@
         {#if existingMembers.length > 0}
           <p class="flex gap-1 items-center">
             <Icon icon="i-mdi-account-outline" color="text-info" />
-            {$t('project_page.bulk_add_members.already_members', {count: existingMembers.length})}
+            {$t('project_page.bulk_add_members.already_members', { count: existingMembers.length })}
           </p>
           <div class="mt-2">
             <BadgeList>
@@ -177,13 +178,13 @@
       {:else}
         <p>Internal error: unknown step {currentStep}</p>
       {/if}
-      {/snippet}
-      {#snippet submitText()}
-        <span >{$t('project_page.bulk_add_members.submit_button')}</span>
-      {/snippet}
+    {/snippet}
+    {#snippet submitText()}
+      <span>{$t('project_page.bulk_add_members.submit_button')}</span>
+    {/snippet}
     {#snippet doneText()}
-        <span >{$t('project_page.bulk_add_members.finish_button')}</span>
-      {/snippet}
+      <span>{$t('project_page.bulk_add_members.finish_button')}</span>
+    {/snippet}
   </FormModal>
 </AdminContent>
 

--- a/frontend/src/routes/(authenticated)/project/[project_code]/BulkAddProjectMembers.svelte
+++ b/frontend/src/routes/(authenticated)/project/[project_code]/BulkAddProjectMembers.svelte
@@ -120,7 +120,7 @@
           bind:value={$form!.password}
           error={errors.password}
         />
-        <PasswordStrengthMeter password={$form!.password} />
+        <PasswordStrengthMeter password={$form!.password} scoreOverride={0} />
         <div class="contents usernames">
           <TextArea
             id="usernamesText"

--- a/frontend/src/routes/(authenticated)/project/[project_code]/ChangeMemberRoleModal.svelte
+++ b/frontend/src/routes/(authenticated)/project/[project_code]/ChangeMemberRoleModal.svelte
@@ -17,7 +17,8 @@
     role: z.enum([ProjectRole.Editor, ProjectRole.Manager]),
   });
   type Schema = typeof schema;
-  let formModal: FormModal<Schema> = $state()!;
+  // eslint-disable-next-line @typescript-eslint/no-redundant-type-constituents
+  let formModal: FormModal<Schema> | undefined = $state();
   let form = $derived(formModal?.form());
 
   let name: string = $state('');
@@ -28,11 +29,11 @@
     role: ProjectRole;
   }): Promise<FormModalResult<Schema>> {
     name = member.name;
-    return await formModal.open(tryParse(schema, member), async () => {
+    return await formModal!.open(tryParse(schema, member), async () => {
       const result = await _changeProjectMemberRole({
         projectId: projectId,
         userId: member.userId,
-        role: $form.role as ProjectRole,
+        role: $form!.role as ProjectRole,
       });
       if (result.error?.byType('ProjectMembersMustBeVerified')) {
         return { role: [$t('project_page.add_user.user_must_be_verified')] };

--- a/frontend/src/routes/(authenticated)/project/[project_code]/ChangeMemberRoleModal.svelte
+++ b/frontend/src/routes/(authenticated)/project/[project_code]/ChangeMemberRoleModal.svelte
@@ -7,16 +7,20 @@
   import { _changeProjectMemberRole } from './+page';
   import type { UUID } from 'crypto';
 
-  export let projectId: string;
+  interface Props {
+    projectId: string;
+  }
+
+  let { projectId }: Props = $props();
 
   const schema = z.object({
     role: z.enum([ProjectRole.Editor, ProjectRole.Manager])
   });
   type Schema = typeof schema;
-  let formModal: FormModal<Schema>;
-  $: form = formModal?.form();
+  let formModal: FormModal<Schema> = $state();
+  let form = $derived(formModal?.form());
 
-  let name: string;
+  let name: string = $state();
 
   export async function open(member: { userId: UUID; name: string; role: ProjectRole }): Promise<FormModalResult<Schema>> {
     name = member.name;
@@ -37,8 +41,14 @@
   }
 </script>
 
-<FormModal bind:this={formModal} {schema} let:errors>
-  <span slot="title">{$t('project_page.change_role_modal.title', { name })}</span>
-  <ProjectRoleSelect bind:value={$form.role} error={errors.role} />
-  <span slot="submitText">{$t('project_page.change_role')}</span>
+<FormModal bind:this={formModal} {schema} >
+  {#snippet title()}
+    <span >{$t('project_page.change_role_modal.title', { name })}</span>
+  {/snippet}
+  {#snippet children({ errors })}
+    <ProjectRoleSelect bind:value={$form.role} error={errors.role} />
+    {/snippet}
+  {#snippet submitText()}
+    <span >{$t('project_page.change_role')}</span>
+  {/snippet}
 </FormModal>

--- a/frontend/src/routes/(authenticated)/project/[project_code]/ChangeMemberRoleModal.svelte
+++ b/frontend/src/routes/(authenticated)/project/[project_code]/ChangeMemberRoleModal.svelte
@@ -14,15 +14,19 @@
   let { projectId }: Props = $props();
 
   const schema = z.object({
-    role: z.enum([ProjectRole.Editor, ProjectRole.Manager])
+    role: z.enum([ProjectRole.Editor, ProjectRole.Manager]),
   });
   type Schema = typeof schema;
-  let formModal: FormModal<Schema> = $state();
+  let formModal: FormModal<Schema> = $state()!;
   let form = $derived(formModal?.form());
 
-  let name: string = $state();
+  let name: string = $state('');
 
-  export async function open(member: { userId: UUID; name: string; role: ProjectRole }): Promise<FormModalResult<Schema>> {
+  export async function open(member: {
+    userId: UUID;
+    name: string;
+    role: ProjectRole;
+  }): Promise<FormModalResult<Schema>> {
     name = member.name;
     return await formModal.open(tryParse(schema, member), async () => {
       const result = await _changeProjectMemberRole({
@@ -41,14 +45,14 @@
   }
 </script>
 
-<FormModal bind:this={formModal} {schema} >
+<FormModal bind:this={formModal} {schema}>
   {#snippet title()}
-    <span >{$t('project_page.change_role_modal.title', { name })}</span>
+    <span>{$t('project_page.change_role_modal.title', { name })}</span>
   {/snippet}
   {#snippet children({ errors })}
     <ProjectRoleSelect bind:value={$form.role} error={errors.role} />
-    {/snippet}
+  {/snippet}
   {#snippet submitText()}
-    <span >{$t('project_page.change_role')}</span>
+    <span>{$t('project_page.change_role')}</span>
   {/snippet}
 </FormModal>

--- a/frontend/src/routes/(authenticated)/project/[project_code]/ChangeMemberRoleModal.svelte
+++ b/frontend/src/routes/(authenticated)/project/[project_code]/ChangeMemberRoleModal.svelte
@@ -51,7 +51,7 @@
     <span>{$t('project_page.change_role_modal.title', { name })}</span>
   {/snippet}
   {#snippet children({ errors })}
-    <ProjectRoleSelect bind:value={$form.role} error={errors.role} />
+    <ProjectRoleSelect bind:value={$form!.role} error={errors.role} />
   {/snippet}
   {#snippet submitText()}
     <span>{$t('project_page.change_role')}</span>

--- a/frontend/src/routes/(authenticated)/project/[project_code]/CrdtSyncButton.svelte
+++ b/frontend/src/routes/(authenticated)/project/[project_code]/CrdtSyncButton.svelte
@@ -1,15 +1,15 @@
 <script lang="ts">
-  import {getErrorMessage} from '$lib/error/utils';
-  import {Button, FormError} from '$lib/forms';
+  import { getErrorMessage } from '$lib/error/utils';
+  import { Button, FormError } from '$lib/forms';
   import t from '$lib/i18n';
-  import {Icon} from '$lib/icons';
-  import {useNotifications} from '$lib/notify';
-  import {bounceIn} from 'svelte/easing';
-  import {scale} from 'svelte/transition';
-  import {_refreshProjectRepoInfo, type Project} from './+page';
-  import {Modal} from '$lib/components/modals';
-  import {NewTabLinkMarkdown} from '$lib/components/Markdown';
-  import {Duration} from '$lib/util/time';
+  import { Icon } from '$lib/icons';
+  import { useNotifications } from '$lib/notify';
+  import { bounceIn } from 'svelte/easing';
+  import { scale } from 'svelte/transition';
+  import { _refreshProjectRepoInfo, type Project } from './+page';
+  import { Modal } from '$lib/components/modals';
+  import { NewTabLinkMarkdown } from '$lib/components/Markdown';
+  import { Duration } from '$lib/util/time';
 
   interface Props {
     project: Project;
@@ -17,7 +17,7 @@
   }
 
   let { project, isEmpty }: Props = $props();
-  type SyncResult = {crdtChanges: number, fwdataChanges: number};
+  type SyncResult = { crdtChanges: number; fwdataChanges: number };
 
   const { notifySuccess, notifyWarning } = useNotifications();
 
@@ -66,12 +66,14 @@
   async function awaitSyncFinished(): Promise<SyncResult | string> {
     while (true) {
       try {
-        const response = await fetch(`/api/fw-lite/sync/await-sync-finished/${project.id}`, {signal: AbortSignal.timeout(30_000)});
+        const response = await fetch(`/api/fw-lite/sync/await-sync-finished/${project.id}`, {
+          signal: AbortSignal.timeout(30_000),
+        });
         if (response.status === 500) {
           return $t('project.crdt.sync_failed');
         }
         if (response.status === 200) {
-          const result = await response.json() as SyncResult;
+          const result = (await response.json()) as SyncResult;
           return result;
         }
       } catch (error) {
@@ -80,7 +82,6 @@
         }
         return getErrorMessage(error);
       }
-
     }
   }
 
@@ -96,11 +97,18 @@
   async function useInFwLite(): Promise<void> {
     await modal.openModal();
   }
-  let modal: Modal = $state();
+  let modal: Modal = $state()!;
 </script>
 
 {#if project.hasHarmonyCommits}
-  <Button variant="btn-primary" class="gap-1 indicator" on:click={syncProject} loading={syncing} active={syncing} customLoader>
+  <Button
+    variant="btn-primary"
+    class="gap-1 indicator"
+    onclick={syncProject}
+    loading={syncing}
+    active={syncing}
+    customLoader
+  >
     <span class="indicator-item badge badge-sm badge-accent translate-x-[calc(50%-16px)] shadow">Beta</span>
     {$t('project.crdt.sync_fwlite')}
     <span style="transform: rotateY(180deg)">
@@ -108,7 +116,7 @@
     </span>
   </Button>
 {:else}
-  <Button variant="btn-primary" class="indicator" on:click={useInFwLite}>
+  <Button variant="btn-primary" class="indicator" onclick={useInFwLite}>
     <span class="indicator-item badge badge-sm badge-accent translate-x-[calc(50%-16px)] shadow">Beta</span>
     <span>
       {$t('project.crdt.try_fw_lite')}
@@ -152,30 +160,28 @@
       <NewTabLinkMarkdown md={$t('project.crdt.try_info')} />
       {#if error}
         <NewTabLinkMarkdown
-          md={`${$t('errors.apology')} ${$t('project.crdt.reach_out_for_help', { subject: encodeURIComponent($t('project.crdt.email_subject', { projectCode: project.code }))})}`}
+          md={`${$t('errors.apology')} ${$t('project.crdt.reach_out_for_help', { subject: encodeURIComponent($t('project.crdt.email_subject', { projectCode: project.code })) })}`}
         />
       {/if}
     </div>
-    <FormError {error} right/>
+    <FormError {error} right />
   {/if}
   {#snippet actions({ close })}
-  
-      {#if modalState === 'idle'}
-        <Button variant="btn-primary" on:click={onSubmit}>
-          {$t('project.crdt.submit')}
-        </Button>
-        <Button on:click={close}>
-          {$t('project.crdt.cancel')}
-        </Button>
-      {:else if modalState === 'empty'}
-        <Button on:click={close}>
-          {$t('common.close')}
-        </Button>
-      {:else if modalState === 'done'}
-        <Button variant="btn-primary" on:click={close}>
-          {$t('project.crdt.finish')}
-        </Button>
-      {/if}
-    
+    {#if modalState === 'idle'}
+      <Button variant="btn-primary" onclick={onSubmit}>
+        {$t('project.crdt.submit')}
+      </Button>
+      <Button onclick={close}>
+        {$t('project.crdt.cancel')}
+      </Button>
+    {:else if modalState === 'empty'}
+      <Button onclick={close}>
+        {$t('common.close')}
+      </Button>
+    {:else if modalState === 'done'}
+      <Button variant="btn-primary" onclick={close}>
+        {$t('project.crdt.finish')}
+      </Button>
+    {/if}
   {/snippet}
 </Modal>

--- a/frontend/src/routes/(authenticated)/project/[project_code]/CrdtSyncButton.svelte
+++ b/frontend/src/routes/(authenticated)/project/[project_code]/CrdtSyncButton.svelte
@@ -11,16 +11,20 @@
   import {NewTabLinkMarkdown} from '$lib/components/Markdown';
   import {Duration} from '$lib/util/time';
 
-  export let project: Project;
-  export let isEmpty: boolean;
+  interface Props {
+    project: Project;
+    isEmpty: boolean;
+  }
+
+  let { project, isEmpty }: Props = $props();
   type SyncResult = {crdtChanges: number, fwdataChanges: number};
 
   const { notifySuccess, notifyWarning } = useNotifications();
 
-  let syncing = false;
-  let done = false;
-  $: modalState = isEmpty ? 'empty' : done ? 'done' : syncing ? 'syncing' : 'idle';
-  let error: string | undefined = undefined;
+  let syncing = $state(false);
+  let done = $state(false);
+  let modalState = $derived(isEmpty ? 'empty' : done ? 'done' : syncing ? 'syncing' : 'idle');
+  let error: string | undefined = $state(undefined);
 
   async function triggerSync(): Promise<string | undefined> {
     syncing = true;
@@ -92,7 +96,7 @@
   async function useInFwLite(): Promise<void> {
     await modal.openModal();
   }
-  let modal: Modal;
+  let modal: Modal = $state();
 </script>
 
 {#if project.hasHarmonyCommits}
@@ -154,22 +158,24 @@
     </div>
     <FormError {error} right/>
   {/if}
-  <svelte:fragment slot="actions" let:close>
-    {#if modalState === 'idle'}
-      <Button variant="btn-primary" on:click={onSubmit}>
-        {$t('project.crdt.submit')}
-      </Button>
-      <Button on:click={close}>
-        {$t('project.crdt.cancel')}
-      </Button>
-    {:else if modalState === 'empty'}
-      <Button on:click={close}>
-        {$t('common.close')}
-      </Button>
-    {:else if modalState === 'done'}
-      <Button variant="btn-primary" on:click={close}>
-        {$t('project.crdt.finish')}
-      </Button>
-    {/if}
-  </svelte:fragment>
+  {#snippet actions({ close })}
+  
+      {#if modalState === 'idle'}
+        <Button variant="btn-primary" on:click={onSubmit}>
+          {$t('project.crdt.submit')}
+        </Button>
+        <Button on:click={close}>
+          {$t('project.crdt.cancel')}
+        </Button>
+      {:else if modalState === 'empty'}
+        <Button on:click={close}>
+          {$t('common.close')}
+        </Button>
+      {:else if modalState === 'done'}
+        <Button variant="btn-primary" on:click={close}>
+          {$t('project.crdt.finish')}
+        </Button>
+      {/if}
+    
+  {/snippet}
 </Modal>

--- a/frontend/src/routes/(authenticated)/project/[project_code]/CrdtSyncButton.svelte
+++ b/frontend/src/routes/(authenticated)/project/[project_code]/CrdtSyncButton.svelte
@@ -95,9 +95,9 @@
   }
 
   async function useInFwLite(): Promise<void> {
-    await modal.openModal();
+    await modal?.openModal();
   }
-  let modal: Modal = $state()!;
+  let modal: Modal | undefined = $state();
 </script>
 
 {#if project.hasHarmonyCommits}

--- a/frontend/src/routes/(authenticated)/project/[project_code]/MembersList.svelte
+++ b/frontend/src/routes/(authenticated)/project/[project_code]/MembersList.svelte
@@ -73,7 +73,7 @@
 
   const { notifySuccess } = useNotifications();
 
-  let changeMemberRoleModal: ChangeMemberRoleModal = $state();
+  let changeMemberRoleModal: ChangeMemberRoleModal = $state()!;
   async function changeMemberRole(member: Member): Promise<void> {
     if (!member.user) return;
     const nameOrEmail = member.user.name ? member.user.name : (member.user.email ?? '');
@@ -156,7 +156,7 @@
 
     {#if members.length > TRUNCATED_MEMBER_COUNT}
       <div class="justify-self-start">
-        <Button outline size="btn-sm" on:click={() => (showAllMembers = !showAllMembers)}>
+        <Button outline size="btn-sm" onclick={() => (showAllMembers = !showAllMembers)}>
           {showAllMembers ? $t('project_page.members.show_less') : $t('project_page.members.show_all')}
         </Button>
       </div>

--- a/frontend/src/routes/(authenticated)/project/[project_code]/MembersList.svelte
+++ b/frontend/src/routes/(authenticated)/project/[project_code]/MembersList.svelte
@@ -3,9 +3,9 @@
   import type { ProjectRole } from '$lib/gql/types';
 
   export type Member = {
-    id: string
-    user: User,
-    role: ProjectRole
+    id: string;
+    user: User;
+    role: ProjectRole;
   };
 </script>
 
@@ -43,7 +43,7 @@
     projectId,
     canViewOtherMembers,
     extraButtons,
-    children
+    children,
   }: Props = $props();
 
   const dispatch = createEventDispatcher<{
@@ -61,10 +61,12 @@
     if (!search) {
       filteredMembers = members;
     } else {
-      filteredMembers = members.filter((m) =>
-        m.user.name.toLowerCase().includes(search) ||
-        m.user.email?.toLowerCase().includes(search) ||
-        m.user.username?.toLowerCase().includes(search));
+      filteredMembers = members.filter(
+        (m) =>
+          m.user.name.toLowerCase().includes(search) ||
+          m.user.email?.toLowerCase().includes(search) ||
+          m.user.username?.toLowerCase().includes(search),
+      );
     }
   });
   let showMembers = $derived(showAllMembers ? filteredMembers : filteredMembers.slice(0, TRUNCATED_MEMBER_COUNT));
@@ -74,7 +76,7 @@
   let changeMemberRoleModal: ChangeMemberRoleModal = $state();
   async function changeMemberRole(member: Member): Promise<void> {
     if (!member.user) return;
-    const nameOrEmail = member.user.name ? member.user.name : member.user.email ?? '';
+    const nameOrEmail = member.user.name ? member.user.name : (member.user.email ?? '');
     const { response, formState } = await changeMemberRoleModal.open({
       userId: member.user.id as UUID,
       name: nameOrEmail,
@@ -101,22 +103,20 @@
       {#if !canViewOtherMembers}
         <span
           class="tooltip tooltip-warning text-warning shrink-0 leading-0"
-          data-tip={$t('project_page.members.membership_confidential')}>
+          data-tip={$t('project_page.members.membership_confidential')}
+        >
           <Icon icon="i-mdi-shield-lock-outline" size="text-xl" />
         </span>
       {/if}
     </h2>
     {#if members?.length > TRUNCATED_MEMBER_COUNT}
       <div class="form-control max-w-full w-96">
-        <PlainInput
-          placeholder={$t('project_page.members.filter_members_placeholder')}
-          bind:value={memberSearch} />
+        <PlainInput placeholder={$t('project_page.members.filter_members_placeholder')} bind:value={memberSearch} />
       </div>
     {/if}
   </div>
 
   <BadgeList grid={showMembers.length > TRUNCATED_MEMBER_COUNT}>
-
     {#if !members.length}
       <span class="text-secondary mx-2 my-1">{$t('common.none')}</span>
     {:else if !showMembers.length}
@@ -126,9 +126,9 @@
     {#each showMembers as member (member.id)}
       {@const canManage = canManageMember(member)}
       <Dropdown disabled={!canManage}>
-        <MemberBadge member={{ name: member.user.name, role: member.role }} canManage={canManage} />
+        <MemberBadge member={{ name: member.user.name, role: member.role }} {canManage} />
         {#snippet content()}
-                <ul  class="menu">
+          <ul class="menu">
             <AdminContent>
               <li>
                 <button onclick={() => dispatch('openUserModal', member)}>
@@ -150,7 +150,7 @@
               </button>
             </li>
           </ul>
-              {/snippet}
+        {/snippet}
       </Dropdown>
     {/each}
 
@@ -169,7 +169,6 @@
     {/if}
 
     {@render children?.()}
-
   </BadgeList>
   <ChangeMemberRoleModal {projectId} bind:this={changeMemberRoleModal} />
 </div>

--- a/frontend/src/routes/(authenticated)/project/[project_code]/MembersList.svelte
+++ b/frontend/src/routes/(authenticated)/project/[project_code]/MembersList.svelte
@@ -73,9 +73,9 @@
 
   const { notifySuccess } = useNotifications();
 
-  let changeMemberRoleModal: ChangeMemberRoleModal = $state()!;
+  let changeMemberRoleModal: ChangeMemberRoleModal | undefined = $state();
   async function changeMemberRole(member: Member): Promise<void> {
-    if (!member.user) return;
+    if (!member.user || !changeMemberRoleModal) return;
     const nameOrEmail = member.user.name ? member.user.name : (member.user.email ?? '');
     const { response, formState } = await changeMemberRoleModal.open({
       userId: member.user.id as UUID,

--- a/frontend/src/routes/(authenticated)/project/[project_code]/MembersList.svelte
+++ b/frontend/src/routes/(authenticated)/project/[project_code]/MembersList.svelte
@@ -10,6 +10,7 @@
 </script>
 
 <script lang="ts">
+  import type { Snippet } from 'svelte';
   import { run } from 'svelte/legacy';
 
   import t from '$lib/i18n';
@@ -31,8 +32,8 @@
     canManageList: boolean;
     projectId: string;
     canViewOtherMembers: boolean;
-    extraButtons?: import('svelte').Snippet;
-    children?: import('svelte').Snippet;
+    extraButtons?: Snippet;
+    children?: Snippet;
   }
 
   let {

--- a/frontend/src/routes/(authenticated)/project/[project_code]/OpenInFlexButton.svelte
+++ b/frontend/src/routes/(authenticated)/project/[project_code]/OpenInFlexButton.svelte
@@ -1,4 +1,7 @@
 <script lang="ts">
+  import { createBubbler } from 'svelte/legacy';
+
+  const bubble = createBubbler();
   import { ProjectTypeIcon } from '$lib/components/ProjectType';
   import { ProjectType } from '$lib/gql/types';
   import t from '$lib/i18n';

--- a/frontend/src/routes/(authenticated)/project/[project_code]/OpenInFlexButton.svelte
+++ b/frontend/src/routes/(authenticated)/project/[project_code]/OpenInFlexButton.svelte
@@ -1,16 +1,23 @@
 <script lang="ts">
+  import { createBubbler } from 'svelte/legacy';
+
+  const bubble = createBubbler();
   import { ProjectTypeIcon } from '$lib/components/ProjectType';
   import { ProjectType } from '$lib/gql/types';
   import t from '$lib/i18n';
 
-  export let projectId: string;
+  interface Props {
+    projectId: string;
+  }
+
+  let { projectId }: Props = $props();
 </script>
 
 <a
   class="btn btn-primary whitespace-nowrap open-in-flex"
   href={`/api/integration/openWithFlex?projectId=${projectId}`}
   data-sveltekit-reload
-  on:click
+  onclick={bubble('click')}
 >
   {$t('project_page.open_with_flex.button')}
   <ProjectTypeIcon type={ProjectType.FlEx} />

--- a/frontend/src/routes/(authenticated)/project/[project_code]/OpenInFlexButton.svelte
+++ b/frontend/src/routes/(authenticated)/project/[project_code]/OpenInFlexButton.svelte
@@ -1,23 +1,21 @@
 <script lang="ts">
-  import { createBubbler } from 'svelte/legacy';
-
-  const bubble = createBubbler();
   import { ProjectTypeIcon } from '$lib/components/ProjectType';
   import { ProjectType } from '$lib/gql/types';
   import t from '$lib/i18n';
 
   interface Props {
     projectId: string;
+    onclick?: () => void;
   }
 
-  let { projectId }: Props = $props();
+  let { projectId, onclick }: Props = $props();
 </script>
 
 <a
   class="btn btn-primary whitespace-nowrap open-in-flex"
   href={`/api/integration/openWithFlex?projectId=${projectId}`}
   data-sveltekit-reload
-  onclick={bubble('click')}
+  {onclick}
 >
   {$t('project_page.open_with_flex.button')}
   <ProjectTypeIcon type={ProjectType.FlEx} />

--- a/frontend/src/routes/(authenticated)/project/[project_code]/OpenInFlexButton.svelte
+++ b/frontend/src/routes/(authenticated)/project/[project_code]/OpenInFlexButton.svelte
@@ -1,7 +1,4 @@
 <script lang="ts">
-  import { createBubbler } from 'svelte/legacy';
-
-  const bubble = createBubbler();
   import { ProjectTypeIcon } from '$lib/components/ProjectType';
   import { ProjectType } from '$lib/gql/types';
   import t from '$lib/i18n';

--- a/frontend/src/routes/(authenticated)/project/[project_code]/OpenInFlexModal.svelte
+++ b/frontend/src/routes/(authenticated)/project/[project_code]/OpenInFlexModal.svelte
@@ -7,8 +7,12 @@
   import OpenInFlexButton from './OpenInFlexButton.svelte';
   import SendReceiveUrlField from './SendReceiveUrlField.svelte';
 
-  export let project: Project;
-  let modal: Modal;
+  interface Props {
+    project: Project;
+  }
+
+  let { project }: Props = $props();
+  let modal: Modal = $state();
 
   export async function open(): Promise<void> {
     await modal.openModal(true, true);
@@ -32,7 +36,7 @@
       <input type="checkbox" />
       <h3 class="collapse-title my-0 px-0 pb-0">{$t('project_page.get_project.instructions_header', { type: project.type, mode: 'manual' })}...</h3>
       <div class="collapse-content p-0">
-        <div class="divider mt-0" />
+        <div class="divider mt-0"></div>
         <Markdown md={$t('project_page.get_project.instructions_flex', { code: project.code, name: project.name })} />
         <SendReceiveUrlField projectCode={project.code} />
       </div>

--- a/frontend/src/routes/(authenticated)/project/[project_code]/OpenInFlexModal.svelte
+++ b/frontend/src/routes/(authenticated)/project/[project_code]/OpenInFlexModal.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import Modal from '$lib/components/modals/Modal.svelte';
   import Markdown from 'svelte-exmarkdown';
-  import {NewTabLinkMarkdown} from '$lib/components/Markdown';
+  import { NewTabLinkMarkdown } from '$lib/components/Markdown';
   import type { Project } from './+page';
   import t from '$lib/i18n';
   import OpenInFlexButton from './OpenInFlexButton.svelte';
@@ -12,7 +12,7 @@
   }
 
   let { project }: Props = $props();
-  let modal: Modal = $state();
+  let modal: Modal = $state()!;
 
   export async function open(): Promise<void> {
     await modal.openModal(true, true);
@@ -34,7 +34,9 @@
     </div>
     <div class="collapse collapse-arrow">
       <input type="checkbox" />
-      <h3 class="collapse-title my-0 px-0 pb-0">{$t('project_page.get_project.instructions_header', { type: project.type, mode: 'manual' })}...</h3>
+      <h3 class="collapse-title my-0 px-0 pb-0">
+        {$t('project_page.get_project.instructions_header', { type: project.type, mode: 'manual' })}...
+      </h3>
       <div class="collapse-content p-0">
         <div class="divider mt-0"></div>
         <Markdown md={$t('project_page.get_project.instructions_flex', { code: project.code, name: project.name })} />

--- a/frontend/src/routes/(authenticated)/project/[project_code]/OpenInFlexModal.svelte
+++ b/frontend/src/routes/(authenticated)/project/[project_code]/OpenInFlexModal.svelte
@@ -12,10 +12,10 @@
   }
 
   let { project }: Props = $props();
-  let modal: Modal = $state()!;
+  let modal: Modal | undefined = $state();
 
   export async function open(): Promise<void> {
-    await modal.openModal(true, true);
+    await modal?.openModal(true, true);
   }
 </script>
 

--- a/frontend/src/routes/(authenticated)/project/[project_code]/OrgList.svelte
+++ b/frontend/src/routes/(authenticated)/project/[project_code]/OrgList.svelte
@@ -16,12 +16,7 @@
     children?: Snippet;
   }
 
-  let {
-    canManage,
-    organizations = [],
-    extraButtons,
-    children
-  }: Props = $props();
+  let { canManage, organizations = [], extraButtons, children }: Props = $props();
 
   const dispatch = createEventDispatcher<{
     removeProjectFromOrg: { orgId: string; orgName: string };
@@ -55,21 +50,24 @@
             </span>
           </ActionBadge>
           {#snippet content()}
-                    <ul  class="menu">
+            <ul class="menu">
               <li>
                 <a href={`/org/${org.id}`}>
-                  <Icon icon="i-mdi-link"/>
-                  {$t('project_page.view_org', {orgName: org.name})}
+                  <Icon icon="i-mdi-link" />
+                  {$t('project_page.view_org', { orgName: org.name })}
                 </a>
               </li>
               <li>
-                <button class="text-error" onclick={() => dispatch('removeProjectFromOrg', {orgId: org.id, orgName: org.name})}>
+                <button
+                  class="text-error"
+                  onclick={() => dispatch('removeProjectFromOrg', { orgId: org.id, orgName: org.name })}
+                >
                   <TrashIcon />
                   {$t('project_page.remove_project_from_org')}
                 </button>
               </li>
             </ul>
-                  {/snippet}
+          {/snippet}
         </Dropdown>
       {/if}
     {/each}

--- a/frontend/src/routes/(authenticated)/project/[project_code]/OrgList.svelte
+++ b/frontend/src/routes/(authenticated)/project/[project_code]/OrgList.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import type { Snippet } from 'svelte';
   import t from '$lib/i18n';
   import { Badge, BadgeList } from '$lib/components/Badges';
   import type { Organization } from '$lib/gql/types';
@@ -11,8 +12,8 @@
   interface Props {
     canManage: boolean;
     organizations?: Org[];
-    extraButtons?: import('svelte').Snippet;
-    children?: import('svelte').Snippet;
+    extraButtons?: Snippet;
+    children?: Snippet;
   }
 
   let {
@@ -28,7 +29,6 @@
 
   const TRUNCATED_MEMBER_COUNT = 5;
 </script>
-
 
 <div>
   <p class="text-2xl mb-4 flex items-baseline gap-4 max-sm:flex-col">

--- a/frontend/src/routes/(authenticated)/project/[project_code]/OrgList.svelte
+++ b/frontend/src/routes/(authenticated)/project/[project_code]/OrgList.svelte
@@ -8,8 +8,19 @@
   import ActionBadge from '$lib/components/Badges/ActionBadge.svelte';
 
   type Org = Pick<Organization, 'id' | 'name'>;
-  export let canManage: boolean;
-  export let organizations: Org[] = [];
+  interface Props {
+    canManage: boolean;
+    organizations?: Org[];
+    extraButtons?: import('svelte').Snippet;
+    children?: import('svelte').Snippet;
+  }
+
+  let {
+    canManage,
+    organizations = [],
+    extraButtons,
+    children
+  }: Props = $props();
 
   const dispatch = createEventDispatcher<{
     removeProjectFromOrg: { orgId: string; orgName: string };
@@ -28,7 +39,7 @@
     {#if !organizations.length}
       <span class="text-secondary mx-2 my-1">{$t('common.none')}</span>
       <div class="flex grow flex-wrap place-self-end gap-3 place-content-end" style="grid-column: -2 / -1">
-        <slot name="extraButtons" />
+        {@render extraButtons?.()}
       </div>
     {/if}
     {#each organizations as org (org.id)}
@@ -43,24 +54,26 @@
               {org.name}
             </span>
           </ActionBadge>
-          <ul slot="content" class="menu">
-            <li>
-              <a href={`/org/${org.id}`}>
-                <Icon icon="i-mdi-link"/>
-                {$t('project_page.view_org', {orgName: org.name})}
-              </a>
-            </li>
-            <li>
-              <button class="text-error" on:click={() => dispatch('removeProjectFromOrg', {orgId: org.id, orgName: org.name})}>
-                <TrashIcon />
-                {$t('project_page.remove_project_from_org')}
-              </button>
-            </li>
-          </ul>
+          {#snippet content()}
+                    <ul  class="menu">
+              <li>
+                <a href={`/org/${org.id}`}>
+                  <Icon icon="i-mdi-link"/>
+                  {$t('project_page.view_org', {orgName: org.name})}
+                </a>
+              </li>
+              <li>
+                <button class="text-error" onclick={() => dispatch('removeProjectFromOrg', {orgId: org.id, orgName: org.name})}>
+                  <TrashIcon />
+                  {$t('project_page.remove_project_from_org')}
+                </button>
+              </li>
+            </ul>
+                  {/snippet}
         </Dropdown>
       {/if}
     {/each}
   </BadgeList>
 
-  <slot />
+  {@render children?.()}
 </div>

--- a/frontend/src/routes/(authenticated)/project/[project_code]/ProjectConfidentialityBadge.svelte
+++ b/frontend/src/routes/(authenticated)/project/[project_code]/ProjectConfidentialityBadge.svelte
@@ -2,8 +2,12 @@
   import t from '$lib/i18n';
   import { BadgeButton } from '$lib/components/Badges';
 
-  export let isConfidential: boolean | undefined;
-  export let canManage: boolean;
+  interface Props {
+    isConfidential: boolean | undefined;
+    canManage: boolean;
+  }
+
+  let { isConfidential, canManage }: Props = $props();
 
 </script>
 

--- a/frontend/src/routes/(authenticated)/project/[project_code]/ProjectConfidentialityBadge.svelte
+++ b/frontend/src/routes/(authenticated)/project/[project_code]/ProjectConfidentialityBadge.svelte
@@ -5,15 +5,16 @@
   interface Props {
     isConfidential: boolean | undefined;
     canManage: boolean;
+    onclick?: () => void;
   }
 
-  let { isConfidential, canManage }: Props = $props();
+  let { isConfidential, canManage, onclick }: Props = $props();
 </script>
 
 {#if isConfidential !== false}
   <BadgeButton
     variant={isConfidential ? 'badge-warning' : 'badge-neutral'}
-    onclick
+    {onclick}
     disabled={!canManage}
     icon={isConfidential === undefined && canManage ? 'i-mdi-pencil-outline' : 'i-mdi-shield-lock-outline'}
     hoverIcon="i-mdi-pencil-outline"

--- a/frontend/src/routes/(authenticated)/project/[project_code]/ProjectConfidentialityBadge.svelte
+++ b/frontend/src/routes/(authenticated)/project/[project_code]/ProjectConfidentialityBadge.svelte
@@ -8,15 +8,16 @@
   }
 
   let { isConfidential, canManage }: Props = $props();
-
 </script>
 
 {#if isConfidential !== false}
-  <BadgeButton variant={isConfidential ? 'badge-warning' : 'badge-neutral'}
-      on:click
-      disabled={!canManage}
-      icon={isConfidential === undefined && canManage ? 'i-mdi-pencil-outline' : 'i-mdi-shield-lock-outline'}
-      hoverIcon="i-mdi-pencil-outline">
+  <BadgeButton
+    variant={isConfidential ? 'badge-warning' : 'badge-neutral'}
+    onclick
+    disabled={!canManage}
+    icon={isConfidential === undefined && canManage ? 'i-mdi-pencil-outline' : 'i-mdi-shield-lock-outline'}
+    hoverIcon="i-mdi-pencil-outline"
+  >
     {#if isConfidential}
       {$t('project.confidential.confidential')}
     {:else if canManage}

--- a/frontend/src/routes/(authenticated)/project/[project_code]/ProjectConfidentialityModal.svelte
+++ b/frontend/src/routes/(authenticated)/project/[project_code]/ProjectConfidentialityModal.svelte
@@ -16,7 +16,7 @@
   const schema = z.object({
     isConfidential: z.boolean(),
   });
-  let formModal: FormModal<typeof schema> = $state();
+  let formModal: FormModal<typeof schema> = $state()!;
   let form = $derived(formModal?.form());
 
   const { notifySuccess, notifyWarning } = useNotifications();
@@ -44,11 +44,11 @@
 
 <FormModal bind:this={formModal} {schema} submitVariant={$form?.isConfidential ? 'btn-warning' : 'btn-primary'}>
   {#snippet title()}
-    <span >{$t('project.confidential.modal.title')}</span>
+    <span>{$t('project.confidential.modal.title')}</span>
   {/snippet}
   <ProjectConfidentialityCombobox bind:value={$form.isConfidential} />
   {#snippet submitText()}
-    <span >
+    <span>
       {#if $form.isConfidential}
         {$t('project.confidential.modal.submit_button_confidential')}
       {:else}

--- a/frontend/src/routes/(authenticated)/project/[project_code]/ProjectConfidentialityModal.svelte
+++ b/frontend/src/routes/(authenticated)/project/[project_code]/ProjectConfidentialityModal.svelte
@@ -16,12 +16,14 @@
   const schema = z.object({
     isConfidential: z.boolean(),
   });
-  let formModal: FormModal<typeof schema> = $state()!;
+  // eslint-disable-next-line @typescript-eslint/no-redundant-type-constituents
+  let formModal: FormModal<typeof schema> | undefined = $state();
   let form = $derived(formModal?.form());
 
   const { notifySuccess, notifyWarning } = useNotifications();
 
   export async function openModal(): Promise<void> {
+    if (!formModal || !$form) return;
     const originalValue = isConfidential;
     const { response, formState } = await formModal.open({ isConfidential: isConfidential ?? false }, async () => {
       const { error } = await _setProjectConfidentiality({
@@ -46,10 +48,10 @@
   {#snippet title()}
     <span>{$t('project.confidential.modal.title')}</span>
   {/snippet}
-  <ProjectConfidentialityCombobox bind:value={$form.isConfidential} />
+  <ProjectConfidentialityCombobox bind:value={$form!.isConfidential} />
   {#snippet submitText()}
     <span>
-      {#if $form.isConfidential}
+      {#if $form!.isConfidential}
         {$t('project.confidential.modal.submit_button_confidential')}
       {:else}
         {$t('project.confidential.modal.submit_button_not_confidential')}

--- a/frontend/src/routes/(authenticated)/project/[project_code]/ProjectConfidentialityModal.svelte
+++ b/frontend/src/routes/(authenticated)/project/[project_code]/ProjectConfidentialityModal.svelte
@@ -6,14 +6,18 @@
   import { _setProjectConfidentiality } from './+page';
   import t from '$lib/i18n';
 
-  export let projectId: string;
-  export let isConfidential: boolean | undefined;
+  interface Props {
+    projectId: string;
+    isConfidential: boolean | undefined;
+  }
+
+  let { projectId, isConfidential }: Props = $props();
 
   const schema = z.object({
     isConfidential: z.boolean(),
   });
-  let formModal: FormModal<typeof schema>;
-  $: form = formModal?.form();
+  let formModal: FormModal<typeof schema> = $state();
+  let form = $derived(formModal?.form());
 
   const { notifySuccess, notifyWarning } = useNotifications();
 
@@ -39,13 +43,17 @@
 </script>
 
 <FormModal bind:this={formModal} {schema} submitVariant={$form?.isConfidential ? 'btn-warning' : 'btn-primary'}>
-  <span slot="title">{$t('project.confidential.modal.title')}</span>
+  {#snippet title()}
+    <span >{$t('project.confidential.modal.title')}</span>
+  {/snippet}
   <ProjectConfidentialityCombobox bind:value={$form.isConfidential} />
-  <span slot="submitText">
-    {#if $form.isConfidential}
-      {$t('project.confidential.modal.submit_button_confidential')}
-    {:else}
-      {$t('project.confidential.modal.submit_button_not_confidential')}
-    {/if}
-  </span>
+  {#snippet submitText()}
+    <span >
+      {#if $form.isConfidential}
+        {$t('project.confidential.modal.submit_button_confidential')}
+      {:else}
+        {$t('project.confidential.modal.submit_button_not_confidential')}
+      {/if}
+    </span>
+  {/snippet}
 </FormModal>

--- a/frontend/src/routes/(authenticated)/project/[project_code]/ResetProjectModal.svelte
+++ b/frontend/src/routes/(authenticated)/project/[project_code]/ResetProjectModal.svelte
@@ -18,8 +18,8 @@
     Finished,
   }
 
-  let currentStep = ResetSteps.Download;
-  let changingSteps = false; // only some steps set and use this
+  let currentStep = $state(ResetSteps.Download);
+  let changingSteps = $state(false); // only some steps set and use this
 
   function nextStep(): void {
     currentStep++;
@@ -31,9 +31,9 @@
     error = undefined;
   }
 
-  let code: string;
-  let modal: Modal;
-  let error: ErrorMessage | undefined = undefined;
+  let code: string = $state();
+  let modal: Modal = $state();
+  let error: ErrorMessage | undefined = $state(undefined);
 
   export async function open(_code: string, resetStatus: ResetStatus): Promise<boolean> {
     code = _code;
@@ -107,8 +107,8 @@
     }
   }
 
-  let tusUpload: TusUpload;
-  let uploadStatus: UploadStatus;
+  let tusUpload: TusUpload = $state();
+  let uploadStatus: UploadStatus = $state();
 </script>
 
 <div class="reset-modal contents">
@@ -121,7 +121,7 @@
       <li class="step" class:step-primary={currentStep >= ResetSteps.Finished}>{$t('finished_step')}</li>
     </ul>
 
-    <div class="divider my-2" />
+    <div class="divider my-2"></div>
 
     {#if currentStep === ResetSteps.Download}
       <p class="mb-2 label">
@@ -129,7 +129,7 @@
       </p>
       <a rel="external" href="/api/project/backupProject/{code}" class="btn btn-success" download>
         {$t('download_button')}
-        <span class="i-mdi-download text-2xl" />
+        <span class="i-mdi-download text-2xl"></span>
       </a>
     {:else if currentStep === ResetSteps.Reset}
       <Form id="reset-form" {enhance}>
@@ -168,49 +168,53 @@
         <span
           class="i-mdi-check-circle-outline text-7xl text-success"
           transition:scale={{ duration: 600, start: 0.7, easing: bounceIn }}
-        />
+></span>
       </div>
     {:else}
       <span>Unknown step</span>
     {/if}
     <FormError {error} />
-    <svelte:fragment slot="extraActions">
-      {#if currentStep === ResetSteps.Reset}
-        <button class="btn btn-secondary" on:click={previousStep}>
-          <span class="i-mdi-chevron-left text-2xl" />
-          {$t('back')}
-        </button>
-      {/if}
-    </svelte:fragment>
-    <svelte:fragment slot="actions">
-      {#if currentStep === ResetSteps.Download}
-      <Button variant="btn-primary" on:click={nextStep}>
-        {$t('i_have_working_backup')}
-        <span class="i-mdi-chevron-right text-2xl" />
-      </Button>
-      {:else if currentStep === ResetSteps.Reset}
-      <Button variant="btn-accent" type="submit" form="reset-form" loading={$submitting}>
-        {$t('submit')}
-        <CircleArrowIcon />
-      </Button>
-      {:else if currentStep === ResetSteps.Upload}
-        {#if uploadStatus !== UploadStatus.NoFile}
-          <Button disabled={uploadStatus !== UploadStatus.Ready && uploadStatus !== UploadStatus.Uploading}
-                  loading={uploadStatus === UploadStatus.Uploading || (uploadStatus === UploadStatus.Complete && changingSteps)}
-                  variant="btn-success" on:click={tusUpload.startUpload}>
-            {$t('upload_project')}
-          </Button>
-        {:else}
-          <Button variant="btn-primary" on:click={leaveProjectEmpty} loading={changingSteps}>
-            {$t('leave_project_empty')}
-            <span class="i-mdi-chevron-right text-2xl" />
-          </Button>
+    {#snippet extraActions()}
+      
+        {#if currentStep === ResetSteps.Reset}
+          <button class="btn btn-secondary" onclick={previousStep}>
+            <span class="i-mdi-chevron-left text-2xl"></span>
+            {$t('back')}
+          </button>
         {/if}
-      {:else if currentStep === ResetSteps.Finished}
-        <button class="btn btn-primary" on:click={() => modal.submitModal()}>
-          {$t('close')}
-        </button>
-      {/if}
-    </svelte:fragment>
+      
+      {/snippet}
+    {#snippet actions()}
+      
+        {#if currentStep === ResetSteps.Download}
+        <Button variant="btn-primary" on:click={nextStep}>
+          {$t('i_have_working_backup')}
+          <span class="i-mdi-chevron-right text-2xl"></span>
+        </Button>
+        {:else if currentStep === ResetSteps.Reset}
+        <Button variant="btn-accent" type="submit" form="reset-form" loading={$submitting}>
+          {$t('submit')}
+          <CircleArrowIcon />
+        </Button>
+        {:else if currentStep === ResetSteps.Upload}
+          {#if uploadStatus !== UploadStatus.NoFile}
+            <Button disabled={uploadStatus !== UploadStatus.Ready && uploadStatus !== UploadStatus.Uploading}
+                    loading={uploadStatus === UploadStatus.Uploading || (uploadStatus === UploadStatus.Complete && changingSteps)}
+                    variant="btn-success" on:click={tusUpload.startUpload}>
+              {$t('upload_project')}
+            </Button>
+          {:else}
+            <Button variant="btn-primary" on:click={leaveProjectEmpty} loading={changingSteps}>
+              {$t('leave_project_empty')}
+              <span class="i-mdi-chevron-right text-2xl"></span>
+            </Button>
+          {/if}
+        {:else if currentStep === ResetSteps.Finished}
+          <button class="btn btn-primary" onclick={() => modal.submitModal()}>
+            {$t('close')}
+          </button>
+        {/if}
+      
+      {/snippet}
   </Modal>
 </div>

--- a/frontend/src/routes/(authenticated)/project/[project_code]/ResetProjectModal.svelte
+++ b/frontend/src/routes/(authenticated)/project/[project_code]/ResetProjectModal.svelte
@@ -9,7 +9,7 @@
   import { _refreshProjectRepoInfo } from './+page';
   import { scale } from 'svelte/transition';
   import { bounceIn } from 'svelte/easing';
-  import {getErrorMessage} from '$lib/error/utils';
+  import { getErrorMessage } from '$lib/error/utils';
 
   enum ResetSteps {
     Download,
@@ -31,8 +31,8 @@
     error = undefined;
   }
 
-  let code: string = $state();
-  let modal: Modal = $state();
+  let code: string = $state('');
+  let modal: Modal = $state()!;
   let error: ErrorMessage | undefined = $state(undefined);
 
   export async function open(_code: string, resetStatus: ResetStatus): Promise<boolean> {
@@ -49,11 +49,11 @@
   let verify = z.object({
     confirmProjectCode: z.string().refine(
       (value) => value === code,
-      () => ({ message: $t('confirm_project_code_error') })
+      () => ({ message: $t('confirm_project_code_error') }),
     ),
     confirmDownloaded: z.boolean().refine(
       (value) => value,
-      () => ({ message: $t('confirm_downloaded_error') })
+      () => ({ message: $t('confirm_downloaded_error') }),
     ),
   });
 
@@ -107,12 +107,17 @@
     }
   }
 
-  let tusUpload: TusUpload = $state();
-  let uploadStatus: UploadStatus = $state();
+  let tusUpload: TusUpload = $state()!;
+  let uploadStatus: UploadStatus | undefined = $state();
 </script>
 
 <div class="reset-modal contents">
-  <Modal bind:this={modal} on:close={onClose} showCloseButton={false} closeOnClickOutside={uploadStatus !== UploadStatus.Uploading && !changingSteps && !$submitting}>
+  <Modal
+    bind:this={modal}
+    on:close={onClose}
+    showCloseButton={false}
+    closeOnClickOutside={uploadStatus !== UploadStatus.Uploading && !changingSteps && !$submitting}
+  >
     <h2 class="text-xl mb-4">{$t('title', { code })}</h2>
     <ul class="steps w-full mb-2">
       <li class="step step-primary">{$t('backup_step')}</li>
@@ -168,53 +173,53 @@
         <span
           class="i-mdi-check-circle-outline text-7xl text-success"
           transition:scale={{ duration: 600, start: 0.7, easing: bounceIn }}
-></span>
+        ></span>
       </div>
     {:else}
       <span>Unknown step</span>
     {/if}
     <FormError {error} />
     {#snippet extraActions()}
-      
-        {#if currentStep === ResetSteps.Reset}
-          <button class="btn btn-secondary" onclick={previousStep}>
-            <span class="i-mdi-chevron-left text-2xl"></span>
-            {$t('back')}
-          </button>
-        {/if}
-      
-      {/snippet}
+      {#if currentStep === ResetSteps.Reset}
+        <button class="btn btn-secondary" onclick={previousStep}>
+          <span class="i-mdi-chevron-left text-2xl"></span>
+          {$t('back')}
+        </button>
+      {/if}
+    {/snippet}
     {#snippet actions()}
-      
-        {#if currentStep === ResetSteps.Download}
-        <Button variant="btn-primary" on:click={nextStep}>
+      {#if currentStep === ResetSteps.Download}
+        <Button variant="btn-primary" onclick={nextStep}>
           {$t('i_have_working_backup')}
           <span class="i-mdi-chevron-right text-2xl"></span>
         </Button>
-        {:else if currentStep === ResetSteps.Reset}
+      {:else if currentStep === ResetSteps.Reset}
         <Button variant="btn-accent" type="submit" form="reset-form" loading={$submitting}>
           {$t('submit')}
           <CircleArrowIcon />
         </Button>
-        {:else if currentStep === ResetSteps.Upload}
-          {#if uploadStatus !== UploadStatus.NoFile}
-            <Button disabled={uploadStatus !== UploadStatus.Ready && uploadStatus !== UploadStatus.Uploading}
-                    loading={uploadStatus === UploadStatus.Uploading || (uploadStatus === UploadStatus.Complete && changingSteps)}
-                    variant="btn-success" on:click={tusUpload.startUpload}>
-              {$t('upload_project')}
-            </Button>
-          {:else}
-            <Button variant="btn-primary" on:click={leaveProjectEmpty} loading={changingSteps}>
-              {$t('leave_project_empty')}
-              <span class="i-mdi-chevron-right text-2xl"></span>
-            </Button>
-          {/if}
-        {:else if currentStep === ResetSteps.Finished}
-          <button class="btn btn-primary" onclick={() => modal.submitModal()}>
-            {$t('close')}
-          </button>
+      {:else if currentStep === ResetSteps.Upload}
+        {#if uploadStatus !== UploadStatus.NoFile}
+          <Button
+            disabled={uploadStatus !== UploadStatus.Ready && uploadStatus !== UploadStatus.Uploading}
+            loading={uploadStatus === UploadStatus.Uploading ||
+              (uploadStatus === UploadStatus.Complete && changingSteps)}
+            variant="btn-success"
+            onclick={tusUpload.startUpload}
+          >
+            {$t('upload_project')}
+          </Button>
+        {:else}
+          <Button variant="btn-primary" onclick={leaveProjectEmpty} loading={changingSteps}>
+            {$t('leave_project_empty')}
+            <span class="i-mdi-chevron-right text-2xl"></span>
+          </Button>
         {/if}
-      
-      {/snippet}
+      {:else if currentStep === ResetSteps.Finished}
+        <button class="btn btn-primary" onclick={() => modal.submitModal()}>
+          {$t('close')}
+        </button>
+      {/if}
+    {/snippet}
   </Modal>
 </div>

--- a/frontend/src/routes/(authenticated)/project/[project_code]/ResetProjectModal.svelte
+++ b/frontend/src/routes/(authenticated)/project/[project_code]/ResetProjectModal.svelte
@@ -11,6 +11,7 @@
   import { bounceIn } from 'svelte/easing';
   import { getErrorMessage } from '$lib/error/utils';
 
+  // svelte-ignore non_reactive_update
   enum ResetSteps {
     Download,
     Reset,
@@ -32,7 +33,7 @@
   }
 
   let code: string = $state('');
-  let modal: Modal = $state()!;
+  let modal: Modal | undefined = $state();
   let error: ErrorMessage | undefined = $state(undefined);
 
   export async function open(_code: string, resetStatus: ResetStatus): Promise<boolean> {
@@ -40,7 +41,7 @@
     if (resetStatus == ResetStatus.InProgress) {
       currentStep = ResetSteps.Upload;
     }
-    await modal.openModal(true, true);
+    await modal?.openModal(true, true);
     return currentStep == ResetSteps.Finished;
   }
 
@@ -107,7 +108,8 @@
     }
   }
 
-  let tusUpload: TusUpload = $state()!;
+  let tusUpload: TusUpload | undefined = $state();
+  // eslint-disable-next-line @typescript-eslint/no-redundant-type-constituents
   let uploadStatus: UploadStatus | undefined = $state();
 </script>
 
@@ -205,7 +207,7 @@
             loading={uploadStatus === UploadStatus.Uploading ||
               (uploadStatus === UploadStatus.Complete && changingSteps)}
             variant="btn-success"
-            onclick={tusUpload.startUpload}
+            onclick={tusUpload?.startUpload}
           >
             {$t('upload_project')}
           </Button>
@@ -216,7 +218,7 @@
           </Button>
         {/if}
       {:else if currentStep === ResetSteps.Finished}
-        <button class="btn btn-primary" onclick={() => modal.submitModal()}>
+        <button class="btn btn-primary" onclick={() => modal?.submitModal()}>
           {$t('close')}
         </button>
       {/if}

--- a/frontend/src/routes/(authenticated)/project/[project_code]/SendReceiveUrlField.svelte
+++ b/frontend/src/routes/(authenticated)/project/[project_code]/SendReceiveUrlField.svelte
@@ -5,12 +5,16 @@
   import t from '$lib/i18n';
   import { AdminContent } from '$lib/layout';
 
-  export let projectCode: string;
+  interface Props {
+    projectCode: string;
+  }
 
-  $: projectHgUrl = import.meta.env.DEV ? `http://hg.${$page.url.hostname}/${projectCode}`
+  let { projectCode }: Props = $props();
+
+  let projectHgUrl = $derived(import.meta.env.DEV ? `http://hg.${$page.url.hostname}/${projectCode}`
     : $page.url.host.includes('develop') || $page.url.host.includes('.dev') ? `https://hg-develop.lexbox.org/${projectCode}`
     : $page.url.host.includes('staging') ? `https://hg-${$page.url.host.replace('depot', 'forge')}/${projectCode}`
-    : `https://hg-public.${$page.url.host.replace('depot', 'forge')}/${projectCode}`;
+    : `https://hg-public.${$page.url.host.replace('depot', 'forge')}/${projectCode}`);
 </script>
 
 <AdminContent>

--- a/frontend/src/routes/(authenticated)/project/[project_code]/SendReceiveUrlField.svelte
+++ b/frontend/src/routes/(authenticated)/project/[project_code]/SendReceiveUrlField.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { page } from '$app/stores';
+  import { page } from '$app/state';
   import CopyToClipboardButton from '$lib/components/CopyToClipboardButton.svelte';
   import { FormField } from '$lib/forms';
   import t from '$lib/i18n';
@@ -11,10 +11,10 @@
 
   let { projectCode }: Props = $props();
 
-  let projectHgUrl = $derived(import.meta.env.DEV ? `http://hg.${$page.url.hostname}/${projectCode}`
-    : $page.url.host.includes('develop') || $page.url.host.includes('.dev') ? `https://hg-develop.lexbox.org/${projectCode}`
-    : $page.url.host.includes('staging') ? `https://hg-${$page.url.host.replace('depot', 'forge')}/${projectCode}`
-    : `https://hg-public.${$page.url.host.replace('depot', 'forge')}/${projectCode}`);
+  let projectHgUrl = $derived(import.meta.env.DEV ? `http://hg.${page.url.hostname}/${projectCode}`
+    : page.url.host.includes('develop') || page.url.host.includes('.dev') ? `https://hg-develop.lexbox.org/${projectCode}`
+    : page.url.host.includes('staging') ? `https://hg-${page.url.host.replace('depot', 'forge')}/${projectCode}`
+    : `https://hg-public.${page.url.host.replace('depot', 'forge')}/${projectCode}`);
 </script>
 
 <AdminContent>

--- a/frontend/src/routes/(authenticated)/project/[project_code]/viewer/+layout@.svelte
+++ b/frontend/src/routes/(authenticated)/project/[project_code]/viewer/+layout@.svelte
@@ -1,9 +1,10 @@
 <script lang="ts">
-	interface Props {
-		children?: import('svelte').Snippet;
-	}
+  import type { Snippet } from 'svelte';
+  interface Props {
+    children?: Snippet;
+  }
 
-	let { children }: Props = $props();
+  let { children }: Props = $props();
 </script>
 
-﻿{@render children?.()}
+{@render children?.()}

--- a/frontend/src/routes/(authenticated)/project/[project_code]/viewer/+layout@.svelte
+++ b/frontend/src/routes/(authenticated)/project/[project_code]/viewer/+layout@.svelte
@@ -1,1 +1,9 @@
-﻿<slot/>
+<script lang="ts">
+	interface Props {
+		children?: import('svelte').Snippet;
+	}
+
+	let { children }: Props = $props();
+</script>
+
+﻿{@render children?.()}

--- a/frontend/src/routes/(authenticated)/project/[project_code]/viewer/+page.svelte
+++ b/frontend/src/routes/(authenticated)/project/[project_code]/viewer/+page.svelte
@@ -1,4 +1,6 @@
 <script lang="ts">
+  import { run } from 'svelte/legacy';
+
   import 'viewer/component';
   import {LfClassicLexboxApi} from './lfClassicLexboxApi';
   import 'viewer/service-declaration';
@@ -6,18 +8,22 @@
   import type {PageData} from './$types';
   import t from '$lib/i18n';
 
-  export let data: PageData;
-  $: project = data.project;
+  interface Props {
+    data: PageData;
+  }
+
+  let { data }: Props = $props();
+  let project = $derived(data.project);
 
   const serviceProvider = window.lexbox.ServiceProvider;
-  let service: LfClassicLexboxApi;
-  $: {
+  let service: LfClassicLexboxApi = $state();
+  run(() => {
     if (serviceProvider) {
       let localService = new LfClassicLexboxApi($project.code);
       serviceProvider.setService(DotnetService.MiniLcmApi, localService);
       service = localService;
     }
-  }
+  });
 
 </script>
 {#if service}

--- a/frontend/src/routes/(authenticated)/project/[project_code]/viewer/+page.svelte
+++ b/frontend/src/routes/(authenticated)/project/[project_code]/viewer/+page.svelte
@@ -2,10 +2,10 @@
   import { run } from 'svelte/legacy';
 
   import 'viewer/component';
-  import {LfClassicLexboxApi} from './lfClassicLexboxApi';
+  import { LfClassicLexboxApi } from './lfClassicLexboxApi';
   import 'viewer/service-declaration';
-  import {DotnetService} from 'viewer/mini-lcm-api';
-  import type {PageData} from './$types';
+  import { DotnetService } from 'viewer/mini-lcm-api';
+  import type { PageData } from './$types';
   import t from '$lib/i18n';
 
   interface Props {
@@ -16,7 +16,7 @@
   let project = $derived(data.project);
 
   const serviceProvider = window.lexbox.ServiceProvider;
-  let service: LfClassicLexboxApi = $state();
+  let service: LfClassicLexboxApi | undefined = $state();
   run(() => {
     if (serviceProvider) {
       let localService = new LfClassicLexboxApi($project.code);
@@ -24,8 +24,8 @@
       service = localService;
     }
   });
-
 </script>
+
 {#if service}
   {#key service}
     <lexbox-svelte projectName={$project.name} about={$t('viewer.about')}></lexbox-svelte>

--- a/frontend/src/routes/(authenticated)/project/[project_code]/viewer/+page.ts
+++ b/frontend/src/routes/(authenticated)/project/[project_code]/viewer/+page.ts
@@ -1,4 +1,4 @@
-﻿import { getClient, graphql } from '$lib/gql';
+import { getClient, graphql } from '$lib/gql';
 
 import type {PageLoadEvent} from './$types';
 import { error } from '@sveltejs/kit';

--- a/frontend/src/routes/(authenticated)/project/[project_code]/viewer/lfClassicLexboxApi.ts
+++ b/frontend/src/routes/(authenticated)/project/[project_code]/viewer/lfClassicLexboxApi.ts
@@ -1,4 +1,4 @@
-﻿/* eslint-disable @typescript-eslint/naming-convention,@typescript-eslint/no-unused-vars */
+/* eslint-disable @typescript-eslint/naming-convention,@typescript-eslint/no-unused-vars */
 
 import type {
   IComplexFormType,

--- a/frontend/src/routes/(authenticated)/project/create/+page.svelte
+++ b/frontend/src/routes/(authenticated)/project/create/+page.svelte
@@ -12,7 +12,7 @@
   import { getSearchParamValues } from '$lib/util/query-params';
   import { onMount } from 'svelte';
   import MemberBadge from '$lib/components/Badges/MemberBadge.svelte';
-  import { derived, writable, type Readable } from 'svelte/store';
+  import { derived as derivedStore, writable, type Readable } from 'svelte/store';
   import { concatAll } from '$lib/util/array';
   import { browser } from '$app/environment';
   import { ProjectConfidentialityCombobox } from '$lib/components/Projects';
@@ -83,24 +83,24 @@
   });
 
   const asyncCodeError = writable<string | undefined>();
-  const codeStore = derived(form, f => f.code);
+  const codeStore = derivedStore(form, f => f.code);
   const codeIsAvailable = deriveAsync(codeStore, async (code) => {
     if (!browser || !code || !user.canCreateProjects) return true;
     return _projectCodeAvailable(code);
   }, true, true);
   $: $asyncCodeError = $codeIsAvailable ? undefined : $t('project.create.code_exists');
-  const codeErrors = derived([errors, asyncCodeError], () => [...new Set(concatAll($errors.code, $asyncCodeError))]);
+  const codeErrors = derivedStore([errors, asyncCodeError], () => [...new Set(concatAll($errors.code, $asyncCodeError))]);
 
-  const projectNameStore = derived(form, f => f.name);
-  const langCodeStore = derived(form, f => f.languageCode);
-  const orgIdStore = derived(form, f => f.orgId);
-  const langCodeAndOrgIdStore: Readable<{langCode: string, orgId: string}> = derived([langCodeStore, orgIdStore], ([langCode, orgId], set) => {
+  const projectNameStore = derivedStore(form, f => f.name);
+  const langCodeStore = derivedStore(form, f => f.languageCode);
+  const orgIdStore = derivedStore(form, f => f.orgId);
+  const langCodeAndOrgIdStore: Readable<{langCode: string, orgId: string}> = derivedStore([langCodeStore, orgIdStore], ([langCode, orgId], set) => {
     if (langCode && orgId && (langCode.length == 2 || langCode.length == 3)) {
       set({ langCode, orgId });
     }
   });
 
-  const projectNameAndOrgIdStore: Readable<{projectName: string, orgId: string}> = derived([projectNameStore, orgIdStore], ([projectName, orgId], set) => {
+  const projectNameAndOrgIdStore: Readable<{projectName: string, orgId: string}> = derivedStore([projectNameStore, orgIdStore], ([projectName, orgId], set) => {
     if (projectName && orgId && projectName.length >= 3) {
       set({ projectName, orgId });
     }
@@ -109,7 +109,7 @@
   const relatedProjectsByLangCode = deriveAsyncIfDefined(langCodeAndOrgIdStore, _getProjectsByLangCodeAndOrg, []);
   const relatedProjectsByName = deriveAsyncIfDefined(projectNameAndOrgIdStore, _getProjectsByNameAndOrg, []);
 
-  const relatedProjects = derived([relatedProjectsByName, relatedProjectsByLangCode], ([byName, byCode]) => {
+  const relatedProjects = derivedStore([relatedProjectsByName, relatedProjectsByLangCode], ([byName, byCode]) => {
     // Put projects related by language code first as they're more likely to be real matches
     var uniqueByName = byName.filter(n => byCode.findIndex(c => c.id == n.id) == -1);
     return [...byCode, ...uniqueByName];

--- a/frontend/src/routes/(authenticated)/project/create/+page.svelte
+++ b/frontend/src/routes/(authenticated)/project/create/+page.svelte
@@ -265,7 +265,9 @@
 
       <ProjectTypeSelect bind:value={$form.type} error={$errors.type} />
 
-      <Select id="org" label={$t('project.create.org')} bind:value={$form.orgId} error={$errors.orgId} on:change>
+      <!-- TODO: This used to have an on:change attribute to bubble up the submit event from HTML.
+           Let's check if the createBubbler() call in Form makes that unnecessary now. -->
+      <Select id="org" label={$t('project.create.org')} bind:value={$form.orgId} error={$errors.orgId}>
         <option value={''}>{$t('project_page.organization.placeholder')}</option>
         {#each myOrgs as org}
           <option value={org.id}>{org.name}</option>

--- a/frontend/src/routes/(authenticated)/project/create/+page.svelte
+++ b/frontend/src/routes/(authenticated)/project/create/+page.svelte
@@ -2,8 +2,25 @@
   import { run } from 'svelte/legacy';
 
   import { goto } from '$app/navigation';
-  import { Checkbox, Form, FormError, Input, ProjectTypeSelect, Select, SubmitButton, TextArea, lexSuperForm } from '$lib/forms';
-  import { CreateProjectResult, DbErrorCode, ProjectRole, ProjectType, RetentionPolicy, type CreateProjectInput } from '$lib/gql/types';
+  import {
+    Checkbox,
+    Form,
+    FormError,
+    Input,
+    ProjectTypeSelect,
+    Select,
+    SubmitButton,
+    TextArea,
+    lexSuperForm,
+  } from '$lib/forms';
+  import {
+    CreateProjectResult,
+    DbErrorCode,
+    ProjectRole,
+    ProjectType,
+    RetentionPolicy,
+    type CreateProjectInput,
+  } from '$lib/gql/types';
   import t from '$lib/i18n';
   import { TitlePage } from '$lib/layout';
   import { z } from 'zod';
@@ -19,14 +36,14 @@
   import { browser } from '$app/environment';
   import { ProjectConfidentialityCombobox } from '$lib/components/Projects';
   import { _getProjectsByLangCodeAndOrg, _getProjectsByNameAndOrg } from './+page';
-  import {NewTabLinkMarkdown} from '$lib/components/Markdown';
+  import { NewTabLinkMarkdown } from '$lib/components/Markdown';
   import Button from '$lib/forms/Button.svelte';
-  import {projectUrl} from '$lib/util/project';
+  import { projectUrl } from '$lib/util/project';
   import DevContent from '$lib/layout/DevContent.svelte';
 
   let { data } = $props();
   let user = $derived(data.user);
-  let requestingUser : typeof data.requestingUser = $state();
+  let requestingUser: typeof data.requestingUser = $state();
   let myOrgs = $derived(data.myOrgs ?? []);
   let projectStatus = $derived(data.projectStatus);
 
@@ -48,12 +65,12 @@
       .regex(/^[a-z\d][a-z-\d]*$/, $t('project.create.code_invalid')),
     customCode: z.boolean().default(false),
     isConfidential: z.boolean().default(false),
-    orgId: z.string().trim()
+    orgId: z.string().trim(),
   });
   let forceDraft = $state(false);
 
   //random guid
-  let projectId:string = crypto.randomUUID();
+  let projectId: string = crypto.randomUUID();
   let { form, errors, message, enhance, submitting, tainted } = lexSuperForm(formSchema, async () => {
     const result = await _createProject({
       id: projectId,
@@ -65,7 +82,7 @@
       isConfidential: $form.isConfidential,
       projectManagerId: requestingUser?.id,
       orgId: $form.orgId === '' ? null : $form.orgId,
-      forceDraft
+      forceDraft,
     });
     if (result.error) {
       if (result.error.byCode(DbErrorCode.DuplicateProjectCode)) {
@@ -85,37 +102,50 @@
   });
 
   const asyncCodeError = writable<string | undefined>();
-  const codeStore = derivedStore(form, f => f.code);
-  const codeIsAvailable = deriveAsync(codeStore, async (code) => {
-    if (!browser || !code || !user.canCreateProjects) return true;
-    return _projectCodeAvailable(code);
-  }, true, true);
+  const codeStore = derivedStore(form, (f) => f.code);
+  const codeIsAvailable = deriveAsync(
+    codeStore,
+    async (code) => {
+      if (!browser || !code || !user.canCreateProjects) return true;
+      return _projectCodeAvailable(code);
+    },
+    true,
+    true,
+  );
   run(() => {
     $asyncCodeError = $codeIsAvailable ? undefined : $t('project.create.code_exists');
   });
-  const codeErrors = derivedStore([errors, asyncCodeError], () => [...new Set(concatAll($errors.code, $asyncCodeError))]);
+  const codeErrors = derivedStore([errors, asyncCodeError], () => [
+    ...new Set(concatAll($errors.code, $asyncCodeError)),
+  ]);
 
-  const projectNameStore = derivedStore(form, f => f.name);
-  const langCodeStore = derivedStore(form, f => f.languageCode);
-  const orgIdStore = derivedStore(form, f => f.orgId);
-  const langCodeAndOrgIdStore: Readable<{langCode: string, orgId: string}> = derivedStore([langCodeStore, orgIdStore], ([langCode, orgId], set) => {
-    if (langCode && orgId && (langCode.length == 2 || langCode.length == 3)) {
-      set({ langCode, orgId });
-    }
-  });
+  const projectNameStore = derivedStore(form, (f) => f.name);
+  const langCodeStore = derivedStore(form, (f) => f.languageCode);
+  const orgIdStore = derivedStore(form, (f) => f.orgId);
+  const langCodeAndOrgIdStore: Readable<{ langCode: string; orgId: string }> = derivedStore(
+    [langCodeStore, orgIdStore],
+    ([langCode, orgId], set) => {
+      if (langCode && orgId && (langCode.length == 2 || langCode.length == 3)) {
+        set({ langCode, orgId });
+      }
+    },
+  );
 
-  const projectNameAndOrgIdStore: Readable<{projectName: string, orgId: string}> = derivedStore([projectNameStore, orgIdStore], ([projectName, orgId], set) => {
-    if (projectName && orgId && projectName.length >= 3) {
-      set({ projectName, orgId });
-    }
-  });
+  const projectNameAndOrgIdStore: Readable<{ projectName: string; orgId: string }> = derivedStore(
+    [projectNameStore, orgIdStore],
+    ([projectName, orgId], set) => {
+      if (projectName && orgId && projectName.length >= 3) {
+        set({ projectName, orgId });
+      }
+    },
+  );
 
   const relatedProjectsByLangCode = deriveAsyncIfDefined(langCodeAndOrgIdStore, _getProjectsByLangCodeAndOrg, []);
   const relatedProjectsByName = deriveAsyncIfDefined(projectNameAndOrgIdStore, _getProjectsByNameAndOrg, []);
 
   const relatedProjects = derivedStore([relatedProjectsByName, relatedProjectsByLangCode], ([byName, byCode]) => {
     // Put projects related by language code first as they're more likely to be real matches
-    var uniqueByName = byName.filter(n => byCode.findIndex(c => c.id == n.id) == -1);
+    var uniqueByName = byName.filter((n) => byCode.findIndex((c) => c.id == n.id) == -1);
     return [...byCode, ...uniqueByName];
   });
 
@@ -142,32 +172,37 @@
     return `${languageCode ?? $form.languageCode}${policyCode}-${typeCode}`;
   }
 
-  onMount(() => { // we want to do this once after the user has been set
+  onMount(() => {
+    // we want to do this once after the user has been set
     requestingUser = data.requestingUser;
     const urlValues = getSearchParamValues<CreateProjectInput>();
-    form.update((form) => {
-      if (urlValues.id) projectId = urlValues.id;
-      if (urlValues.name) form.name = urlValues.name;
-      if (urlValues.description) form.description = urlValues.description;
-      if (urlValues.type) form.type = urlValues.type;
-      if (urlValues.orgId) form.orgId = urlValues.orgId;
-      if (!form.orgId && !user.isAdmin && myOrgs?.[0]) {
-        form.orgId = myOrgs[0].id;
-      }
-      if (urlValues.retentionPolicy && (urlValues.retentionPolicy !== RetentionPolicy.Dev || user.isAdmin)) form.retentionPolicy = urlValues.retentionPolicy;
-      if (urlValues.isConfidential === 'true') form.isConfidential = true;
-      if (urlValues.code) {
-        const standardCodeSuffix = buildProjectCode('', urlValues.type, urlValues.retentionPolicy);
-        const isCustomCode = !urlValues.code.endsWith(standardCodeSuffix);
-        if (isCustomCode && user.isAdmin) {
-          form.customCode = true;
-          form.code = form.languageCode = urlValues.code;
-        } else {
-          form.languageCode = urlValues.code.replace(new RegExp(`${standardCodeSuffix}$`), '');
+    form.update(
+      (form) => {
+        if (urlValues.id) projectId = urlValues.id;
+        if (urlValues.name) form.name = urlValues.name;
+        if (urlValues.description) form.description = urlValues.description;
+        if (urlValues.type) form.type = urlValues.type;
+        if (urlValues.orgId) form.orgId = urlValues.orgId;
+        if (!form.orgId && !user.isAdmin && myOrgs?.[0]) {
+          form.orgId = myOrgs[0].id;
         }
-      }
-      return form;
-    }, { taint: false });
+        if (urlValues.retentionPolicy && (urlValues.retentionPolicy !== RetentionPolicy.Dev || user.isAdmin))
+          form.retentionPolicy = urlValues.retentionPolicy;
+        if (urlValues.isConfidential === 'true') form.isConfidential = true;
+        if (urlValues.code) {
+          const standardCodeSuffix = buildProjectCode('', urlValues.type, urlValues.retentionPolicy);
+          const isCustomCode = !urlValues.code.endsWith(standardCodeSuffix);
+          if (isCustomCode && user.isAdmin) {
+            form.customCode = true;
+            form.code = form.languageCode = urlValues.code;
+          } else {
+            form.languageCode = urlValues.code.replace(new RegExp(`${standardCodeSuffix}$`), '');
+          }
+        }
+        return form;
+      },
+      { taint: false },
+    );
   });
 
   run(() => {
@@ -180,17 +215,17 @@
           form.code = buildProjectCode(languageCode, type, retentionPolicy);
           return form;
         },
-        { taint: false }
+        { taint: false },
       );
     }
   });
 
-  let selectedProject: { name: string, id: string } | undefined = $state(undefined);
+  let selectedProject: { name: string; id: string } | undefined = $state(undefined);
   let showRelatedProjects = $state(true);
 
   // When the related-projects list changes, keep selectedProject up-to-date
-  relatedProjects.subscribe(projects => {
-    if (selectedProject) selectedProject = projects.find(p => selectedProject?.id === p.id);
+  relatedProjects.subscribe((projects) => {
+    if (selectedProject) selectedProject = projects.find((p) => selectedProject?.id === p.id);
   });
 
   async function askToJoinProject(projectId: string, projectName: string): Promise<void> {
@@ -204,165 +239,166 @@
 </script>
 
 <TitlePage title={$t('project.create.title')}>
-{#if projectStatus?.exists}
-  <div class="text-center">
-    <div>
-      <p>{$t('project.create.already_approved')}</p>
-      {#if projectStatus.deleted}
-        <p>{$t('project.create.already_approved_deleted')}</p>
-      {/if}
-    </div>
-    {#if projectStatus.accessibleCode}
-      <a class="btn btn-primary mt-4" href={projectUrl({ code: projectStatus.accessibleCode })}>{$t('project.create.go_to_project')}</a>
-    {/if}
-  </div>
-{:else}
-  <Form {enhance}>
-    <Input
-      label={$t('project.create.name')}
-      description={$t('project.create.name_description')}
-      bind:value={$form.name}
-      error={$errors.name}
-      autofocus
-    />
-
-    <ProjectTypeSelect bind:value={$form.type} error={$errors.type} />
-
-    <Select
-      id="org"
-      label={$t('project.create.org')}
-      bind:value={$form.orgId}
-      error={$errors.orgId}
-      on:change
-    >
-      <option value={''} >{$t('project_page.organization.placeholder')}</option>
-      {#each myOrgs as org}
-        <option value={org.id}>{org.name}</option>
-      {/each}
-    </Select>
-
-    <AdminContent>
-      <div class="form-control">
-        <div class="label">
-          <span class="label-text">{$t('project_page.members.title')}</span>
-        </div>
-        {#if requestingUser}
-          <MemberBadge canManage member={{...requestingUser, role: ProjectRole.Manager}} type="new" on:action={() => requestingUser = undefined} />
-        {:else}
-          <span class="text-secondary mx-2 my-1">{$t('common.none')}</span>
+  {#if projectStatus?.exists}
+    <div class="text-center">
+      <div>
+        <p>{$t('project.create.already_approved')}</p>
+        {#if projectStatus.deleted}
+          <p>{$t('project.create.already_approved_deleted')}</p>
         {/if}
       </div>
-    </AdminContent>
+      {#if projectStatus.accessibleCode}
+        <a class="btn btn-primary mt-4" href={projectUrl({ code: projectStatus.accessibleCode })}
+          >{$t('project.create.go_to_project')}</a
+        >
+      {/if}
+    </div>
+  {:else}
+    <Form {enhance}>
+      <Input
+        label={$t('project.create.name')}
+        description={$t('project.create.name_description')}
+        bind:value={$form.name}
+        error={$errors.name}
+        autofocus
+      />
 
-    <Select
-      id="policy"
-      label={$t('project.create.retention_policy')}
-      bind:value={$form.retentionPolicy}
-      error={$errors.retentionPolicy}
-    >
-      <option value={RetentionPolicy.Verified}>{$t('retention_policy.language_project')}</option>
-      <option value={RetentionPolicy.Training}>{$t('retention_policy.training')}</option>
-      <option value={RetentionPolicy.Test}>{$t('retention_policy.test')}</option>
+      <ProjectTypeSelect bind:value={$form.type} error={$errors.type} />
+
+      <Select id="org" label={$t('project.create.org')} bind:value={$form.orgId} error={$errors.orgId} on:change>
+        <option value={''}>{$t('project_page.organization.placeholder')}</option>
+        {#each myOrgs as org}
+          <option value={org.id}>{org.name}</option>
+        {/each}
+      </Select>
+
       <AdminContent>
-        <option value={RetentionPolicy.Dev}>{$t('retention_policy.dev')}</option>
-      </AdminContent>
-    </Select>
-
-    <Input
-      label={$t('project.create.language_code')}
-      description={$t('project.create.language_code_description')}
-      bind:value={$form.languageCode}
-      error={$errors.languageCode}
-    />
-
-    <AdminContent>
-      <Checkbox label={$t('project.create.custom_code')} bind:value={$form.customCode} />
-    </AdminContent>
-    <Input
-      label={$t('project.create.code')}
-      bind:value={$form.code}
-      error={$codeErrors}
-      readonly={!$form.customCode}
-    />
-
-    {#if $relatedProjects.length}
-      {#if showRelatedProjects}
-        <!-- Note, not using RadioButtonGroup here so we can better customize the display to the needs of this form -->
-        <div
-          role="radiogroup"
-          aria-labelledby="label-extra-projects"
-          id="group-extra-projects"
-          >
-          <div class="legend" id="label-extra-projects">
-            {$t('project.create.maybe_related')}
+        <div class="form-control">
+          <div class="label">
+            <span class="label-text">{$t('project_page.members.title')}</span>
           </div>
-          {#each $relatedProjects as proj}
-          <div class="form-control w-full">
-            <label class="label cursor-pointer justify-normal pb-0">
-              <input id={`extra-projects-${proj.code}`} type="radio" bind:group={selectedProject} value={proj} class="radio mr-2" />
-              <span class="label-text inline-flex items-center gap-2">
-                {proj.name} ({proj.code}) <br/>
-                {proj.description ?? $t('project.create.no_description')}
+          {#if requestingUser}
+            <MemberBadge
+              canManage
+              member={{ ...requestingUser, role: ProjectRole.Manager }}
+              type="new"
+              on:action={() => (requestingUser = undefined)}
+            />
+          {:else}
+            <span class="text-secondary mx-2 my-1">{$t('common.none')}</span>
+          {/if}
+        </div>
+      </AdminContent>
+
+      <Select
+        id="policy"
+        label={$t('project.create.retention_policy')}
+        bind:value={$form.retentionPolicy}
+        error={$errors.retentionPolicy}
+      >
+        <option value={RetentionPolicy.Verified}>{$t('retention_policy.language_project')}</option>
+        <option value={RetentionPolicy.Training}>{$t('retention_policy.training')}</option>
+        <option value={RetentionPolicy.Test}>{$t('retention_policy.test')}</option>
+        <AdminContent>
+          <option value={RetentionPolicy.Dev}>{$t('retention_policy.dev')}</option>
+        </AdminContent>
+      </Select>
+
+      <Input
+        label={$t('project.create.language_code')}
+        description={$t('project.create.language_code_description')}
+        bind:value={$form.languageCode}
+        error={$errors.languageCode}
+      />
+
+      <AdminContent>
+        <Checkbox label={$t('project.create.custom_code')} bind:value={$form.customCode} />
+      </AdminContent>
+      <Input
+        label={$t('project.create.code')}
+        bind:value={$form.code}
+        error={$codeErrors}
+        readonly={!$form.customCode}
+      />
+
+      {#if $relatedProjects.length}
+        {#if showRelatedProjects}
+          <!-- Note, not using RadioButtonGroup here so we can better customize the display to the needs of this form -->
+          <div role="radiogroup" aria-labelledby="label-extra-projects" id="group-extra-projects">
+            <div class="legend" id="label-extra-projects">
+              {$t('project.create.maybe_related')}
+            </div>
+            {#each $relatedProjects as proj}
+              <div class="form-control w-full">
+                <label class="label cursor-pointer justify-normal pb-0">
+                  <input
+                    id={`extra-projects-${proj.code}`}
+                    type="radio"
+                    bind:group={selectedProject}
+                    value={proj}
+                    class="radio mr-2"
+                  />
+                  <span class="label-text inline-flex items-center gap-2">
+                    {proj.name} ({proj.code}) <br />
+                    {proj.description ?? $t('project.create.no_description')}
+                  </span>
+                </label>
+              </div>
+            {/each}
+            <label for="group-extra-projects" class="label pb-0">
+              <span class="label-text-alt">
+                <NewTabLinkMarkdown md={$t('project.create.maybe_related_description')} />
               </span>
             </label>
           </div>
-          {/each}
-          <label for="group-extra-projects" class="label pb-0">
-            <span class="label-text-alt">
-              <NewTabLinkMarkdown md={$t('project.create.maybe_related_description')} />
-            </span>
-          </label>
-        </div>
 
-        <div class="inline-flex mt-2">
-          <Button
-            class="mr-2"
-            variant="btn-primary"
-            disabled={!selectedProject}
-            on:click={() => {if (selectedProject) void askToJoinProject(selectedProject.id, selectedProject.name)}}
-          >
-            {$t('project.create.ask_to_join')}
-          </Button>
-          <Button
-            class="mr-2"
-            variant="btn-warning"
-            on:click={() => showRelatedProjects = false}
-          >
-          {$t('project.create.no_thanks')}
-          </Button>
-        </div>
-      {:else}
-        <button class="btn btn-ghost btn-sm mb-4" tabindex="0" onclick={() => showRelatedProjects = true}>
-          {$t('project.create.click_to_view_related_projects', {count: $relatedProjects.length})}
-        </button>
+          <div class="inline-flex mt-2">
+            <Button
+              class="mr-2"
+              variant="btn-primary"
+              disabled={!selectedProject}
+              onclick={() => {
+                if (selectedProject) void askToJoinProject(selectedProject.id, selectedProject.name);
+              }}
+            >
+              {$t('project.create.ask_to_join')}
+            </Button>
+            <Button class="mr-2" variant="btn-warning" onclick={() => (showRelatedProjects = false)}>
+              {$t('project.create.no_thanks')}
+            </Button>
+          </div>
+        {:else}
+          <button class="btn btn-ghost btn-sm mb-4" tabindex="0" onclick={() => (showRelatedProjects = true)}>
+            {$t('project.create.click_to_view_related_projects', { count: $relatedProjects.length })}
+          </button>
+        {/if}
       {/if}
-    {/if}
 
-    {#if !$relatedProjects?.length || !showRelatedProjects}
-      <TextArea
-        id="description"
-        label={$t('project.create.description')}
-        bind:value={$form.description}
-        error={$errors.description}
-      />
+      {#if !$relatedProjects?.length || !showRelatedProjects}
+        <TextArea
+          id="description"
+          label={$t('project.create.description')}
+          bind:value={$form.description}
+          error={$errors.description}
+        />
 
-      <div class="mt-4 mb-2">
-        <!-- It feels appropriate to give this option a bit more real estate -->
-        <ProjectConfidentialityCombobox bind:value={$form.isConfidential} />
-      </div>
+        <div class="mt-4 mb-2">
+          <!-- It feels appropriate to give this option a bit more real estate -->
+          <ProjectConfidentialityCombobox bind:value={$form.isConfidential} />
+        </div>
 
-      <DevContent>
-        <Checkbox label="Force draft project creation" bind:value={forceDraft}/>
-      </DevContent>
-      <FormError error={$message} />
-      <SubmitButton loading={$submitting}>
+        <DevContent>
+          <Checkbox label="Force draft project creation" bind:value={forceDraft} />
+        </DevContent>
+        <FormError error={$message} />
+        <SubmitButton loading={$submitting}>
           {#if data.user.canCreateProjects}
-              {$t('project.create.submit')}
+            {$t('project.create.submit')}
           {:else}
-              {$t('project.create.request')}
+            {$t('project.create.request')}
           {/if}
-      </SubmitButton>
-    {/if}
-  </Form>
-{/if}
+        </SubmitButton>
+      {/if}
+    </Form>
+  {/if}
 </TitlePage>

--- a/frontend/src/routes/(authenticated)/project/create/+page.svelte
+++ b/frontend/src/routes/(authenticated)/project/create/+page.svelte
@@ -265,8 +265,6 @@
 
       <ProjectTypeSelect bind:value={$form.type} error={$errors.type} />
 
-      <!-- TODO: This used to have an on:change attribute to bubble up the submit event from HTML.
-           Let's check if the createBubbler() call in Form makes that unnecessary now. -->
       <Select id="org" label={$t('project.create.org')} bind:value={$form.orgId} error={$errors.orgId}>
         <option value={''}>{$t('project_page.organization.placeholder')}</option>
         {#each myOrgs as org}

--- a/frontend/src/routes/(authenticated)/resetPassword/+page.svelte
+++ b/frontend/src/routes/(authenticated)/resetPassword/+page.svelte
@@ -10,7 +10,11 @@
   import { getAspResponseErrorMessage } from '$lib/util/asp-response';
   import PasswordStrengthMeter from '$lib/components/PasswordStrengthMeter.svelte';
 
-  export let data: PageData;
+  interface Props {
+    data: PageData;
+  }
+
+  let { data }: Props = $props();
 
   const { notifySuccess } = useNotifications();
 

--- a/frontend/src/routes/(authenticated)/resetPassword/+page.svelte
+++ b/frontend/src/routes/(authenticated)/resetPassword/+page.svelte
@@ -51,7 +51,7 @@
       error={$errors.password}
       autofocus
     />
-    <PasswordStrengthMeter bind:score={$form.score} password={$form.password} />
+    <PasswordStrengthMeter onScoreUpdated={(score) => ($form.score = score)} password={$form.password} />
     <FormError error={$message} />
     <SubmitButton loading={$submitting}>{$t('reset_password.submit')}</SubmitButton>
   </Form>

--- a/frontend/src/routes/(authenticated)/user/+page.svelte
+++ b/frontend/src/routes/(authenticated)/user/+page.svelte
@@ -23,7 +23,7 @@
 
   let { data }: Props = $props();
   let user = $derived(data.account);
-  let deleteModal: DeleteUserModal = $state()!;
+  let deleteModal: DeleteUserModal | undefined = $state();
 
   const emailResult = useEmailResult();
   const requestedEmail = useRequestedEmail();
@@ -34,6 +34,7 @@
   const { notifySuccess, notifyWarning } = useNotifications();
 
   async function openDeleteModal(): Promise<void> {
+    if (!deleteModal) return;
     let { response } = await deleteModal.open($user);
     if (response == DialogResponse.Submit) {
       notifyWarning($t('account_settings.delete_success'));

--- a/frontend/src/routes/(authenticated)/user/+page.svelte
+++ b/frontend/src/routes/(authenticated)/user/+page.svelte
@@ -23,7 +23,7 @@
 
   let { data }: Props = $props();
   let user = $derived(data.account);
-  let deleteModal: DeleteUserModal = $state();
+  let deleteModal: DeleteUserModal = $state()!;
 
   const emailResult = useEmailResult();
   const requestedEmail = useRequestedEmail();
@@ -55,7 +55,7 @@
       locale: $form.locale,
       userId: $user.id,
     });
-    if (data?.changeUserAccountBySelf.errors?.some(e => e.__typename === 'UniqueValueError')) {
+    if (data?.changeUserAccountBySelf.errors?.some((e) => e.__typename === 'UniqueValueError')) {
       $errors.email = [$t('account_settings.email_taken')];
       return;
     }
@@ -75,7 +75,7 @@
   // This is a bit of a hack to make sure that the email field is not required if the user has no email
   // even if the user edited the email field
   run(() => {
-    if(!$form.email && $user && !$user.email) $form.email = null;
+    if (!$form.email && $user && !$user.email) $form.email = null;
   });
 
   onMount(() => {
@@ -85,7 +85,7 @@
         name: $user.name,
         locale: $user.locale,
       },
-      { taint: false }
+      { taint: false },
     );
   });
 </script>
@@ -107,9 +107,7 @@
       error={$errors.email}
       bind:value={$form.email}
     />
-    <DisplayLanguageSelect
-      bind:value={$form.locale}
-    />
+    <DisplayLanguageSelect bind:value={$form.locale} />
     <FormError error={$message} />
     <SubmitButton loading={$submitting}>{$t('account_settings.button_update')}</SubmitButton>
   </Form>

--- a/frontend/src/routes/(authenticated)/user/+page.svelte
+++ b/frontend/src/routes/(authenticated)/user/+page.svelte
@@ -1,4 +1,6 @@
 <script lang="ts">
+  import { run } from 'svelte/legacy';
+
   import { useEmailResult, useRequestedEmail } from '$lib/email/EmailVerificationStatus.svelte';
   import { DisplayLanguageSelect, Form, FormError, Input, SubmitButton, lexSuperForm } from '$lib/forms';
   import t from '$lib/i18n';
@@ -15,13 +17,19 @@
   import MoreSettings from '$lib/components/MoreSettings.svelte';
   import { delay } from '$lib/util/time';
 
-  export let data: PageData;
-  $: user = data.account;
-  let deleteModal: DeleteUserModal;
+  interface Props {
+    data: PageData;
+  }
+
+  let { data }: Props = $props();
+  let user = $derived(data.account);
+  let deleteModal: DeleteUserModal = $state();
 
   const emailResult = useEmailResult();
   const requestedEmail = useRequestedEmail();
-  $: if (data.emailResult) emailResult.set(data.emailResult);
+  run(() => {
+    if (data.emailResult) emailResult.set(data.emailResult);
+  });
 
   const { notifySuccess, notifyWarning } = useNotifications();
 
@@ -66,7 +74,9 @@
 
   // This is a bit of a hack to make sure that the email field is not required if the user has no email
   // even if the user edited the email field
-  $: if(!$form.email && $user && !$user.email) $form.email = null;
+  run(() => {
+    if(!$form.email && $user && !$user.email) $form.email = null;
+  });
 
   onMount(() => {
     form.set(
@@ -109,7 +119,7 @@
     </a>
   </div>
   <MoreSettings>
-    <button class="btn btn-error" on:click={openDeleteModal}>
+    <button class="btn btn-error" onclick={openDeleteModal}>
       {$t('account_settings.delete_account.submit')}<TrashIcon />
     </button>
   </MoreSettings>

--- a/frontend/src/routes/(unauthenticated)/+layout.svelte
+++ b/frontend/src/routes/(unauthenticated)/+layout.svelte
@@ -1,7 +1,12 @@
-<script>
+<script lang="ts">
   import { Layout } from '$lib/layout';
+  interface Props {
+    children?: import('svelte').Snippet;
+  }
+
+  let { children }: Props = $props();
 </script>
 
 <Layout>
-  <slot />
+  {@render children?.()}
 </Layout>

--- a/frontend/src/routes/(unauthenticated)/+layout.svelte
+++ b/frontend/src/routes/(unauthenticated)/+layout.svelte
@@ -1,7 +1,8 @@
 <script lang="ts">
+  import type { Snippet } from 'svelte';
   import { Layout } from '$lib/layout';
   interface Props {
-    children?: import('svelte').Snippet;
+    children?: Snippet;
   }
 
   let { children }: Props = $props();

--- a/frontend/src/routes/(unauthenticated)/forgotPassword/+page.svelte
+++ b/frontend/src/routes/(unauthenticated)/forgotPassword/+page.svelte
@@ -17,7 +17,7 @@
     email: z.string().email($t('form.invalid_email')),
   });
 
-  let turnstileToken = '';
+  let turnstileToken = $state('');
 
   let { form, errors, enhance, submitting, message } = lexSuperForm(formSchema, async () => {
     const response = await fetch(`api/login/forgotPassword`, {

--- a/frontend/src/routes/(unauthenticated)/login/+page.svelte
+++ b/frontend/src/routes/(unauthenticated)/login/+page.svelte
@@ -1,3 +1,4 @@
+<!-- @migration task: review uses of `navigating` -->
 <script lang="ts">
   import {goto} from '$app/navigation';
   import {SubmitButton, Form, FormError, Input, lexSuperForm} from '$lib/forms';
@@ -11,13 +12,13 @@
   import oneStoryEditorLogo from '$lib/assets/onestory-editor-logo.svg';
   import weSayLogo from '$lib/assets/we-say-logo.png';
   import {z} from 'zod';
-  import {navigating} from '$app/stores';
+  import {navigating} from '$app/state';
   import {AUTHENTICATED_ROOT} from '../..';
   import SigninWithGoogleButton from '$lib/components/SigninWithGoogleButton.svelte';
   import AppLogo from '$lib/icons/AppLogo.svelte';
 
   //return url should be a relative path, or empty string
-  let returnUrl: string = '';
+  let returnUrl: string = $state('');
 
   const formSchema = z.object({
     email: z.string().trim().min(1, $t('login.missing_user_info')),
@@ -76,7 +77,7 @@
     return '';
   }
 
-  let badCredentials = false;
+  let badCredentials = $state(false);
 </script>
 
 <div class="hero flex-grow">
@@ -111,7 +112,7 @@
             {$t('login.forgot_password')}
           </a>
 
-          <SubmitButton loading={$submitting || $navigating?.to?.route.id?.includes(AUTHENTICATED_ROOT)}>
+          <SubmitButton loading={$submitting || navigating?.to?.route.id?.includes(AUTHENTICATED_ROOT)}>
             {badCredentials ? $t('login.button_login_again') : $t('login.button_login')}
           </SubmitButton>
 

--- a/frontend/src/routes/(unauthenticated)/login/+page.svelte
+++ b/frontend/src/routes/(unauthenticated)/login/+page.svelte
@@ -1,4 +1,3 @@
-<!-- @migration task: review uses of `navigating` -->
 <script lang="ts">
   import {goto} from '$app/navigation';
   import {SubmitButton, Form, FormError, Input, lexSuperForm} from '$lib/forms';
@@ -112,7 +111,7 @@
             {$t('login.forgot_password')}
           </a>
 
-          <SubmitButton loading={$submitting || navigating?.to?.route.id?.includes(AUTHENTICATED_ROOT)}>
+          <SubmitButton loading={$submitting || navigating.to?.route.id?.includes(AUTHENTICATED_ROOT)}>
             {badCredentials ? $t('login.button_login_again') : $t('login.button_login')}
           </SubmitButton>
 

--- a/frontend/src/routes/(unauthenticated)/sandbox/+page.svelte
+++ b/frontend/src/routes/(unauthenticated)/sandbox/+page.svelte
@@ -40,7 +40,7 @@
     form.update(f => ({...f, name: 'John'}), {taint: false});
   }
 
-  let disableDropdown = false;
+  let disableDropdown = $state(false);
 
   async function gqlThrows500(): Promise<void> {
     await _gqlThrows500();
@@ -48,10 +48,10 @@
 
   const { notifySuccess } = useNotifications();
 
-  let modal: ConfirmModal;
-  let deleteModal: DeleteModal;
-  let notificationModal: Modal;
-  let notificationModalIsAtBottom = false;
+  let modal: ConfirmModal = $state();
+  let deleteModal: DeleteModal = $state();
+  let notificationModal: Modal = $state();
+  let notificationModalIsAtBottom = $state(false);
 
 </script>
 <PageBreadcrumb>Hello from sandbox</PageBreadcrumb>
@@ -60,21 +60,21 @@
 <div class="grid gap-2 grid-cols-3">
   <div class="card w-96 bg-base-200 shadow-lg">
     <a rel="external" class="btn" href="/">Go home</a>
-    <div class="divider"/>
+    <div class="divider"></div>
     <a rel="external" class="btn" href="/sandbox/403">Goto page load 403</a>
     <a rel="external" target="_blank" class="btn" href="/sandbox/403">Goto page load 403 new tab</a>
     <a rel="external" class="btn" href="/api/AuthTesting/403">Goto API 403</a>
     <a rel="external" target="_blank" class="btn" href="/api/AuthTesting/403">Goto API 403 new tab</a>
-    <button class="btn" on:click={fetch403}>Fetch 403</button>
+    <button class="btn" onclick={fetch403}>Fetch 403</button>
 
-    <div class="divider"/>
+    <div class="divider"></div>
 
     <a rel="external" class="btn" href="/sandbox/500">Goto page load 500</a>
     <a rel="external" target="_blank" class="btn" href="/sandbox/500">Goto page load 500 new tab</a>
     <a rel="external" class="btn" href="/api/testing/test500NoException">Goto API 500</a>
     <a rel="external" target="_blank" class="btn" href="/api/testing/test500NoException">Goto API 500 new tab</a>
-    <button class="btn" on:click={fetch500}>Fetch 500</button>
-    <button class="btn" on:click={gqlThrows500}>GQL 500</button>
+    <button class="btn" onclick={fetch500}>Fetch 500</button>
+    <button class="btn" onclick={gqlThrows500}>GQL 500</button>
   </div>
   <div class="card w-96 bg-base-200 shadow-lg">
     <div class="card-body">
@@ -88,27 +88,33 @@
       <span>Clicking menu items inside dropdown should cause it to close</span>
       <Dropdown>
         <Button variant="btn-primary">Open Me!</Button>
-        <ul slot="content" class="menu bg-info rounded-box">
-          <li><button>First item</button></li>
-          <li><button>Second item</button></li>
-        </ul>
+        {#snippet content()}
+                <ul  class="menu bg-info rounded-box">
+            <li><button>First item</button></li>
+            <li><button>Second item</button></li>
+          </ul>
+              {/snippet}
       </Dropdown>
       <div>
         <Dropdown>
           <Button variant="btn-primary">Open Me!</Button>
-          <ul slot="content" class="menu bg-info rounded-box">
-            <li><button>First item</button></li>
-            <li><button>Second item</button></li>
-          </ul>
+          {#snippet content()}
+                    <ul  class="menu bg-info rounded-box">
+              <li><button>First item</button></li>
+              <li><button>Second item</button></li>
+            </ul>
+                  {/snippet}
         </Dropdown>
       </div>
       <div>
         <Dropdown disabled={disableDropdown}>
           <Button variant="btn-primary" disabled={disableDropdown}>Open dropdown</Button>
-          <div slot="content" class="bg-neutral p-5">
-            <p>Some content</p>
-            <Button outline on:click={() => disableDropdown = true}>Disable myself</Button>
-          </div>
+          {#snippet content()}
+                    <div  class="bg-neutral p-5">
+              <p>Some content</p>
+              <Button outline on:click={() => disableDropdown = true}>Disable myself</Button>
+            </div>
+                  {/snippet}
         </Dropdown>
 
         <label class="cursor-pointer label gap-4">

--- a/frontend/src/routes/(unauthenticated)/sandbox/+page.svelte
+++ b/frontend/src/routes/(unauthenticated)/sandbox/+page.svelte
@@ -46,9 +46,9 @@
 
   const { notifySuccess } = useNotifications();
 
-  let modal: ConfirmModal = $state()!;
-  let deleteModal: DeleteModal = $state()!;
-  let notificationModal: Modal = $state()!;
+  let modal: ConfirmModal | undefined = $state();
+  let deleteModal: DeleteModal | undefined = $state();
+  let notificationModal: Modal | undefined = $state();
   let notificationModalIsAtBottom = $state(false);
 </script>
 
@@ -184,7 +184,7 @@
       <Button
         variant="btn-primary"
         onclick={async () => {
-          const result = await modal.open(async () => delay(2000));
+          const result = await modal?.open(async () => delay(2000));
           if (result) alert('submitted');
         }}
       >
@@ -196,7 +196,7 @@
       <Button
         variant="btn-primary"
         onclick={async () => {
-          const result = await deleteModal.prompt(async () => delay(2000));
+          const result = await deleteModal?.prompt(async () => delay(2000));
           if (result) alert('deleted');
         }}
       >
@@ -212,7 +212,7 @@
       <Button
         variant="btn-primary"
         onclick={() => {
-          notificationModal.openModal();
+          notificationModal?.openModal();
         }}
       >
         Play with notifications

--- a/frontend/src/routes/(unauthenticated)/sandbox/+page.svelte
+++ b/frontend/src/routes/(unauthenticated)/sandbox/+page.svelte
@@ -1,18 +1,18 @@
-﻿<script lang="ts">
+<script lang="ts">
   import TusUpload from '$lib/components/TusUpload.svelte';
   import Dropdown from '$lib/components/Dropdown.svelte';
-  import {Button, Form, Input, lexSuperForm, SubmitButton} from '$lib/forms';
-  import {PageBreadcrumb} from '$lib/layout';
+  import { Button, Form, Input, lexSuperForm, SubmitButton } from '$lib/forms';
+  import { PageBreadcrumb } from '$lib/layout';
   import z from 'zod';
   // eslint-disable-next-line no-restricted-imports
-  import {t as otherT} from 'svelte-intl-precompile';
+  import { t as otherT } from 'svelte-intl-precompile';
   import t from '$lib/i18n';
-  import {_gqlThrows500} from './+page';
+  import { _gqlThrows500 } from './+page';
   import ConfirmModal from '$lib/components/modals/ConfirmModal.svelte';
-  import {delay} from '$lib/util/time';
+  import { delay } from '$lib/util/time';
   import DeleteModal from '$lib/components/modals/DeleteModal.svelte';
-  import {Modal} from '$lib/components/modals';
-  import {useNotifications} from '$lib/notify';
+  import { Modal } from '$lib/components/modals';
+  import { useNotifications } from '$lib/notify';
 
   function uploadFinished(): void {
     alert('upload done!');
@@ -25,19 +25,17 @@
   async function fetch403(): Promise<Response> {
     return fetch('/api/AuthTesting/403');
   }
-  const formSchema = z.object(
-    {
-      name: z.string().trim().min(3).max(255),
-      lastName: z.string().min(3).max(255),
-    }
-  );
+  const formSchema = z.object({
+    name: z.string().trim().min(3).max(255),
+    lastName: z.string().min(3).max(255),
+  });
 
   // eslint-disable-next-line @typescript-eslint/require-await
-  let {form, enhance, errors} = lexSuperForm(formSchema, async () => {
-      console.log('submit', $form);
+  let { form, enhance, errors } = lexSuperForm(formSchema, async () => {
+    console.log('submit', $form);
   });
   function preFillForm(): void {
-    form.update(f => ({...f, name: 'John'}), {taint: false});
+    form.update((f) => ({ ...f, name: 'John' }), { taint: false });
   }
 
   let disableDropdown = $state(false);
@@ -48,12 +46,12 @@
 
   const { notifySuccess } = useNotifications();
 
-  let modal: ConfirmModal = $state();
-  let deleteModal: DeleteModal = $state();
-  let notificationModal: Modal = $state();
+  let modal: ConfirmModal = $state()!;
+  let deleteModal: DeleteModal = $state()!;
+  let notificationModal: Modal = $state()!;
   let notificationModalIsAtBottom = $state(false);
-
 </script>
+
 <PageBreadcrumb>Hello from sandbox</PageBreadcrumb>
 <PageBreadcrumb>second value</PageBreadcrumb>
 <h2 class="text-lg">Sandbox</h2>
@@ -78,7 +76,7 @@
   </div>
   <div class="card w-96 bg-base-200 shadow-lg">
     <div class="card-body">
-      <TusUpload internalButton endpoint="/api/tus-test" accept="image/*" on:uploadComplete={uploadFinished}/>
+      <TusUpload internalButton endpoint="/api/tus-test" accept="image/*" on:uploadComplete={uploadFinished} />
     </div>
   </div>
 
@@ -89,37 +87,37 @@
       <Dropdown>
         <Button variant="btn-primary">Open Me!</Button>
         {#snippet content()}
-                <ul  class="menu bg-info rounded-box">
+          <ul class="menu bg-info rounded-box">
             <li><button>First item</button></li>
             <li><button>Second item</button></li>
           </ul>
-              {/snippet}
+        {/snippet}
       </Dropdown>
       <div>
         <Dropdown>
           <Button variant="btn-primary">Open Me!</Button>
           {#snippet content()}
-                    <ul  class="menu bg-info rounded-box">
+            <ul class="menu bg-info rounded-box">
               <li><button>First item</button></li>
               <li><button>Second item</button></li>
             </ul>
-                  {/snippet}
+          {/snippet}
         </Dropdown>
       </div>
       <div>
         <Dropdown disabled={disableDropdown}>
           <Button variant="btn-primary" disabled={disableDropdown}>Open dropdown</Button>
           {#snippet content()}
-                    <div  class="bg-neutral p-5">
+            <div class="bg-neutral p-5">
               <p>Some content</p>
-              <Button outline on:click={() => disableDropdown = true}>Disable myself</Button>
+              <Button outline onclick={() => (disableDropdown = true)}>Disable myself</Button>
             </div>
-                  {/snippet}
+          {/snippet}
         </Dropdown>
 
         <label class="cursor-pointer label gap-4">
           <span class="label-text">Disabled</span>
-          <input bind:checked={disableDropdown} type="checkbox" class="toggle toggle-error"/>
+          <input bind:checked={disableDropdown} type="checkbox" class="toggle toggle-error" />
         </label>
       </div>
     </div>
@@ -128,13 +126,7 @@
     <div class="card-body">
       <h2 class="card-title">Form Example</h2>
       <Form {enhance}>
-        <Input
-          id="name"
-          label="Name"
-          type="text"
-          error={$errors.name}
-          bind:value={$form.name}
-        />
+        <Input id="name" label="Name" type="text" error={$errors.name} bind:value={$form.name} />
         <Input
           id="lastName"
           label="Last Name (allows only white space)"
@@ -143,7 +135,7 @@
           bind:value={$form.lastName}
         />
         <SubmitButton>Submit</SubmitButton>
-        <Button outline on:click={preFillForm}>Pre fill</Button>
+        <Button outline onclick={preFillForm}>Pre fill</Button>
       </Form>
     </div>
   </div>
@@ -151,69 +143,78 @@
     <div class="card-body">
       <h2 class="card-title">Translations of login.title</h2>
       <div>Current: {$t('login.title')}</div>
-      <div>English: {$otherT('login.title', { locale: 'en'})} (always works, because it's the fallback)</div>
-      <div>French: {$otherT('login.title', { locale: 'fr'})} (only works if it's the current, otherwise uses fallback)</div>
-      <div>Spanish: {$otherT('login.title', { locale: 'es'})} (only works if it's the current, otherwise uses fallback)</div>
+      <div>English: {$otherT('login.title', { locale: 'en' })} (always works, because it's the fallback)</div>
+      <div>
+        French: {$otherT('login.title', { locale: 'fr' })} (only works if it's the current, otherwise uses fallback)
+      </div>
+      <div>
+        Spanish: {$otherT('login.title', { locale: 'es' })} (only works if it's the current, otherwise uses fallback)
+      </div>
     </div>
   </div>
   <div class="card bg-base-200 shadow-lg">
     <div class="card-body grid-cols-2 grid justify-items-start">
       <h2 class="card-title col-span-2">Buttons</h2>
-        <Button variant="btn-primary" on:click={() => alert('hello')}>Primary Button</Button>
-        <Button variant="btn-primary" size="btn-sm" on:click={() => alert('hello')}>Primary Small Button</Button>
-        <Button variant="btn-success" on:click={() => alert('hello')}>Success Button</Button>
-        <Button variant="btn-error" on:click={() => alert('hello')}>Error Button</Button>
-        <Button outline on:click={() => alert('hello')}>Outline Button</Button>
-        <Button variant="btn-ghost" on:click={() => alert('hello')}>Ghost Button</Button>
-        <Button variant="btn-primary" disabled on:click={() => alert('should not fire')}>
-          Disabled Button
-        </Button>
-        <Button variant="btn-primary" loading on:click={() => alert('should not fire')}>
-          Loading Button
-        </Button>
-        <Button variant="btn-primary" disabled loading on:click={() => alert('should not fire')}>
-          Disabled Loading Button
-        </Button>
+      <Button variant="btn-primary" onclick={() => alert('hello')}>Primary Button</Button>
+      <Button variant="btn-primary" size="btn-sm" onclick={() => alert('hello')}>Primary Small Button</Button>
+      <Button variant="btn-success" onclick={() => alert('hello')}>Success Button</Button>
+      <Button variant="btn-error" onclick={() => alert('hello')}>Error Button</Button>
+      <Button outline onclick={() => alert('hello')}>Outline Button</Button>
+      <Button variant="btn-ghost" onclick={() => alert('hello')}>Ghost Button</Button>
+      <Button variant="btn-primary" disabled onclick={() => alert('should not fire')}>Disabled Button</Button>
+      <Button variant="btn-primary" loading onclick={() => alert('should not fire')}>Loading Button</Button>
+      <Button variant="btn-primary" disabled loading onclick={() => alert('should not fire')}>
+        Disabled Loading Button
+      </Button>
     </div>
   </div>
-
 
   <div class="card bg-base-200 shadow-lg">
     <div class="card-body">
       <h2 class="card-title">Confirm Modal</h2>
-      <ConfirmModal bind:this={modal} title="Confirm?"
-                    submitText="Confirm"
-                    submitIcon="i-mdi-hand-wave"
-                    cancelText="Don't confirm">
+      <ConfirmModal
+        bind:this={modal}
+        title="Confirm?"
+        submitText="Confirm"
+        submitIcon="i-mdi-hand-wave"
+        cancelText="Don't confirm"
+      >
         Would you like to confirm this modal?
       </ConfirmModal>
-      <Button variant="btn-primary" on:click={async () => {
-        const result = await modal.open(async () => delay(2000));
-        if (result) alert('submitted')
-      }}>
+      <Button
+        variant="btn-primary"
+        onclick={async () => {
+          const result = await modal.open(async () => delay(2000));
+          if (result) alert('submitted');
+        }}
+      >
         Open Modal
       </Button>
 
       <h2 class="card-title">Delete Modal</h2>
-      <DeleteModal bind:this={deleteModal} entityName="Car">
-        Would you like to delete this car?
-      </DeleteModal>
-      <Button variant="btn-primary" on:click={async () => {
-        const result = await deleteModal.prompt(async () => delay(2000));
-        if (result) alert('deleted')
-      }}>
+      <DeleteModal bind:this={deleteModal} entityName="Car">Would you like to delete this car?</DeleteModal>
+      <Button
+        variant="btn-primary"
+        onclick={async () => {
+          const result = await deleteModal.prompt(async () => delay(2000));
+          if (result) alert('deleted');
+        }}
+      >
         Delete Car
       </Button>
 
       <h2 class="card-title">Notification modal</h2>
       <Modal bind:this={notificationModal} bottom={notificationModalIsAtBottom}>
         <h2 class="text-xl mb-2">Notification fun 🎉</h2>
-        <Button on:click={() => notifySuccess('Hurra you generated a notification! 😎')}>Generate notification</Button>
-        <Button on:click={() => notificationModalIsAtBottom = !notificationModalIsAtBottom}>Toggle position</Button>
+        <Button onclick={() => notifySuccess('Hurra you generated a notification! 😎')}>Generate notification</Button>
+        <Button onclick={() => (notificationModalIsAtBottom = !notificationModalIsAtBottom)}>Toggle position</Button>
       </Modal>
-      <Button variant="btn-primary" on:click={() => {
-        notificationModal.openModal();
-      }}>
+      <Button
+        variant="btn-primary"
+        onclick={() => {
+          notificationModal.openModal();
+        }}
+      >
         Play with notifications
       </Button>
     </div>

--- a/frontend/src/routes/(unauthenticated)/sandbox/+page.ts
+++ b/frontend/src/routes/(unauthenticated)/sandbox/+page.ts
@@ -1,4 +1,4 @@
-﻿import {getClient, graphql} from '$lib/gql';
+import {getClient, graphql} from '$lib/gql';
 
 import type { PageLoadEvent } from './$types';
 import type {Readable} from 'svelte/store';

--- a/frontend/src/routes/(unauthenticated)/sandbox/[status_code]/+page.svelte
+++ b/frontend/src/routes/(unauthenticated)/sandbox/[status_code]/+page.svelte
@@ -1,7 +1,11 @@
 ﻿<script lang="ts">
   import type { PageData } from './$types';
 
-  export let data: PageData;
+  interface Props {
+    data: PageData;
+  }
+
+  let { data }: Props = $props();
 
 </script>
 

--- a/frontend/src/routes/(unauthenticated)/sandbox/i18n/late/+page.svelte
+++ b/frontend/src/routes/(unauthenticated)/sandbox/i18n/late/+page.svelte
@@ -2,7 +2,7 @@
   import t from '$lib/i18n';
   import { onMount } from 'svelte';
 
-  let text: string | undefined = undefined;
+  let text: string | undefined = $state(undefined);
 
   onMount(() => {
     setTimeout(() => {

--- a/frontend/src/routes/+error.svelte
+++ b/frontend/src/routes/+error.svelte
@@ -1,15 +1,15 @@
 <script lang="ts">
-  import { page } from '$app/stores';
+  import { page } from '$app/state';
   import UnexpectedError from '$lib/error/UnexpectedError.svelte';
   import t from '$lib/i18n';
   import { Layout, Page, HomeBreadcrumb, PageBreadcrumb } from '$lib/layout';
 
-  const status = $page.status;
+  const status = page.status;
 </script>
 
-{#if $page.data.user}
+{#if page.data.user}
   <HomeBreadcrumb />
-  {#each $page.url.pathname.split('/').slice(1) as path}
+  {#each page.url.pathname.split('/').slice(1) as path}
     <PageBreadcrumb>{path}</PageBreadcrumb>
   {/each}
 {/if}
@@ -20,7 +20,7 @@
       {#if status === 404}
         <div class="flex flex-col gap-4 items-center">
           <div class="flex gap-2">
-            <span class="i-mdi-emoticon-confused-outline text-3xl" />
+            <span class="i-mdi-emoticon-confused-outline text-3xl"></span>
             <span class="text-2xl">{$t('errors.not_found')}</span>
           </div>
         </div>

--- a/frontend/src/routes/+layout.server.ts
+++ b/frontend/src/routes/+layout.server.ts
@@ -4,7 +4,6 @@ import type { LayoutServerLoadEvent } from './$types'
 import { USER_LOAD_KEY } from '$lib/user';
 import { getRootTraceparent } from '$lib/otel/otel.server'
 
-// eslint-disable-next-line @typescript-eslint/unbound-method
 export async function load({ locals, depends, fetch }: LayoutServerLoadEvent) {
   const user = locals.getUser();
   const traceParent = getRootTraceparent()

--- a/frontend/src/routes/+layout.svelte
+++ b/frontend/src/routes/+layout.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import type { Snippet } from 'svelte';
   import { run } from 'svelte/legacy';
 
   import { getStores, navigating } from '$app/stores';
@@ -18,7 +19,7 @@
 
   interface Props {
     data: LayoutData;
-    children?: import('svelte').Snippet;
+    children?: Snippet;
   }
 
   let { data, children }: Props = $props();

--- a/frontend/src/routes/+layout.svelte
+++ b/frontend/src/routes/+layout.svelte
@@ -13,8 +13,8 @@
   import { overlayContainer } from '$lib/overlay';
   import { Duration } from '$lib/util/time';
   import { browser } from '$app/environment';
-  import {onMount, setContext} from 'svelte';
-  import {derived, writable} from 'svelte/store';
+  import { onMount, setContext } from 'svelte';
+  import { derived, writable } from 'svelte/store';
   import { initI18n } from '$lib/i18n';
 
   interface Props {
@@ -44,7 +44,7 @@
   });
 
   let hydrating = $state(true);
-  onMount(() => hydrating = false);
+  onMount(() => (hydrating = false));
 
   const loading = derived(navigating, (nav) => {
     if (!nav?.to) return false;
@@ -74,7 +74,7 @@
   <progress class="progress progress-info block fixed z-50 h-[3px] rounded-none bg-transparent"></progress>
 {/if}
 
-<div class="flex flex-col justify-between min-h-full" class:hydrating={hydrating}>
+<div class="flex flex-col justify-between min-h-full" class:hydrating>
   <div class="flex flex-col flex-grow">
     {@render children?.()}
   </div>

--- a/frontend/src/routes/email/tester/+page@.svelte
+++ b/frontend/src/routes/email/tester/+page@.svelte
@@ -1,4 +1,6 @@
 <script lang="ts">
+    import { run } from 'svelte/legacy';
+
     import {EmailTemplate, type EmailTemplateProps} from '../emails';
     import {browser} from '$app/environment';
     import {ProjectType, RetentionPolicy} from '$lib/gql/generated/graphql';
@@ -104,19 +106,21 @@
         }
     ];
 
-    let currEmail = emails[0];
-    let emailJson: RenderEmailResult;
-    $: if (browser) {
-        void fetch('.', {method: 'POST', body: JSON.stringify(currEmail)})
-            .then(res => res.json())
-            .then(json => {
-                if (json.message) {
-                    emailJson = {html: json.message, subject: ''};
-                } else {
-                    emailJson = json;
-                }
-            });
-    }
+    let currEmail = $state(emails[0]);
+    let emailJson: RenderEmailResult = $state();
+    run(() => {
+        if (browser) {
+            void fetch('.', {method: 'POST', body: JSON.stringify(currEmail)})
+                .then(res => res.json())
+                .then(json => {
+                    if (json.message) {
+                        emailJson = {html: json.message, subject: ''};
+                    } else {
+                        emailJson = json;
+                    }
+                });
+        }
+    });
 
 </script>
 
@@ -139,6 +143,6 @@
                 height="500"
                 src={'data:text/html;charset=utf-8,' + encodeURIComponent(emailJson.html)}
                 title={currEmail.template}
-        />
+></iframe>
     {/if}
 </div>

--- a/frontend/src/routes/email/tester/+page@.svelte
+++ b/frontend/src/routes/email/tester/+page@.svelte
@@ -1,148 +1,147 @@
 <script lang="ts">
-    import { run } from 'svelte/legacy';
+  import { run } from 'svelte/legacy';
 
-    import {EmailTemplate, type EmailTemplateProps} from '../emails';
-    import {browser} from '$app/environment';
-    import {ProjectType, RetentionPolicy} from '$lib/gql/generated/graphql';
-    import type {RenderEmailResult} from '$lib/email/emailRenderer.server';
+  import { EmailTemplate, type EmailTemplateProps } from '../emails';
+  import { browser } from '$app/environment';
+  import { ProjectType, RetentionPolicy } from '$lib/gql/generated/graphql';
+  import type { RenderEmailResult } from '$lib/email/emailRenderer.server';
 
-    function absoluteUrl(path: string): string {
-      return `${location.origin}/${path}`;
+  function absoluteUrl(path: string): string {
+    return `${location.origin}/${path}`;
+  }
+
+  let emails: Array<EmailTemplateProps & { label?: string }> = [
+    {
+      template: EmailTemplate.ForgotPassword,
+      name: 'Bob',
+      resetUrl: absoluteUrl('resetPassword'),
+      lifetime: '3.00:00:00', // 3 days
+    },
+    {
+      template: EmailTemplate.VerifyEmailAddress,
+      name: 'Bob',
+      verifyUrl: absoluteUrl('user?emailResult=verifiedEmail'),
+      lifetime: '3.00:00:00', // 3 days
+    },
+    {
+      label: 'Verify New Email Address',
+      name: 'Bob',
+      template: EmailTemplate.VerifyEmailAddress,
+      verifyUrl: absoluteUrl('user?emailResult=changedEmail'),
+      lifetime: '3.00:00:00', // 3 days
+      newAddress: true,
+    },
+    {
+      label: 'Create Account Request for Org',
+      name: 'Bob',
+      managerName: 'John',
+      orgName: 'Payap University',
+      template: EmailTemplate.CreateAccountRequestOrg,
+      verifyUrl: absoluteUrl('register?name=Bob'), // TODO: Get correct URL
+      lifetime: '3.00:00:00', // 3 days
+    },
+    {
+      label: 'Create Account Request for Project',
+      name: 'Bob',
+      managerName: 'John',
+      projectName: 'Elawa',
+      template: EmailTemplate.CreateAccountRequestProject,
+      verifyUrl: absoluteUrl('register?name=Bob'), // TODO: Get correct URL
+      lifetime: '3.00:00:00', // 3 days
+    },
+    {
+      label: 'Create Project Request',
+      name: 'Admin',
+      baseUrl: location.origin,
+      template: EmailTemplate.CreateProjectRequest,
+      project: {
+        name: 'My Project',
+        code: 'myproj-test-onestory',
+        type: ProjectType.OneStoryEditor,
+        description: 'My project description',
+        retentionPolicy: RetentionPolicy.Test,
+        isConfidential: false,
+      },
+      user: {
+        name: 'Bob',
+        email: 'test@test.com',
+      },
+    },
+    {
+      label: 'Create Project Request (Language Project)',
+      name: 'Admin',
+      baseUrl: location.origin,
+      template: EmailTemplate.CreateProjectRequest,
+      project: {
+        name: 'My Project',
+        code: 'myproj-onestory',
+        type: ProjectType.OneStoryEditor,
+        description: 'My project description',
+        retentionPolicy: RetentionPolicy.Verified,
+        isConfidential: true,
+      },
+      user: {
+        name: 'Bob',
+        email: 'test@test.com',
+      },
+    },
+    {
+      label: 'Create Project Request - custom code',
+      name: 'Admin',
+      baseUrl: location.origin,
+      template: EmailTemplate.CreateProjectRequest,
+      project: {
+        name: 'My Project',
+        code: 'my-proj-custom-onestory',
+        type: ProjectType.WeSay,
+        description: 'My project description',
+        retentionPolicy: RetentionPolicy.Dev,
+        projectManagerId: '703701a8-005c-4747-91f2-ac7650455118', // manager from seeding data
+        isConfidential: true,
+      },
+      user: {
+        name: 'Bob',
+        email: 'test@test.com',
+      },
+    },
+  ];
+
+  let currEmail = $state(emails[0]);
+  let emailJson: RenderEmailResult | undefined = $state();
+  run(() => {
+    if (browser) {
+      void fetch('.', { method: 'POST', body: JSON.stringify(currEmail) })
+        .then((res) => res.json())
+        .then((json) => {
+          if (json.message) {
+            emailJson = { html: json.message, subject: '' };
+          } else {
+            emailJson = json;
+          }
+        });
     }
-
-    let emails: Array<EmailTemplateProps & { label?: string }> = [
-        {
-            template: EmailTemplate.ForgotPassword,
-            name: 'Bob',
-            resetUrl: absoluteUrl('resetPassword'),
-            lifetime: '3.00:00:00', // 3 days
-        },
-        {
-            template: EmailTemplate.VerifyEmailAddress,
-            name: 'Bob',
-            verifyUrl: absoluteUrl('user?emailResult=verifiedEmail'),
-            lifetime: '3.00:00:00', // 3 days
-        },
-        {
-            label: 'Verify New Email Address',
-            name: 'Bob',
-            template: EmailTemplate.VerifyEmailAddress,
-            verifyUrl: absoluteUrl('user?emailResult=changedEmail'),
-            lifetime: '3.00:00:00', // 3 days
-            newAddress: true,
-        },
-        {
-            label: 'Create Account Request for Org',
-            name: 'Bob',
-            managerName: 'John',
-            orgName: 'Payap University',
-            template: EmailTemplate.CreateAccountRequestOrg,
-            verifyUrl: absoluteUrl('register?name=Bob'), // TODO: Get correct URL
-            lifetime: '3.00:00:00', // 3 days
-        },
-        {
-            label: 'Create Account Request for Project',
-            name: 'Bob',
-            managerName: 'John',
-            projectName: 'Elawa',
-            template: EmailTemplate.CreateAccountRequestProject,
-            verifyUrl: absoluteUrl('register?name=Bob'), // TODO: Get correct URL
-            lifetime: '3.00:00:00', // 3 days
-        },
-        {
-            label: 'Create Project Request',
-            name: 'Admin',
-            baseUrl: location.origin,
-            template: EmailTemplate.CreateProjectRequest,
-            project: {
-                name: 'My Project',
-                code: 'myproj-test-onestory',
-                type: ProjectType.OneStoryEditor,
-                description: 'My project description',
-                retentionPolicy: RetentionPolicy.Test,
-                isConfidential: false,
-            },
-            user: {
-                name: 'Bob',
-                email: 'test@test.com'
-            },
-        },
-        {
-            label: 'Create Project Request (Language Project)',
-            name: 'Admin',
-            baseUrl: location.origin,
-            template: EmailTemplate.CreateProjectRequest,
-            project: {
-                name: 'My Project',
-                code: 'myproj-onestory',
-                type: ProjectType.OneStoryEditor,
-                description: 'My project description',
-                retentionPolicy: RetentionPolicy.Verified,
-                isConfidential: true,
-            },
-            user: {
-                name: 'Bob',
-                email: 'test@test.com'
-            }
-        },
-        {
-            label: 'Create Project Request - custom code',
-            name: 'Admin',
-            baseUrl: location.origin,
-            template: EmailTemplate.CreateProjectRequest,
-            project: {
-                name: 'My Project',
-                code: 'my-proj-custom-onestory',
-                type: ProjectType.WeSay,
-                description: 'My project description',
-                retentionPolicy: RetentionPolicy.Dev,
-                projectManagerId: '703701a8-005c-4747-91f2-ac7650455118', // manager from seeding data
-                isConfidential: true,
-            },
-            user: {
-                name: 'Bob',
-                email: 'test@test.com'
-            }
-        }
-    ];
-
-    let currEmail = $state(emails[0]);
-    let emailJson: RenderEmailResult = $state();
-    run(() => {
-        if (browser) {
-            void fetch('.', {method: 'POST', body: JSON.stringify(currEmail)})
-                .then(res => res.json())
-                .then(json => {
-                    if (json.message) {
-                        emailJson = {html: json.message, subject: ''};
-                    } else {
-                        emailJson = json;
-                    }
-                });
-        }
-    });
-
+  });
 </script>
 
 <label class="label cursor-pointer inline-flex gap-4 m-4">
-    <span class="label-text">Email template:</span>
-    <select class="select select-info" bind:value={currEmail}>
-        {#each emails as email}
-            <option value={email}>{email.label ?? email.template.replaceAll(/([a-z])([A-Z])/g, '$1 $2')}</option>
-        {/each}
-    </select>
+  <span class="label-text">Email template:</span>
+  <select class="select select-info" bind:value={currEmail}>
+    {#each emails as email}
+      <option value={email}>{email.label ?? email.template.replaceAll(/([a-z])([A-Z])/g, '$1 $2')}</option>
+    {/each}
+  </select>
 </label>
 
 <div class="m-4 mockup-browser border bg-white">
-    {#if emailJson}
-        <div class="mockup-browser-toolbar text-base-100">
-            Subject: {emailJson.subject}
-        </div>
-        <iframe
-                width="100%"
-                height="500"
-                src={'data:text/html;charset=utf-8,' + encodeURIComponent(emailJson.html)}
-                title={currEmail.template}
-></iframe>
-    {/if}
+  {#if emailJson}
+    <div class="mockup-browser-toolbar text-base-100">
+      Subject: {emailJson.subject}
+    </div>
+    <iframe
+      width="100%"
+      height="500"
+      src={'data:text/html;charset=utf-8,' + encodeURIComponent(emailJson.html)}
+      title={currEmail.template}
+    ></iframe>
+  {/if}
 </div>

--- a/frontend/tests/oauth.test.ts
+++ b/frontend/tests/oauth.test.ts
@@ -65,13 +65,13 @@ test.describe('oauth tests', () => {
     });
   }
 
-  async function addUserToProjectNewContext(browser: Browser, userId: string) {
+  async function addUserToProjectNewContext(browser: Browser, userId: string): Promise<void> {
     const context = await browser.newContext();
     await loginAs(context.request, 'admin');
     await addUserToProject(context.request, userId, elawaProjectId, 'EDITOR');
   }
 
-  async function userProjectCount(apiOrToken: APIRequestContext | string) {
+  async function userProjectCount(apiOrToken: APIRequestContext | string): Promise<number> {
     if (typeof apiOrToken === 'string') {
       const response = await fetch(`${serverBaseUrl}/api/AuthTesting/token-project-count`, {method: 'GET', headers: {'authorization': `Bearer ${apiOrToken}`}});
       expect(response.status).toBe(200);

--- a/frontend/tests/oauth.test.ts
+++ b/frontend/tests/oauth.test.ts
@@ -1,4 +1,4 @@
-﻿import {type APIRequestContext, type Browser, expect} from '@playwright/test';
+import {type APIRequestContext, type Browser, expect} from '@playwright/test';
 import {test} from './fixtures';
 import {LoginPage} from './pages/loginPage';
 import {OidcDebuggerPage} from './pages/oidcDebuggerPage';

--- a/frontend/tests/pages/oauthApprovalPage.ts
+++ b/frontend/tests/pages/oauthApprovalPage.ts
@@ -1,4 +1,4 @@
-﻿import type {Page} from '@playwright/test';
+import type {Page} from '@playwright/test';
 import {BasePage} from './basePage';
 
 export class OauthApprovalPage extends BasePage {

--- a/frontend/tests/pages/oidcDebuggerPage.ts
+++ b/frontend/tests/pages/oidcDebuggerPage.ts
@@ -11,7 +11,7 @@ export class OidcDebuggerPage extends BasePage {
     super(page, page.getByText('OpenID Connect Debugger'), 'https://oidcdebugger.com');
   }
 
-  async fillForm(baseURL: string) {
+  async fillForm(baseURL: string): Promise<void> {
     await this.page.locator('#authorizeUri').fill(`${baseURL}/api/oauth/open-id-auth`);
     await this.page.locator('#redirectUri').fill(OidcDebuggerPage.redirectUrl);
     await this.page.locator('#clientId').fill(OidcDebuggerPage.clientId);

--- a/frontend/tests/pages/oidcDebuggerPage.ts
+++ b/frontend/tests/pages/oidcDebuggerPage.ts
@@ -1,4 +1,4 @@
-﻿import {BasePage} from './basePage';
+import {BasePage} from './basePage';
 import {expect, type Page} from '@playwright/test';
 
 export class OidcDebuggerPage extends BasePage {


### PR DESCRIPTION
Fixes #1630.
Also closes #1177, since we'll no longer need migration examples.

Migration was quite straightforward. The only difficulty was three pages that used derived stores, and also had a `$:` block that the migration tool wanted to change to `$derived`. Since there was already a variable named `derived` (the standard derived-store function from Svelte 4) this would have caused a naming conflict. I solved that by importing `derived` under the name `derivedStore` in the affected files, and this made the migration script run cleanly.

A couple of minor post-migration cleanups were needed, but nothing near as much manual cleanup as I had originally anticipated needing. Manual testing of the site showed that everything seemed to be working as it should.