### PR TITLE
display a dictionary preview on the entry list

### DIFF
--- a/frontend/viewer/src/lib/DictionaryEntry.svelte
+++ b/frontend/viewer/src/lib/DictionaryEntry.svelte
@@ -74,17 +74,17 @@
 
 {#snippet senseNumber(index: number)}
   {#if showLinks}
-    <a href={`#sense${index+1}`} class="font-bold group">
+    <a href={`#sense${index+1}`} class="font-bold group underline inline-flex items-center">
       <Icon icon="i-mdi-link" class={cn(
           'invisible opacity-0',
           'group-hover:opacity-100 group-hover:visible transition-all',
           'size-4'
-        )}/>
-      {index + 1} ·
+        )}/><span class="ml-[2px]">{index + 1}</span>
     </a>
   {:else}
-    <span class="font-bold">{index + 1} ·</span>
+    <span class="font-bold">{index + 1}</span>
   {/if}
+  {' · '}
 {/snippet}
 
 <div {...restProps}>

--- a/frontend/viewer/src/lib/DictionaryEntry.svelte
+++ b/frontend/viewer/src/lib/DictionaryEntry.svelte
@@ -5,15 +5,19 @@
   import type {HTMLAttributes} from 'svelte/elements';
   import {Icon} from '$lib/components/ui/icon';
   import {cn} from '$lib/utils';
+  import type {Snippet} from 'svelte';
   let {
     entry,
     showLinks = false,
     lines = $bindable(),
+    actions,
+    class: className,
     ...restProps
   }: HTMLAttributes<HTMLDivElement> & {
     entry: IEntry,
     showLinks?: boolean,
-    lines?: number
+    lines?: number,
+    actions?: Snippet
   } = $props();
 
   $effect(() => {
@@ -74,10 +78,10 @@
 
 {#snippet senseNumber(index: number)}
   {#if showLinks}
-    <a href={`#sense${index+1}`} class="font-bold group underline inline-flex items-center">
+    <a href={`#sense${index+1}`} class="font-bold group/sense underline inline-flex items-center">
       <Icon icon="i-mdi-link" class={cn(
           'invisible opacity-0',
-          'group-hover:opacity-100 group-hover:visible transition-all',
+          'group-hover/sense:opacity-100 group-hover/sense:visible transition-all',
           'size-4'
         )}/><span class="ml-[2px]">{index + 1}</span>
     </a>
@@ -87,10 +91,13 @@
   {' · '}
 {/snippet}
 
-<div {...restProps}>
-  <strong class="inline-flex gap-1 mr-1">
+<div class={cn('group/container', className)} {...restProps}>
+  <div class="float-right group-[&:not(:hover)]/container:invisible relative -top-1">
+    {@render actions?.()}
+  </div>
+  <strong class="inline space-x-1 mr-1">
     {#each headwords as headword, i (headword.wsId)}
-      {#if i > 0}/{/if}
+      {#if i > 0}<span>/</span>{/if}
       <span class={headword.color}>{headword.value}</span>
     {/each}
   </strong>

--- a/frontend/viewer/src/locales/en.json
+++ b/frontend/viewer/src/locales/en.json
@@ -18,7 +18,7 @@
     "origin": [
       [
         "src/lib/components/editor/field/field-title.svelte",
-        22
+        21
       ]
     ],
     "translation": "{0} (FieldWorks Lite)"
@@ -30,7 +30,7 @@
     "origin": [
       [
         "src/lib/components/editor/field/field-title.svelte",
-        26
+        25
       ]
     ],
     "translation": "{0} (FieldWorks)"
@@ -57,7 +57,8 @@
         77
       ]
     ],
-    "translation": "🤷 nothing here"
+    "translation": "🤷 nothing here",
+    "obsolete": true
   },
   "uyJsf6": {
     "message": "About",
@@ -78,7 +79,7 @@
     "origin": [
       [
         "src/project/ProjectSidebar.svelte",
-        98
+        92
       ]
     ],
     "translation": "Account"
@@ -90,7 +91,7 @@
     "origin": [
       [
         "src/project/ProjectSidebar.svelte",
-        74
+        68
       ],
       [
         "src/lib/activity/ActivityView.svelte",
@@ -138,7 +139,7 @@
     "origin": [
       [
         "src/lib/entry-editor/DeleteDialog.svelte",
-        48
+        53
       ]
     ],
     "translation": "Are you sure you want to delete {0}?"
@@ -182,7 +183,7 @@
     "origin": [
       [
         "src/project/ProjectSidebar.svelte",
-        72
+        66
       ]
     ],
     "translation": "Browse"
@@ -194,15 +195,19 @@
     "origin": [
       [
         "src/lib/entry-editor/NewEntryDialog.svelte",
-        101
+        102
       ],
       [
         "src/lib/entry-editor/EntryOrSensePicker.svelte",
         254
       ],
       [
+        "src/lib/components/field-editors/select.svelte",
+        149
+      ],
+      [
         "src/lib/components/field-editors/multi-select.svelte",
-        270
+        268
       ]
     ],
     "translation": "Cancel"
@@ -225,8 +230,12 @@
     "comments": [],
     "origin": [
       [
+        "src/lib/components/field-editors/select.svelte",
+        106
+      ],
+      [
         "src/lib/components/field-editors/multi-select.svelte",
-        196
+        198
       ]
     ],
     "translation": "clear"
@@ -238,11 +247,11 @@
     "origin": [
       [
         "src/lib/components/ui/button/x-button.svelte",
-        19
+        14
       ],
       [
         "src/lib/components/responsive-popup/responsive-popup.svelte",
-        40
+        38
       ],
       [
         "src/lib/components/field-editors/multi-select.svelte",
@@ -262,7 +271,7 @@
     "origin": [
       [
         "src/project/ProjectSidebar.svelte",
-        116
+        110
       ]
     ],
     "translation": "Close Dictionary"
@@ -286,7 +295,7 @@
     "origin": [
       [
         "src/lib/entry-editor/NewEntryDialog.svelte",
-        103
+        104
       ],
       [
         "src/lib/entry-editor/NewEntryButton.svelte",
@@ -327,7 +336,7 @@
     "origin": [
       [
         "src/project/ProjectSidebar.svelte",
-        71
+        65
       ]
     ],
     "translation": "Dashboard"
@@ -363,11 +372,11 @@
     "origin": [
       [
         "src/lib/entry-editor/DeleteDialog.svelte",
-        45
+        50
       ],
       [
         "src/lib/entry-editor/DeleteDialog.svelte",
-        52
+        57
       ]
     ],
     "translation": "Delete {0}"
@@ -379,7 +388,7 @@
     "origin": [
       [
         "src/project/browse/EntryMenu.svelte",
-        20
+        44
       ]
     ],
     "translation": "Delete Entry"
@@ -407,10 +416,22 @@
     "origin": [
       [
         "src/project/ProjectSidebar.svelte",
-        68
+        62
       ]
     ],
     "translation": "Dictionary"
+  },
+  "OVGpil": {
+    "message": "Dictionary Preview",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/project/browse/ViewPicker.svelte",
+        50
+      ]
+    ],
+    "translation": "Dictionary Preview"
   },
   "z9VIKz": {
     "message": "Don't delete",
@@ -419,7 +440,7 @@
     "origin": [
       [
         "src/lib/entry-editor/DeleteDialog.svelte",
-        51
+        56
       ]
     ],
     "translation": "Don't delete"
@@ -441,6 +462,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
+      [
+        "src/project/browse/EntryMenu.svelte",
+        37
+      ],
       [
         "src/lib/entry-editor/EntryOrSensePicker.svelte",
         259
@@ -467,7 +492,7 @@
     "origin": [
       [
         "src/project/browse/EntriesList.svelte",
-        84
+        100
       ]
     ],
     "translation": "Failed to load entries"
@@ -491,7 +516,7 @@
     "origin": [
       [
         "src/project/ProjectSidebar.svelte",
-        133
+        127
       ],
       [
         "src/home/HomeView.svelte",
@@ -507,7 +532,7 @@
     "origin": [
       [
         "src/project/browse/ViewPicker.svelte",
-        25
+        29
       ]
     ],
     "translation": "Field Labels"
@@ -550,7 +575,8 @@
         76
       ]
     ],
-    "translation": "Filter semantic domains..."
+    "translation": "Filter semantic domains...",
+    "obsolete": true
   },
   "6HLTEb": {
     "message": "Filter...",
@@ -558,8 +584,12 @@
     "comments": [],
     "origin": [
       [
+        "src/lib/components/field-editors/select.svelte",
+        102
+      ],
+      [
         "src/lib/components/field-editors/multi-select.svelte",
-        192
+        194
       ]
     ],
     "translation": "Filter..."
@@ -571,10 +601,22 @@
     "origin": [
       [
         "src/project/browse/BrowseView.svelte",
-        59
+        65
       ]
     ],
     "translation": "Headword"
+  },
+  "vLyv1R": {
+    "message": "Hide",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/project/browse/ViewPicker.svelte",
+        60
+      ]
+    ],
+    "translation": "Hide"
   },
   "0caMy7": {
     "message": "History",
@@ -583,7 +625,7 @@
     "origin": [
       [
         "src/project/browse/EntryMenu.svelte",
-        21
+        45
       ],
       [
         "src/lib/history/HistoryView.svelte",
@@ -615,6 +657,18 @@
       ]
     ],
     "translation": "Lexbox logo"
+  },
+  "8oegWV": {
+    "message": "List mode",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/project/browse/BrowseView.svelte",
+        67
+      ]
+    ],
+    "translation": "List mode"
   },
   "4PN67S": {
     "message": "Loading Dictionaries...",
@@ -702,7 +756,8 @@
         78
       ]
     ],
-    "translation": "Looked hard, found nothing"
+    "translation": "Looked hard, found nothing",
+    "obsolete": true
   },
   "nK30Fy": {
     "message": "Made with ❤️ from 🇦🇹 🇹🇭 🇺🇸",
@@ -711,7 +766,7 @@
     "origin": [
       [
         "src/project/ProjectSidebar.svelte",
-        142
+        136
       ]
     ],
     "translation": "Made with ❤️ from 🇦🇹 🇹🇭 🇺🇸"
@@ -783,7 +838,7 @@
     "origin": [
       [
         "src/lib/entry-editor/NewEntryDialog.svelte",
-        88
+        89
       ]
     ],
     "translation": "New {0}"
@@ -843,7 +898,7 @@
     "origin": [
       [
         "src/project/browse/EntriesList.svelte",
-        99
+        120
       ],
       [
         "src/lib/entry-editor/EntryOrSensePicker.svelte",
@@ -870,8 +925,12 @@
     "comments": [],
     "origin": [
       [
+        "src/lib/components/field-editors/select.svelte",
+        114
+      ],
+      [
         "src/lib/components/field-editors/multi-select.svelte",
-        215
+        213
       ]
     ],
     "translation": "No items found"
@@ -894,8 +953,12 @@
     "comments": [],
     "origin": [
       [
+        "src/lib/components/field-editors/select.svelte",
+        89
+      ],
+      [
         "src/lib/components/field-editors/multi-select.svelte",
-        167
+        169
       ]
     ],
     "translation": "None"
@@ -911,6 +974,18 @@
       ]
     ],
     "translation": "Open Data Directory"
+  },
+  "OsAKOS": {
+    "message": "Open in new Window",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/project/browse/EntryMenu.svelte",
+        47
+      ]
+    ],
+    "translation": "Open in new Window"
   },
   "sccXTS": {
     "message": "Open Log file",
@@ -938,7 +1013,32 @@
         41
       ]
     ],
