### PR TITLE
implement accent/diacritic ignore search

### DIFF
--- a/backend/FwLite/FwDataMiniLcmBridge/Api/LcmHelpers.cs
+++ b/backend/FwLite/FwDataMiniLcmBridge/Api/LcmHelpers.cs
@@ -1,4 +1,5 @@
 using System.Globalization;
+using MiniLcm.Culture;
 using MiniLcm.Models;
 using SIL.LCModel;
 using SIL.LCModel.Core.KernelInterfaces;
@@ -13,7 +14,7 @@ internal static class LcmHelpers
         {
             var tsString = multiString.GetStringFromIndex(i, out var _);
             if (string.IsNullOrEmpty(tsString.Text)) continue;
-            if (tsString.Text.Contains(value, StringComparison.InvariantCultureIgnoreCase))
+            if (tsString.Text.Contains(value, CultureInfo.InvariantCulture, CompareOptions.IgnoreNonSpace | CompareOptions.IgnoreCase))
             {
                 return true;
             }

--- a/backend/FwLite/FwDataMiniLcmBridge/Api/LcmHelpers.cs
+++ b/backend/FwLite/FwDataMiniLcmBridge/Api/LcmHelpers.cs
@@ -14,7 +14,7 @@ internal static class LcmHelpers
         {
             var tsString = multiString.GetStringFromIndex(i, out var _);
             if (string.IsNullOrEmpty(tsString.Text)) continue;
-            if (tsString.Text.Contains(value, CultureInfo.InvariantCulture, CompareOptions.IgnoreNonSpace | CompareOptions.IgnoreCase))
+            if (tsString.Text.ContainsDiacriticMatch(value))
             {
                 return true;
             }

--- a/backend/FwLite/LcmCrdt.Tests/MiniLcmTests/QueryEntryTests.cs
+++ b/backend/FwLite/LcmCrdt.Tests/MiniLcmTests/QueryEntryTests.cs
@@ -1,6 +1,9 @@
-﻿namespace LcmCrdt.Tests.MiniLcmTests;
+﻿using System.Diagnostics;
+using Xunit.Abstractions;
 
-public class QueryEntryTests : QueryEntryTestsBase
+namespace LcmCrdt.Tests.MiniLcmTests;
+
+public class QueryEntryTests(ITestOutputHelper outputHelper) : QueryEntryTestsBase
 {
     private readonly MiniLcmApiFixture _fixture = new();
 
@@ -9,6 +12,32 @@ public class QueryEntryTests : QueryEntryTestsBase
         await _fixture.InitializeAsync();
         var api = _fixture.Api;
         return api;
+    }
+
+
+
+    [Theory]
+    [InlineData(50_000)]
+    [InlineData(100_000)]
+    public async Task QueryPerformanceTesting(int count)
+    {
+        await _fixture.Api.BulkCreateEntries(AsyncEnumerable.Range(0, count).Select(i => new Entry { LexemeForm = { ["en"] = Guid.NewGuid().ToString() } }));
+
+        var testIterations = 10;
+        var startTimestamp = Stopwatch.GetTimestamp();
+        for (int i = 0; i < testIterations; i++)
+        {
+            //search should not match anything as we only want to test the match performance
+            var results = await Api.SearchEntries("asdfgbope").ToArrayAsync();
+            results.Should().BeEmpty();
+        }
+
+        var totalRuntime = Stopwatch.GetElapsedTime(startTimestamp);
+        var queryTime = totalRuntime / testIterations;
+        var timePerEntry = queryTime / count;
+        outputHelper.WriteLine(
+            $"Total query time: {queryTime.TotalMilliseconds}ms, time per entry: {timePerEntry.TotalMicroseconds}microseconds");
+        timePerEntry.TotalMicroseconds.Should().BeLessThan(10);//on my machine I got 3.9, so this is a safe margin
     }
 
     public override async Task DisposeAsync()

--- a/backend/FwLite/LcmCrdt/Data/CustomSqliteFunctionInterceptor.cs
+++ b/backend/FwLite/LcmCrdt/Data/CustomSqliteFunctionInterceptor.cs
@@ -1,0 +1,33 @@
+using System.Data.Common;
+using System.Globalization;
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore.Diagnostics;
+using MiniLcm.Culture;
+
+namespace LcmCrdt.Data;
+
+public class CustomSqliteFunctionInterceptor : IDbConnectionInterceptor
+{
+    public const string ContainsFunction = "contains";
+    public void ConnectionOpened(DbConnection connection, ConnectionEndEventData eventData)
+    {
+        var sqliteConnection = (SqliteConnection)connection;
+        //creates a new function that can be used in queries
+        sqliteConnection.CreateFunction(ContainsFunction,
+            (string? str, string? value) =>
+            {
+                if (str is null || value is null) return false;
+                return str.Contains(value,
+                    CultureInfo.InvariantCulture,
+                    CompareOptions.IgnoreNonSpace | CompareOptions.IgnoreCase);
+            });
+    }
+
+    public Task ConnectionOpenedAsync(DbConnection connection,
+        ConnectionEndEventData eventData,
+        CancellationToken cancellationToken = new CancellationToken())
+    {
+        ConnectionOpened(connection, eventData);
+        return Task.CompletedTask;
+    }
+}

--- a/backend/FwLite/LcmCrdt/Data/CustomSqliteFunctionInterceptor.cs
+++ b/backend/FwLite/LcmCrdt/Data/CustomSqliteFunctionInterceptor.cs
@@ -1,5 +1,6 @@
 using System.Data.Common;
 using System.Globalization;
+using System.Runtime.CompilerServices;
 using System.Text;
 using Microsoft.Data.Sqlite;
 using Microsoft.EntityFrameworkCore.Diagnostics;
@@ -10,6 +11,9 @@ namespace LcmCrdt.Data;
 public class CustomSqliteFunctionInterceptor : IDbConnectionInterceptor
 {
     public const string ContainsFunction = "contains";
+
+    private record DiacriticResult(bool HasDiacritic);
+    private static readonly ConditionalWeakTable<object, DiacriticResult> Cache = new();
     public void ConnectionOpened(DbConnection connection, ConnectionEndEventData eventData)
     {
         var sqliteConnection = (SqliteConnection)connection;
@@ -19,14 +23,38 @@ public class CustomSqliteFunctionInterceptor : IDbConnectionInterceptor
             (byte[]? str, byte[]? value) =>
             {
                 if (str is null || value is null) return false;
+
                 Span<char> source = stackalloc char[Encoding.UTF8.GetCharCount(str)];
                 Span<char> search = stackalloc char[Encoding.UTF8.GetCharCount(value)];
                 Encoding.UTF8.GetChars(str, source);
                 Encoding.UTF8.GetChars(value, search);
                 return CultureInfo.InvariantCulture.CompareInfo.IndexOf(source,
                     search,
-                    CompareOptions.IgnoreNonSpace | CompareOptions.IgnoreCase) >= 0;
+                    ContainsDiacritic(search, value)
+                        ? CompareOptions.IgnoreCase
+                        : CompareOptions.IgnoreNonSpace | CompareOptions.IgnoreCase
+                ) >= 0;
             });
+    }
+
+    private static bool ContainsDiacritic(in ReadOnlySpan<char> value, object resultKey)
+    {
+        if (Cache.TryGetValue(resultKey, out var result)) return result.HasDiacritic;
+        bool hasAccent = false;
+        var str = new string(value);
+        //todo we could maybe get rid of this normalization step if the text is already normalized
+        //that would mean we could just iterate the value here rather than creating a new string
+        foreach (var ch in str.Normalize(NormalizationForm.FormD))
+        {
+            if (CharUnicodeInfo.GetUnicodeCategory(ch) == UnicodeCategory.NonSpacingMark)
+            {
+                hasAccent = true;
+                break;
+            }
+        }
+
+        Cache.Add(resultKey, new DiacriticResult(hasAccent));
+        return hasAccent;
     }
 
     public Task ConnectionOpenedAsync(DbConnection connection,

--- a/backend/FwLite/LcmCrdt/LcmCrdtDbContext.cs
+++ b/backend/FwLite/LcmCrdt/LcmCrdtDbContext.cs
@@ -15,7 +15,7 @@ public class LcmCrdtDbContext(DbContextOptions<LcmCrdtDbContext> dbContextOption
     public IQueryable<WritingSystem> WritingSystems => Set<WritingSystem>().AsNoTracking();
     protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
     {
-        optionsBuilder.AddInterceptors(setupCollationInterceptor);
+        optionsBuilder.AddInterceptors(setupCollationInterceptor, new CustomSqliteFunctionInterceptor());
     }
 
     protected override void OnModelCreating(ModelBuilder modelBuilder)

--- a/backend/FwLite/LcmCrdt/SqlHelpers.cs
+++ b/backend/FwLite/LcmCrdt/SqlHelpers.cs
@@ -1,5 +1,9 @@
-﻿using System.Linq.Expressions;
+﻿using System.Globalization;
+using System.Linq.Expressions;
+using LcmCrdt.Data;
 using LinqToDB;
+using LinqToDB.DataProvider.SQLite;
+using MiniLcm.Culture;
 
 namespace LcmCrdt;
 
@@ -24,6 +28,10 @@ public static class SqlHelpers
 
     private static Expression<Func<MultiString, string, bool>> SearchValueExpression()
     {
-        return (ms, search) => Json.QueryValues(ms).Any(s => s.Contains(search));
+        return (ms, search) => Json.QueryValues(ms).Any(s => ContainsIgnoreCaseAccents(s, search));
     }
+
+    [Sql.Expression(CustomSqliteFunctionInterceptor.ContainsFunction + "({0}, {1})")]
+    private static bool ContainsIgnoreCaseAccents(string s, string search) =>
+        s.Contains(search, CultureInfo.InvariantCulture, CompareOptions.IgnoreCase | CompareOptions.IgnoreNonSpace);
 }

--- a/backend/FwLite/LcmCrdt/SqlHelpers.cs
+++ b/backend/FwLite/LcmCrdt/SqlHelpers.cs
@@ -23,7 +23,7 @@ public static class SqlHelpers
     [ExpressionMethod(nameof(SearchValueExpression))]
     public static bool SearchValue(this MultiString ms, string search)
     {
-        return ms.Values.Any(pair => pair.Value.Contains(search));
+        return ms.Values.Any(pair => pair.Value.Contains(search, CultureInfo.InvariantCulture, CompareOptions.IgnoreCase | CompareOptions.IgnoreNonSpace));
     }
 
     private static Expression<Func<MultiString, string, bool>> SearchValueExpression()

--- a/backend/FwLite/LcmCrdt/SqlHelpers.cs
+++ b/backend/FwLite/LcmCrdt/SqlHelpers.cs
@@ -23,7 +23,7 @@ public static class SqlHelpers
     [ExpressionMethod(nameof(SearchValueExpression))]
     public static bool SearchValue(this MultiString ms, string search)
     {
-        return ms.Values.Any(pair => pair.Value.Contains(search, CultureInfo.InvariantCulture, CompareOptions.IgnoreCase | CompareOptions.IgnoreNonSpace));
+        return ms.Values.Any(pair => pair.Value.ContainsDiacriticMatch(search));
     }
 
     private static Expression<Func<MultiString, string, bool>> SearchValueExpression()
@@ -32,6 +32,5 @@ public static class SqlHelpers
     }
 
     [Sql.Expression(CustomSqliteFunctionInterceptor.ContainsFunction + "({0}, {1})")]
-    private static bool ContainsIgnoreCaseAccents(string s, string search) =>
-        s.Contains(search, CultureInfo.InvariantCulture, CompareOptions.IgnoreCase | CompareOptions.IgnoreNonSpace);
+    private static bool ContainsIgnoreCaseAccents(string s, string search) => s.ContainsDiacriticMatch(search);
 }

