### PR TITLE
Shadcn low-hanging fruit follow-up

### DIFF
--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -8987,7 +8987,7 @@ snapshots:
       sirv: 3.0.0
       tinyglobby: 0.2.10
       tinyrainbow: 2.0.0
-      vitest: 3.0.5(@types/debug@4.1.12)(@types/node@20.17.32)(@vitest/ui@3.0.5)(happy-dom@17.1.0)(jiti@2.4.2)(yaml@2.7.1)
+      vitest: 3.0.5(@types/debug@4.1.12)(@types/node@22.15.3)(@vitest/ui@3.0.5)(happy-dom@17.1.0)(jiti@2.4.2)(yaml@2.7.1)
 
   '@vitest/utils@3.0.5':
     dependencies:

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -381,6 +381,9 @@ importers:
       svelte-ux:
         specifier: ^0.76.0
         version: 0.76.0(@babel/core@7.26.8)(postcss-load-config@4.0.2(postcss@8.5.2))(postcss@8.5.2)(svelte@5.28.2)
+      tabbable:
+        specifier: ^6.2.0
+        version: 6.2.0
       type-fest:
         specifier: ^4.18.2
         version: 4.34.1

--- a/frontend/viewer/package.json
+++ b/frontend/viewer/package.json
@@ -97,6 +97,7 @@
     "svelte-preprocess": "catalog:",
     "svelte-routing": "^2.12.0",
     "svelte-ux": "^0.76.0",
+    "tabbable": "^6.2.0",
     "type-fest": "^4.18.2"
   }
 }

--- a/frontend/viewer/src/home/HomeView.svelte
+++ b/frontend/viewer/src/home/HomeView.svelte
@@ -29,6 +29,7 @@
   import {Button} from '$lib/components/ui/button';
   import {mode} from 'mode-watcher';
   import * as ResponsiveMenu from '$lib/components/responsive-menu';
+  import {iconVariants} from '$lib/components/ui/icon';
 
   const projectsService = useProjectsService();
   const importFwdataService = useImportFwdataService();
@@ -104,7 +105,7 @@
 
 <AppBar title={$t`Dictionaries`} class="bg-primary/15 min-h-12 shadow-md justify-between" menuIcon={null}>
   <div slot="title" class="text-lg flex gap-2 items-center">
-    <img src={mode.current === 'dark' ? logoLight : logoDark} alt={$t`Lexbox logo`} class="h-6 shrink-0" />
+    <img src={mode.current === 'dark' ? logoLight : logoDark} alt={$t`Lexbox logo`} class={iconVariants()} />
     <h3>{$t`Dictionaries`}</h3>
   </div>
   <div slot="actions" class="flex">
@@ -222,7 +223,7 @@
                 <ButtonListItem href={`/fwdata/${project.code}`}>
                   <ListItem classes={{root: 'dark:bg-muted/50 bg-muted/80 hover:bg-muted/30 hover:dark:bg-muted' }}>
                     <ProjectTitle slot="title" {project}/>
-                    <img slot="avatar" src={flexLogo} alt={$t`FieldWorks logo`} class="h-6 shrink-0" />
+                    <img slot="avatar" src={flexLogo} alt={$t`FieldWorks logo`} class={iconVariants()} />
                     <div slot="actions" class="shrink-0">
                       <DevContent invisible>
                         <UxButton

--- a/frontend/viewer/src/home/HomeView.svelte
+++ b/frontend/viewer/src/home/HomeView.svelte
@@ -29,7 +29,7 @@
   import {Button} from '$lib/components/ui/button';
   import {mode} from 'mode-watcher';
   import * as ResponsiveMenu from '$lib/components/responsive-menu';
-  import {iconVariants} from '$lib/components/ui/icon';
+  import {Icon} from '$lib/components/ui/icon';
 
   const projectsService = useProjectsService();
   const importFwdataService = useImportFwdataService();
@@ -105,7 +105,7 @@
 
 <AppBar title={$t`Dictionaries`} class="bg-primary/15 min-h-12 shadow-md justify-between" menuIcon={null}>
   <div slot="title" class="text-lg flex gap-2 items-center">
-    <img src={mode.current === 'dark' ? logoLight : logoDark} alt={$t`Lexbox logo`} class={iconVariants()} />
+    <Icon src={mode.current === 'dark' ? logoLight : logoDark} alt={$t`Lexbox logo`} />
     <h3>{$t`Dictionaries`}</h3>
   </div>
   <div slot="actions" class="flex">
@@ -223,7 +223,7 @@
                 <ButtonListItem href={`/fwdata/${project.code}`}>
                   <ListItem classes={{root: 'dark:bg-muted/50 bg-muted/80 hover:bg-muted/30 hover:dark:bg-muted' }}>
                     <ProjectTitle slot="title" {project}/>
-                    <img slot="avatar" src={flexLogo} alt={$t`FieldWorks logo`} class={iconVariants()} />
+                    <Icon slot="avatar" src={flexLogo} alt={$t`FieldWorks logo`} />
                     <div slot="actions" class="shrink-0">
                       <DevContent invisible>
                         <UxButton

--- a/frontend/viewer/src/home/Server.svelte
+++ b/frontend/viewer/src/home/Server.svelte
@@ -123,12 +123,12 @@
             </ButtonListItem>
           {/if}
         {/each}
-        <div class="text-center py-2">
-          <Button variant="link" target="_blank" href="{server?.authority}/wheresMyProject">
-            {$t`I don't see my project`}
-            <Icon icon="i-mdi-open-in-new" class="size-4" />
-          </Button>
-        </div>
+      </div>
+      <div class="text-center pt-2">
+        <Button variant="link" target="_blank" href="{server?.authority}/wheresMyProject">
+          {$t`I don't see my project`}
+          <Icon icon="i-mdi-open-in-new" class="size-4" />
+        </Button>
       </div>
     {/if}
   </div>

--- a/frontend/viewer/src/lib/OpenInFieldWorksButton.svelte
+++ b/frontend/viewer/src/lib/OpenInFieldWorksButton.svelte
@@ -8,6 +8,7 @@
   import {t} from 'svelte-i18n-lingui';
   import {mergeProps} from 'bits-ui';
   import {cn} from './utils';
