### PR TITLE
Submit new entry dialog on Enter key press (desktop only)

### DIFF
--- a/frontend/viewer/src/lib/entry-editor/NewEntryDialog.svelte
+++ b/frontend/viewer/src/lib/entry-editor/NewEntryDialog.svelte
@@ -81,11 +81,21 @@
   }
 
   let entryLabel = fieldName({id: 'entry'}, $currentView.i18nKey);
+
+  function isDesktop(): boolean {
+    return window.matchMedia("(hover: hover) and (pointer: fine)").matches;
+  }
+
+  function handleKeydown(event: KeyboardEvent) {
+    if (event.key === 'Enter' && isDesktop()) {
+      createEntry(event);
+    }
+  }
 </script>
 
 {#if open}
 <Dialog.Root bind:open={open}>
-  <Dialog.DialogContent>
+  <Dialog.DialogContent on:keydown={handleKeydown}>
     <Dialog.DialogHeader>
       <Dialog.DialogTitle>{$t`New ${entryLabel}`}</Dialog.DialogTitle>
     </Dialog.DialogHeader>

--- a/frontend/viewer/src/lib/entry-editor/NewEntryDialog.svelte
+++ b/frontend/viewer/src/lib/entry-editor/NewEntryDialog.svelte
@@ -85,7 +85,7 @@
 
   function handleKeydown(event: KeyboardEvent) {
     if (event.key === 'Enter' && !IsMobile.value) {
-      createEntry(event);
+      void createEntry(event);
     }
   }
 </script>

--- a/frontend/viewer/src/lib/entry-editor/NewEntryDialog.svelte
+++ b/frontend/viewer/src/lib/entry-editor/NewEntryDialog.svelte
@@ -100,9 +100,9 @@
       <EntryEditor bind:entry={entry} modalMode canAddSense={false} canAddExample={false} />
     </OverrideFields>
     {#if errors.length}
-      <div class="self-end my-4">
+      <div class="text-end space-y-2">
         {#each errors as error}
-          <p class="text-danger p-2">{error}</p>
+          <p class="text-destructive">{error}</p>
         {/each}
       </div>
     {/if}

--- a/frontend/viewer/src/lib/entry-editor/NewEntryDialog.svelte
+++ b/frontend/viewer/src/lib/entry-editor/NewEntryDialog.svelte
@@ -13,6 +13,7 @@
   import {useWritingSystemService} from '$lib/writing-system-service.svelte';
   import {useDialogsService} from '$lib/services/dialogs-service.js';
   import {useBackHandler} from '$lib/utils/back-handler.svelte';
+  import {IsMobile} from '$lib/hooks/is-mobile.svelte';
 
   let open = $state(false);
   useBackHandler({addToStack: () => open, onBack: () => open = false});
@@ -82,12 +83,8 @@
 
   let entryLabel = fieldName({id: 'entry'}, $currentView.i18nKey);
 
-  function isDesktop(): boolean {
-    return window.matchMedia("(hover: hover) and (pointer: fine)").matches;
-  }
-
   function handleKeydown(event: KeyboardEvent) {
-    if (event.key === 'Enter' && isDesktop()) {
+    if (event.key === 'Enter' && !IsMobile.value) {
       createEntry(event);
     }
   }
@@ -95,7 +92,7 @@
 
 {#if open}
 <Dialog.Root bind:open={open}>
-  <Dialog.DialogContent on:keydown={handleKeydown}>
+  <Dialog.DialogContent onkeydown={handleKeydown}>
     <Dialog.DialogHeader>
       <Dialog.DialogTitle>{$t`New ${entryLabel}`}</Dialog.DialogTitle>
     </Dialog.DialogHeader>

--- a/frontend/viewer/src/lib/entry-editor/object-editors/EntryEditor.svelte
+++ b/frontend/viewer/src/lib/entry-editor/object-editors/EntryEditor.svelte
@@ -154,7 +154,7 @@
     {#each entry.senses as sense, i (sense.id)}
       <Editor.SubGrid class={cn(sense.id === highlightedEntity?.id && 'highlight')}>
         <div id="sense{i + 1}"></div> <!-- shouldn't be in the sticky header -->
-        <div class="col-span-full flex items-center py-2 mb-1 sticky top-0 bg-background z-[1] w-[calc(100%+2px)] pr-[2px] animate-fade-out animation-scroll">
+        <div class:stick={!modalMode} class="col-span-full flex items-center py-2 mb-1 top-0 bg-background z-[1] w-[calc(100%+2px)] pr-[2px] animate-fade-out animation-scroll">
           <h2 class="text-lg text-muted-foreground">{pt($t`Sense`, $t`Meaning`, $currentView)} {i + 1}</h2>
           <hr class="grow border-t-2 mx-4">
           <EntityListItemActions {i}


### PR DESCRIPTION
closes #1686 
I've implemented functionality to allow you to submit the new entry dialog
by pressing the Enter key. This behavior is restricted to desktop devices.

Changes:
- Modified `frontend/viewer/src/lib/entry-editor/NewEntryDialog.svelte`:
  - Added an `isDesktop()` helper function using `window.matchMedia` to detect desktop environments.
  - Added a `keydown` event listener to the dialog content.
  - The listener calls the `createEntry` function when the 'Enter' key is pressed and `isDesktop()` returns true.
- I wrote unit tests to cover desktop and mobile scenarios, as well as other key presses. However, I was prevented from running these tests by an `npm install` issue in the testing environment.