### PR TITLE
Url state tracking (ShadCN)

### DIFF
--- a/backend/FwLite/FwLiteShared/Pages/CrdtProject.razor
+++ b/backend/FwLite/FwLiteShared/Pages/CrdtProject.razor
@@ -1,8 +1,10 @@
-﻿@page "/project/{projectName}"
+﻿@page "/project/{projectName}/{*path}"
 @using FwLiteShared.Layout
 @layout SvelteLayout;
 
 @code {
     [Parameter]
     public required string ProjectName { get; set; }
+    [Parameter]
+    public required string Path { get; set; }
 }

--- a/backend/FwLite/FwLiteShared/Pages/FwdataProject.razor
+++ b/backend/FwLite/FwLiteShared/Pages/FwdataProject.razor
@@ -1,4 +1,4 @@
-﻿@page "/fwdata/{projectName}"
+﻿@page "/fwdata/{projectName}/{*path}"
 @using FwLiteShared.Layout
 @layout SvelteLayout;
 
@@ -6,5 +6,7 @@
 
     [Parameter]
     public required string ProjectName { get; set; }
+    [Parameter]
+    public required string Path { get; set; }
 
 }

--- a/backend/FwLite/FwLiteShared/Pages/Sandbox.razor
+++ b/backend/FwLite/FwLiteShared/Pages/Sandbox.razor
@@ -1,6 +1,11 @@
-﻿@page "/sandbox"
+﻿@page "/sandbox/{*path}"
 @using FwLiteShared.Layout
 @using FwLiteShared.Services
 @layout SvelteLayout;
 
-@*this looks empty because it is, but it's required to declare the route which is then used by the svelte router*@
+@code {
+
+    [Parameter]
+    public required string Path { get; set; }
+
+}

--- a/backend/FwLite/FwLiteShared/Pages/TestingProject.razor
+++ b/backend/FwLite/FwLiteShared/Pages/TestingProject.razor
@@ -1,3 +1,10 @@
-﻿@page "/testing/project-view"
+﻿@page "/testing/project-view/{*path}"
 @using FwLiteShared.Layout
 @layout SvelteLayout;
+
+@code {
+
+    [Parameter]
+    public required string Path { get; set; }
+
+}

--- a/frontend/viewer/src/App.svelte
+++ b/frontend/viewer/src/App.svelte
@@ -76,21 +76,21 @@
   <nav>
   </nav>
   <div class="app">