-    "translation": "Order of semantic domains"
+    "translation": "Order of semantic domains",
+    "obsolete": true
+  },
+  "kNiQp6": {
+    "message": "Pinned",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/project/browse/ViewPicker.svelte",
+        66
+      ]
+    ],
+    "translation": "Pinned"
+  },
+  "rdUucN": {
+    "message": "Preview",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/project/browse/BrowseView.svelte",
+        80
+      ]
+    ],
+    "translation": "Preview"
   },
   "Xp1CO/": {
     "message": "Project name...",
@@ -966,7 +1066,8 @@
         56
       ]
     ],
-    "translation": "Readonly"
+    "translation": "Readonly",
+    "obsolete": true
   },
   "TG4hr2": {
     "message": "Refresh Projects",
@@ -1038,7 +1139,8 @@
         75
       ]
     ],
-    "translation": "Semantic domains"
+    "translation": "Semantic domains",
+    "obsolete": true
   },
   "Ivc0e8": {
     "message": "Sense",
@@ -1059,7 +1161,7 @@
     "origin": [
       [
         "src/project/ProjectSidebar.svelte",
-        104
+        98
       ]
     ],
     "translation": "Settings"
@@ -1075,6 +1177,18 @@
       ]
     ],
     "translation": "Share Log file"
+  },
+  "8vETh9": {
+    "message": "Show",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/project/browse/ViewPicker.svelte",
+        54
+      ]
+    ],
+    "translation": "Show"
   },
   "0IaUwR": {
     "message": "Show {0} more...",
@@ -1095,10 +1209,22 @@
     "origin": [
       [
         "src/project/browse/ViewPicker.svelte",
-        45
+        47
       ]
     ],
     "translation": "Show Empty Fields"
+  },
+  "AQK14J": {
+    "message": "Simple",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/project/browse/BrowseView.svelte",
+        76
+      ]
+    ],
+    "translation": "Simple"
   },
   "hQRttt": {
     "message": "Submit",
@@ -1115,7 +1241,7 @@
       ],
       [
         "src/lib/components/field-editors/multi-select.svelte",
-        273
+        271
       ]
     ],
     "translation": "Submit"
