### PR TITLE
Fix inconsistent dictionary preview whitespace

### DIFF
--- a/frontend/viewer/src/lib/DictionaryEntry.svelte
+++ b/frontend/viewer/src/lib/DictionaryEntry.svelte
@@ -78,11 +78,11 @@
 
 {#snippet senseNumber(index: number)}
   {#if showLinks}
-    <a href={`${location.href.replace(location.hash, '')}#sense${index+1}`} class="font-bold group/sense underline inline-flex items-center">
+    <a href={`${location.href.replace(location.hash, '')}#sense${index+1}`} class="font-bold group/sense underline">
       <Icon icon="i-mdi-link" class={cn(
-          'invisible opacity-0',
+          'opacity-0',
           'group-hover/sense:opacity-100 group-hover/sense:visible transition-all',
-          'size-4'
+          'size-4 align-sub'
         )}/><span class="ml-[2px]">{index + 1}</span>
     </a>
   {:else}


### PR DESCRIPTION
Argos might do a better job than this 😆:

![image](https://github.com/user-attachments/assets/59df48db-5954-4ae8-b265-f4e2080b2280)


Second commit centers the sense numbers / links, which were shifted up:

![image](https://github.com/user-attachments/assets/7accfde2-9e15-46a3-8f75-5340685d3c1d)
