### PR TITLE
Hide audio writing systems from UI

### DIFF
--- a/backend/FwLite/MiniLcm.Tests/WritingSystemIdTests.cs
+++ b/backend/FwLite/MiniLcm.Tests/WritingSystemIdTests.cs
@@ -13,6 +13,14 @@ public class WritingSystemIdTests
     }
 
     [Theory]
+    [InlineData("en-Zxxx-x-audio")]
+    public void DetectsAudioWritingSystems(string code)
+    {
+        var ws = new WritingSystemId(code);
+        ws.IsAudio.Should().BeTrue();
+    }
+
+    [Theory]
     [InlineData("gx")]
     [InlineData("oo")]
     [InlineData("eng")] // Three-letter codes not allowed when there's a valid two-letter code

--- a/backend/FwLite/MiniLcm.Tests/WritingSystemIdTests.cs
+++ b/backend/FwLite/MiniLcm.Tests/WritingSystemIdTests.cs
@@ -14,6 +14,7 @@ public class WritingSystemIdTests
 
     [Theory]
     [InlineData("en-Zxxx-x-audio")]
+    [InlineData("seh-Zxxx-x-audio-var")]
     public void DetectsAudioWritingSystems(string code)
     {
         var ws = new WritingSystemId(code);

--- a/backend/FwLite/MiniLcm.Tests/WritingSystemIdTests.cs
+++ b/backend/FwLite/MiniLcm.Tests/WritingSystemIdTests.cs
@@ -1,10 +1,23 @@
-﻿namespace MiniLcm.Tests;
+﻿using SIL.WritingSystems;
+
+namespace MiniLcm.Tests;
 
 public class WritingSystemIdTests
 {
+    public WritingSystemIdTests()
+    {
+        if (!Sldr.IsInitialized)
+            Sldr.Initialize();
+    }
+
+    public static IEnumerable<object[]> ValidWritingSystemIds =>
+        WritingSystemCodes.ValidTwoLetterCodes.Select(code => new object[] { code });
+
     [Theory]
+    [MemberData(nameof(ValidWritingSystemIds))]
     [InlineData("en")]
     [InlineData("th")]
+    [InlineData("xba")]
     [InlineData("en-Zxxx-x-audio")]
     public void ValidWritingSystemId_ShouldNotThrow(string code)
     {

--- a/backend/FwLite/MiniLcm.Tests/WritingSystemIdTests.cs
+++ b/backend/FwLite/MiniLcm.Tests/WritingSystemIdTests.cs
@@ -1,15 +1,7 @@
-﻿using SIL.WritingSystems;
-
-namespace MiniLcm.Tests;
+﻿namespace MiniLcm.Tests;
 
 public class WritingSystemIdTests
 {
-    public WritingSystemIdTests()
-    {
-        if (!Sldr.IsInitialized)
-            Sldr.Initialize();
-    }
-
     public static IEnumerable<object[]> ValidWritingSystemIds =>
         WritingSystemCodes.ValidTwoLetterCodes.Select(code => new object[] { code });
 

--- a/backend/FwLite/MiniLcm/Models/WritingSystem.cs
+++ b/backend/FwLite/MiniLcm/Models/WritingSystem.cs
@@ -6,6 +6,7 @@ public record WritingSystem: IObjectWithId<WritingSystem>
 {
     public required Guid Id { get; set; }
     public virtual required WritingSystemId WsId { get; set; }
+    public bool IsAudio => WsId.IsAudio;
     public virtual required string Name { get; set; }
     public virtual required string Abbreviation { get; set; }
     public virtual required string Font { get; set; }

--- a/backend/FwLite/MiniLcm/Models/WritingSystemId.cs
+++ b/backend/FwLite/MiniLcm/Models/WritingSystemId.cs
@@ -30,6 +30,7 @@ public class WritingSystemIdJsonConverter : JsonConverter<WritingSystemId>
 public readonly record struct WritingSystemId: ISpanFormattable, ISpanParsable<WritingSystemId>
 {
     public string Code { get; init; }
+    public bool IsAudio => Code.EndsWith("-audio", StringComparison.InvariantCultureIgnoreCase);
 
     public static readonly WritingSystemId Default = "default";
 

--- a/backend/FwLite/MiniLcm/Models/WritingSystemId.cs
+++ b/backend/FwLite/MiniLcm/Models/WritingSystemId.cs
@@ -41,16 +41,15 @@ public readonly record struct WritingSystemId: ISpanFormattable, ISpanParsable<W
         {
             Code = code;
         }
-        else if (IetfLanguageTag.TryGetSubtags(code,
-                     out LanguageSubtag subtag,
-                     out ScriptSubtag scriptSubtag,
-                     out RegionSubtag regionSubtag,
-                     out IEnumerable<VariantSubtag> variantSubtags))
+        else if (IetfLanguageTag.TryGetParts(code,
+                     out string? subtag,
+                     out string? script,
+                     out string? region,
+                     out string? variants))
         {
             Code = code;
-            VariantSubtag audioVariant = WellKnownSubtags.AudioPrivateUse;
-            IsAudio = scriptSubtag?.Code.Equals(WellKnownSubtags.AudioScript, StringComparison.OrdinalIgnoreCase) == true &&
-                      variantSubtags.Any(v => v == audioVariant);
+            IsAudio = script?.Equals(WellKnownSubtags.AudioScript, StringComparison.OrdinalIgnoreCase) == true &&
+                      variants?.Split('-').Any(v => v == WellKnownSubtags.AudioPrivateUse) == true;
         }
         else
         {

--- a/backend/FwLite/MiniLcm/Models/WritingSystemId.cs
+++ b/backend/FwLite/MiniLcm/Models/WritingSystemId.cs
@@ -49,7 +49,7 @@ public readonly record struct WritingSystemId: ISpanFormattable, ISpanParsable<W
         {
             Code = code;
             VariantSubtag audioVariant = WellKnownSubtags.AudioPrivateUse;
-            IsAudio = scriptSubtag.Code.Equals(WellKnownSubtags.AudioScript, StringComparison.OrdinalIgnoreCase) &&
+            IsAudio = scriptSubtag?.Code.Equals(WellKnownSubtags.AudioScript, StringComparison.OrdinalIgnoreCase) == true &&
                       variantSubtags.Any(v => v == audioVariant);
         }
         else

--- a/frontend/viewer/src/SvelteUxProjectView.svelte
+++ b/frontend/viewer/src/SvelteUxProjectView.svelte
@@ -119,7 +119,9 @@
 
   const writingSystemService = initWritingSystemService(deriveAsync(connected, isConnected => {
     if (!isConnected) return Promise.resolve(null);
-    return lexboxApi.getWritingSystems();
+    return lexboxApi.getWritingSystems().then(ws => {
+      return {analysis: ws.analysis.filter(ws => !ws.isAudio), vernacular: ws.vernacular.filter(ws => !ws.isAudio)};
+    });
   }).value);
 
   const trigger = writable(0);

--- a/frontend/viewer/src/lib/demo-entry-data.ts
+++ b/frontend/viewer/src/lib/demo-entry-data.ts
@@ -40,7 +40,8 @@ export const writingSystems: IWritingSystems = {
       'font': '???',
       'exemplars': ['A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J', 'K', 'L', 'M', 'N', 'O', 'P', 'Q', 'R', 'S', 'T', 'U', 'V', 'W', 'X', 'Y', 'Z'],
       'type': WritingSystemType.Analysis,
-      'order': 0
+      'order': 0,
+      isAudio: false,
     },
     {
       'id': 'pt',
@@ -50,7 +51,8 @@ export const writingSystems: IWritingSystems = {
       'font': '???',
       'exemplars': ['A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J', 'K', 'L', 'M', 'N', 'O', 'P', 'Q', 'R', 'S', 'T', 'U', 'V', 'W', 'X', 'Y', 'Z'],
       'type': WritingSystemType.Analysis,
-      'order': 1
+      'order': 1,
+      isAudio: false,
     }
   ],
   'vernacular': [
@@ -62,7 +64,8 @@ export const writingSystems: IWritingSystems = {
       'font': '???',
       'exemplars': ['A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J', 'K', 'L', 'M', 'N', 'O', 'P', 'Q', 'R', 'S', 'T', 'U', 'V', 'W', 'X', 'Y', 'Z'],
       'type': WritingSystemType.Vernacular,
-      'order': 0
+      'order': 0,
+      isAudio: false,
     },
     {
       'id': 'seh-fonipa-x-etic',
@@ -72,7 +75,8 @@ export const writingSystems: IWritingSystems = {
       'font': '???',
       'exemplars': ['A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J', 'K', 'L', 'M', 'N', 'O', 'P', 'Q', 'R', 'S', 'T', 'U', 'V', 'W', 'X', 'Y', 'Z'],
       'type': WritingSystemType.Vernacular,
-      'order': 1
+      'order': 1,
+      isAudio: false,
     }
   ]
 };

--- a/frontend/viewer/src/lib/dotnet-types/generated-types/MiniLcm/Models/IWritingSystem.ts
+++ b/frontend/viewer/src/lib/dotnet-types/generated-types/MiniLcm/Models/IWritingSystem.ts
@@ -10,6 +10,7 @@ export interface IWritingSystem extends IObjectWithId
 {
 	id: string;
 	wsId: string;
+	isAudio: boolean;
 	name: string;
 	abbreviation: string;
 	font: string;

--- a/frontend/viewer/src/lib/entry-editor/field-editors/MultiOptionEditor.test.svelte.ts
+++ b/frontend/viewer/src/lib/entry-editor/field-editors/MultiOptionEditor.test.svelte.ts
@@ -28,6 +28,7 @@ const context = new Map<string, unknown>([
       exemplars: ['test'],
       order: 0,
       type: WritingSystemType.Vernacular,
+      isAudio: false,
     }],
   }))],
   ['currentView', readable(views[0])],

--- a/frontend/viewer/src/lib/sandbox/OptionSandbox.svelte
+++ b/frontend/viewer/src/lib/sandbox/OptionSandbox.svelte
@@ -18,6 +18,7 @@
       exemplars: [],
       type: WritingSystemType.Analysis,
       order: 0,
+      isAudio: false,
     }],
     vernacular: [],
   }));

--- a/frontend/viewer/src/lib/utils.ts
+++ b/frontend/viewer/src/lib/utils.ts
@@ -61,6 +61,7 @@ export function defaultWritingSystem(type: WritingSystemType): IWritingSystem {
   return {
     id: randomId(),
     wsId: 'en',
+    isAudio: false,
     name: 'English',
     abbreviation: 'en',
     font: 'Arial',


### PR DESCRIPTION
currently if there's an audio writing system we just show whatever is there as text, since we don't support audio that might be confusing, especially for blank fields where a user might type in text but field works will expect it to be a file path.

For now we'll just hide these, once this is merged in we should update the shadCN PR