### PR TITLE
Fix example sentence filter

### DIFF
--- a/backend/FwLite/FwDataMiniLcmBridge/LexEntryFilterMapProvider.cs
+++ b/backend/FwLite/FwDataMiniLcmBridge/LexEntryFilterMapProvider.cs
@@ -17,7 +17,7 @@ public class LexEntryFilterMapProvider : EntryFilterMapProvider<ILexEntry>
             // ReSharper disable once ConvertClosureToMethodGroup
             .Select(domain => LcmHelpers.GetSemanticDomainCode(domain));
     public override Func<string, object>? EntrySensesSemanticDomainsConverter => EntryFilter.NormalizeEmptyToNullString<ICmSemanticDomain>;
-    public override Expression<Func<ILexEntry, object?>> EntrySensesExampleSentences => e => EmptyToNull(e.AllSenses.SelectMany(s => s.ExamplesOS));
+    public override Expression<Func<ILexEntry, object?>> EntrySensesExampleSentences => e => e.AllSenses.Select(s => EmptyToNull(s.ExamplesOS));
     public override Expression<Func<ILexEntry, string, object?>> EntrySensesExampleSentencesSentence => (entry, ws) =>
         entry.AllSenses.SelectMany(s => s.ExamplesOS).Select(example => example.PickText(example.Example, ws));
 

--- a/backend/FwLite/LcmCrdt/EntryFilterMapProvider.cs
+++ b/backend/FwLite/LcmCrdt/EntryFilterMapProvider.cs
@@ -13,7 +13,7 @@ public class EntryFilterMapProvider : EntryFilterMapProvider<Entry>
     public override Func<string, object>? EntrySensesSemanticDomainsConverter =>
         //linq2db treats Sense.SemanticDomains as a table, if we use "null" then it'll write the query we want
         EntryFilter.NormalizeEmptyToNullString<SemanticDomain>;
-    public override Expression<Func<Entry, object?>> EntrySensesExampleSentences => e => e.Senses.SelectMany(s => s.ExampleSentences);
+    public override Expression<Func<Entry, object?>> EntrySensesExampleSentences => e => e.Senses.Select(s => s.ExampleSentences);
     public override Expression<Func<Entry, string, object?>> EntrySensesExampleSentencesSentence =>
         (e, ws) => e.Senses.SelectMany(s => s.ExampleSentences).Select(example => Json.Value(example.Sentence, ms => ms[ws]));
     public override Expression<Func<Entry, object?>> EntrySensesPartOfSpeechId => e => e.Senses.Select(s => s.PartOfSpeechId);

--- a/backend/FwLite/MiniLcm.Tests/QueryEntryTestsBase.cs
+++ b/backend/FwLite/MiniLcm.Tests/QueryEntryTestsBase.cs
@@ -91,6 +91,13 @@ public abstract class QueryEntryTestsBase : MiniLcmTestBase
     }
 
     [Fact]
+    public async Task CanFilterToNotMissingSenses()
+    {
+        var results = await Api.GetEntries(new(Filter: new() { GridifyFilter = "Senses!=null" })).ToArrayAsync();
+        results.Select(e => e.LexemeForm["en"]).Should().BeEquivalentTo(Kiwi, Peach, Banana);
+    }
+
+    [Fact]
     public async Task CanFilterToMissingPartOfSpeech()
     {
         var results = await Api.GetEntries(new(Filter: new() { GridifyFilter = "Senses.PartOfSpeechId=null" })).ToArrayAsync();
@@ -125,21 +132,21 @@ public abstract class QueryEntryTestsBase : MiniLcmTestBase
     public async Task CanFilterSemanticDomainCodeContains()
     {
         var results = await Api.GetEntries(new(Filter: new() { GridifyFilter = "Senses.SemanticDomains.Code=*Fruit" })).ToArrayAsync();
-        results.Select(e => e.LexemeForm["en"]).Should().BeEquivalentTo(Banana);
+        results.Select(e => e.LexemeForm["en"]).Should().BeEquivalentTo(Banana, Kiwi);
     }
 
     [Fact]
     public async Task CanFilterToMissingComplexFormTypes()
     {
         var results = await Api.GetEntries(new(Filter: new() { GridifyFilter = "ComplexFormTypes=null" })).ToArrayAsync();
-        results.Select(e => e.LexemeForm["en"]).Should().BeEquivalentTo(Apple, Banana);
+        results.Select(e => e.LexemeForm["en"]).Should().BeEquivalentTo(Apple, Banana, Kiwi);
     }
 
     [Fact]
     public async Task CanFilterToMissingComplexFormTypesWithEmptyArray()
     {
         var results = await Api.GetEntries(new(Filter: new() { GridifyFilter = "ComplexFormTypes=[]" })).ToArrayAsync();
-        results.Select(e => e.LexemeForm["en"]).Should().BeEquivalentTo(Apple, Banana);
+        results.Select(e => e.LexemeForm["en"]).Should().BeEquivalentTo(Apple, Banana, Kiwi);
     }
 
     [Fact]
@@ -188,7 +195,7 @@ public abstract class QueryEntryTestsBase : MiniLcmTestBase
     public async Task CanFilterGlossEqualsFruit()
     {
         var results = await Api.GetEntries(new(Filter: new() { GridifyFilter = "Senses.Gloss[en]=Fruit" })).ToArrayAsync();
-        results.Select(e => e.LexemeForm["en"]).Should().BeEquivalentTo(Banana);
+        results.Select(e => e.LexemeForm["en"]).Should().BeEquivalentTo(Banana, Kiwi);
     }
 
     [Fact]


### PR DESCRIPTION
Currently only entries with no example sentences will match the filter `Senses.ExampleSentences=null`, so if there's 2 senses and one has no examples, that entry would not match. This PR changes that so that now it does match the filter.