### PR TITLE
Add sense to correct parent if it needs to be a subsense

### DIFF
--- a/backend/FwLite/FwDataMiniLcmBridge/Api/FwDataMiniLcmApi.cs
+++ b/backend/FwLite/FwDataMiniLcmBridge/Api/FwDataMiniLcmApi.cs
@@ -1141,7 +1141,7 @@ public class FwDataMiniLcmApi(
                     : throw new InvalidOperationException("Sense parent is not a sense or the expected entry");
                 var insertI = allSiblings.IndexOf(previousSense) + 1;
                 // ILcmOwningSequence treats an insert as a move if the item is already in it
-                lexEntry.SensesOS.Insert(insertI, lexSense);
+                allSiblings.Insert(insertI, lexSense);
             }
             return;
         }
@@ -1155,7 +1155,7 @@ public class FwDataMiniLcmApi(
                     : throw new InvalidOperationException("Sense parent is not a sense or the expected entry");
             var insertI = allSiblings.IndexOf(nextSense);
             // ILcmOwningSequence treats an insert as a move if the item is already in it
-            lexEntry.SensesOS.Insert(insertI, lexSense);
+            allSiblings.Insert(insertI, lexSense);
             return;
         }
 


### PR DESCRIPTION
Ran into this bug when I was curiously checking how we handle ordering with sub-senses.

Note:
If you move a sense after the last subsense it will add it as a subsense. Whether or not it should is somewhat subjective.

Changing the UI or even the API w.r.t. how relative positioning is handled in the context of sub-senses (i.e. if the moved sense should always be a sibling of the sense(s) used for relative positioning) probably doesn't make sense unless sub-senses were to be modeled in MiniLcm.