-    <Route path="/project/:code" let:params>
+    <Route path="/project/:code/*" let:params>
       <Router {url} basepath="/project/{params.code}">
         {#key params.code}
           <DotnetProjectView code={params.code} type="crdt"/>
         {/key}
       </Router>
     </Route>
-    <Route path="/fwdata/:name" let:params>
+    <Route path="/fwdata/:name/*" let:params>
       <Router {url} basepath="/fwdata/{params.name}">
         {#key params.name}
           <DotnetProjectView code={params.name} type="fwdata"/>
         {/key}
       </Router>
     </Route>
-    <Route path="/testing/project-view">
+    <Route path="/testing/project-view/*">
       <Router {url} basepath="/testing/project-view">
         <TestProjectView/>
       </Router>

--- a/frontend/viewer/src/ShadcnProjectView.svelte
+++ b/frontend/viewer/src/ShadcnProjectView.svelte
@@ -19,8 +19,8 @@
   import TasksView from './project/tasks/TasksView.svelte';
   import {initView, initViewSettings} from '$lib/views/view-service';
   import DialogsProvider from '$lib/DialogsProvider.svelte';
-  import {navigate, Route, Router, useLocation, useRouter} from 'svelte-routing';
-  import {untrack} from 'svelte';
+  import {navigate, Route, useRouter} from 'svelte-routing';
+  import {watch} from 'runed';
 
   const {
     onloaded,
@@ -33,14 +33,17 @@
     isConnected: boolean;
     showHomeButton?: boolean;
   } = $props();
+
   let currentView: View = $state('browse');
-  $effect(() => {
-    let newLocation = '/' + untrack(() => $base.path) + currentView;
+  const {base} = useRouter();
+
+  watch(() => currentView, () => {
+    let newLocation = `${$base.uri}/${currentView}`;
     setTimeout(() => navigate(newLocation));
   });
+
   const fieldView = initView();
   const viewSettings = initViewSettings();
-  const {base} = useRouter();
 
   onMount(() => {
     onloaded(true);

--- a/frontend/viewer/src/ShadcnProjectView.svelte
+++ b/frontend/viewer/src/ShadcnProjectView.svelte
@@ -19,6 +19,8 @@
   import TasksView from './project/tasks/TasksView.svelte';
   import {initView, initViewSettings} from '$lib/views/view-service';
   import DialogsProvider from '$lib/DialogsProvider.svelte';
+  import {navigate, Route, Router, useLocation, useRouter} from 'svelte-routing';
+  import {untrack} from 'svelte';
 
   const {
     onloaded,
@@ -32,8 +34,13 @@
     showHomeButton?: boolean;
   } = $props();
   let currentView: View = $state('browse');
+  $effect(() => {
+    let newLocation = '/' + untrack(() => $base.path) + currentView;
+    setTimeout(() => navigate(newLocation));
+  });
   const fieldView = initView();
   const viewSettings = initViewSettings();
+  const {base} = useRouter();
 
   onMount(() => {
     onloaded(true);
@@ -45,11 +52,12 @@
   <Sidebar.Provider bind:open>
       <ProjectSidebar bind:currentView />
       <Sidebar.Inset class="flex-1 relative">
-        {#if currentView === 'browse'}
-          <BrowseView />
-        {:else if currentView === 'tasks'}
-          <TasksView />
-        {/if}
+          <Route path="">
+            <BrowseView />
+          </Route>
+          <Route path="/tasks">
+            <TasksView />
+          </Route>
       </Sidebar.Inset>
   </Sidebar.Provider>
 </div>

--- a/frontend/viewer/src/ShadcnProjectView.svelte
+++ b/frontend/viewer/src/ShadcnProjectView.svelte
@@ -50,14 +50,17 @@
 <DialogsProvider/>
 <div class="h-screen flex PortalTarget overflow-hidden shadcn-root">
   <Sidebar.Provider bind:open>
-      <ProjectSidebar bind:currentView />
-      <Sidebar.Inset class="flex-1 relative">
-          <Route path="">
-            <BrowseView />
-          </Route>
-          <Route path="/tasks">
-            <TasksView />
-          </Route>
-      </Sidebar.Inset>
+    <ProjectSidebar bind:currentView/>
+    <Sidebar.Inset class="flex-1 relative">
+      <Route path="/browse">
+        <BrowseView/>
+      </Route>
+      <Route path="/tasks">
+        <TasksView/>
+      </Route>
+      <Route path="/*">
+        Unknown view {currentView}
+      </Route>
+    </Sidebar.Inset>
   </Sidebar.Provider>
 </div>

--- a/frontend/viewer/src/ShadcnProjectView.svelte
+++ b/frontend/viewer/src/ShadcnProjectView.svelte
@@ -38,6 +38,9 @@
   const {base} = useRouter();
 
   watch(() => currentView, () => {
+    const urlView = location.pathname.split('/').pop();
+    if (urlView === currentView) return; // avoid losing query params
+
     let newLocation = `${$base.uri}/${currentView}`;
     setTimeout(() => navigate(newLocation));
   });

--- a/frontend/viewer/src/ShadcnProjectView.svelte
+++ b/frontend/viewer/src/ShadcnProjectView.svelte
@@ -34,17 +34,6 @@
     showHomeButton?: boolean;
   } = $props();
 
-  let currentView: View = $state('browse');
-  const {base} = useRouter();
-
-  watch(() => currentView, () => {
-    const urlView = location.pathname.split('/').pop();
-    if (urlView === currentView) return; // avoid losing query params
-
-    let newLocation = `${$base.uri}/${currentView}`;
-    setTimeout(() => navigate(newLocation));
-  });
-
   const fieldView = initView();
   const viewSettings = initViewSettings();
 
@@ -52,11 +41,12 @@
     onloaded(true);
   });
   let open = $state(true);
+  const {base} = useRouter();
 </script>
 <DialogsProvider/>
 <div class="h-screen flex PortalTarget overflow-hidden shadcn-root">
   <Sidebar.Provider bind:open>
-    <ProjectSidebar bind:currentView/>
+    <ProjectSidebar/>
     <Sidebar.Inset class="flex-1 relative">
       <Route path="/browse">
         <BrowseView/>
@@ -64,8 +54,11 @@
       <Route path="/tasks">
         <TasksView/>
       </Route>
+      <Route path="/">
+        {setTimeout(() => navigate(`${$base.uri}/browse`, {replace: true}))}
+      </Route>
       <Route path="/*">
-        Unknown view {currentView}
+        Unknown route
       </Route>
     </Sidebar.Inset>
   </Sidebar.Provider>

--- a/frontend/viewer/src/lib/entry-editor/DeleteDialog.svelte
+++ b/frontend/viewer/src/lib/entry-editor/DeleteDialog.svelte
@@ -3,6 +3,7 @@
   import * as AlertDialog from '$lib/components/ui/alert-dialog';
   import {t} from 'svelte-i18n-lingui';
   import {useDialogsService} from '$lib/services/dialogs-service';
+  import {QueryParamStateBool} from '$lib/utils/url.svelte';
 
   const dialogsService = useDialogsService();
   dialogsService.invokeDeleteDialog = prompt;
@@ -10,7 +11,7 @@
   let description = $state<string>();
   const subjectWithDescription = $derived(description ? `${subject}: ${description}` : subject);
 
-  let open = $state(false);
+  const open = new QueryParamStateBool('deleteDialogOpen', true);
   let requester: {
     resolve: (result: boolean) => void
   } | undefined = undefined;
@@ -29,7 +30,7 @@
   function resolve(shouldDelete: boolean) {
     requester?.resolve(shouldDelete);
     requester = undefined;
-    open = false;
+    open.current = false;
   }
 
   export function prompt(promptSubject: string, subjectDescription?: string): Promise<boolean> {
@@ -38,13 +39,13 @@
       requester = { resolve };
       subject = promptSubject;
       description = subjectDescription;
-      open = true;
+      open.current = true;
     });
   }
 </script>
 
-{#if open}
-<AlertDialog.Root bind:open>
+{#if open.current}
+<AlertDialog.Root bind:open={open.current}>
   <AlertDialog.Content>
     <AlertDialog.Header>
       <AlertDialog.Title>{$t`Delete ${subject}`}</AlertDialog.Title>

--- a/frontend/viewer/src/lib/entry-editor/EntryOrSenseItemList.svelte
+++ b/frontend/viewer/src/lib/entry-editor/EntryOrSenseItemList.svelte
@@ -20,7 +20,7 @@
   getDisplayName={getHeadword}>
   {#snippet menuItems(entry)}
     <DropdownMenu.Item>
-      <Link to="?entryId={getEntryId(entry)}}">
+      <Link to="?entryId={getEntryId(entry)}">
         <Icon icon="i-mdi-book-outline" />
         {$t`Go to ${getHeadword(entry) || '–'}`}
       </Link>

--- a/frontend/viewer/src/lib/entry-editor/NewEntryDialog.svelte
+++ b/frontend/viewer/src/lib/entry-editor/NewEntryDialog.svelte
@@ -13,8 +13,9 @@
   import OverrideFields from '$lib/OverrideFields.svelte';
   import {useWritingSystemService} from '$lib/writing-system-service.svelte';
   import {useDialogsService} from '$lib/services/dialogs-service.js';
+  import {QueryParamStateBool} from '$lib/utils/url.svelte';
 
-  let open = $state(false);
+  const open = new QueryParamStateBool('newEntryDialogOpen', true);
   let loading = $state(false);
   let entry: IEntry = $state(defaultEntry());
 
@@ -30,7 +31,7 @@
 
   // Watch for changes in the open state to detect when the dialog is closed
   $effect(() => {
-    if (!open) {
+    if (!open.current) {
       onClosing();
     }
   });
@@ -46,7 +47,7 @@
     requester.resolve(entry);
     requester = undefined;
     loading = false;
-    open = false;
+    open.current = false;
   }
 
   let errors: string[] = $state([]);
@@ -62,7 +63,7 @@
       if (requester) requester.resolve(undefined);
       requester = { resolve };
       const tmpEntry = defaultEntry();
-      open = true;
+      open.current = true;
       entry = {...tmpEntry, ...newEntry, id: tmpEntry.id};
       if (entry.senses.length === 0) {
         entry.senses.push(defaultSense(entry.id));
@@ -82,8 +83,8 @@
   let entryLabel = fieldName({id: 'entry'}, $currentView.i18nKey);
 </script>
 
-{#if open}
-<Dialog.Root bind:open>
+{#if open.current}
+<Dialog.Root bind:open={open.current}>
   <Dialog.DialogContent>
     <Dialog.DialogHeader>
       <Dialog.DialogTitle>{$t`New ${entryLabel}`}</Dialog.DialogTitle>
@@ -99,7 +100,7 @@
       </div>
     {/if}
     <Dialog.DialogFooter>
-      <Button onclick={() => open = false} variant="secondary">{$t`Cancel`}</Button>
+      <Button onclick={() => open.current = false} variant="secondary">{$t`Cancel`}</Button>
       <Button onclick={e => createEntry(e)} disabled={loading} {loading}>
         {$t`Create ${entryLabel}`}
       </Button>

--- a/frontend/viewer/src/lib/sandbox/Sandbox.svelte
+++ b/frontend/viewer/src/lib/sandbox/Sandbox.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import OverrideFields from '$lib/OverrideFields.svelte';
-  import {Button} from '$lib/components/ui/button';
+  import {Button, buttonVariants} from '$lib/components/ui/button';
   import {Checkbox} from '$lib/components/ui/checkbox';
   import {DotnetService, type IEntry, type ISense} from '$lib/dotnet-types';
   import type {FieldIds} from '$lib/entry-editor/field-data';
@@ -25,6 +25,10 @@
   import DialogsProvider from '$lib/DialogsProvider.svelte';
   import {TabsList, TabsTrigger, Tabs} from '$lib/components/ui/tabs';
   import {Reorderer} from '$lib/components/reorderer/index.js';
+  import {Switch} from '$lib/components/ui/switch';
+  import {QueryParamState, QueryParamStateBool} from '$lib/utils/url.svelte';
+  import {Link} from 'svelte-routing';
+
 
   const testingService = tryUseService(DotnetService.TestingService);
 
@@ -89,6 +93,11 @@
     items = Array.from({length: 10}, () => (Math.random() * 100).toFixed(0));
     currentItem = items[0];
   }
+
+
+
+  let nameSearchParam = new QueryParamState('name');
+  let goodSearchParam = new QueryParamStateBool('good', true, true);
 </script>
 <DialogsProvider/>
 <div class="p-6 shadcn-root">
@@ -182,6 +191,12 @@
     <div>
       <code>{JSON.stringify(items)}</code>
     </div>
+  </div>
+  <div class="flex flex-col gap-2 border p-4 justify-between">
+    <h3 class="font-medium">Search Params binding</h3>
+    <input bind:value={nameSearchParam.current}/>
+    <Link to="/sandbox?name=batman" class={buttonVariants({variant: 'default'})}>Go to Batman</Link>
+    <Switch label="Good" bind:checked={goodSearchParam.current}/>
   </div>
 </div>
 

--- a/frontend/viewer/src/lib/sandbox/Sandbox.svelte
+++ b/frontend/viewer/src/lib/sandbox/Sandbox.svelte
@@ -195,7 +195,7 @@
   <div class="flex flex-col gap-2 border p-4 justify-between">
     <h3 class="font-medium">Search Params binding</h3>
     <input bind:value={nameSearchParam.current}/>
-    <Link to="/sandbox?name=batman" class={buttonVariants({variant: 'default'})}>Go to Batman</Link>
+    <Link to="/sandbox?name=batman" class={buttonVariants({variant: 'default'})} preserveScroll>Go to Batman</Link>
     <Switch label="Good" bind:checked={goodSearchParam.current}/>
   </div>
 </div>

--- a/frontend/viewer/src/lib/utils/url.svelte.ts
+++ b/frontend/viewer/src/lib/utils/url.svelte.ts
@@ -1,0 +1,69 @@
+import {createSubscriber} from 'svelte/reactivity';
+import {useLocation} from 'svelte-routing';
+
+/**
+ *
+ * A reactive query parameter state
+ * it reacts to users pressing back and svelte router changes
+ */
+export class QueryParamState {
+  #subscribe: ReturnType<typeof createSubscriber>;
+  #current: string = $state('');
+  public get current(): string {
+    this.#subscribe();
+    return this.#current;
+  }
+
+  public set current(value: string) {
+    if (value === this.#current) return;
+    const currentUrl = new URL(document.location.href);
+    if (value === this.defaultValue) {
+      currentUrl.searchParams.delete(this.key);
+    } else {
+      currentUrl.searchParams.set(this.key, value);
+    }
+    if (currentUrl.href == document.location.href) return;
+    if (this.allowBack) {
+      history.pushState(null, '', currentUrl.href);
+    } else {
+      history.replaceState(null, '', currentUrl.href);
+    }
+    //history events don't trigger popstate, so we need to set the value directly
+    this.#current = value;
+  }
+
+  constructor(private key: string, private allowBack: boolean = false, private defaultValue: string = '') {
+    const location = useLocation();
+
+    this.#current = this.readUrlValue();
+    //ensures that we only subscribe to popstate if current is being watched/used in an $effect
+    this.#subscribe = createSubscriber(update => {
+      const off = location.subscribe(() => {
+        this.#current = this.readUrlValue();
+        console.log(this.#current);
+        update();
+      });
+      return () => off();
+    });
+  }
+
+  private readUrlValue(): string {
+    return new URL(document.location.href).searchParams.get(this.key) ?? this.defaultValue;
+  }
+}
+
+export class QueryParamStateBool {
+  #stringState: QueryParamState;
+
+  get current(): boolean {
+    return this.#stringState.current === 'true';
+  }
+
+  set current(value: boolean) {
+    this.#stringState.current = value.toString();
+  }
+
+  constructor(private key: string, allowBack: boolean = false, defaultValue: boolean = false) {
+    this.#stringState = new QueryParamState(key, allowBack, defaultValue.toString());
+  }
+}

--- a/frontend/viewer/src/lib/utils/url.svelte.ts
+++ b/frontend/viewer/src/lib/utils/url.svelte.ts
@@ -40,7 +40,6 @@ export class QueryParamState {
     this.#subscribe = createSubscriber(update => {
       const off = location.subscribe(() => {
         this.#current = this.readUrlValue();
-        console.log(this.#current);
         update();
       });
       return () => off();

--- a/frontend/viewer/src/lib/utils/url.svelte.ts
+++ b/frontend/viewer/src/lib/utils/url.svelte.ts
@@ -22,7 +22,6 @@ export class QueryParamState {
     } else {
       currentUrl.searchParams.set(this.key, value);
     }
-    if (currentUrl.href == document.location.href) return;
     if (this.allowBack) {
       history.pushState(null, '', currentUrl.href);
     } else {

--- a/frontend/viewer/src/project/ProjectSidebar.svelte
+++ b/frontend/viewer/src/project/ProjectSidebar.svelte
@@ -9,13 +9,9 @@
   import ProjectDropdown from './ProjectDropdown.svelte';
   import { t } from 'svelte-i18n-lingui';
   import ThemePicker from '$lib/ThemePicker.svelte';
-  import {navigate} from 'svelte-routing';
+  import {navigate, useRouter} from 'svelte-routing';
   import type {IProjectModel} from '$lib/dotnet-types';
   import {usePrimaryAction} from './SidebarPrimaryAction.svelte';
-
-  let { currentView = $bindable() } = $props<{
-    currentView: View;
-  }>();
 
   const config = useFwLiteConfig();
   let isSynchronizing = $state(false);
@@ -30,11 +26,17 @@
 
   let sidebar: Sidebar.Root | undefined = $state();
   const primaryAction = usePrimaryAction();
+
+  const {base, activeRoute} = useRouter();
+  function goto(view: string) {
+    let newLocation = `${$base.uri}/${view}`;
+    navigate(newLocation);
+  }
 </script>
 
 {#snippet ViewButton(view: View, icon: IconClass, label: string)}
   <Sidebar.MenuItem>
-    <Sidebar.MenuButton onclick={() => (currentView = view)} isActive={currentView === view}>
+    <Sidebar.MenuButton onclick={() => goto(view)} isActive={$activeRoute?.uri.endsWith(view)}>
       <Icon {icon} />
       <span>{label}</span>
     </Sidebar.MenuButton>

--- a/frontend/viewer/src/project/browse/EntriesList.svelte
+++ b/frontend/viewer/src/project/browse/EntriesList.svelte
@@ -18,14 +18,14 @@
 
   const {
     search = '',
-    selectedEntry = undefined,
+    selectedEntryId = undefined,
     sortDirection = 'asc',
     onSelectEntry,
     gridifyFilter = undefined,
     previewDictionary = false
   }: {
     search?: string;
-    selectedEntry?: IEntry;
+    selectedEntryId?: string;
     sortDirection: 'asc' | 'desc';
     onSelectEntry: (entry?: IEntry) => void;
     gridifyFilter?: string;
@@ -36,7 +36,7 @@
   const projectEventBus = useProjectEventBus();
 
   projectEventBus.onEntryDeleted(entryId => {
-    if (selectedEntry?.id === entryId) onSelectEntry(undefined);
+    if (selectedEntryId === entryId) onSelectEntry(undefined);
     if (entriesResource.loading || !entries.some(e => e.id === entryId)) return;
     entriesResource.refetch();
   });
@@ -112,7 +112,7 @@
         {#each entries as entry}
           <EntryMenu {entry} contextMenu>
               <EntryRow {entry}
-                isSelected={selectedEntry?.id === entry.id}
+                isSelected={selectedEntryId === entry.id}
                 onclick={() => onSelectEntry(entry)}
                 {previewDictionary} />
           </EntryMenu>


### PR DESCRIPTION
fixes various issues around state that should be tracked in the URL (and therefore back button handling). This now includes:

- selected entry
- current view (eg browse or tasks)
- open delete or new entry dialogs

we could also track current search query in the URL, but I'm not sure that's useful.