### PR TITLE
fix bug opening a project after trying to S&R it

### DIFF
--- a/backend/LexBoxApi/Controllers/CrdtController.cs
+++ b/backend/LexBoxApi/Controllers/CrdtController.cs
@@ -90,12 +90,12 @@ public class CrdtController(
     {
         await permissionService.AssertCanViewProject(code);
         var projectId = await projectService.LookupProjectId(code);
-        if (projectId == default)
+        if (projectId is null)
         {
             return NotFound();
         }
 
-        return Ok(projectId);
+        return Ok(projectId.Value);
     }
 
     [HttpGet("checkConnection")]

--- a/backend/LexBoxApi/Controllers/IntegrationController.cs
+++ b/backend/LexBoxApi/Controllers/IntegrationController.cs
@@ -59,8 +59,8 @@ public class IntegrationController(
     public async Task<ActionResult<RefreshResponse>> GetProjectToken(string projectCode)
     {
         var projectId = await projectService.LookupProjectId(projectCode);
-        if (projectId == default) return NotFound();
-        return GetRefreshResponse(projectId);
+        if (projectId is null) return NotFound();
+        return GetRefreshResponse(projectId.Value);
     }
 
     private RefreshResponse GetRefreshResponse(Guid projectId)

--- a/backend/LexBoxApi/GraphQL/LexQueries.cs
+++ b/backend/LexBoxApi/GraphQL/LexQueries.cs
@@ -158,7 +158,7 @@ public class LexQueries
             ? await lexAuthService.RefreshUser(LexAuthConstants.ProjectsClaimType)
             : null;
 
-        await permissionService.AssertCanViewProject(code, updatedUser);
+        await permissionService.AssertCanViewProject(project.Id, updatedUser);
         return project;
     }
 

--- a/backend/LexBoxApi/GraphQL/ProjectMutations.cs
+++ b/backend/LexBoxApi/GraphQL/ProjectMutations.cs
@@ -361,8 +361,8 @@ public class ProjectMutations
         LexBoxDbContext dbContext)
     {
         var projectId = await projectService.LookupProjectId(code);
-        await permissionService.AssertCanViewProject(projectId);
-        if (projectId == default) throw NotFoundException.ForType<Project>();
+        if (projectId is null) throw NotFoundException.ForType<Project>();
+        await permissionService.AssertCanViewProject(projectId.Value);
         await projectService.UpdateRepoSizeInKb(code);
         return dbContext.Projects.Where(p => p.Id == projectId);
     }
@@ -379,7 +379,8 @@ public class ProjectMutations
         LexBoxDbContext dbContext)
     {
         var projectId = await projectService.LookupProjectId(code);
-        await permissionService.AssertCanManageProject(projectId);
+        if (projectId is null) throw NotFoundException.ForType<Project>();
+        await permissionService.AssertCanManageProject(projectId.Value);
         var project = await dbContext.Projects.FindAsync(projectId);
         NotFoundException.ThrowIfNull(project);
         var result = await projectService.UpdateLexEntryCount(code);
@@ -398,10 +399,11 @@ public class ProjectMutations
         LexBoxDbContext dbContext)
     {
         var projectId = await projectService.LookupProjectId(code);
-        await permissionService.AssertCanManageProject(projectId);
+        if (projectId is null) throw NotFoundException.ForType<Project>();
+        await permissionService.AssertCanManageProject(projectId.Value);
         var project = await dbContext.Projects.FindAsync(projectId);
         NotFoundException.ThrowIfNull(project);
-        await projectService.UpdateProjectLangTags(projectId);
+        await projectService.UpdateProjectLangTags(projectId.Value);
         return dbContext.Projects.Where(p => p.Id == projectId);
     }
 
@@ -417,10 +419,11 @@ public class ProjectMutations
         LexBoxDbContext dbContext)
     {
         var projectId = await projectService.LookupProjectId(code);
-        await permissionService.AssertCanManageProject(projectId);
+        if (projectId is null) throw NotFoundException.ForType<Project>();
+        await permissionService.AssertCanManageProject(projectId.Value);
         var project = await dbContext.Projects.FindAsync(projectId);
         NotFoundException.ThrowIfNull(project);
-        await projectService.UpdateProjectLangProjectId(projectId);
+        await projectService.UpdateProjectLangProjectId(projectId.Value);
         return dbContext.Projects.Where(p => p.Id == projectId);
     }
 
