### PR TITLE
Use analysis WS's for literal meaning

### DIFF
--- a/frontend/viewer/src/lib/entry-editor/object-editors/EntryEditorPrimitive.svelte
+++ b/frontend/viewer/src/lib/entry-editor/object-editors/EntryEditorPrimitive.svelte
@@ -103,7 +103,7 @@
           onchange={() => onFieldChanged('literalMeaning')}
           bind:value={entry.literalMeaning}
           {readonly}
-          writingSystems={writingSystemService.vernacular} />
+          writingSystems={writingSystemService.analysis} />
     </Editor.Field.Body>
   </Editor.Field.Root>
 


### PR DESCRIPTION
Oooooooops.

Rainer pointed this out a long time ago, but I never took a close look.

![image](https://github.com/user-attachments/assets/17e886f0-7fd4-4b7b-a365-a22dcbbaa776)

Us previously:
![image](https://github.com/user-attachments/assets/8e5fb6de-5e4b-4f58-8e86-a1fcefa921cf)

Us with this change:
![image](https://github.com/user-attachments/assets/d3aacf54-a910-414f-95a1-0c8967f214c6)

FLEx:
![image](https://github.com/user-attachments/assets/45d1418f-5662-4cf2-b75b-9cdf9c5dc6fa)
