### PR TITLE
Make all whitespace in and around filter input clickable

### DIFF
--- a/frontend/viewer/src/lib/components/ui/input/composable-input.svelte
+++ b/frontend/viewer/src/lib/components/ui/input/composable-input.svelte
@@ -4,6 +4,7 @@
   import type {Snippet} from 'svelte';
   import InputShell from './input-shell.svelte';
   import {Input} from '.';
+  import {cn} from '$lib/utils';
 
   type Props = WithElementRef<HTMLAttributes<HTMLDivElement>>;
 
@@ -26,8 +27,8 @@
   const focusRingClass = 'has-[.real-input:focus-visible]:ring-ring has-[.real-input:focus-visible]:outline-none has-[.real-input:focus-visible]:ring-2 has-[.real-input:focus-visible]:ring-offset-2';
 </script>
 
-<InputShell bind:ref {focusRingClass} class={className} {...restProps}>
+<InputShell bind:ref {focusRingClass} class={cn('gap-0', className)} {...restProps}>
   {@render before?.()}
-  <Input variant="ghost" {placeholder} class="grow real-input" bind:ref={inputRef} bind:value />
+  <Input variant="ghost" {placeholder} class="grow real-input h-full px-2" bind:ref={inputRef} bind:value />
   {@render after?.()}
 </InputShell>


### PR DESCRIPTION
Replace the gap with clickable padding and increase the height of the input to fill the input-shell.
I guess if the text-size of an <input> is always vertically positioned in the middle of the element if the text-size doesn't fill the height of the element itself.
So, this just works.

![image](https://github.com/user-attachments/assets/3248e470-8362-434b-a45f-8bd640dd9cf5)
