### PR TITLE
Tweak muted backgrounds

### DIFF
--- a/frontend/viewer/src/lib/components/ListItem.svelte
+++ b/frontend/viewer/src/lib/components/ListItem.svelte
@@ -1,0 +1,20 @@
+<script lang="ts" module>
+  import {cn} from '$lib/utils';
+  import type {WithElementRef} from 'bits-ui';
+  import type {HTMLButtonAttributes} from 'svelte/elements';
+
+  export type ListItemProps = WithElementRef<HTMLButtonAttributes>;
+</script>
+
+<script lang="ts">
+  let {class: className, ref = $bindable(null), children, ...restProps}: ListItemProps = $props();
+</script>
+
+<button class={cn('w-full px-4 py-3 dark:bg-muted/50 bg-muted/80 hover:bg-primary/10 hover:dark:bg-primary/10 justify-between items-center text-left max-w-full overflow-hidden aria-selected:ring-2 ring-primary ring-offset-background rounded',
+  className)}
+  role="row"
+  bind:this={ref}
+  {...restProps}
+  >
+  {@render children?.()}
+</button>

--- a/frontend/viewer/src/lib/entry-editor/EntryOrSensePicker.svelte
+++ b/frontend/viewer/src/lib/entry-editor/EntryOrSensePicker.svelte
@@ -23,6 +23,7 @@
   import EntryRow from '../../project/browse/EntryRow.svelte';
   import Loading from '$lib/components/Loading.svelte';
   import {t, T} from 'svelte-i18n-lingui';
+  import ListItem from '$lib/components/ListItem.svelte';
 
   const dialogsService = useDialogsService();
   const saveHandler = useSaveHandler();
@@ -211,22 +212,20 @@
       {#if !onlyEntries && selectedEntry}
         <div class="pointer-events-auto flex-1 px-2 space-y-2 pb-4 max-h-[min(50cqh,20rem)] overflow-y-auto overscroll-contains">
           <p class="text-muted-foreground p-2 text-sm">Senses:</p>
-          <button
-            class="w-full bg-muted/30 hover:bg-muted flex-1 flex justify-between items-center text-left max-w-full overflow-hidden p-2 pl-4 aria-selected:ring-2 ring-primary ring-offset-background rounded"
-            role="row"
+          <ListItem
+            class="flex"
             aria-selected={!selectedSense}
             onclick={() => select(selectedEntry, undefined)}>
             <div class="flex flex-col items-start">
               <p class="font-medium">{$t`Entry Only`}</p>
             </div>
-          </button>
+          </ListItem>
           {#each selectedEntry.senses as sense}
             {@const disabledSense = disableSense?.(sense, selectedEntry)}
-            <button
-              class="w-full bg-muted/30 hover:bg-muted flex-1 flex justify-between items-center text-left max-w-full overflow-hidden p-2 pl-4 aria-selected:ring-2 ring-primary ring-offset-background rounded"
-              role="row"
+            <ListItem
+              class="flex"
               aria-selected={selectedSense?.id === sense.id}
-              class:disabled={disabledSense}
+              disabled={!!disabledSense}
               onclick={() => select(selectedEntry, sense)}>
               <div class="flex flex-col items-start">
                 <p class="font-medium text-xl">{writingSystemService.firstGloss(sense).padStart(1, '–')}</p>
@@ -238,7 +237,7 @@
                   {disabledSense}
                 </span>
               {/if}
-            </button>
+            </ListItem>
           {/each}
 <!--          disabled for now because this didn't prompt the user to define the sense, it just created it with no data-->
 <!--          <button

--- a/frontend/viewer/src/project/browse/EntryRow.svelte
+++ b/frontend/viewer/src/project/browse/EntryRow.svelte
@@ -5,6 +5,8 @@
   import type {Snippet} from 'svelte';
   import {t} from 'svelte-i18n-lingui';
   import DictionaryEntry from '$lib/DictionaryEntry.svelte';
+  import ListItem from '$lib/components/ListItem.svelte';
+  import {cn} from '$lib/utils';
 
   const { entry, isSelected = false, onclick, skeleton = false, badge = undefined, previewDictionary = false }: {
     entry?: IEntry;
@@ -34,12 +36,9 @@
   const animationDelay = `${(Math.random() * 5) * 0.15}s`;
 </script>
 
-<button
-  class="w-full px-4 py-3 text-left bg-muted/30 aria-selected:ring-2 ring-primary ring-offset-background hover:bg-muted rounded"
-  role="row"
+<ListItem
   aria-selected={isSelected}
-  class:cursor-default={skeleton}
-  class:hover:bg-transparent={skeleton}
+  class={cn(skeleton && 'cursor-default hover:bg-transparent')}
   onclick={skeleton ? undefined : onclick}
   disabled={skeleton}
 >
@@ -69,4 +68,4 @@
     </div>
 
   {/if}
-</button>
+</ListItem>

--- a/frontend/viewer/src/project/browse/EntryView.svelte
+++ b/frontend/viewer/src/project/browse/EntryView.svelte
@@ -46,7 +46,7 @@
 
 {#snippet preview(entry: IEntry)}
   <div class="pb-4">
-    <DictionaryEntry {entry} showLinks class={cn('rounded bg-muted/30 p-4')}>
+    <DictionaryEntry {entry} showLinks class={cn('rounded bg-muted/80 dark:bg-muted/50 p-4')}>
       {#snippet actions()}
         <Toggle bind:pressed={() => sticky, (value) => dictionaryPreview = value ? 'sticky' : 'show'}
           aria-label={`Toggle pinned`} class="aspect-square" size="xs">


### PR DESCRIPTION
How does this look?
After making the items darker by default, there wasn't much contrast left for a hover effect, so I opted to use color instead of contrast for hovering.

Once we're happy we can decide if playing with the css theme variables is something we want to do.

It's tricky. On my 4k monitor, the contrast in light mode changes drastically depending on my viewing angle.

![image](https://github.com/user-attachments/assets/b97c8770-f263-46c1-b360-fa97a4db3ea6)
