### PR TITLE
Fix entry view and filter outline overflow

### DIFF
--- a/frontend/viewer/src/lib/components/responsive-popup/responsive-popup.svelte
+++ b/frontend/viewer/src/lib/components/responsive-popup/responsive-popup.svelte
@@ -4,16 +4,16 @@
   import * as Drawer from '$lib/components/ui/drawer';
   import { buttonVariants } from '$lib/components/ui/button';
   import { t } from 'svelte-i18n-lingui';
-  import type {WithChildren} from 'bits-ui';
-  import type {Snippet} from 'svelte';
-  let { open = $bindable(false), children, title, trigger }: WithChildren<{ open?: boolean, title: string, trigger: Snippet }> = $props();
+  import type {PopoverTriggerProps, WithChildren} from 'bits-ui';
+
+  type TriggerSnippet = PopoverTriggerProps['child'];
+
+  let { open = $bindable(false), children, title, trigger }: WithChildren<{ open?: boolean, title: string, trigger: TriggerSnippet }> = $props();
 </script>
 
 {#if !IsMobile.value}
   <Popover.Root bind:open>
-    <Popover.Trigger class={buttonVariants({ variant: 'ghost', size: 'sm', class: 'float-right' })}>
-      {@render trigger()}
-    </Popover.Trigger>
+    <Popover.Trigger child={trigger} />
     <Popover.Content class="w-64 sm:mr-4">
       <div class="space-y-3">
         <h3 class="font-medium">{title}</h3>
@@ -25,9 +25,7 @@
   </Popover.Root>
 {:else}
   <Drawer.Root bind:open>
-    <Drawer.Trigger class={buttonVariants({ variant: 'ghost', size: 'sm', class: 'float-right' })}>
-      {@render trigger()}
-    </Drawer.Trigger>
+    <Drawer.Trigger child={trigger} />
     <Drawer.Content>
       <div class="mx-auto w-full max-w-sm p-4">
         <Drawer.Header>

--- a/frontend/viewer/src/project/NewEntryButton.svelte
+++ b/frontend/viewer/src/project/NewEntryButton.svelte
@@ -40,7 +40,7 @@
 </script>
 
 {#if isActive}
-  <div in:receive={{ key: 'new-entry-button' }} out:send={{ key: 'new-entry-button' }}>
+  <div class="relative z-[1]" in:receive={{ key: 'new-entry-button' }} out:send={{ key: 'new-entry-button' }}>
     <Button variant="default" size="extended-fab" class="font-semibold" icon="i-mdi-plus-thick" {onclick}>
       {#if shortForm}
         <span>{$t`New`}</span>

--- a/frontend/viewer/src/project/browse/BrowseView.svelte
+++ b/frontend/viewer/src/project/browse/BrowseView.svelte
@@ -36,7 +36,7 @@
     <NewEntryButton active={!IsMobile.value && isOpen} onclick={newEntry}/>
   {/snippet}
 </SidebarPrimaryAction>
-<div class="flex flex-col h-full p-2 md:p-4">
+<div class="flex flex-col h-full">
   <ResizablePaneGroup direction="horizontal" class="flex-1 min-h-0 !overflow-visible">
     {#if !IsMobile.value || !selectedEntry}
       <ResizablePane
@@ -47,40 +47,44 @@
         minSize={15}
         class="min-h-0 flex flex-col relative"
       >
-        <div class="mb-2 md:mb-4 md:mr-4">
-          <SearchFilter bind:search bind:gridifyFilter />
-          <div class="mt-2 md:mt-3">
-            <Badge
-              variant="secondary"
-              class="cursor-pointer"
-              onclick={toggleSort}
-            >
-            <Icon icon={sortDirection === 'asc' ? 'i-mdi-sort-alphabetical-ascending' : 'i-mdi-sort-alphabetical-descending'} class="h-4 w-4" />
-              {$t`Headword`}
-            </Badge>
+        <div class="flex flex-col h-full p-2 md:p-4 md:pr-1">
+          <div class="mb-2 md:mb-4 md:mr-3">
+            <SearchFilter bind:search bind:gridifyFilter />
+            <div class="mt-2 md:mt-3">
+              <Badge
+                variant="secondary"
+                class="cursor-pointer"
+                onclick={toggleSort}
+              >
+              <Icon icon={sortDirection === 'asc' ? 'i-mdi-sort-alphabetical-ascending' : 'i-mdi-sort-alphabetical-descending'} class="h-4 w-4" />
+                {$t`Headword`}
+              </Badge>
+            </div>
           </div>
+          <EntriesList {search} {selectedEntry} {sortDirection} {gridifyFilter} onSelectEntry={(e) => (selectedEntry = e)} />
         </div>
-        <EntriesList {search} {selectedEntry} {sortDirection} {gridifyFilter} onSelectEntry={(e) => (selectedEntry = e)} />
       </ResizablePane>
     {/if}
     {#if !IsMobile.value}
-      <ResizableHandle {leftPane} {rightPane} withHandle resetTo={defaultLayout} />
+      <ResizableHandle class="my-4" {leftPane} {rightPane} withHandle resetTo={defaultLayout} />
     {/if}
     {#if selectedEntry || !IsMobile.value}
       <ResizablePane
         bind:this={rightPane}
         defaultSize={defaultLayout[1]} collapsible collapsedSize={0} minSize={15}>
-        {#if !selectedEntry}
-          <div class="flex items-center justify-center h-full text-muted-foreground">
-            <p>Select an entry to view details</p>
-          </div>
-        {:else}
-          <EntryView
-            entryId={selectedEntry.id}
-            onClose={() => (selectedEntry = undefined)}
-            showClose={IsMobile.value}
-          />
-        {/if}
+          {#if !selectedEntry}
+            <div class="flex items-center justify-center h-full text-muted-foreground text-center m-2">
+              <p>Select an entry to view details</p>
+            </div>
+          {:else}
+            <div class="p-2 md:p-4 md:pl-6 h-full">
+              <EntryView
+                entryId={selectedEntry.id}
+                onClose={() => (selectedEntry = undefined)}
+                showClose={IsMobile.value}
+              />
+            </div>
+          {/if}
       </ResizablePane>
     {/if}
   </ResizablePaneGroup>

--- a/frontend/viewer/src/project/browse/EntriesList.svelte
+++ b/frontend/viewer/src/project/browse/EntriesList.svelte
@@ -67,11 +67,11 @@
 <div class="absolute bottom-0 right-0 m-4 flex flex-col items-end z-10">
   <DevContent>
     <Button
-      icon="i-mdi-refresh"
-      variant="secondary"
+      icon={loading.current ? 'i-mdi-loading' : 'i-mdi-refresh'}
+      variant="outline"
       iconProps={{ class: cn(loading.current && 'animate-spin') }}
       size="icon"
-      class="mt-4 mb-6"
+      class="mb-4"
       onclick={() => entriesResource.refetch()}
     />
   </DevContent>

--- a/frontend/viewer/src/project/browse/EntriesList.svelte
+++ b/frontend/viewer/src/project/browse/EntriesList.svelte
@@ -78,7 +78,7 @@
   <NewEntryButton onclick={handleNewEntry} shortForm />
 </div>
 
-<ScrollArea class="md:pr-5 flex-1" role="table">
+<ScrollArea class="md:pr-3 flex-1" role="table">
   {#if entriesResource.error}
     <div class="flex items-center justify-center h-full text-muted-foreground">
       <p>{$t`Failed to load entries`}</p>

--- a/frontend/viewer/src/project/browse/EntryMenu.svelte
+++ b/frontend/viewer/src/project/browse/EntryMenu.svelte
@@ -42,7 +42,9 @@
 {#if !IsMobile.value}
   <DropdownMenu.Root bind:open>
     <DropdownMenu.Trigger class={triggerVariant}>
-      <Icon icon="i-mdi-dots-vertical" class="cursor-pointer" />
+      {#snippet child({props})}
+        <Button {...props} size="icon" variant="ghost" icon="i-mdi-dots-vertical" />
+      {/snippet}
     </DropdownMenu.Trigger>
     <DropdownMenu.Content align="end">
       {@render items()}

--- a/frontend/viewer/src/project/browse/EntryView.svelte
+++ b/frontend/viewer/src/project/browse/EntryView.svelte
@@ -44,7 +44,7 @@
   }
 </script>
 
-<div class="h-full md:px-6 pt-2 relative">
+<div class="h-full flex flex-col md:px-6 pt-2 relative">
   {#if entry}
     <header class="mb-4 flex">
       {#if showClose && onClose}
@@ -55,7 +55,7 @@
       <ViewPicker/>
       <EntryMenu onDelete={handleDelete} />
     </header>
-    <ScrollArea class={cn('h-full md:pr-5', !$viewSettings.showEmptyFields && 'hide-unused')}>
+    <ScrollArea class={cn('grow md:pr-5', !$viewSettings.showEmptyFields && 'hide-unused')}>
       <EntryEditor {entry} disablePortalButtons />
     </ScrollArea>
   {/if}

--- a/frontend/viewer/src/project/browse/EntryView.svelte
+++ b/frontend/viewer/src/project/browse/EntryView.svelte
@@ -46,14 +46,17 @@
 
 <div class="h-full flex flex-col relative">
   {#if entry}
-    <header class="mb-4 flex">
-      {#if showClose && onClose}
-        <Button icon="i-mdi-close" onclick={onClose} variant="ghost" size="icon"></Button>
-      {/if}
-      <h2 class="ml-4 text-2xl font-semibold mb-2 inline">{writingSystemService.headword(entry) || $t`Untitled`}</h2>
-      <div class="flex-1"></div>
-      <ViewPicker/>
-      <EntryMenu onDelete={handleDelete} />
+    <header class="mb-4 flex justify-between">
+      <div>
+        {#if showClose && onClose}
+          <Button icon="i-mdi-close" onclick={onClose} variant="ghost" size="icon"></Button>
+        {/if}
+        <h2 class="ml-4 text-2xl font-semibold mb-2 inline">{writingSystemService.headword(entry) || $t`Untitled`}</h2>
+      </div>
+      <div class="flex gap-2">
+        <ViewPicker/>
+        <EntryMenu onDelete={handleDelete} />
+      </div>
     </header>
     <ScrollArea class={cn('grow md:pr-4', !$viewSettings.showEmptyFields && 'hide-unused')}>
       <EntryEditor {entry} disablePortalButtons />

--- a/frontend/viewer/src/project/browse/EntryView.svelte
+++ b/frontend/viewer/src/project/browse/EntryView.svelte
@@ -44,7 +44,7 @@
   }
 </script>
 
-<div class="h-full flex flex-col md:px-6 pt-2 relative">
+<div class="h-full flex flex-col relative">
   {#if entry}
     <header class="mb-4 flex">
       {#if showClose && onClose}
@@ -55,7 +55,7 @@
       <ViewPicker/>
       <EntryMenu onDelete={handleDelete} />
     </header>
-    <ScrollArea class={cn('grow md:pr-5', !$viewSettings.showEmptyFields && 'hide-unused')}>
+    <ScrollArea class={cn('grow md:pr-4', !$viewSettings.showEmptyFields && 'hide-unused')}>
       <EntryEditor {entry} disablePortalButtons />
     </ScrollArea>
   {/if}

--- a/frontend/viewer/src/project/browse/ViewPicker.svelte
+++ b/frontend/viewer/src/project/browse/ViewPicker.svelte
@@ -1,5 +1,4 @@
 <script lang="ts">
-  import { Icon } from '$lib/components/ui/icon';
   import * as RadioGroup from '$lib/components/ui/radio-group';
   import { t } from 'svelte-i18n-lingui';
   import { views } from '$lib/views/view-data';
@@ -7,6 +6,7 @@
   import Label from '$lib/components/ui/label/label.svelte';
   import Switch from '$lib/components/ui/switch/switch.svelte';
   import ResponsivePopup from '$lib/components/responsive-popup/responsive-popup.svelte';
+  import {Button} from '$lib/components/ui/button';
   const currentView = useCurrentView();
   const viewSettings = useViewSettings();
   function getCurrentView() {
@@ -17,8 +17,8 @@
   }
 </script>
 <ResponsivePopup title={$t`View Configuration`}>
-  {#snippet trigger()}
-    <Icon icon="i-mdi-layers" />
+  {#snippet trigger({props})}
+    <Button {...props} size="icon" variant="ghost" icon="i-mdi-layers" />
   {/snippet}
   <div class="space-y-6">
     <RadioGroup.Root bind:value={getCurrentView, setCurrentView}>
@@ -37,10 +37,8 @@
       <div class="flex items-center space-x-2">
         <Switch
           id="showEmptyFields"
-          bind:checked={
-            () => $viewSettings.showEmptyFields,
-            (value) => ($viewSettings = { ...$viewSettings, showEmptyFields: value })
-          }
+          bind:checked={() => $viewSettings.showEmptyFields,
+            (value) => ($viewSettings = { ...$viewSettings, showEmptyFields: value })}
         />
         <Label for="showEmptyFields">{$t`Show Empty Fields`}</Label>
       </div>


### PR DESCRIPTION
The primary goal here was to fix the filter-field outline from getting covered up.
I also made the entry-view icon-buttons the same size as our other icon-buttons.
And I played with padding and margins.

![image](https://github.com/user-attachments/assets/92247782-dc89-4dbb-9844-75c2f818e697)

![image](https://github.com/user-attachments/assets/ea246da7-4278-4a6a-a439-58ec70d3bbc7)

And I fixed the button from getting covered up by list items 😉 
![image](https://github.com/user-attachments/assets/750d3627-6859-4f53-9bac-409ac7536e6f)