--- a/backend/FwLite/MiniLcm.Tests/QueryEntryTestsBase.cs
+++ b/backend/FwLite/MiniLcm.Tests/QueryEntryTestsBase.cs
@@ -217,7 +217,7 @@ public abstract class QueryEntryTestsBase : MiniLcmTestBase
     [Theory]
     [InlineData("a", "a")]
     [InlineData("a", "A")]
-    [InlineData("Ã", "A")]
+    [InlineData("Ã", "A")] // todo: make it fail
     [InlineData("A", "Ã")]
     [InlineData("ap", "apple")]
     [InlineData("ap", "APPLE")]
@@ -237,6 +237,11 @@ public abstract class QueryEntryTestsBase : MiniLcmTestBase
 
     [Theory]
     [InlineData("a", "b")]
+    [InlineData("ab", "b")]
+    [InlineData("apple", "orange")]
+    // todo: make them pass
+    // [InlineData("Ã", "A")]
+    // [InlineData("É", "È")]
     public async Task NegativeMatches(string searchTerm, string word)
     {
         word = word.Normalize(NormalizationForm.FormD);

--- a/backend/FwLite/MiniLcm.Tests/QueryEntryTestsBase.cs
+++ b/backend/FwLite/MiniLcm.Tests/QueryEntryTestsBase.cs
@@ -217,13 +217,13 @@ public abstract class QueryEntryTestsBase : MiniLcmTestBase
     [Theory]
     [InlineData("a", "a")]
     [InlineData("a", "A")]
-    [InlineData("Ã", "A")] // todo: make it fail
     [InlineData("A", "Ã")]
     [InlineData("ap", "apple")]
     [InlineData("ap", "APPLE")]
     [InlineData("ing", "walking")]
     [InlineData("ing", "WALKING")]
     [InlineData("Ãp", "Ãpple")]
+    [InlineData("Ãp", "ãpple")]
     [InlineData("ap", "Ãpple")]
     public async Task SuccessfulMatches(string searchTerm, string word)
     {
@@ -238,10 +238,9 @@ public abstract class QueryEntryTestsBase : MiniLcmTestBase
     [Theory]
     [InlineData("a", "b")]
     [InlineData("ab", "b")]
-    [InlineData("apple", "orange")]
-    // todo: make them pass
-    // [InlineData("Ã", "A")]
-    // [InlineData("É", "È")]
+    [InlineData("Ã", "A")] // Accented should not match base
+    [InlineData("apple", "orange")] // Completely different words
+    [InlineData("É", "È")] // Different accents
     public async Task NegativeMatches(string searchTerm, string word)
     {
         word = word.Normalize(NormalizationForm.FormD);

--- a/backend/FwLite/MiniLcm.Tests/SerializationTests.cs
+++ b/backend/FwLite/MiniLcm.Tests/SerializationTests.cs
@@ -1,7 +1,4 @@
-﻿using System.Globalization;
-using System.Text;
-using System.Text.Json;
-using MiniLcm.Culture;
+﻿using System.Text.Json;
 using Xunit.Abstractions;
 
 namespace MiniLcm.Tests;

--- a/backend/FwLite/MiniLcm.Tests/SerializationTests.cs
+++ b/backend/FwLite/MiniLcm.Tests/SerializationTests.cs
@@ -1,4 +1,7 @@
-﻿using System.Text.Json;
+﻿using System.Globalization;
+using System.Text;
+using System.Text.Json;
+using MiniLcm.Culture;
 using Xunit.Abstractions;
 
 namespace MiniLcm.Tests;

--- a/backend/FwLite/MiniLcm/Culture/StringExtensions.cs
+++ b/backend/FwLite/MiniLcm/Culture/StringExtensions.cs
@@ -1,4 +1,6 @@
 using System.Globalization;
+using System.Runtime.CompilerServices;
+using System.Text;
 
 namespace MiniLcm.Culture;
 
@@ -7,6 +9,42 @@ public static class StringExtensions
     public static bool Contains(this string str, string value, CultureInfo cultureInfo, CompareOptions comparison = CompareOptions.None)
     {
         return cultureInfo.CompareInfo.IndexOf(str, value, comparison) >= 0;
+    }
+
+    /// <summary>
+    /// searches a string for a match ignoring diacritics, but only when the search string does not contain diacritics
+    /// </summary>
+    /// <param name="str">source of the search</param>
+    /// <param name="search">string to search for</param>
+    public static bool ContainsDiacriticMatch(this string str, string search)
+    {
+        if (ContainsDiacritic(search))
+        {
+            return Contains(str, search, CultureInfo.InvariantCulture, CompareOptions.IgnoreCase);
+        }
+
+        return Contains(str,
+            search,
+            CultureInfo.InvariantCulture,
+            CompareOptions.IgnoreCase | CompareOptions.IgnoreNonSpace);
+    }
+
+    private record DiacriticResult(bool HasDiacritic);
+    private static readonly ConditionalWeakTable<string, DiacriticResult> Cache = new();
+    public static bool ContainsDiacritic(string value)
+    {
+        if (Cache.TryGetValue(value, out var result)) return result.HasDiacritic;
+        bool hasAccent = false;
+        foreach (var ch in value.Normalize(NormalizationForm.FormD))
+        {
+            if (CharUnicodeInfo.GetUnicodeCategory(ch) == UnicodeCategory.NonSpacingMark)
+            {
+                hasAccent = true;
+                break;
+            }
+        }
+        Cache.Add(value, new DiacriticResult(hasAccent));
+        return hasAccent;
     }
 
     public static bool Equals(this string str,

--- a/backend/FwLite/MiniLcm/Culture/StringExtensions.cs
+++ b/backend/FwLite/MiniLcm/Culture/StringExtensions.cs
@@ -1,5 +1,4 @@
 using System.Globalization;
-using System.Runtime.CompilerServices;
 using System.Text;
 
 namespace MiniLcm.Culture;
@@ -29,11 +28,8 @@ public static class StringExtensions
             CompareOptions.IgnoreCase | CompareOptions.IgnoreNonSpace);
     }
 
-    private record DiacriticResult(bool HasDiacritic);
-    private static readonly ConditionalWeakTable<string, DiacriticResult> Cache = new();
     public static bool ContainsDiacritic(string value)
     {
-        if (Cache.TryGetValue(value, out var result)) return result.HasDiacritic;
         bool hasAccent = false;
         foreach (var ch in value.Normalize(NormalizationForm.FormD))
         {
@@ -43,7 +39,6 @@ public static class StringExtensions
                 break;
             }
         }
-        Cache.Add(value, new DiacriticResult(hasAccent));
         return hasAccent;
     }
 

--- a/backend/FwLite/MiniLcm/Culture/StringExtensions.cs
+++ b/backend/FwLite/MiniLcm/Culture/StringExtensions.cs
@@ -1,0 +1,19 @@
+using System.Globalization;
+
+namespace MiniLcm.Culture;
+
+public static class StringExtensions
+{
+    public static bool Contains(this string str, string value, CultureInfo cultureInfo, CompareOptions comparison = CompareOptions.None)
+    {
+        return cultureInfo.CompareInfo.IndexOf(str, value, comparison) >= 0;
+    }
+
+    public static bool Equals(this string str,
+        string value,
+        CultureInfo cultureInfo,
+        CompareOptions comparison = CompareOptions.None)
+    {
+        return cultureInfo.CompareInfo.Compare(str, value, comparison) == 0;
+    }
+}


### PR DESCRIPTION
closes #1718 

Expected implementation:
| Search| Headword | Matches |
|--------|--------|--------|
| A | A | ✅ |
| A | Ã | ✅ |
| Ã | A | ❌ |
| Ã | Ã | ✅ | 

Actual:
| Search| Headword | Matches |
|--------|--------|--------|
| A | A | ✅ |
| A | Ã | ✅ |
| Ã | A | ✅ |
| Ã | Ã | ✅ | 

this also raised some normalization issues, so I'm going to get some input from Jason on that.