### PR TITLE
Allow double-clicking multi-ws-inputs to select text

### DIFF
--- a/frontend/viewer/src/lib/components/ui/label/label.svelte
+++ b/frontend/viewer/src/lib/components/ui/label/label.svelte
@@ -1,12 +1,16 @@
 <script lang="ts">
   import {cn} from '$lib/utils.js';
-  import {Label as LabelPrimitive} from 'bits-ui';
+  import type {WithElementRef} from 'bits-ui';
+  import type {HTMLLabelAttributes} from 'svelte/elements';
 
-  let { ref = $bindable(null), class: className, ...restProps }: LabelPrimitive.RootProps = $props();
+  type Props = WithElementRef<HTMLLabelAttributes>;
+
+  let { ref = $bindable(null), class: className, children, ...restProps }: Props = $props();
 </script>
 
-<LabelPrimitive.Root
-  bind:ref
+<label
+  bind:this={ref}
   class={cn('text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70', className)}
-  {...restProps}
-/>
+  {...restProps}>
+  {@render children?.()}
+</label>


### PR DESCRIPTION
Looks exactly the same, but now you can double-click to select the text.

![image](https://github.com/user-attachments/assets/d4ff43b8-a30b-46d3-b2f1-a18fbd7d8a93)

See [this issue](https://github.com/huntabyte/bits-ui/issues/1323) for why we're just using a normal `<label>` now.