### PR TITLE
Fix matching projects

### DIFF
--- a/frontend/viewer/src/CrdtProjectView.svelte
+++ b/frontend/viewer/src/CrdtProjectView.svelte
@@ -6,5 +6,5 @@
 </script>
 
 <ProjectLoader {projectName} let:onProjectLoaded>
-  <ProjectView {projectName} isConnected onloaded={onProjectLoaded}></ProjectView>
+  <ProjectView isConnected onloaded={onProjectLoaded}></ProjectView>
 </ProjectLoader>

--- a/frontend/viewer/src/DotnetProjectView.svelte
+++ b/frontend/viewer/src/DotnetProjectView.svelte
@@ -15,7 +15,7 @@
   const projectServicesProvider = useProjectServicesProvider();
   const projectContext = initProjectContext();
 
-  const {code, type}: {
+  const {code, type: projectType}: {
     code: string; // Code for CRDTs, project-name for FWData
     type: 'fwdata' | 'crdt'
   } = $props();
@@ -28,7 +28,7 @@
   let destroyed = false;
   onMount(async () => {
     console.debug('ProjectView mounted');
-    if (type === 'crdt') {
+    if (projectType === 'crdt') {
       const projectData = await projectServicesProvider.getCrdtProjectData(code);
       projectName = projectData.name;
       projectScope = await projectServicesProvider.openCrdtProject(code);
@@ -45,7 +45,7 @@
       historyService = wrapInProxy(projectScope.historyService, 'HistoryService') as IHistoryServiceJsInvokable;
     }
     const api = wrapInProxy(projectScope.miniLcm, 'MiniLcmApi') as IMiniLcmJsInvokable;
-    projectContext.setup({api, historyService, projectName});
+    projectContext.setup({api, historyService, projectName, projectType});
     serviceLoaded = true;
   });
   onDestroy(() => {
@@ -67,5 +67,5 @@
 <ThemeSyncer />
 
 <ProjectLoader readyToLoadProject={serviceLoaded} {projectName} let:onProjectLoaded>
-  <ProjectView {projectName} isConnected onloaded={onProjectLoaded}></ProjectView>
+  <ProjectView isConnected onloaded={onProjectLoaded}></ProjectView>
 </ProjectLoader>

--- a/frontend/viewer/src/FwDataProjectView.svelte
+++ b/frontend/viewer/src/FwDataProjectView.svelte
@@ -44,5 +44,5 @@
 </script>
 
 <ProjectLoader {projectName} let:onProjectLoaded>
-  <ProjectView {projectName} isConnected={$connected} onloaded={onProjectLoaded}></ProjectView>
+  <ProjectView isConnected={$connected} onloaded={onProjectLoaded}></ProjectView>
 </ProjectLoader>

--- a/frontend/viewer/src/ProjectView.svelte
+++ b/frontend/viewer/src/ProjectView.svelte
@@ -3,17 +3,15 @@
 
   const {
     onloaded,
-    projectName,
     isConnected,
     showHomeButton = true,
     about = undefined,
   }: {
     onloaded: (loaded: boolean) => void;
     about?: string | undefined;
-    projectName: string;
     isConnected: boolean;
     showHomeButton?: boolean;
   } = $props();
 </script>
 
-<ShadcnProjectView {onloaded} {projectName} {about} {isConnected} {showHomeButton}/>
+<ShadcnProjectView {onloaded} {about} {isConnected} {showHomeButton}/>

--- a/frontend/viewer/src/ShadcnProjectView.svelte
+++ b/frontend/viewer/src/ShadcnProjectView.svelte
@@ -22,14 +22,12 @@
 
   const {
     onloaded,
-    projectName,
     // isConnected,
     // showHomeButton = true,
     // about = undefined,
   }: {
     onloaded: (loaded: boolean) => void;
     about?: string | undefined;
-    projectName: string;
     isConnected: boolean;
     showHomeButton?: boolean;
   } = $props();
@@ -45,7 +43,7 @@
 <DialogsProvider/>
 <div class="h-screen flex PortalTarget overflow-hidden shadcn-root">
   <Sidebar.Provider bind:open>
-      <ProjectSidebar {projectName} bind:currentView />
+      <ProjectSidebar bind:currentView />
       <Sidebar.Inset class="flex-1 relative">
         {#if currentView === 'browse'}
           <BrowseView />

--- a/frontend/viewer/src/TestProjectView.svelte
+++ b/frontend/viewer/src/TestProjectView.svelte
@@ -7,5 +7,5 @@ const projectName = InMemoryApiService.setup().projectName;
 </script>
 
 <ProjectLoader {projectName} let:onProjectLoaded>
-  <ProjectView {projectName} isConnected onloaded={onProjectLoaded}></ProjectView>
+  <ProjectView isConnected onloaded={onProjectLoaded}></ProjectView>
 </ProjectLoader>

--- a/frontend/viewer/src/WebComponent.svelte
+++ b/frontend/viewer/src/WebComponent.svelte
@@ -65,6 +65,6 @@
 
 <div class="app contents" class:dark={$currentTheme.dark}>
   <ProjectLoader readyToLoadProject={!loading} {projectName} let:onProjectLoaded>
-    <ProjectView {projectName} isConnected showHomeButton={false} {about}  onloaded={onProjectLoaded} />
+    <ProjectView isConnected showHomeButton={false} {about}  onloaded={onProjectLoaded} />
   </ProjectLoader>
 </div>

--- a/frontend/viewer/src/home/HomeView.svelte
+++ b/frontend/viewer/src/home/HomeView.svelte
@@ -212,7 +212,8 @@
             <div>
               {#each projects.filter((p) => p.fwdata) as project (project.id ?? project.name)}
                 <ButtonListItem href={`/fwdata/${project.code}`}>
-                  <ListItem title={project.name}>
+                  <ListItem>
+                    <ProjectTitle slot="title" {project}/>
                     <img slot="avatar" src={flexLogo} alt={$t`FieldWorks logo`} class="h-6 shrink-0" />
                     <div slot="actions" class="shrink-0">
                       <DevContent invisible>

--- a/frontend/viewer/src/home/HomeView.svelte
+++ b/frontend/viewer/src/home/HomeView.svelte
@@ -211,7 +211,7 @@
             <p class="sub-title">{$t`Classic FieldWorks Projects`}</p>
             <div>
               {#each projects.filter((p) => p.fwdata) as project (project.id ?? project.name)}
-                <ButtonListItem href={`/fwdata/${project.name}`}>
+                <ButtonListItem href={`/fwdata/${project.code}`}>
                   <ListItem title={project.name}>
                     <img slot="avatar" src={flexLogo} alt={$t`FieldWorks logo`} class="h-6 shrink-0" />
                     <div slot="actions" class="shrink-0">

--- a/frontend/viewer/src/home/Server.svelte
+++ b/frontend/viewer/src/home/Server.svelte
@@ -90,8 +90,8 @@
         {#if localProject?.crdt}
           <ButtonListItem href={`/project/${project.code}`}>
             <ListItem icon={mdiCloud}
-                      title={project.name}
                       loading={downloading === project.name}>
+              <ProjectTitle slot="title" {project}/>
               <div slot="actions" class="pointer-events-none shrink-0">
                 <Button disabled icon={mdiBookSyncOutline} class="p-2">
                   {$t`Synced`}

--- a/frontend/viewer/src/lib/project-context.svelte.ts
+++ b/frontend/viewer/src/lib/project-context.svelte.ts
@@ -7,10 +7,14 @@ import {resource, type ResourceReturn} from 'runed';
 import {SvelteMap} from 'svelte/reactivity';
 
 const projectContextKey = 'current-project';
+
+type ProjectType = 'crdt' | 'fwdata' | undefined;
+
 interface ProjectContextSetup {
   api: IMiniLcmJsInvokable;
   historyService?: IHistoryServiceJsInvokable;
   projectName: string;
+  projectType?: 'crdt' | 'fwdata';
 }
 export function initProjectContext(args?: ProjectContextSetup) {
   const context = new ProjectContext(args);
@@ -24,6 +28,7 @@ export class ProjectContext {
   #stateCache = new SvelteMap<symbol, unknown>();
   #api: IMiniLcmJsInvokable | undefined = $state(undefined);
   #projectName: string | undefined = $state(undefined);
+  #projectType: ProjectType = $state(undefined);
   #historyService: IHistoryServiceJsInvokable | undefined = $state(undefined);
   #features = resource(() => this.#api, (api) => {
     if (!api) return Promise.resolve({} satisfies IMiniLcmFeatures);
@@ -40,6 +45,9 @@ export class ProjectContext {
     if (!this.#projectName) throw new Error('projectName not set');
     return this.#projectName;
   }
+  public get projectType(): ProjectType {
+    return this.#projectType;
+  }
   public get features(): IMiniLcmFeatures {
     return this.#features.current;
   }
@@ -51,12 +59,14 @@ export class ProjectContext {
     this.#api = args?.api;
     this.#historyService = args?.historyService;
     this.#projectName = args?.projectName;
+    this.#projectType = args?.projectType;
   }
 
   public setup(args: ProjectContextSetup) {
     this.#api = args.api;
     this.#historyService = args.historyService;
-    this.#projectName = args?.projectName;
+    this.#projectName = args.projectName;
+    this.#projectType = args.projectType;
   }
 
   public getOrAddAsync<T>(key: symbol, initialValue: T, factory: (api: IMiniLcmJsInvokable) => Promise<T>): ResourceReturn<T, unknown, true> {

--- a/frontend/viewer/src/project/ProjectDropdown.svelte
+++ b/frontend/viewer/src/project/ProjectDropdown.svelte
@@ -11,11 +11,14 @@
   import {resource} from 'runed';
   import type {IProjectModel} from '$lib/dotnet-types';
   import ProjectTitle from '../home/ProjectTitle.svelte';
+  import {useProjectContext} from '$lib/project-context.svelte';
 
-  let { projectName, onSelect } = $props<{
-    projectName: string;
+  let { onSelect } = $props<{
     onSelect: (project: IProjectModel) => void;
   }>();
+  const projectContext = useProjectContext();
+  const projectName = $derived(projectContext.projectName);
+  const isCrdt = $derived(projectContext.projectType === 'crdt');
   const projectsService = useProjectsService();
   const projectsResource = resource(() => projectsService, async (projectsService) => {
       const projects = await projectsService.localProjects();
@@ -99,7 +102,7 @@
             <Command.Item
               value={project.name + project.crdt}
               onSelect={() => handleSelect(project)}
-              class={cn('cursor-pointer', (project.name === projectName || project.code === projectName) && 'bg-secondary')}
+              class={cn('cursor-pointer', (project.name === projectName || project.code === projectName) && project.crdt === isCrdt && 'bg-secondary')}
             >
               {#if project.fwdata}
                 <img src={flexLogo} alt={$t`FieldWorks logo`} class="h-6 shrink-0"/>

--- a/frontend/viewer/src/project/ProjectDropdown.svelte
+++ b/frontend/viewer/src/project/ProjectDropdown.svelte
@@ -16,8 +16,18 @@
     onSelect: (project: IProjectModel) => void;
   }>();
   const projectsService = useProjectsService();
-  const projectsResource = resource(() => projectsService, (projectsService) => {
-      return projectsService.localProjects();
+  const projectsResource = resource(() => projectsService, async (projectsService) => {
+      const projects = await projectsService.localProjects();
+      return projects.flatMap((project) => {
+        if (project.fwdata && project.crdt) {
+          return [
+            { ...project, fwdata: false },
+            { ...project, crdt: false }
+          ];
+        }
+        return [project];
+      })
+      .sort((a, b) => a.name.localeCompare(b.name));
   }, {lazy: true});
 
   let open = $state(false);

--- a/frontend/viewer/src/project/ProjectDropdown.svelte
+++ b/frontend/viewer/src/project/ProjectDropdown.svelte
@@ -96,7 +96,7 @@
         {:else}
           {#each projectsResource.current ?? [] as project}
             <Command.Item
-              value={project.name}
+              value={project.name + project.crdt}
               onSelect={() => handleSelect(project)}
               class={cn('cursor-pointer', project.name === projectName && 'bg-secondary')}
             >

--- a/frontend/viewer/src/project/ProjectDropdown.svelte
+++ b/frontend/viewer/src/project/ProjectDropdown.svelte
@@ -10,6 +10,7 @@
   import {useProjectsService} from '$lib/services/service-provider';
   import {resource} from 'runed';
   import type {IProjectModel} from '$lib/dotnet-types';
+  import ProjectTitle from '../home/ProjectTitle.svelte';
 
   let { projectName, onSelect } = $props<{
     projectName: string;
@@ -98,14 +99,14 @@
             <Command.Item
               value={project.name + project.crdt}
               onSelect={() => handleSelect(project)}
-              class={cn('cursor-pointer', project.name === projectName && 'bg-secondary')}
+              class={cn('cursor-pointer', (project.name === projectName || project.code === projectName) && 'bg-secondary')}
             >
               {#if project.fwdata}
                 <img src={flexLogo} alt={$t`FieldWorks logo`} class="h-6 shrink-0"/>
-                {:else}
+              {:else}
                 <Icon icon="i-mdi-book-edit-outline"/>
               {/if}
-              {project.name}
+              <ProjectTitle {project} />
             </Command.Item>
           {/each}
         {/if}

--- a/frontend/viewer/src/project/ProjectSidebar.svelte
+++ b/frontend/viewer/src/project/ProjectSidebar.svelte
@@ -13,8 +13,7 @@
   import type {IProjectModel} from '$lib/dotnet-types';
   import {usePrimaryAction} from './SidebarPrimaryAction.svelte';
 
-  let { projectName, currentView = $bindable() } = $props<{
-    projectName: string;
+  let { currentView = $bindable() } = $props<{
     currentView: View;
   }>();
 
@@ -46,7 +45,6 @@
     <div class="flex flex-col gap-2">
       <div class="flex flex-row items-center gap-1">
         <ProjectDropdown
-          {projectName}
           onSelect={handleProjectSelect}
         />
         <div class="flex-1" ></div>

--- a/frontend/viewer/src/project/ProjectSidebar.svelte
+++ b/frontend/viewer/src/project/ProjectSidebar.svelte
@@ -23,9 +23,9 @@
 
   function handleProjectSelect(selectedProject: IProjectModel) {
     if (selectedProject.fwdata) {
-      navigate('/fwdata/' + selectedProject.name);
+      navigate('/fwdata/' + selectedProject.code);
     } else if (selectedProject.crdt) {
-      navigate('/project/' + selectedProject.code)
+      navigate('/project/' + selectedProject.code);
     }
   }
 


### PR DESCRIPTION
I found a large handful of issues surrounding having a crdt and fwdata copy of the same project. I'm suprised we haven't had any bug reports, because the biggest issue was that you just can't open the fwdata copy.

This PR has the interesting side effect that we now show the Lexbox project name on fwdata projects. Which seems kind of cool to me.

The project-picker was fixed so that:
- Both the crdt and fwdata copies are shown
  - this required a handful of changes to prevent them from being highlighted simultaneously
- The current project is always highlighted whether it's a crdt or fwdata project
- The projects are sorted
![image](https://github.com/user-attachments/assets/699b8984-dff8-4151-a124-fd688f162655)

Finally: after downloading a CRDT project the project name format changed to only the name without the code. I added the code there.