### PR TITLE
Rich text focus and selection improvements

### DIFF
--- a/frontend/viewer/src/lib/components/lcm-rich-text-editor/lcm-rich-text-editor.svelte
+++ b/frontend/viewer/src/lib/components/lcm-rich-text-editor/lcm-rich-text-editor.svelte
@@ -45,6 +45,7 @@
   import {IsUsingKeyboard} from 'bits-ui';
   import type {IRichSpan} from '$lib/dotnet-types/generated-types/MiniLcm/Models/IRichSpan';
   import {inputVariants} from '../ui/input/input.svelte';
+  import {on} from 'svelte/events';
 
   let {
     value = $bindable(),
@@ -95,6 +96,9 @@
       }
     });
     editor.dom.setAttribute('tabindex', '0');
+
+    const parentLabel = elementRef?.closest('label');
+    if (parentLabel) return on(parentLabel, 'click', onFocusTargetClick);
   });
 
   function onfocus(editor: EditorView) {
@@ -187,6 +191,12 @@
   function replaceLineSeparatorWithNewLine(text: string) {
     return text.replaceAll(lineSeparator, newLine);
   }
+
+  function onFocusTargetClick(event: MouseEvent) {
+    if (!editor) return;
+    if (event.target === editor?.dom) return; // the editor will handle focus itself
+    editor.focus();
+  }
 </script>
 <style>
   :global(.ProseMirror) {
@@ -204,7 +214,7 @@
 
 {#if label}
   <div {...rest}>
-    <Label>{label}</Label>
+    <Label onclick={onFocusTargetClick}>{label}</Label>
     <div bind:this={elementRef}></div>
   </div>
 {:else}

--- a/frontend/viewer/src/lib/components/lcm-rich-text-editor/lcm-rich-text-editor.svelte
+++ b/frontend/viewer/src/lib/components/lcm-rich-text-editor/lcm-rich-text-editor.svelte
@@ -35,7 +35,7 @@
   import type {IRichString} from '$lib/dotnet-types/generated-types/MiniLcm/Models/IRichString';
   import {Label} from '$lib/components/ui/label';
   import {EditorView} from 'prosemirror-view';
-  import {AllSelection, EditorState, TextSelection} from 'prosemirror-state';
+  import {AllSelection, EditorState} from 'prosemirror-state';
   import {keymap} from 'prosemirror-keymap';
   import {baseKeymap} from 'prosemirror-commands';
   import {undo, redo, history} from 'prosemirror-history';
@@ -181,7 +181,6 @@
     if (selection && editor.dom.contains(selection.anchorNode) && editor.dom.contains(selection.focusNode)) {
       selection.removeAllRanges();
     }
-    editor.dispatch(editor.state.tr.setSelection(TextSelection.create(editor.state.doc, 0)));
   }
 
   //lcm expects line separators, but html does not render them, so we replace them with \n

--- a/frontend/viewer/src/lib/components/lcm-rich-text-editor/lcm-rich-text-editor.svelte
+++ b/frontend/viewer/src/lib/components/lcm-rich-text-editor/lcm-rich-text-editor.svelte
@@ -34,7 +34,6 @@
 <script lang="ts">
   import type {IRichString} from '$lib/dotnet-types/generated-types/MiniLcm/Models/IRichString';
   import {Label} from '$lib/components/ui/label';
-  import InputShell from '../ui/input/input-shell.svelte';
   import {EditorView} from 'prosemirror-view';
   import {AllSelection, EditorState, TextSelection} from 'prosemirror-state';
   import {keymap} from 'prosemirror-keymap';
@@ -43,8 +42,9 @@
   import {onDestroy, onMount} from 'svelte';
   import {watch} from 'runed';
   import type {HTMLAttributes} from 'svelte/elements';
-  import {IsUsingKeyboard, mergeProps} from 'bits-ui';
+  import {IsUsingKeyboard} from 'bits-ui';
   import type {IRichSpan} from '$lib/dotnet-types/generated-types/MiniLcm/Models/IRichSpan';
+  import {inputVariants} from '../ui/input/input.svelte';
 
   let {
     value = $bindable(),
@@ -82,6 +82,9 @@
           dirty = true;
         }
         editor.updateState(newState);
+      },
+      attributes: {
+        class: inputVariants({class: 'min-h-10 h-auto block'}),
       },
       editable() {
         return !readonly;
@@ -202,8 +205,8 @@
 {#if label}
   <div {...rest}>
     <Label>{label}</Label>
-    <InputShell {autofocus} class="p-2 h-auto" bind:ref={elementRef}/>
+    <div bind:this={elementRef}></div>
   </div>
 {:else}
-  <InputShell {autofocus} {...mergeProps({ class: 'p-2 h-auto'}, rest)} bind:ref={elementRef}/>
+  <div bind:this={elementRef}></div>
 {/if}


### PR DESCRIPTION
Now just like normal inputs:
- clicking in the padding of a rich-text field focuses it
- clicking on related labels focuses it (I intentionally did not implement the "for" attribute, because we don't need it right now)
- the rich-text field remembers its selection on blur and re-focus

https://github.com/user-attachments/assets/e9b7e381-9fa8-4640-8ec3-e4e1bd84179d

