### PR TITLE
Persist changes in EntryView.svelte

### DIFF
--- a/backend/FwLite/FwLiteShared/Services/MiniLcmApiNotifyWrapper.cs
+++ b/backend/FwLite/FwLiteShared/Services/MiniLcmApiNotifyWrapper.cs
@@ -116,6 +116,18 @@ public partial class MiniLcmApiNotifyWrapper(
         NotifyEntryDeleted(id);
     }
 
+    async Task IMiniLcmWriteApi.DeleteSense(Guid entryId, Guid senseId)
+    {
+        await _api.DeleteSense(entryId, senseId);
+        await NotifyEntryChangedAsync(entryId);
+    }
+
+    async Task IMiniLcmWriteApi.DeleteExampleSentence(Guid entryId, Guid senseId, Guid exampleSentenceId)
+    {
+        await _api.DeleteExampleSentence(entryId, senseId, exampleSentenceId);
+        await NotifyEntryChangedAsync(entryId);
+    }
+
     void IDisposable.Dispose()
     {
     }

--- a/frontend/viewer/src/lib/entry-editor/entry-persistence.svelte.ts
+++ b/frontend/viewer/src/lib/entry-editor/entry-persistence.svelte.ts
@@ -1,0 +1,54 @@
+import { type Props } from './object-editors/EntryEditor.svelte';
+import { useLexboxApi } from '$lib/services/service-provider';
+import { useSaveHandler } from '$lib/services/save-event-service.svelte';
+import type { Getter } from 'runed';
+import type { IEntry } from '$lib/dotnet-types';
+
+export class EntryPersistence {
+  lexboxApi = useLexboxApi();
+  saveHandler = useSaveHandler();
+  initialEntry: IEntry | undefined = undefined;
+  constructor(private entryGetter: Getter<IEntry | undefined>, private onRefresh: () => void = () => { }) {
+    $effect(() => {
+      if (this.initialEntry) return;
+      if (entryGetter()) this.updateInitialEntry();
+    });
+  }
+
+  private get entry(): IEntry {
+    const entry = this.entryGetter();
+    if (!entry) throw new Error('Entry not found');
+    return entry;
+  }
+
+  get entryEditorProps(): Partial<Props> {
+    return {
+      onchange: async changed => {
+        await this.updateEntry(changed.entry);
+        this.onRefresh();
+        this.updateInitialEntry();
+      },
+      ondelete: async (e) => {
+        if (e.example !== undefined && e.sense !== undefined) {
+          await this.saveHandler.handleSave(() => this.lexboxApi.deleteExampleSentence(e.entry.id, e.sense!.id, e.example!.id));
+        } else if (e.sense !== undefined) {
+          await this.saveHandler.handleSave(() => this.lexboxApi.deleteSense(e.entry.id, e.sense!.id));
+        } else {
+          await this.saveHandler.handleSave(() => this.lexboxApi.deleteEntry(e.entry.id));
+          this.onRefresh();
+          return;
+        }
+        this.updateInitialEntry();
+      }
+    };
+  }
+
+  async updateEntry(updatedEntry: IEntry) {
+    if (this.initialEntry.id != updatedEntry.id) throw new Error('Entry id mismatch');
+    await this.saveHandler.handleSave(() => this.lexboxApi.updateEntry(this.initialEntry, updatedEntry));
+  }
+
+  updateInitialEntry() {
+    this.initialEntry = JSON.parse(JSON.stringify(this.entry)) as IEntry;
+  }
+}

--- a/frontend/viewer/src/lib/entry-editor/object-editors/EntryEditor.svelte
+++ b/frontend/viewer/src/lib/entry-editor/object-editors/EntryEditor.svelte
@@ -1,3 +1,14 @@
+<script lang="ts" module>
+  export type Props = {
+    entry: IEntry;
+    readonly?: boolean;
+    modalMode?: boolean;
+    canAddSense?: boolean;
+    canAddExample?: boolean;
+    onchange?: (changed: { entry: IEntry, sense?: ISense, example?: IExampleSentence }) => void;
+    ondelete?: (deleted: { entry: IEntry, sense?: ISense, example?: IExampleSentence }) => void;
+  };
+</script>
 <script lang="ts">
   import type {IEntry, IExampleSentence, ISense} from '$lib/dotnet-types';
   import {useDialogsService} from '$lib/services/dialogs-service';
@@ -16,16 +27,6 @@
   import {watch} from 'runed';
   import FabContainer from '$lib/components/fab/fab-container.svelte';
   import {IsMobile} from '$lib/hooks/is-mobile.svelte';
-
-  type Props = {
-    entry: IEntry;
-    readonly?: boolean;
-    modalMode?: boolean;
-    canAddSense?: boolean;
-    canAddExample?: boolean;
-    onchange?: (changed: { entry: IEntry, sense?: ISense, example?: IExampleSentence}) => void;
-    ondelete?: (deleted: { entry: IEntry, sense?: ISense, example?: IExampleSentence}) => void;
-  };
 
   let {
     entry = $bindable(),

--- a/frontend/viewer/src/project/browse/EntryView.svelte
+++ b/frontend/viewer/src/project/browse/EntryView.svelte
@@ -15,6 +15,7 @@
   import {Toggle} from '$lib/components/ui/toggle';
   import {XButton} from '$lib/components/ui/button';
   import type {IEntry} from '$lib/dotnet-types';
+  import {EntryPersistence} from '$lib/entry-editor/entry-persistence.svelte';
 
   const viewSettings = useViewSettings();
   const writingSystemService = useWritingSystemService();
@@ -42,6 +43,7 @@
   const sticky = $derived.by(() => dictionaryPreview === 'sticky');
 
   let readonly = $state(false);
+  const entryPersistence = new EntryPersistence(() => entry, () => entryResource.refetch());
 </script>
 
 {#snippet preview(entry: IEntry)}
@@ -81,7 +83,7 @@
         {@render preview(entry)}
       {/if}
       <div class="max-md:p-2 md:pr-2">
-        <EntryEditor {entry} {readonly} />
+        <EntryEditor {entry} {readonly} {...entryPersistence.entryEditorProps} />
       </div>
     </ScrollArea>
   {/if}


### PR DESCRIPTION
I decided to try something new here shifting as much code as I could into a new file entry-persistence.svelte.ts which EntryView creates and passes props to EntryEditor, this way it can be easily reused in other places without complicating EntryEditor