+  import {iconVariants} from './components/ui/icon';
 
   type Props = {
     entry: IEntry
@@ -52,6 +53,6 @@
 
 <!--button must be a link otherwise it won't follow the redirect to a protocol handler-->
 <button class={cn(buttonVariants({ variant: 'ghost'}), className)} {...mergedProps}>
-  <img src={flexLogo} alt={$t`FieldWorks logo`} class="h-6 max-w-fit"/>
+  <img src={flexLogo} alt={$t`FieldWorks logo`} class={iconVariants()}/>
   {$t`Open in FieldWorks`}
 </button>

--- a/frontend/viewer/src/lib/OpenInFieldWorksButton.svelte
+++ b/frontend/viewer/src/lib/OpenInFieldWorksButton.svelte
@@ -8,7 +8,7 @@
   import {t} from 'svelte-i18n-lingui';
   import {mergeProps} from 'bits-ui';
   import {cn} from './utils';
-  import {iconVariants} from './components/ui/icon';
+  import {Icon} from './components/ui/icon';
 
   type Props = {
     entry: IEntry
@@ -53,6 +53,6 @@
 
 <!--button must be a link otherwise it won't follow the redirect to a protocol handler-->
 <button class={cn(buttonVariants({ variant: 'ghost'}), className)} {...mergedProps}>
-  <img src={flexLogo} alt={$t`FieldWorks logo`} class={iconVariants()}/>
+  <Icon src={flexLogo} alt={$t`FieldWorks logo`} />
   {$t`Open in FieldWorks`}
 </button>

--- a/frontend/viewer/src/lib/components/editor/editor-root.svelte
+++ b/frontend/viewer/src/lib/components/editor/editor-root.svelte
@@ -6,7 +6,7 @@
 
   type EditorRootProps = WithElementRef<HTMLAttributes<HTMLDivElement>>;
 
-  const {
+  let {
     class: className,
     children,
     ref = $bindable(null),
@@ -14,6 +14,6 @@
   }: EditorRootProps = $props();
 </script>
 
-<div class={cn('@container/editor', className)} {...restProps}>
+<div class={cn('@container/editor', className)} {...restProps} bind:this={ref}>
   {@render children?.()}
 </div>

--- a/frontend/viewer/src/lib/components/editor/editor-sub-grid.svelte
+++ b/frontend/viewer/src/lib/components/editor/editor-sub-grid.svelte
@@ -3,7 +3,7 @@
   import type {WithElementRef} from 'bits-ui';
   import type {HTMLAttributes} from 'svelte/elements';
 
-  type EditorSubGridProps = WithElementRef<HTMLAttributes<HTMLDivElement>>;
+  export type EditorSubGridProps = WithElementRef<HTMLAttributes<HTMLDivElement>>;
 
   const {
     class: className,

--- a/frontend/viewer/src/lib/components/reorderer/reorderer-item-list.svelte
+++ b/frontend/viewer/src/lib/components/reorderer/reorderer-item-list.svelte
@@ -43,7 +43,7 @@
 <DropdownMenu.Group {...mergedProps}>
   {#each displayItems as item, i}
     {@const reorderName = getDisplayName(item) || '–'}
-    <DropdownMenu.Item class="grid grid-cols-subgrid col-span-full justify-items-start items-center cursor-pointer"
+    <DropdownMenu.Item class="grid grid-cols-subgrid col-span-full justify-items-start items-center"
       onmouseover={() => displayIndex = i}
       onfocus={() => displayIndex = i}
       onSelect={() => {

--- a/frontend/viewer/src/lib/components/responsive-menu/responsive-menu-item.svelte
+++ b/frontend/viewer/src/lib/components/responsive-menu/responsive-menu-item.svelte
@@ -4,19 +4,20 @@
   import * as DropdownMenu from '$lib/components/ui/dropdown-menu';
   import * as ContextMenu from '$lib/components/ui/context-menu';
   import { IsMobile } from '$lib/hooks/is-mobile.svelte';
-  import Button, {buttonVariants} from '$lib/components/ui/button/button.svelte';
+  import {buttonVariants} from '$lib/components/ui/button/button.svelte';
   import type {Snippet} from 'svelte';
   import {useResponsiveMenuItemList} from './responsive-menu.svelte';
-  import type {ButtonProps} from 'node_modules/bits-ui/dist/bits/toolbar/exports';
-  import {mergeProps, type ContextMenuItemProps} from 'bits-ui';
+  import type {ContextMenuItemProps} from 'bits-ui';
+  import type {DrawerCloseProps} from 'vaul-svelte';
   import {cn} from '$lib/utils';
+  import {DrawerClose} from '../ui/drawer';
 
   type Props = {
     children?: Snippet;
     icon?: IconClass;
     onSelect?: () => void;
     href?: string;
-  } & ContextMenuItemProps & ButtonProps;
+  } & Omit<ContextMenuItemProps & DrawerCloseProps, 'onclick'>;
 
   let {
     icon,
@@ -28,14 +29,6 @@
   }: Props = $props();
 
   const state = useResponsiveMenuItemList();
-
-  const buttonProps = $derived({
-    variant: 'ghost',
-    class: cn(buttonVariants({ variant: 'ghost', class: 'w-full justify-start gap-2' }), className),
-    onclick: onSelect,
-  } as const);
-
-  const mergedProps = $derived(mergeProps(buttonProps, rest));
 </script>
 
 {#snippet content()}
@@ -52,21 +45,21 @@
 {/snippet}
 
 {#if state.contextMenu}
-  <ContextMenu.Item class={cn('cursor-pointer gap-2 w-full', className)} onclick={onSelect} bind:ref
+  <ContextMenu.Item class={cn('gap-2 w-full', className)} {onSelect} bind:ref
     child={rest.href ? anchorChild : undefined} {...rest}>
     {@render content()}
   </ContextMenu.Item>
 {:else if !IsMobile.value}
-  <DropdownMenu.Item class={cn('cursor-pointer gap-2 w-full', className)} {onSelect} bind:ref
+  <DropdownMenu.Item class={cn('gap-2 w-full', className)} {onSelect} bind:ref
     child={rest.href ? anchorChild : undefined} {...rest}>
     {@render content()}
   </DropdownMenu.Item>
-{:else if rest.child}
-  {@render rest.child({ props: mergedProps})}
 {:else}
-  <Button
-    {...buttonProps}
+  <DrawerClose
+    class={cn(buttonVariants({ variant: 'ghost', class: 'w-full justify-start gap-2' }), className)}
+    onclick={onSelect}
+    {...rest}
     bind:ref>
     {@render content()}
-  </Button>
+  </DrawerClose>
 {/if}

--- a/frontend/viewer/src/lib/components/ui/button/index.ts
+++ b/frontend/viewer/src/lib/components/ui/button/index.ts
@@ -8,10 +8,13 @@ import Root, {
 import XButton from './x-button.svelte';
 
 export {
+  Root,
+  XButton,
+  type ButtonProps,
+  type ButtonSize,
+  type ButtonVariant,
+  buttonVariants,
   //
   Root as Button,
-  XButton,
-  buttonVariants, Root, type ButtonProps,
-  type ButtonSize,
-  type ButtonVariant, type ButtonProps as Props
+  type ButtonProps as Props
 };

--- a/frontend/viewer/src/lib/components/ui/context-menu/context-menu-item.svelte
+++ b/frontend/viewer/src/lib/components/ui/context-menu/context-menu-item.svelte
@@ -15,7 +15,7 @@
 <ContextMenuPrimitive.Item
 	bind:ref
 	class={cn(
-		'data-[highlighted]:bg-accent data-[highlighted]:text-accent-foreground relative flex cursor-default select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50',
+		'data-[highlighted]:bg-accent data-[highlighted]:text-accent-foreground relative flex cursor-pointer select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50',
 		inset && 'pl-8',
 		className
 	)}

--- a/frontend/viewer/src/lib/components/ui/dropdown-menu/dropdown-menu-item.svelte
+++ b/frontend/viewer/src/lib/components/ui/dropdown-menu/dropdown-menu-item.svelte
@@ -15,7 +15,7 @@
 <DropdownMenuPrimitive.Item
   bind:ref
   class={cn(
-    'data-[highlighted]:bg-accent data-[highlighted]:text-accent-foreground relative flex cursor-default select-none items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-none transition-colors data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0',
+    'data-[highlighted]:bg-accent data-[highlighted]:text-accent-foreground relative flex cursor-pointer select-none items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-none transition-colors data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0',
     inset && 'pl-8',
     className,
   )}

--- a/frontend/viewer/src/lib/components/ui/icon/icon.svelte
+++ b/frontend/viewer/src/lib/components/ui/icon/icon.svelte
@@ -18,7 +18,7 @@
   });
 
   export type IconProps = WithoutChildren<WithElementRef<HTMLAttributes<HTMLSpanElement>>> &
-    ({ icon: IconClass; } | ({ src: string} & HTMLImgAttributes));
+    ({ icon: IconClass; } | ({ src: string, alt: string } & HTMLImgAttributes));
 </script>
 
 <script lang="ts">

--- a/frontend/viewer/src/lib/components/ui/icon/icon.svelte
+++ b/frontend/viewer/src/lib/components/ui/icon/icon.svelte
@@ -3,6 +3,19 @@
   import {cn} from '$lib/utils';
   import type {WithElementRef, WithoutChildren} from 'bits-ui';
   import type {HTMLAttributes} from 'svelte/elements';
+  import {tv} from 'tailwind-variants';
+
+  export const iconVariants = tv({
+    base: 'inline-block shrink-0',
+    variants: {
+      size: {
+        default: 'size-6'
+      }
+    },
+    defaultVariants: {
+      size: 'default',
+    },
+  });
 
   export type IconProps = WithoutChildren<WithElementRef<HTMLAttributes<HTMLSpanElement>>> & {
     icon: IconClass;
@@ -13,7 +26,7 @@
   const { icon, class: className, ...restProps }: IconProps = $props();
 </script>
 
-<span {...restProps} class={cn('size-6 inline-block shrink-0', className, icon)}>
+<span {...restProps} class={cn(iconVariants(), className, icon)}>
   <!-- ensures that baseline alignment works for consumers of this component -->
   &nbsp;
 </span>

--- a/frontend/viewer/src/lib/components/ui/icon/icon.svelte
+++ b/frontend/viewer/src/lib/components/ui/icon/icon.svelte
@@ -2,7 +2,7 @@
   import type {IconClass} from '$lib/icon-class';
   import {cn} from '$lib/utils';
   import type {WithElementRef, WithoutChildren} from 'bits-ui';
-  import type {HTMLAttributes} from 'svelte/elements';
+  import type {HTMLAttributes, HTMLImgAttributes} from 'svelte/elements';
   import {tv} from 'tailwind-variants';
 
   export const iconVariants = tv({
@@ -17,16 +17,19 @@
     },
   });
 
-  export type IconProps = WithoutChildren<WithElementRef<HTMLAttributes<HTMLSpanElement>>> & {
-    icon: IconClass;
-  };
+  export type IconProps = WithoutChildren<WithElementRef<HTMLAttributes<HTMLSpanElement>>> &
+    ({ icon: IconClass; } | ({ src: string} & HTMLImgAttributes));
 </script>
 
 <script lang="ts">
-  const { icon, class: className, ...restProps }: IconProps = $props();
+  const { class: className, ...restProps }: IconProps = $props();
 </script>
 
-<span {...restProps} class={cn(iconVariants(), className, icon)}>
-  <!-- ensures that baseline alignment works for consumers of this component -->
-  &nbsp;
-</span>
+{#if 'src' in restProps}
+  <img {...restProps} class={cn(iconVariants(), className)} />
+{:else}
+  <span {...restProps} class={cn(iconVariants(), className, restProps.icon)}>
+    <!-- ensures that baseline alignment works for consumers of this component -->
+    &nbsp;
+  </span>
+{/if}

--- a/frontend/viewer/src/lib/components/ui/icon/index.ts
+++ b/frontend/viewer/src/lib/components/ui/icon/index.ts
@@ -1,4 +1,10 @@
-import Icon from './icon.svelte';
+import Icon, {
+  type IconProps,
+  iconVariants,
+} from './icon.svelte';
 
-export {Icon};
-
+export {
+  Icon,
+  type IconProps,
+  iconVariants
+};

--- a/frontend/viewer/src/lib/components/ui/input/composable-input.svelte
+++ b/frontend/viewer/src/lib/components/ui/input/composable-input.svelte
@@ -22,10 +22,12 @@
     before?: Snippet,
     after?: Snippet,
   } = $props();
+
+  const focusRingClass = 'has-[.real-input:focus-visible]:ring-ring has-[.real-input:focus-visible]:outline-none has-[.real-input:focus-visible]:ring-2 has-[.real-input:focus-visible]:ring-offset-2';
 </script>
 
-<InputShell bind:ref class={className} {...restProps}>
+<InputShell bind:ref {focusRingClass} class={className} {...restProps}>
   {@render before?.()}
-  <Input variant="ghost" {placeholder} class="grow" bind:ref={inputRef} bind:value />
+  <Input variant="ghost" {placeholder} class="grow real-input" bind:ref={inputRef} bind:value />
   {@render after?.()}
 </InputShell>

--- a/frontend/viewer/src/lib/components/ui/input/input-shell.svelte
+++ b/frontend/viewer/src/lib/components/ui/input/input-shell.svelte
@@ -4,11 +4,16 @@
   import type {HTMLAttributes} from 'svelte/elements';
   import {inputVariants} from './input.svelte';
 
-  type Props = WithElementRef<HTMLAttributes<HTMLDivElement>>;
+  interface Props extends WithElementRef<HTMLAttributes<HTMLDivElement>> {
+    focusRingClass?: string;
+  }
+
+  const anyChildHasFocusRing = 'has-[:focus-visible]:ring-ring has-[:focus-visible]:outline-none has-[:focus-visible]:ring-2 has-[:focus-visible]:ring-offset-2';
 
   let {
     ref = $bindable(null),
     class: className,
+    focusRingClass = anyChildHasFocusRing,
     children,
     ...restProps
   }: Props = $props();
@@ -16,7 +21,7 @@
 
 <div
   bind:this={ref}
-  class={cn(inputVariants({ variant: 'shell' }), className)}
+  class={cn(inputVariants({ variant: 'shell' }), focusRingClass, className)}
   {...restProps}
 >
   {@render children?.()}

--- a/frontend/viewer/src/lib/components/ui/input/input.svelte
+++ b/frontend/viewer/src/lib/components/ui/input/input.svelte
@@ -11,7 +11,7 @@
         default: 'border-input bg-background ring-offset-background placeholder:text-muted-foreground focus-visible:ring-ring flex h-10 w-full rounded-md border px-3 py-2 text-base file:border-0 file:bg-transparent file:text-sm file:font-medium focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 md:text-sm',
         ghost: 'outline-none min-w-0 bg-transparent',
         // shell variant has a dedicated component
-        shell: 'border-input bg-background ring-offset-background placeholder:text-muted-foreground has-[:focus-visible]:ring-ring flex h-10 w-full rounded-md border text-base has-[:focus-visible]:outline-none has-[:focus-visible]:ring-2 has-[:focus-visible]:ring-offset-2 has-[:disabled]:cursor-not-allowed has-[:disabled]:opacity-50 md:text-sm flex gap-2 items-center justify-between',
+        shell: 'border-input bg-background ring-offset-background placeholder:text-muted-foreground flex h-10 w-full rounded-md border text-base has-[:disabled]:cursor-not-allowed has-[:disabled]:opacity-50 md:text-sm flex gap-2 items-center justify-between',
       },
     },
     defaultVariants: {

--- a/frontend/viewer/src/lib/components/ui/scroll-area/scroll-area.svelte
+++ b/frontend/viewer/src/lib/components/ui/scroll-area/scroll-area.svelte
@@ -6,6 +6,7 @@
 
   let {
     ref = $bindable(null),
+    viewportRef = $bindable(null),
     class: className,
     type: explicitType,
     orientation = 'vertical',
@@ -17,13 +18,14 @@
     orientation?: 'vertical' | 'horizontal' | 'both' | undefined;
     scrollbarXClasses?: string | undefined;
     scrollbarYClasses?: string | undefined;
+    viewportRef?: HTMLElement | null;
   } = $props();
 
   const type = $derived(explicitType ?? (IsMobile.value ? 'scroll' : 'auto'));
 </script>
 
 <ScrollAreaPrimitive.Root {type} bind:ref {...restProps} class={cn('relative overflow-hidden', className)}>
-  <ScrollAreaPrimitive.Viewport class="h-full w-full rounded-[inherit]">
+  <ScrollAreaPrimitive.Viewport bind:ref={viewportRef} class="h-full w-full rounded-[inherit]">
     {@render children?.()}
   </ScrollAreaPrimitive.Viewport>
   {#if orientation === 'vertical' || orientation === 'both'}

--- a/frontend/viewer/src/lib/entry-editor/EntryOrSenseItemList.svelte
+++ b/frontend/viewer/src/lib/entry-editor/EntryOrSenseItemList.svelte
@@ -19,11 +19,13 @@
   {...rest}
   getDisplayName={getHeadword}>
   {#snippet menuItems(entry)}
-    <DropdownMenu.Item>
-      <Link to="browse?entryId={getEntryId(entry)}">
-        <Icon icon="i-mdi-book-outline" />
-        {$t`Go to ${getHeadword(entry) || '–'}`}
-      </Link>
+    <DropdownMenu.Item class="cursor-pointer">
+      {#snippet child({props})}
+        <Link {...props} to="browse?entryId={getEntryId(entry)}">
+          <Icon icon="i-mdi-book-outline" />
+          {$t`Go to ${getHeadword(entry) || '–'}`}
+        </Link>
+      {/snippet}
     </DropdownMenu.Item>
   {/snippet}
 </ItemList>

--- a/frontend/viewer/src/lib/entry-editor/ItemListItem.svelte
+++ b/frontend/viewer/src/lib/entry-editor/ItemListItem.svelte
@@ -68,7 +68,7 @@
             </Reorderer.Root>
           </DropdownMenu.Sub>
           {/if}
-          <DropdownMenu.Item onSelect={() => remove(item)}>
+          <DropdownMenu.Item class="cursor-pointer" onSelect={() => remove(item)}>
             <Icon icon="i-mdi-trash-can-outline" />
             {$t`Remove`}
           </DropdownMenu.Item>

--- a/frontend/viewer/src/lib/entry-editor/object-editors/EntryEditor.svelte
+++ b/frontend/viewer/src/lib/entry-editor/object-editors/EntryEditor.svelte
@@ -7,6 +7,7 @@
     canAddExample?: boolean;
     onchange?: (changed: { entry: IEntry, sense?: ISense, example?: IExampleSentence }) => void;
     ondelete?: (deleted: { entry: IEntry, sense?: ISense, example?: IExampleSentence }) => void;
+    ref?: HTMLElement | null;
   };
 </script>
 <script lang="ts">
@@ -30,6 +31,7 @@
 
   let {
     entry = $bindable(),
+    ref = $bindable(null),
     readonly = false,
     modalMode = false,
     canAddSense = true,
@@ -147,7 +149,7 @@
   const currentView = useCurrentView();
 </script>
 
-<Editor.Root>
+<Editor.Root bind:ref>
   <Editor.Grid bind:ref={editorElem}>
     <EntryEditorPrimitive bind:entry {readonly} {modalMode} onchange={(entry) => onchange?.({entry})} />
 

--- a/frontend/viewer/src/lib/entry-editor/object-editors/EntryEditorPrimitive.svelte
+++ b/frontend/viewer/src/lib/entry-editor/object-editors/EntryEditorPrimitive.svelte
@@ -11,8 +11,10 @@
   import {useComplexFormTypes} from '$lib/complex-form-types';
   import ComplexFormComponents from '../field-editors/ComplexFormComponents.svelte';
   import ComplexForms from '../field-editors/ComplexForms.svelte';
+  import type {EditorSubGridProps} from '$lib/components/editor/editor-sub-grid.svelte';
+  import {mergeProps} from 'bits-ui';
 
-  type Props = {
+  interface Props extends Omit<EditorSubGridProps, 'onchange'> {
     entry: IEntry;
     readonly?: boolean;
     modalMode?: boolean;
@@ -24,6 +26,7 @@
     onchange,
     readonly = false,
     modalMode = false,
+    ...rest
   }: Props = $props();
 
   const writingSystemService = useWritingSystemService();
@@ -35,7 +38,7 @@
   }
 </script>
 
-<Editor.SubGrid class="gap-2 editor-primitive" style="grid-template-areas: {objectTemplateAreas($currentView, entry)}">
+<Editor.SubGrid {...mergeProps(rest, { class: 'gap-2', style: { gridTemplateAreas: objectTemplateAreas($currentView, entry) } })}>
   <Editor.Field.Root style="grid-area: lexemeForm" class={cn($currentView.fields.lexemeForm.show || 'hidden')}>
     <Editor.Field.Title name={vt($t`Lexeme form`, $t`Word`)} helpId={fieldData.lexemeForm.helpId} />
     <Editor.Field.Body subGrid>

--- a/frontend/viewer/src/lib/entry-editor/object-editors/EntryEditorPrimitive.svelte
+++ b/frontend/viewer/src/lib/entry-editor/object-editors/EntryEditorPrimitive.svelte
@@ -35,7 +35,7 @@
   }
 </script>
 
-<Editor.SubGrid class="gap-2" style="grid-template-areas: {objectTemplateAreas($currentView, entry)}">
+<Editor.SubGrid class="gap-2 editor-primitive" style="grid-template-areas: {objectTemplateAreas($currentView, entry)}">
   <Editor.Field.Root style="grid-area: lexemeForm" class={cn($currentView.fields.lexemeForm.show || 'hidden')}>
     <Editor.Field.Title name={vt($t`Lexeme form`, $t`Word`)} helpId={fieldData.lexemeForm.helpId} />
     <Editor.Field.Body subGrid>

--- a/frontend/viewer/src/lib/entry-editor/object-editors/ExampleEditorPrimitive.svelte
+++ b/frontend/viewer/src/lib/entry-editor/object-editors/ExampleEditorPrimitive.svelte
@@ -29,7 +29,7 @@
   }
 </script>
 
-<Editor.SubGrid class="gap-2" style="grid-template-areas: {objectTemplateAreas($currentView, example)}">
+<Editor.SubGrid class="gap-2 editor-primitive" style="grid-template-areas: {objectTemplateAreas($currentView, example)}">
   <Editor.Field.Root style="grid-area: sentence" class={cn($currentView.fields.sentence.show || 'hidden')}>
     <Editor.Field.Title name={vt($t`Sentence`)} helpId={fieldData.sentence.helpId} />
     <Editor.Field.Body subGrid>

--- a/frontend/viewer/src/lib/entry-editor/object-editors/ExampleEditorPrimitive.svelte
+++ b/frontend/viewer/src/lib/entry-editor/object-editors/ExampleEditorPrimitive.svelte
@@ -8,8 +8,10 @@
   import {vt} from '$lib/views/view-text';
   import {t} from 'svelte-i18n-lingui';
   import {MultiWsInput, WsInput} from '$lib/components/field-editors';
+  import type {EditorSubGridProps} from '$lib/components/editor/editor-sub-grid.svelte';
+  import {mergeProps} from 'bits-ui';
 
-  type Props = {
+  interface Props extends Omit<EditorSubGridProps, 'onchange'> {
     example: IExampleSentence;
     readonly?: boolean;
     onchange?: (sense: IExampleSentence, field: FieldId) => void;
@@ -19,6 +21,7 @@
     example = $bindable(),
     readonly = false,
     onchange,
+    ...rest
   }: Props = $props();
 
   const writingSystemService = useWritingSystemService();
@@ -29,7 +32,7 @@
   }
 </script>
 
-<Editor.SubGrid class="gap-2 editor-primitive" style="grid-template-areas: {objectTemplateAreas($currentView, example)}">
+<Editor.SubGrid {...mergeProps(rest, { class: 'gap-2', style: { gridTemplateAreas: objectTemplateAreas($currentView, example) } })}>
   <Editor.Field.Root style="grid-area: sentence" class={cn($currentView.fields.sentence.show || 'hidden')}>
     <Editor.Field.Title name={vt($t`Sentence`)} helpId={fieldData.sentence.helpId} />
     <Editor.Field.Body subGrid>

--- a/frontend/viewer/src/lib/entry-editor/object-editors/SenseEditorPrimitive.svelte
+++ b/frontend/viewer/src/lib/entry-editor/object-editors/SenseEditorPrimitive.svelte
@@ -33,7 +33,7 @@
   }
 </script>
 
-<Editor.SubGrid class="gap-2" style="grid-template-areas: {objectTemplateAreas($currentView, sense)}">
+<Editor.SubGrid class="gap-2 editor-primitive" style="grid-template-areas: {objectTemplateAreas($currentView, sense)}">
   <Editor.Field.Root style="grid-area: gloss" class={cn($currentView.fields.gloss.show || 'hidden')}>
     <Editor.Field.Title name={$t`Gloss`} helpId={fieldData.gloss.helpId} />
     <Editor.Field.Body subGrid>

--- a/frontend/viewer/src/lib/entry-editor/object-editors/SenseEditorPrimitive.svelte
+++ b/frontend/viewer/src/lib/entry-editor/object-editors/SenseEditorPrimitive.svelte
@@ -10,17 +10,20 @@
   import {MultiSelect, MultiWsInput, Select} from '$lib/components/field-editors';
   import {fieldData, type FieldId} from '../field-data';
   import {cn} from '$lib/utils';
+  import type {EditorSubGridProps} from '$lib/components/editor/editor-sub-grid.svelte';
+  import {mergeProps} from 'bits-ui';
 
-  type Props = {
+  interface Props extends Omit<EditorSubGridProps, 'onchange'> {
     sense: ISense;
     readonly?: boolean;
     onchange?: (sense: ISense, field: FieldId) => void;
-  }
+  };
 
   const {
     sense = $bindable(),
     readonly = false,
     onchange,
+    ...rest
   }: Props = $props();
 
   const writingSystemService = useWritingSystemService();
@@ -33,7 +36,7 @@
   }
 </script>
 
-<Editor.SubGrid class="gap-2 editor-primitive" style="grid-template-areas: {objectTemplateAreas($currentView, sense)}">
+<Editor.SubGrid {...mergeProps(rest, { class: 'gap-2', style: { gridTemplateAreas: objectTemplateAreas($currentView, sense) } })}>
   <Editor.Field.Root style="grid-area: gloss" class={cn($currentView.fields.gloss.show || 'hidden')}>
     <Editor.Field.Title name={$t`Gloss`} helpId={fieldData.gloss.helpId} />
     <Editor.Field.Body subGrid>

--- a/frontend/viewer/src/lib/utils/tabbable.ts
+++ b/frontend/viewer/src/lib/utils/tabbable.ts
@@ -1,0 +1,20 @@
+import {isTabbable} from 'tabbable';
+
+export function findFirstTabbable(container: HTMLElement | null | undefined): HTMLElement | undefined {
+  if (!container) {
+    return undefined;
+  }
+  const walker = document.createTreeWalker(
+    container,
+    NodeFilter.SHOW_ELEMENT,
+    {
+      acceptNode: node => {
+        console.log(node);
+        return isTabbable(node as HTMLElement, {displayCheck: 'full'})
+          ? NodeFilter.FILTER_ACCEPT
+          : NodeFilter.FILTER_SKIP;
+      }
+    }
+  );
+  return walker.nextNode() as HTMLElement;
+}

--- a/frontend/viewer/src/lib/utils/tabbable.ts
+++ b/frontend/viewer/src/lib/utils/tabbable.ts
@@ -1,6 +1,6 @@
 import {isTabbable} from 'tabbable';
 
-export function findFirstTabbable(container: HTMLElement | null | undefined): HTMLElement | undefined {
+export function findFirstTabbable(container: Element | null | undefined): HTMLElement | undefined {
   if (!container) {
     return undefined;
   }
@@ -8,12 +8,9 @@ export function findFirstTabbable(container: HTMLElement | null | undefined): HT
     container,
     NodeFilter.SHOW_ELEMENT,
     {
-      acceptNode: node => {
-        console.log(node);
-        return isTabbable(node as HTMLElement, {displayCheck: 'full'})
-          ? NodeFilter.FILTER_ACCEPT
-          : NodeFilter.FILTER_SKIP;
-      }
+      acceptNode: node => isTabbable(node as HTMLElement, {displayCheck: 'full'})
+        ? NodeFilter.FILTER_ACCEPT
+        : NodeFilter.FILTER_SKIP
     }
   );
   return walker.nextNode() as HTMLElement;

--- a/frontend/viewer/src/project/ProjectDropdown.svelte
+++ b/frontend/viewer/src/project/ProjectDropdown.svelte
@@ -2,7 +2,7 @@
   import * as Command from '$lib/components/ui/command';
   import * as Popover from '$lib/components/ui/popover';
   import { Button } from '$lib/components/ui/button';
-  import { Icon } from '$lib/components/ui/icon';
+  import { Icon, iconVariants } from '$lib/components/ui/icon';
   import { cn } from '$lib/utils';
   import {t} from 'svelte-i18n-lingui';
   import {tick} from 'svelte';
@@ -105,7 +105,7 @@
               class={cn('cursor-pointer', (project.name === projectName || project.code === projectName) && project.crdt === isCrdt && 'bg-secondary')}
             >
               {#if project.fwdata}
-                <img src={flexLogo} alt={$t`FieldWorks logo`} class="h-6 shrink-0"/>
+                <img src={flexLogo} alt={$t`FieldWorks logo`} class={iconVariants()} />
               {:else}
                 <Icon icon="i-mdi-book-edit-outline"/>
               {/if}

--- a/frontend/viewer/src/project/ProjectDropdown.svelte
+++ b/frontend/viewer/src/project/ProjectDropdown.svelte
@@ -62,6 +62,14 @@
   }
 </script>
 
+{#snippet projectIcon(isCrdt: boolean)}
+  {#if isCrdt}
+    <Icon icon="i-mdi-book-edit-outline" />
+  {:else}
+    <img src={flexLogo} alt={$t`FieldWorks logo`} class={iconVariants()} />
+  {/if}
+{/snippet}
+
 <Popover.Root bind:open onOpenChange={handleOpen}>
   <Popover.Trigger bind:ref={triggerRef}>
     {#snippet child({ props })}
@@ -73,7 +81,7 @@
         {...props}
       >
         <div class="flex items-center gap-2 overflow-hidden">
-          <Icon icon="i-mdi-book" class="size-4" />
+          {@render projectIcon(isCrdt)}
           <span class="x-ellipsis">
             {projectName}
           </span>
@@ -104,11 +112,7 @@
               onSelect={() => handleSelect(project)}
               class={cn('cursor-pointer', (project.name === projectName || project.code === projectName) && project.crdt === isCrdt && 'bg-secondary')}
             >
-              {#if project.fwdata}
-                <img src={flexLogo} alt={$t`FieldWorks logo`} class={iconVariants()} />
-              {:else}
-                <Icon icon="i-mdi-book-edit-outline"/>
-              {/if}
+              {@render projectIcon(project.crdt)}
               <ProjectTitle {project} />
             </Command.Item>
           {/each}

--- a/frontend/viewer/src/project/ProjectDropdown.svelte
+++ b/frontend/viewer/src/project/ProjectDropdown.svelte
@@ -97,7 +97,6 @@
     <Command.Root>
       <Command.Input placeholder={$t`Search Dictionaries`} />
       <Command.List>
-        <Command.Empty>{$t`No Dictionaries found`}</Command.Empty>
         {#if projectsResource.loading}
           <Command.Loading>
             <div class="flex items-center justify-center p-4">
@@ -106,6 +105,7 @@
             </div>
           </Command.Loading>
         {:else}
+          <Command.Empty>{$t`No Dictionaries found`}</Command.Empty>
           {#each projectsResource.current ?? [] as project}
             <Command.Item
               value={project.name + project.crdt}

--- a/frontend/viewer/src/project/ProjectDropdown.svelte
+++ b/frontend/viewer/src/project/ProjectDropdown.svelte
@@ -2,7 +2,7 @@
   import * as Command from '$lib/components/ui/command';
   import * as Popover from '$lib/components/ui/popover';
   import { Button } from '$lib/components/ui/button';
-  import { Icon, iconVariants } from '$lib/components/ui/icon';
+  import { Icon } from '$lib/components/ui/icon';
   import { cn } from '$lib/utils';
   import {t} from 'svelte-i18n-lingui';
   import {tick} from 'svelte';
@@ -66,7 +66,7 @@
   {#if isCrdt}
     <Icon icon="i-mdi-book-edit-outline" />
   {:else}
-    <img src={flexLogo} alt={$t`FieldWorks logo`} class={iconVariants()} />
+    <Icon src={flexLogo} alt={$t`FieldWorks logo`} />
   {/if}
 {/snippet}
 

--- a/frontend/viewer/src/project/browse/BrowseView.svelte
+++ b/frontend/viewer/src/project/browse/BrowseView.svelte
@@ -4,7 +4,7 @@
   import EntryView from './EntryView.svelte';
   import SearchFilter from './SearchFilter.svelte';
   import EntriesList from './EntriesList.svelte';
-  import { Badge } from '$lib/components/ui/badge';
+  import { badgeVariants } from '$lib/components/ui/badge';
   import { Icon } from '$lib/components/ui/icon';
   import { t } from 'svelte-i18n-lingui';
   import SidebarPrimaryAction from '../SidebarPrimaryAction.svelte';
@@ -56,14 +56,13 @@
           <div class="md:mr-3">
             <SearchFilter bind:search bind:gridifyFilter />
             <div class="my-2 flex items-center justify-between">
-              <Badge
-                variant="secondary"
-                class="cursor-pointer"
+              <button
+                class={badgeVariants({ variant: 'secondary' })}
                 onclick={toggleSort}
               >
                 <Icon icon={sortDirection === 'asc' ? 'i-mdi-sort-alphabetical-ascending' : 'i-mdi-sort-alphabetical-descending'} class="h-4 w-4" />
                 {$t`Headword`}
-              </Badge>
+              </button>
               <ResponsivePopup title={$t`List mode`}>
                 {#snippet trigger({props})}
                   <Button {...props} size="xs-icon" variant="ghost" icon="i-mdi-format-list-text" />

--- a/frontend/viewer/src/project/browse/EntriesList.svelte
+++ b/frontend/viewer/src/project/browse/EntriesList.svelte
@@ -67,6 +67,9 @@
       }
       return miniLcmApi.getEntries(queryOptions);
     },
+    {
+      debounce: 300,
+    }
   );
   const entries = $derived(entriesResource.current ?? []);
   const loading = new Debounced(() => entriesResource.loading, 50);

--- a/frontend/viewer/src/project/browse/EntryMenu.svelte
+++ b/frontend/viewer/src/project/browse/EntryMenu.svelte
@@ -63,7 +63,7 @@
         {$t`Open in new Window`}
       </ResponsiveMenu.Item>
     {/if}
-    {#if features.openWithFlex && (appLauncher || !IsMobile.value || true)}
+    {#if features.openWithFlex && (appLauncher || !IsMobile.value)}
       <ResponsiveMenu.Item>
         {#snippet child({props})}
           <OpenInFieldWorksButton {entry} {...props} />

--- a/frontend/viewer/src/project/browse/EntryMenu.svelte
+++ b/frontend/viewer/src/project/browse/EntryMenu.svelte
@@ -63,7 +63,7 @@
         {$t`Open in new Window`}
       </ResponsiveMenu.Item>
     {/if}
-    {#if features.openWithFlex && (appLauncher || !IsMobile.value)}
+    {#if features.openWithFlex && (appLauncher || !IsMobile.value || true)}
       <ResponsiveMenu.Item>
         {#snippet child({props})}
           <OpenInFieldWorksButton {entry} {...props} />

--- a/frontend/viewer/src/project/browse/EntryView.svelte
+++ b/frontend/viewer/src/project/browse/EntryView.svelte
@@ -2,7 +2,7 @@
   import { Icon } from '$lib/components/ui/icon';
   import EntryEditor from '$lib/entry-editor/object-editors/EntryEditor.svelte';
   import { useViewSettings } from '$lib/views/view-service';
-  import {resource, Debounced} from 'runed';
+  import {resource, Debounced, watch} from 'runed';
   import { useMiniLcmApi } from '$lib/services/service-provider';
   import { fade } from 'svelte/transition';
   import ViewPicker from './ViewPicker.svelte';
@@ -40,7 +40,7 @@
   );
   eventBus.onEntryUpdated((e) => {
     if (e.id === entryId) {
-      entryResource.refetch();
+      void entryResource.refetch();
     }
   });
   const entry = $derived(entryResource.current ?? undefined);
@@ -51,6 +51,12 @@
 
   let readonly = $state(false);
   const entryPersistence = new EntryPersistence(() => entry, () => void entryResource.refetch());
+
+  const loadedEntryId = $derived(entry?.id);
+  let entryScrollViewportRef: HTMLElement | null = $state(null);
+  watch([() => loadedEntryId, () => entryScrollViewportRef], () =>{
+    entryScrollViewportRef?.scrollTo({ top: 0, left: 0 });
+  });
 </script>
 
 {#snippet preview(entry: IEntry)}
@@ -85,7 +91,7 @@
         </div>
       {/if}
     </header>
-    <ScrollArea class={cn('grow md:pr-2', !$viewSettings.showEmptyFields && 'hide-unused')}>
+    <ScrollArea bind:viewportRef={entryScrollViewportRef} class={cn('grow md:pr-2', !$viewSettings.showEmptyFields && 'hide-unused')}>
       {#if dictionaryPreview === 'show'}
         {@render preview(entry)}
       {/if}

--- a/frontend/viewer/src/project/browse/EntryView.svelte
+++ b/frontend/viewer/src/project/browse/EntryView.svelte
@@ -57,7 +57,7 @@
   const loadedEntryId = $derived(entry?.id);
   let entryScrollViewportRef: HTMLElement | null = $state(null);
   let editorRef: HTMLElement | null = $state(null);
-  watch([() => loadedEntryId, () => entryScrollViewportRef, () => editorRef], () =>{
+  watch([() => [loadedEntryId, entryScrollViewportRef, editorRef]], () =>{
     entryScrollViewportRef?.scrollTo({ top: 0, left: 0 });
     if (!IsMobile.value) findFirstTabbable(editorRef)?.focus();
   });

--- a/frontend/viewer/src/project/browse/EntryView.svelte
+++ b/frontend/viewer/src/project/browse/EntryView.svelte
@@ -17,6 +17,8 @@
   import type {IEntry} from '$lib/dotnet-types';
   import {EntryPersistence} from '$lib/entry-editor/entry-persistence.svelte';
   import {useProjectEventBus} from '$lib/services/event-bus';
+  import {IsMobile} from '$lib/hooks/is-mobile.svelte';
+  import {findFirstTabbable} from '$lib/utils/tabbable';
 
   const viewSettings = useViewSettings();
   const writingSystemService = useWritingSystemService();
@@ -54,8 +56,10 @@
 
   const loadedEntryId = $derived(entry?.id);
   let entryScrollViewportRef: HTMLElement | null = $state(null);
-  watch([() => loadedEntryId, () => entryScrollViewportRef], () =>{
+  let editorRef: HTMLElement | null = $state(null);
+  watch([() => loadedEntryId, () => entryScrollViewportRef, () => editorRef], () =>{
     entryScrollViewportRef?.scrollTo({ top: 0, left: 0 });
+    if (!IsMobile.value) findFirstTabbable(editorRef)?.focus();
   });
 </script>
 
@@ -96,7 +100,7 @@
         {@render preview(entry)}
       {/if}
       <div class="max-md:p-2 md:pr-2">
-        <EntryEditor {entry} {readonly} {...entryPersistence.entryEditorProps} />
+        <EntryEditor bind:ref={editorRef} {entry} {readonly} {...entryPersistence.entryEditorProps} />
       </div>
     </ScrollArea>
   {/if}

--- a/frontend/viewer/src/project/browse/SearchFilter.svelte
+++ b/frontend/viewer/src/project/browse/SearchFilter.svelte
@@ -7,6 +7,7 @@
   import {Switch} from '$lib/components/ui/switch';
   import {Toggle} from '$lib/components/ui/toggle';
   import {cn} from '$lib/utils';
+  import {mergeProps} from 'bits-ui';
 
   let {
     search = $bindable(),

--- a/frontend/viewer/src/project/browse/SearchFilter.svelte
+++ b/frontend/viewer/src/project/browse/SearchFilter.svelte
@@ -48,9 +48,11 @@
       {/snippet}
       {#snippet after()}
         <Collapsible.Trigger>
-          <Toggle aria-label={$t`Toggle filters`} class="aspect-square" size="xs">
-            <Icon icon={gridifyFilter ? 'i-mdi-filter' : 'i-mdi-filter-outline'} class="size-5" />
-          </Toggle>
+          {#snippet child({props})}
+            <Toggle {...mergeProps(props, { class: 'aspect-square' })} aria-label={$t`Toggle filters`} size="xs">
+              <Icon icon={gridifyFilter ? 'i-mdi-filter' : 'i-mdi-filter-outline'} class="size-5" />
+            </Toggle>
+          {/snippet}
         </Collapsible.Trigger>
       {/snippet}
     </ComposableInput>


### PR DESCRIPTION
The most visual changes:

"I don't see my project" accidently got inside the bordered list if projects. I moved it out:
![image](https://github.com/user-attachments/assets/27caf727-6042-442b-844d-74c0cf479230)

![image](https://github.com/user-attachments/assets/a6d9a8b6-1aa3-4197-9904-3edf81380759)

Scroll to top and focus first field:
https://github.com/user-attachments/assets/34c5520a-66b0-4f92-8ce2-3d4e5d754a8e

Tabbing:
https://github.com/user-attachments/assets/dab3ce70-0bd7-4d67-8786-cdb4fb1a0d6e

FieldWorks and Lexbox icons now share the Icon component (i.e. sizing), so alignment should always just work:
![image](https://github.com/user-attachments/assets/2a7da479-901c-40ab-ac33-a0915acf5af4)

Autofocusing first field of new senses and examples:

https://github.com/user-attachments/assets/8a0506f4-ca37-4315-bdbc-bbab88a50b83