@@ -1155,7 +1281,7 @@
     "origin": [
       [
         "src/project/ProjectSidebar.svelte",
-        86
+        80
       ]
     ],
     "translation": "Synchronize"
@@ -1167,7 +1293,7 @@
     "origin": [
       [
         "src/project/ProjectSidebar.svelte",
-        73
+        67
       ]
     ],
     "translation": "Tasks"
@@ -1215,7 +1341,7 @@
     "origin": [
       [
         "src/project/ProjectSidebar.svelte",
-        127
+        121
       ],
       [
         "src/lib/troubleshoot/TroubleshootDialog.svelte",
@@ -1251,11 +1377,15 @@
     "origin": [
       [
         "src/project/browse/EntryView.svelte",
-        53
+        40
       ],
       [
         "src/project/browse/EntryRow.svelte",
-        51
+        55
+      ],
+      [
+        "src/project/browse/EntryMenu.svelte",
+        31
       ]
     ],
     "translation": "Untitled"
@@ -1267,7 +1397,7 @@
     "origin": [
       [
         "src/project/ProjectSidebar.svelte",
-        141
+        135
       ]
     ],
     "translation": "Version {0}"
@@ -1279,7 +1409,7 @@
     "origin": [
       [
         "src/project/browse/ViewPicker.svelte",
-        19
+        23
       ]
     ],
     "translation": "View Configuration"
@@ -1291,7 +1421,7 @@
     "origin": [
       [
         "src/project/browse/ViewPicker.svelte",
-        36
+        40
       ]
     ],
     "translation": "View Settings"

--- a/frontend/viewer/src/locales/es.json
+++ b/frontend/viewer/src/locales/es.json
@@ -18,7 +18,7 @@
     "origin": [
       [
         "src/lib/components/editor/field/field-title.svelte",
-        22
+        21
       ]
     ],
     "translation": ""
@@ -30,7 +30,7 @@
     "origin": [
       [
         "src/lib/components/editor/field/field-title.svelte",
-        26
+        25
       ]
     ],
     "translation": ""
@@ -57,7 +57,8 @@
         77
       ]
     ],
-    "translation": ""
+    "translation": "",
+    "obsolete": true
   },
   "uyJsf6": {
     "message": "About",
@@ -78,7 +79,7 @@
     "origin": [
       [
         "src/project/ProjectSidebar.svelte",
-        98
+        92
       ]
     ],
     "translation": "Cuenta"
@@ -90,7 +91,7 @@
     "origin": [
       [
         "src/project/ProjectSidebar.svelte",
-        74
+        68
       ],
       [
         "src/lib/activity/ActivityView.svelte",
@@ -138,7 +139,7 @@
     "origin": [
       [
         "src/lib/entry-editor/DeleteDialog.svelte",
-        48
+        53
       ]
     ],
     "translation": ""
@@ -182,7 +183,7 @@
     "origin": [
       [
         "src/project/ProjectSidebar.svelte",
-        72
+        66
       ]
     ],
     "translation": "Explorar"
@@ -194,15 +195,19 @@
     "origin": [
       [
         "src/lib/entry-editor/NewEntryDialog.svelte",
-        101
+        102
       ],
       [
         "src/lib/entry-editor/EntryOrSensePicker.svelte",
         254
       ],
       [
+        "src/lib/components/field-editors/select.svelte",
+        149
+      ],
+      [
         "src/lib/components/field-editors/multi-select.svelte",
-        270
+        268
       ]
     ],
     "translation": ""
@@ -225,8 +230,12 @@
     "comments": [],
     "origin": [
       [
+        "src/lib/components/field-editors/select.svelte",
+        106
+      ],
+      [
         "src/lib/components/field-editors/multi-select.svelte",
-        196
+        198
       ]
     ],
     "translation": ""
@@ -238,11 +247,11 @@
     "origin": [
       [
         "src/lib/components/ui/button/x-button.svelte",
-        19
+        14
       ],
       [
         "src/lib/components/responsive-popup/responsive-popup.svelte",
-        40
+        38
       ],
       [
         "src/lib/components/field-editors/multi-select.svelte",
@@ -262,7 +271,7 @@
     "origin": [
       [
         "src/project/ProjectSidebar.svelte",
-        116
+        110
       ]
     ],
     "translation": "Cerrar Diccionario"
@@ -286,7 +295,7 @@
     "origin": [
       [
         "src/lib/entry-editor/NewEntryDialog.svelte",
-        103
+        104
       ],
       [
         "src/lib/entry-editor/NewEntryButton.svelte",
@@ -327,7 +336,7 @@
     "origin": [
       [
         "src/project/ProjectSidebar.svelte",
-        71
+        65
       ]
     ],
     "translation": "Panel de Control"
@@ -363,11 +372,11 @@
     "origin": [
       [
         "src/lib/entry-editor/DeleteDialog.svelte",
-        45
+        50
       ],
       [
         "src/lib/entry-editor/DeleteDialog.svelte",
-        52
+        57
       ]
     ],
     "translation": ""
@@ -379,7 +388,7 @@
     "origin": [
       [
         "src/project/browse/EntryMenu.svelte",
-        20
+        44
       ]
     ],
     "translation": ""
@@ -407,10 +416,22 @@
     "origin": [
       [
         "src/project/ProjectSidebar.svelte",
-        68
+        62
       ]
     ],
     "translation": "Diccionario"
+  },
+  "OVGpil": {
+    "message": "Dictionary Preview",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/project/browse/ViewPicker.svelte",
+        50
+      ]
+    ],
+    "translation": ""
   },
   "z9VIKz": {
     "message": "Don't delete",
@@ -419,7 +440,7 @@
     "origin": [
       [
         "src/lib/entry-editor/DeleteDialog.svelte",
-        51
+        56
       ]
     ],
     "translation": ""
@@ -441,6 +462,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
+      [
+        "src/project/browse/EntryMenu.svelte",
+        37
+      ],
       [
         "src/lib/entry-editor/EntryOrSensePicker.svelte",
         259
@@ -467,7 +492,7 @@
     "origin": [
       [
         "src/project/browse/EntriesList.svelte",
-        84
+        100
       ]
     ],
     "translation": ""
@@ -491,7 +516,7 @@
     "origin": [
       [
         "src/project/ProjectSidebar.svelte",
-        133
+        127
       ],
       [
         "src/home/HomeView.svelte",
@@ -507,7 +532,7 @@
     "origin": [
       [
         "src/project/browse/ViewPicker.svelte",
-        25
+        29
       ]
     ],
     "translation": ""
@@ -550,7 +575,8 @@
         76
       ]
     ],
-    "translation": ""
+    "translation": "",
+    "obsolete": true
   },
   "6HLTEb": {
     "message": "Filter...",
@@ -558,8 +584,12 @@
     "comments": [],
     "origin": [
       [
+        "src/lib/components/field-editors/select.svelte",
+        102
+      ],
+      [
         "src/lib/components/field-editors/multi-select.svelte",
-        192
+        194
       ]
     ],
     "translation": ""
@@ -571,7 +601,19 @@
     "origin": [
       [
         "src/project/browse/BrowseView.svelte",
-        59
+        65
+      ]
+    ],
+    "translation": ""
+  },
+  "vLyv1R": {
+    "message": "Hide",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/project/browse/ViewPicker.svelte",
+        60
       ]
     ],
     "translation": ""
@@ -583,7 +625,7 @@
     "origin": [
       [
         "src/project/browse/EntryMenu.svelte",
-        21
+        45
       ],
       [
         "src/lib/history/HistoryView.svelte",
@@ -615,6 +657,18 @@
       ]
     ],
     "translation": "Logotipo de Lexbox"
+  },
+  "8oegWV": {
+    "message": "List mode",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/project/browse/BrowseView.svelte",
+        67
+      ]
+    ],
+    "translation": ""
   },
   "4PN67S": {
     "message": "Loading Dictionaries...",
@@ -702,7 +756,8 @@
         78
       ]
     ],
