### PR TITLE
Create new example sentence translation if needed

### DIFF
--- a/backend/FwLite/FwDataMiniLcmBridge/Api/FwDataMiniLcmApi.cs
+++ b/backend/FwLite/FwDataMiniLcmBridge/Api/FwDataMiniLcmApi.cs
@@ -1331,6 +1331,12 @@ public class FwDataMiniLcmApi(
             lexExampleSentence.Reference.get_WritingSystem(0));
     }
 
+    public ICmTranslation CreateExampleSentenceTranslation(ILexExampleSentence parent)
+    {
+        var freeTranslationType = CmPossibilityRepository.GetObject(CmPossibilityTags.kguidTranFreeTranslation);
+        return CmTranslationFactory.Create(parent, freeTranslationType);
+    }
+
     public async Task<ExampleSentence> CreateExampleSentence(Guid entryId, Guid senseId, ExampleSentence exampleSentence, BetweenPosition? between = null)
     {
         if (exampleSentence.Id == default) exampleSentence.Id = Guid.NewGuid();

--- a/backend/FwLite/FwDataMiniLcmBridge/Api/FwDataMiniLcmApi.cs
+++ b/backend/FwLite/FwDataMiniLcmBridge/Api/FwDataMiniLcmApi.cs
@@ -1324,8 +1324,7 @@ public class FwDataMiniLcmApi(
         var lexExampleSentence = LexExampleSentenceFactory.Create(exampleSentence.Id);
         InsertExampleSentence(lexSense, lexExampleSentence, between);
         UpdateLcmMultiString(lexExampleSentence.Example, exampleSentence.Sentence);
-        var freeTranslationType = CmPossibilityRepository.GetObject(CmPossibilityTags.kguidTranFreeTranslation);
-        var translation = CmTranslationFactory.Create(lexExampleSentence, freeTranslationType);
+        var translation = CreateExampleSentenceTranslation(lexExampleSentence);
         UpdateLcmMultiString(translation.Translation, exampleSentence.Translation);
         lexExampleSentence.Reference = TsStringUtils.MakeString(exampleSentence.Reference,
             lexExampleSentence.Reference.get_WritingSystem(0));

--- a/backend/FwLite/FwDataMiniLcmBridge/Api/UpdateProxy/UpdateExampleSentenceProxy.cs
+++ b/backend/FwLite/FwDataMiniLcmBridge/Api/UpdateProxy/UpdateExampleSentenceProxy.cs
@@ -1,10 +1,10 @@
-﻿using MiniLcm.Models;
+using MiniLcm.Models;
 using SIL.LCModel;
 using SIL.LCModel.Core.Text;
 
 namespace FwDataMiniLcmBridge.Api.UpdateProxy;
 
-public class UpdateExampleSentenceProxy(ILexExampleSentence sentence, FwDataMiniLcmApi lexboxLcmApi): ExampleSentence
+public class UpdateExampleSentenceProxy(ILexExampleSentence sentence, FwDataMiniLcmApi lexboxLcmApi) : ExampleSentence
 {
     public override Guid Id
     {
@@ -23,7 +23,13 @@ public class UpdateExampleSentenceProxy(ILexExampleSentence sentence, FwDataMini
         get
         {
             var firstTranslation = sentence.TranslationsOC.FirstOrDefault()?.Translation;
-            return firstTranslation is null ? new RichMultiString() : new UpdateRichMultiStringProxy(firstTranslation, lexboxLcmApi);
+            if (firstTranslation is null)
+            {
+                var translation = lexboxLcmApi.CreateExampleSentenceTranslation(sentence);
+                sentence.TranslationsOC.Add(translation);
+                firstTranslation = translation.Translation;
+            }
+            return new UpdateRichMultiStringProxy(firstTranslation, lexboxLcmApi);
         }
         set => throw new NotImplementedException();
     }


### PR DESCRIPTION
Fixes #1621. Includes unit test that fails on `develop` but passes with the bugfix in this branch.

Since UpdateExampleSentenceProxy needs to create a new ICmTranslation object, I had two choices:

1. Expose the CmTranslationFactory to UpdateExampleSentenceProxy so it can call the factory Create method.
2. Create a new API in FwDataMiniLcmBridge (but NOT in IMiniLcmWrite) to allow creating a new ICmTranslation object.

I decided to go with option 2 as it seemed the minimum change required to fix the issue. But if @hahn-kev prefers to go with option 1, we can do that too. Let me know.