@@ -436,8 +439,9 @@ public class ProjectMutations
         LexBoxDbContext dbContext)
     {
         var projectId = await projectService.LookupProjectId(code);
-        await permissionService.AssertCanManageProject(projectId);
-        await projectService.UpdateFLExModelVersion(projectId);
+        if (projectId is null) throw NotFoundException.ForType<Project>();
+        await permissionService.AssertCanManageProject(projectId.Value);
+        await projectService.UpdateFLExModelVersion(projectId.Value);
         return dbContext.Projects.Where(p => p.Id == projectId);
     }
 

--- a/backend/LexBoxApi/Services/PermissionService.cs
+++ b/backend/LexBoxApi/Services/PermissionService.cs
@@ -81,9 +81,9 @@ public class PermissionService(
         return isConfidential == false; // Explicitly set to public
     }
 
-    public async ValueTask AssertCanViewProject(Guid projectId)
+    public async ValueTask AssertCanViewProject(Guid projectId, LexAuthUser? overrideUser = null)
     {
-        if (!await CanViewProject(projectId)) throw new UnauthorizedAccessException();
+        if (!await CanViewProject(projectId, overrideUser)) throw new UnauthorizedAccessException();
     }
 
     public async ValueTask<bool> CanViewProject(string projectCode, LexAuthUser? overrideUser = null)

--- a/backend/LexBoxApi/Services/PermissionService.cs
+++ b/backend/LexBoxApi/Services/PermissionService.cs
@@ -40,7 +40,9 @@ public class PermissionService(
     {
         if (User is null) return false;
         if (User.Role == UserRole.admin) return true;
-        return await CanSyncProject(await projectService.LookupProjectId(projectCode));
+        var projectId = await projectService.LookupProjectId(projectCode);
+        if (projectId is null) return false;
+        return await CanSyncProject(projectId.Value);
     }
 
     public bool IsProjectMember(Guid projectId, LexAuthUser? overrideUser = null)
@@ -90,7 +92,9 @@ public class PermissionService(
     {
         var user = overrideUser ?? User;
         if (user is not null && user.Role == UserRole.admin) return true;
-        return await CanViewProject(await projectService.LookupProjectId(projectCode), overrideUser);
+        var projectId = await projectService.LookupProjectId(projectCode);
+        if (projectId is null) return false;
+        return await CanViewProject(projectId.Value, overrideUser);
     }
 
     public async ValueTask AssertCanViewProject(string projectCode, LexAuthUser? overrideUser = null)
@@ -125,7 +129,9 @@ public class PermissionService(
 
     public async ValueTask<bool> CanManageProject(string projectCode)
     {
-        return await CanManageProject(await projectService.LookupProjectId(projectCode));
+        var projectId = await projectService.LookupProjectId(projectCode);
+        if (projectId is null) return false;
+        return await CanManageProject(projectId.Value);
     }
 
     public async ValueTask AssertCanManageProject(string projectCode)
@@ -181,7 +187,9 @@ public class PermissionService(
 
     public async ValueTask<bool> CanAskToJoinProject(string projectCode)
     {
-        return await CanAskToJoinProject(await projectService.LookupProjectId(projectCode));
+        var projectId = await projectService.LookupProjectId(projectCode);
+        if (projectId is null) return false;
+        return await CanAskToJoinProject(projectId.Value);
     }
 
     public async ValueTask AssertCanAskToJoinProject(string projectCode)

--- a/backend/LexCore/ServiceInterfaces/IPermissionService.cs
+++ b/backend/LexCore/ServiceInterfaces/IPermissionService.cs
@@ -11,7 +11,7 @@ public interface IPermissionService
     ValueTask AssertCanSyncProject(string projectCode);
     ValueTask AssertCanSyncProject(Guid projectId);
     ValueTask<bool> CanViewProject(Guid projectId, LexAuthUser? overrideUser = null);
-    ValueTask AssertCanViewProject(Guid projectId);
+    ValueTask AssertCanViewProject(Guid projectId, LexAuthUser? overrideUser = null);
     ValueTask<bool> CanViewProject(string projectCode, LexAuthUser? overrideUser = null);
     ValueTask AssertCanViewProject(string projectCode, LexAuthUser? overrideUser = null);
     ValueTask<bool> CanViewProjectMembers(Guid projectId);


### PR DESCRIPTION
fixes a bug reported by a user.

to reproduce:
1. try to S&R a project code which doesn't exist
2. create said project code, there will be an error trying to open the project page.

The problem is that step 1 caused the project code to be associated with an empty guid (because it doesn't exist) and cache that association, when the new project was created that cache was not invalidated, then when asking for permission to view the project it was rejected because the user didn't have permission to view a project of empty guid.

I've added code to invalidate the code to id cache one project creation, in addition I've changed the signature of the project code lookup to return `Guid?` so the caller is forced to explicitly handle the null case, rather than just getting `Guid.Empty`