-    "translation": ""
+    "translation": "",
+    "obsolete": true
   },
   "nK30Fy": {
     "message": "Made with ❤️ from 🇦🇹 🇹🇭 🇺🇸",
@@ -711,7 +766,7 @@
     "origin": [
       [
         "src/project/ProjectSidebar.svelte",
-        142
+        136
       ]
     ],
     "translation": "Hecho con ❤️ desde 🇦🇹 🇹🇭 🇺🇸"
@@ -783,7 +838,7 @@
     "origin": [
       [
         "src/lib/entry-editor/NewEntryDialog.svelte",
-        88
+        89
       ]
     ],
     "translation": ""
@@ -843,7 +898,7 @@
     "origin": [
       [
         "src/project/browse/EntriesList.svelte",
-        99
+        120
       ],
       [
         "src/lib/entry-editor/EntryOrSensePicker.svelte",
@@ -870,8 +925,12 @@
     "comments": [],
     "origin": [
       [
+        "src/lib/components/field-editors/select.svelte",
+        114
+      ],
+      [
         "src/lib/components/field-editors/multi-select.svelte",
-        215
+        213
       ]
     ],
     "translation": ""
@@ -894,8 +953,12 @@
     "comments": [],
     "origin": [
       [
+        "src/lib/components/field-editors/select.svelte",
+        89
+      ],
+      [
         "src/lib/components/field-editors/multi-select.svelte",
-        167
+        169
       ]
     ],
     "translation": ""
@@ -908,6 +971,18 @@
       [
         "src/lib/troubleshoot/TroubleshootDialog.svelte",
         31
+      ]
+    ],
+    "translation": ""
+  },
+  "OsAKOS": {
+    "message": "Open in new Window",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/project/browse/EntryMenu.svelte",
+        47
       ]
     ],
     "translation": ""
@@ -938,6 +1013,31 @@
         41
       ]
     ],
+    "translation": "",
+    "obsolete": true
+  },
+  "kNiQp6": {
+    "message": "Pinned",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/project/browse/ViewPicker.svelte",
+        66
+      ]
+    ],
+    "translation": ""
+  },
+  "rdUucN": {
+    "message": "Preview",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/project/browse/BrowseView.svelte",
+        80
+      ]
+    ],
     "translation": ""
   },
   "Xp1CO/": {
@@ -966,7 +1066,8 @@
         56
       ]
     ],
-    "translation": ""
+    "translation": "",
+    "obsolete": true
   },
   "TG4hr2": {
     "message": "Refresh Projects",
@@ -1038,7 +1139,8 @@
         75
       ]
     ],
-    "translation": ""
+    "translation": "",
+    "obsolete": true
   },
   "Ivc0e8": {
     "message": "Sense",
@@ -1059,7 +1161,7 @@
     "origin": [
       [
         "src/project/ProjectSidebar.svelte",
-        104
+        98
       ]
     ],
     "translation": "Configuración"
@@ -1072,6 +1174,18 @@
       [
         "src/lib/troubleshoot/TroubleshootDialog.svelte",
         44
+      ]
+    ],
+    "translation": ""
+  },
+  "8vETh9": {
+    "message": "Show",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/project/browse/ViewPicker.svelte",
+        54
       ]
     ],
     "translation": ""
@@ -1095,7 +1209,19 @@
     "origin": [
       [
         "src/project/browse/ViewPicker.svelte",
-        45
+        47
+      ]
+    ],
+    "translation": ""
+  },
+  "AQK14J": {
+    "message": "Simple",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/project/browse/BrowseView.svelte",
+        76
       ]
     ],
     "translation": ""
@@ -1115,7 +1241,7 @@
       ],
       [
         "src/lib/components/field-editors/multi-select.svelte",
-        273
+        271
       ]
     ],
     "translation": ""
@@ -1155,7 +1281,7 @@
     "origin": [
       [
         "src/project/ProjectSidebar.svelte",
-        86
+        80
       ]
     ],
     "translation": "Sincronizar"
@@ -1167,7 +1293,7 @@
     "origin": [
       [
         "src/project/ProjectSidebar.svelte",
-        73
+        67
       ]
     ],
     "translation": "Tareas"
@@ -1215,7 +1341,7 @@
     "origin": [
       [
         "src/project/ProjectSidebar.svelte",
-        127
+        121
       ],
       [
         "src/lib/troubleshoot/TroubleshootDialog.svelte",
@@ -1251,11 +1377,15 @@
     "origin": [
       [
         "src/project/browse/EntryView.svelte",
-        53
+        40
       ],
       [
         "src/project/browse/EntryRow.svelte",
-        51
+        55
+      ],
+      [
+        "src/project/browse/EntryMenu.svelte",
+        31
       ]
     ],
     "translation": ""
@@ -1267,7 +1397,7 @@
     "origin": [
       [
         "src/project/ProjectSidebar.svelte",
-        141
+        135
       ]
     ],
     "translation": "Versión {0}"
@@ -1279,7 +1409,7 @@
     "origin": [
       [
         "src/project/browse/ViewPicker.svelte",
-        19
+        23
       ]
     ],
     "translation": ""
@@ -1291,7 +1421,7 @@
     "origin": [
       [
         "src/project/browse/ViewPicker.svelte",
-        36
+        40
       ]
     ],
     "translation": ""

--- a/frontend/viewer/src/locales/fr.json
+++ b/frontend/viewer/src/locales/fr.json
@@ -18,7 +18,7 @@
     "origin": [
       [
         "src/lib/components/editor/field/field-title.svelte",
-        22
+        21
       ]
     ],
     "translation": ""
@@ -30,7 +30,7 @@
     "origin": [
       [
         "src/lib/components/editor/field/field-title.svelte",
-        26
+        25
       ]
     ],
     "translation": ""
@@ -57,7 +57,8 @@
         77
       ]
     ],
