### PR TITLE
Remove server-side beta FF check on sync-controller

### DIFF
--- a/backend/LexBoxApi/Controllers/SyncController.cs
+++ b/backend/LexBoxApi/Controllers/SyncController.cs
@@ -10,7 +10,6 @@ namespace LexBoxApi.Controllers;
 
 [ApiController]
 [Route("/api/fw-lite/sync")]
-[FeatureFlagRequired(FeatureFlag.FwLiteBeta, AllowAdmin = true)]
 [ApiExplorerSettings(GroupName = LexBoxKernel.OpenApiPublicDocumentName)]
 public class SyncController(
     IPermissionService permissionService,


### PR DESCRIPTION
With this change, non-beta users can access and use the full feature-set of the sync dialog.

See: https://sil-language-software.slack.com/archives/CGDKZ7NTV/p1748485267548119?thread_ts=1748462102.699679&cid=CGDKZ7NTV

Here's my no-beta-access user currently doing a Send/Receive:
![image](https://github.com/user-attachments/assets/bd29c4dd-b070-4d4a-88df-c3d30644094e)