-    "translation": ""
+    "translation": "",
+    "obsolete": true
   },
   "uyJsf6": {
     "message": "About",
@@ -78,7 +79,7 @@
     "origin": [
       [
         "src/project/ProjectSidebar.svelte",
-        98
+        92
       ]
     ],
     "translation": "Compte"
@@ -90,7 +91,7 @@
     "origin": [
       [
         "src/project/ProjectSidebar.svelte",
-        74
+        68
       ],
       [
         "src/lib/activity/ActivityView.svelte",
@@ -138,7 +139,7 @@
     "origin": [
       [
         "src/lib/entry-editor/DeleteDialog.svelte",
-        48
+        53
       ]
     ],
     "translation": ""
@@ -182,7 +183,7 @@
     "origin": [
       [
         "src/project/ProjectSidebar.svelte",
-        72
+        66
       ]
     ],
     "translation": "Parcourir"
@@ -194,15 +195,19 @@
     "origin": [
       [
         "src/lib/entry-editor/NewEntryDialog.svelte",
-        101
+        102
       ],
       [
         "src/lib/entry-editor/EntryOrSensePicker.svelte",
         254
       ],
       [
+        "src/lib/components/field-editors/select.svelte",
+        149
+      ],
+      [
         "src/lib/components/field-editors/multi-select.svelte",
-        270
+        268
       ]
     ],
     "translation": ""
@@ -225,8 +230,12 @@
     "comments": [],
     "origin": [
       [
+        "src/lib/components/field-editors/select.svelte",
+        106
+      ],
+      [
         "src/lib/components/field-editors/multi-select.svelte",
-        196
+        198
       ]
     ],
     "translation": ""
@@ -238,11 +247,11 @@
     "origin": [
       [
         "src/lib/components/ui/button/x-button.svelte",
-        19
+        14
       ],
       [
         "src/lib/components/responsive-popup/responsive-popup.svelte",
-        40
+        38
       ],
       [
         "src/lib/components/field-editors/multi-select.svelte",
@@ -262,7 +271,7 @@
     "origin": [
       [
         "src/project/ProjectSidebar.svelte",
-        116
+        110
       ]
     ],
     "translation": "Fermer le Dictionnaire"
@@ -286,7 +295,7 @@
     "origin": [
       [
         "src/lib/entry-editor/NewEntryDialog.svelte",
-        103
+        104
       ],
       [
         "src/lib/entry-editor/NewEntryButton.svelte",
@@ -327,7 +336,7 @@
     "origin": [
       [
         "src/project/ProjectSidebar.svelte",
-        71
+        65
       ]
     ],
     "translation": "Tableau de Bord"
@@ -363,11 +372,11 @@
     "origin": [
       [
         "src/lib/entry-editor/DeleteDialog.svelte",
-        45
+        50
       ],
       [
         "src/lib/entry-editor/DeleteDialog.svelte",
-        52
+        57
       ]
     ],
     "translation": ""
@@ -379,7 +388,7 @@
     "origin": [
       [
         "src/project/browse/EntryMenu.svelte",
-        20
+        44
       ]
     ],
     "translation": ""
@@ -407,10 +416,22 @@
     "origin": [
       [
         "src/project/ProjectSidebar.svelte",
-        68
+        62
       ]
     ],
     "translation": "Dictionnaire"
+  },
+  "OVGpil": {
+    "message": "Dictionary Preview",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/project/browse/ViewPicker.svelte",
+        50
+      ]
+    ],
+    "translation": ""
   },
   "z9VIKz": {
     "message": "Don't delete",
@@ -419,7 +440,7 @@
     "origin": [
       [
         "src/lib/entry-editor/DeleteDialog.svelte",
-        51
+        56
       ]
     ],
     "translation": ""
@@ -441,6 +462,10 @@
     "placeholders": {},
     "comments": [],
     "origin": [
+      [
+        "src/project/browse/EntryMenu.svelte",
+        37
+      ],
       [
         "src/lib/entry-editor/EntryOrSensePicker.svelte",
         259
@@ -467,7 +492,7 @@
     "origin": [
       [
         "src/project/browse/EntriesList.svelte",
-        84
+        100
       ]
     ],
     "translation": ""
@@ -491,7 +516,7 @@
     "origin": [
       [
         "src/project/ProjectSidebar.svelte",
-        133
+        127
       ],
       [
         "src/home/HomeView.svelte",
@@ -507,7 +532,7 @@
     "origin": [
       [
         "src/project/browse/ViewPicker.svelte",
-        25
+        29
       ]
     ],
     "translation": ""
@@ -550,7 +575,8 @@
         76
       ]
     ],
-    "translation": ""
+    "translation": "",
+    "obsolete": true
   },
   "6HLTEb": {
     "message": "Filter...",
@@ -558,8 +584,12 @@
     "comments": [],
     "origin": [
       [
+        "src/lib/components/field-editors/select.svelte",
+        102
+      ],
+      [
         "src/lib/components/field-editors/multi-select.svelte",
-        192
+        194
       ]
     ],
     "translation": ""
@@ -571,7 +601,19 @@
     "origin": [
       [
         "src/project/browse/BrowseView.svelte",
-        59
+        65
+      ]
+    ],
+    "translation": ""
+  },
+  "vLyv1R": {
+    "message": "Hide",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/project/browse/ViewPicker.svelte",
+        60
       ]
     ],
     "translation": ""
@@ -583,7 +625,7 @@
     "origin": [
       [
         "src/project/browse/EntryMenu.svelte",
-        21
+        45
       ],
       [
         "src/lib/history/HistoryView.svelte",
@@ -615,6 +657,18 @@
       ]
     ],
     "translation": "Logo Lexbox"
+  },
+  "8oegWV": {
+    "message": "List mode",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/project/browse/BrowseView.svelte",
+        67
+      ]
+    ],
+    "translation": ""
   },
   "4PN67S": {
     "message": "Loading Dictionaries...",
@@ -702,7 +756,8 @@
         78
       ]
     ],
-    "translation": ""
+    "translation": "",
+    "obsolete": true
   },
   "nK30Fy": {
     "message": "Made with ❤️ from 🇦🇹 🇹🇭 🇺🇸",
@@ -711,7 +766,7 @@
     "origin": [
       [
         "src/project/ProjectSidebar.svelte",
-        142
+        136
       ]
     ],
     "translation": "Fait avec ❤️ depuis 🇦🇹 🇹🇭 🇺🇸"
@@ -783,7 +838,7 @@
     "origin": [
       [
         "src/lib/entry-editor/NewEntryDialog.svelte",
-        88
+        89
       ]
     ],
     "translation": ""
@@ -843,7 +898,7 @@
     "origin": [
       [
         "src/project/browse/EntriesList.svelte",
-        99
+        120
       ],
       [
         "src/lib/entry-editor/EntryOrSensePicker.svelte",
@@ -870,8 +925,12 @@
     "comments": [],
     "origin": [
       [
+        "src/lib/components/field-editors/select.svelte",
+        114
+      ],
+      [
         "src/lib/components/field-editors/multi-select.svelte",
-        215
+        213
       ]
     ],
     "translation": ""
@@ -894,8 +953,12 @@
     "comments": [],
     "origin": [
       [
+        "src/lib/components/field-editors/select.svelte",
+        89
+      ],
+      [
         "src/lib/components/field-editors/multi-select.svelte",
-        167
+        169
       ]
     ],
     "translation": ""
@@ -908,6 +971,18 @@
       [
         "src/lib/troubleshoot/TroubleshootDialog.svelte",
         31
+      ]
+    ],
+    "translation": ""
+  },
+  "OsAKOS": {
+    "message": "Open in new Window",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/project/browse/EntryMenu.svelte",
+        47
       ]
     ],
     "translation": ""
@@ -938,6 +1013,31 @@
         41
       ]
     ],
+    "translation": "",
+    "obsolete": true
+  },
+  "kNiQp6": {
+    "message": "Pinned",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/project/browse/ViewPicker.svelte",
+        66
+      ]
+    ],
+    "translation": ""
+  },
+  "rdUucN": {
+    "message": "Preview",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/project/browse/BrowseView.svelte",
+        80
+      ]
+    ],
     "translation": ""
   },
   "Xp1CO/": {
@@ -966,7 +1066,8 @@
         56
       ]
     ],
-    "translation": ""
+    "translation": "",
+    "obsolete": true
   },
   "TG4hr2": {
     "message": "Refresh Projects",
@@ -1038,7 +1139,8 @@
         75
       ]
     ],
-    "translation": ""
+    "translation": "",
+    "obsolete": true
   },
   "Ivc0e8": {
     "message": "Sense",
@@ -1059,7 +1161,7 @@
     "origin": [
       [
         "src/project/ProjectSidebar.svelte",
-        104
+        98
       ]
     ],
     "translation": "Paramètres"
@@ -1072,6 +1174,18 @@
       [
         "src/lib/troubleshoot/TroubleshootDialog.svelte",
         44
+      ]
+    ],
+    "translation": ""
+  },
+  "8vETh9": {
+    "message": "Show",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/project/browse/ViewPicker.svelte",
+        54
       ]
     ],
     "translation": ""
@@ -1095,7 +1209,19 @@
     "origin": [
       [
         "src/project/browse/ViewPicker.svelte",
-        45
+        47
+      ]
+    ],
+    "translation": ""
+  },
+  "AQK14J": {
+    "message": "Simple",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/project/browse/BrowseView.svelte",
+        76
       ]
     ],
     "translation": ""
@@ -1115,7 +1241,7 @@
       ],
       [
         "src/lib/components/field-editors/multi-select.svelte",
-        273
+        271
       ]
     ],
     "translation": ""
@@ -1155,7 +1281,7 @@
     "origin": [
       [
         "src/project/ProjectSidebar.svelte",
-        86
+        80
       ]
     ],
     "translation": "Synchroniser"
@@ -1167,7 +1293,7 @@
     "origin": [
       [
         "src/project/ProjectSidebar.svelte",
-        73
+        67
       ]
     ],
     "translation": "Tâches"
@@ -1215,7 +1341,7 @@
     "origin": [
       [
         "src/project/ProjectSidebar.svelte",
-        127
+        121
       ],
       [
         "src/lib/troubleshoot/TroubleshootDialog.svelte",
@@ -1251,11 +1377,15 @@
     "origin": [
       [
         "src/project/browse/EntryView.svelte",
-        53
+        40
       ],
       [
         "src/project/browse/EntryRow.svelte",
-        51
+        55
+      ],
+      [
+        "src/project/browse/EntryMenu.svelte",
+        31
       ]
     ],
     "translation": ""
@@ -1267,7 +1397,7 @@
     "origin": [
       [
         "src/project/ProjectSidebar.svelte",
-        141
+        135
       ]
     ],
     "translation": "Version {0}"
@@ -1279,7 +1409,7 @@
     "origin": [
       [
         "src/project/browse/ViewPicker.svelte",
-        19
+        23
       ]
     ],
     "translation": ""
@@ -1291,7 +1421,7 @@
     "origin": [
       [
         "src/project/browse/ViewPicker.svelte",
-        36
+        40
       ]
     ],
     "translation": ""

--- a/frontend/viewer/src/project/browse/BrowseView.svelte
+++ b/frontend/viewer/src/project/browse/BrowseView.svelte
@@ -64,13 +64,12 @@
                 <Icon icon={sortDirection === 'asc' ? 'i-mdi-sort-alphabetical-ascending' : 'i-mdi-sort-alphabetical-descending'} class="h-4 w-4" />
                 {$t`Headword`}
               </Badge>
-              <ResponsivePopup title={$t`List View`}>
+              <ResponsivePopup title={$t`List mode`}>
                 {#snippet trigger({props})}
                   <Button {...props} size="xs-icon" variant="ghost" icon="i-mdi-format-list-text" />
                 {/snippet}
                 <div class="space-y-6">
                   <Tabs bind:value={entryMode} class="mb-1">
-                    <h3 class="font-normal mb-1">{$t`Row display`}</h3>
                     <TabsList>
                       <TabsTrigger value="simple">
                         <Icon icon="i-mdi-format-list-bulleted-square" class="mr-1"/>

--- a/frontend/viewer/src/project/browse/BrowseView.svelte
+++ b/frontend/viewer/src/project/browse/BrowseView.svelte
@@ -73,11 +73,11 @@
                     <TabsList>
                       <TabsTrigger value="simple">
                         <Icon icon="i-mdi-format-list-bulleted-square" class="mr-1"/>
-                        Simple
+                        {$t`Simple`}
                       </TabsTrigger>
                       <TabsTrigger value="preview">
                         <Icon icon="i-mdi-format-list-text" class="mr-1"/>
-                        Preview
+                        {$t`Preview`}
                       </TabsTrigger>
                     </TabsList>
                   </Tabs>
@@ -103,7 +103,7 @@
         defaultSize={defaultLayout[1]} collapsible collapsedSize={0} minSize={15}>
           {#if !selectedEntry}
             <div class="flex items-center justify-center h-full text-muted-foreground text-center m-2">
-              <p>Select an entry to view details</p>
+              <p>{$t`Select an entry to view details`}</p>
             </div>
           {:else}
             <div class="p-2 md:p-4 md:pl-6 h-full">

--- a/frontend/viewer/src/project/browse/BrowseView.svelte
+++ b/frontend/viewer/src/project/browse/BrowseView.svelte
@@ -11,12 +11,16 @@
   import SidebarPrimaryAction from '../SidebarPrimaryAction.svelte';
   import {useDialogsService} from '$lib/services/dialogs-service';
   import NewEntryButton from '../NewEntryButton.svelte';
+  import ResponsivePopup from '$lib/components/responsive-popup/responsive-popup.svelte';
+  import {Tabs, TabsList, TabsTrigger} from '$lib/components/ui/tabs';
+
   const dialogsService = useDialogsService();
   let selectedEntry = $state<IEntry | undefined>(undefined);
   const defaultLayout = [30, 70] as const; // Default split: 30% for list, 70% for details
   let search = $state('');
   let gridifyFilter = $state<string | undefined>(undefined);
   let sortDirection = $state<'asc' | 'desc'>('asc');
+  let entryMode: 'preview' | 'simple' = $state('simple');
 
   function toggleSort() {
     sortDirection = sortDirection === 'asc' ? 'desc' : 'asc';
@@ -58,9 +62,34 @@
             <Icon icon={sortDirection === 'asc' ? 'i-mdi-sort-alphabetical-ascending' : 'i-mdi-sort-alphabetical-descending'} class="h-4 w-4" />
               {$t`Headword`}
             </Badge>
+            <ResponsivePopup title={$t`List View`}>
+              {#snippet trigger()}
+                <Icon icon="i-mdi-format-list-text"/>
+              {/snippet}
+              <div class="space-y-6">
+                  <Tabs bind:value={entryMode} class="mb-1">
+                    <h3 class="font-normal mb-1">{$t`Row display`}</h3>
+                    <TabsList>
+                      <TabsTrigger value="simple">
+                        <Icon icon="i-mdi-format-list-bulleted-square" class="mr-1"/>
+                        Simple
+                      </TabsTrigger>
+                      <TabsTrigger value="preview">
+                        <Icon icon="i-mdi-format-list-text" class="mr-1"/>
+                        Preview
+                      </TabsTrigger>
+                    </TabsList>
+                  </Tabs>
+              </div>
+            </ResponsivePopup>
           </div>
         </div>
-        <EntriesList {search} {selectedEntry} {sortDirection} {gridifyFilter} onSelectEntry={(e) => (selectedEntry = e)} />
+        <EntriesList {search}
+                     {selectedEntry}
+                     {sortDirection}
+                     {gridifyFilter}
+                     onSelectEntry={(e) => (selectedEntry = e)}
+                     previewDictionary={entryMode === 'preview'}/>
       </ResizablePane>
     {/if}
     {#if !IsMobile.value}

--- a/frontend/viewer/src/project/browse/EntriesList.svelte
+++ b/frontend/viewer/src/project/browse/EntriesList.svelte
@@ -19,12 +19,14 @@
     sortDirection = 'asc',
     onSelectEntry,
     gridifyFilter = undefined,
+    previewDictionary = false
   }: {
     search?: string;
     selectedEntry?: IEntry;
     sortDirection: 'asc' | 'desc';
     onSelectEntry: (entry: IEntry) => void;
     gridifyFilter?: string;
+    previewDictionary?: boolean
   } = $props();
   const miniLcmApi = useMiniLcmApi();
   const dialogsService = useDialogsService();
@@ -93,7 +95,10 @@
         {/each}
       {:else}
         {#each entries as entry}
-          <EntryRow {entry} isSelected={selectedEntry?.id === entry.id} onclick={() => onSelectEntry(entry)} />
+          <EntryRow {entry}
+                    isSelected={selectedEntry?.id === entry.id}
+                    onclick={() => onSelectEntry(entry)}
+                    {previewDictionary} />
         {:else}
           <div class="flex items-center justify-center h-full text-muted-foreground">
             <p>{$t`No entries found`}</p>

--- a/frontend/viewer/src/project/browse/EntryRow.svelte
+++ b/frontend/viewer/src/project/browse/EntryRow.svelte
@@ -4,13 +4,15 @@
   import {useWritingSystemService} from '$lib/writing-system-service.svelte';
   import type {Snippet} from 'svelte';
   import {t} from 'svelte-i18n-lingui';
+  import DictionaryEntry from '$lib/DictionaryEntry.svelte';
 
-  const { entry, isSelected = false, onclick, skeleton = false, badge = undefined }: {
+  const { entry, isSelected = false, onclick, skeleton = false, badge = undefined, previewDictionary = false }: {
     entry?: IEntry;
     isSelected?: boolean;
     onclick?: () => void;
     skeleton?: boolean;
-    badge?: Snippet
+    badge?: Snippet,
+    previewDictionary?: boolean;
   } = $props();
 
   const writingSystemService = useWritingSystemService();
@@ -47,6 +49,8 @@
       <div class="h-4 bg-muted-foreground/20 rounded mb-2" style="width: {definitionWidth}"></div>
       <div class="h-6 bg-muted-foreground/20 rounded-full" style="width: {badgeWidth}"></div>
     </div>
+  {:else if previewDictionary}
+    <DictionaryEntry {entry}/>
   {:else}
     <h2 class="font-medium text-2xl">{writingSystemService.headword(entry) || $t`Untitled`}</h2>
     <div class="flex flex-row items-start justify-between gap-2">

--- a/frontend/viewer/src/project/browse/EntryView.svelte
+++ b/frontend/viewer/src/project/browse/EntryView.svelte
@@ -3,7 +3,7 @@
   import type { IEntry } from '$lib/dotnet-types';
   import EntryEditor from '$lib/entry-editor/object-editors/EntryEditor.svelte';
   import { useViewSettings } from '$lib/views/view-service';
-  import { resource, Debounced } from 'runed';
+  import {resource, Debounced, PersistedState} from 'runed';
   import { useMiniLcmApi } from '$lib/services/service-provider';
   import { fade } from 'svelte/transition';
   import ViewPicker from './ViewPicker.svelte';
@@ -13,6 +13,7 @@
   import {cn} from '$lib/utils';
   import {useWritingSystemService} from '$lib/writing-system-service.svelte';
   import {t} from 'svelte-i18n-lingui';
+  import DictionaryEntry from '$lib/DictionaryEntry.svelte';
 
   const viewSettings = useViewSettings();
   const miniLcmApi = useMiniLcmApi();
@@ -35,6 +36,7 @@
   );
   const entry = $derived(entryResource.current ?? undefined);
   const loadingDebounced = new Debounced(() => entryResource.loading, 50);
+  let showDictionaryPreview = $state(true);
 
   const writingSystemService = useWritingSystemService();
 
@@ -52,10 +54,13 @@
       {/if}
       <h2 class="ml-4 text-2xl font-semibold mb-2 inline">{writingSystemService.headword(entry) || $t`Untitled`}</h2>
       <div class="flex-1"></div>
-      <ViewPicker/>
+      <ViewPicker bind:dictionaryPreview={showDictionaryPreview}/>
       <EntryMenu onDelete={handleDelete} />
     </header>
     <ScrollArea class={cn('h-full md:pr-5', !$viewSettings.showEmptyFields && 'hide-unused')}>
+      {#if showDictionaryPreview}
+        <DictionaryEntry {entry} showLinks class="mb-2 rounded border p-4"/>
+      {/if}
       <EntryEditor {entry} disablePortalButtons />
     </ScrollArea>
   {/if}

--- a/frontend/viewer/src/project/browse/EntryView.svelte
+++ b/frontend/viewer/src/project/browse/EntryView.svelte
@@ -36,7 +36,7 @@
   );
   const entry = $derived(entryResource.current ?? undefined);
   const loadingDebounced = new Debounced(() => entryResource.loading, 50);
-  let showDictionaryPreview = $state(true);
+  let dictionaryPreview: 'show' | 'hide' | 'sticky' = $state('show');
 
   const writingSystemService = useWritingSystemService();
 
@@ -54,12 +54,12 @@
       {/if}
       <h2 class="ml-4 text-2xl font-semibold mb-2 inline">{writingSystemService.headword(entry) || $t`Untitled`}</h2>
       <div class="flex-1"></div>
-      <ViewPicker bind:dictionaryPreview={showDictionaryPreview}/>
+      <ViewPicker bind:dictionaryPreview/>
       <EntryMenu onDelete={handleDelete} />
     </header>
     <ScrollArea class={cn('h-full md:pr-5', !$viewSettings.showEmptyFields && 'hide-unused')}>
-      {#if showDictionaryPreview}
-        <DictionaryEntry {entry} showLinks class="mb-2 rounded border p-4"/>
+      {#if dictionaryPreview !== 'hide'}
+        <DictionaryEntry {entry} showLinks class={cn('mb-2 rounded border p-4 z-10 bg-background top-0', dictionaryPreview === 'sticky' && 'sticky')}/>
       {/if}
       <EntryEditor {entry} disablePortalButtons />
     </ScrollArea>

--- a/frontend/viewer/src/project/browse/ViewPicker.svelte
+++ b/frontend/viewer/src/project/browse/ViewPicker.svelte
@@ -7,8 +7,8 @@
   import Label from '$lib/components/ui/label/label.svelte';
   import Switch from '$lib/components/ui/switch/switch.svelte';
   import ResponsivePopup from '$lib/components/responsive-popup/responsive-popup.svelte';
-  let {dictionaryPreview = $bindable(true)}: {
-    dictionaryPreview?: boolean
+  let {dictionaryPreview = $bindable('show')}: {
+    dictionaryPreview?: 'show' | 'hide' | 'sticky'
   } = $props();
   const currentView = useCurrentView();
   const viewSettings = useViewSettings();
@@ -47,13 +47,27 @@
         />
         <Label for="showEmptyFields">{$t`Show Empty Fields`}</Label>
       </div>
-      <div class="flex items-center space-x-2">
-        <Switch
-          id="showDictionaryPreview"
-          bind:checked={dictionaryPreview}
-        />
-        <Label for="showDictionaryPreview">{$t`Show Dictionary Preview`}</Label>
-      </div>
+      <RadioGroup.Root bind:value={dictionaryPreview}>
+        <h3 class="font-normal">{$t`Dictionary Preview`}</h3>
+        <div class="flex items-center space-x-2">
+          <RadioGroup.Item value="show" id="show"/>
+          <Label for="show">
+            {$t`Show`}
+          </Label>
+        </div>
+        <div class="flex items-center space-x-2">
+          <RadioGroup.Item value="hide" id="hide"/>
+          <Label for="hide">
+            {$t`Hide`}
+          </Label>
+        </div>
+        <div class="flex items-center space-x-2">
+          <RadioGroup.Item value="sticky" id="sticky"/>
+          <Label for="sticky">
+            {$t`Pinned`}
+          </Label>
+        </div>
+      </RadioGroup.Root>
     </div>
   </div>
 </ResponsivePopup>

--- a/frontend/viewer/src/project/browse/ViewPicker.svelte
+++ b/frontend/viewer/src/project/browse/ViewPicker.svelte
@@ -7,6 +7,9 @@
   import Label from '$lib/components/ui/label/label.svelte';
   import Switch from '$lib/components/ui/switch/switch.svelte';
   import ResponsivePopup from '$lib/components/responsive-popup/responsive-popup.svelte';
+  let {dictionaryPreview = $bindable(true)}: {
+    dictionaryPreview?: boolean
+  } = $props();
   const currentView = useCurrentView();
   const viewSettings = useViewSettings();
   function getCurrentView() {
@@ -32,7 +35,7 @@
         </div>
       {/each}
     </RadioGroup.Root>
-    <div>
+    <div class="space-y-2">
       <h3 class="font-normal mb-2">{$t`View Settings`}</h3>
       <div class="flex items-center space-x-2">
         <Switch
@@ -43,6 +46,13 @@
           }
         />
         <Label for="showEmptyFields">{$t`Show Empty Fields`}</Label>
+      </div>
+      <div class="flex items-center space-x-2">
+        <Switch
+          id="showDictionaryPreview"
+          bind:checked={dictionaryPreview}
+        />
+        <Label for="showDictionaryPreview">{$t`Show Dictionary Preview`}</Label>
       </div>
     </div>
   </div>


### PR DESCRIPTION
related to #1587 

entry list:
![image](https://github.com/user-attachments/assets/e6b02fbc-c090-41f4-bb3d-4330a18b4df1)
open to alternatives to "Row display" for what to call the setting.

entry view:
![image](https://github.com/user-attachments/assets/bc5bc9ac-075f-4ee8-a1f9-c144615e0802)
you can disable the preview if you want. It's part of the scrolled content so it doesn't take up a bunch of space.
alt style I considered (grey box instead of thin border):
![image](https://github.com/user-attachments/assets/e2f2cac6-590c-485f-8348-4a685098c8af)


entries with a number of senses displays them as links:
![image](https://github.com/user-attachments/assets/1c2cdc23-e63b-4284-a2ca-0e18d69f2027)
in the screenshot the last one is being hovered over displaying the link icon.