### PR TITLE
Restore loading debouncing

### DIFF
--- a/backend/FwLite/FwLiteShared/TypeGen/ReinforcedFwLiteTypingConfig.cs
+++ b/backend/FwLite/FwLiteShared/TypeGen/ReinforcedFwLiteTypingConfig.cs
@@ -22,6 +22,7 @@ using Reinforced.Typings.Visitors.TypeScript;
 using SIL.Harmony;
 using SIL.Harmony.Core;
 using SIL.Harmony.Db;
+using System.Runtime.CompilerServices;
 
 namespace FwLiteShared.TypeGen;
 
@@ -102,7 +103,10 @@ public static class ReinforcedFwLiteTypingConfig
             .WithPublicMethods(b => b.AlwaysReturnPromise().OnlyJsInvokable());
         builder.ExportAsEnum<SortField>().UseString();
         builder.ExportAsInterfaces([typeof(QueryOptions), typeof(FilterQueryOptions), typeof(SortOptions), typeof(ExemplarOptions), typeof(EntryFilter)],
-            exportBuilder => exportBuilder.WithPublicNonStaticProperties());
+            exportBuilder => exportBuilder.WithPublicNonStaticProperties(propExportBuilder =>
+        {
+            propExportBuilder.IgnoreComputedGetters();
+        }));
     }
 
     private static void ConfigureFwLiteSharedTypes(ConfigurationBuilder builder)
@@ -178,6 +182,14 @@ public static class ReinforcedFwLiteTypingConfig
             }
         }
         return exportBuilder;
+    }
+
+    private static void IgnoreComputedGetters(this PropertyExportBuilder exportBuilder)
+    {
+        // see: https://stackoverflow.com/a/72266104
+        var property = exportBuilder.Member;
+        if (property.SetMethod == null && property.GetMethod?.GetCustomAttribute(typeof(CompilerGeneratedAttribute)) is null)
+            exportBuilder.Ignore();
     }
 
     private static void OnlyJsInvokable(this MethodExportBuilder exportBuilder)

--- a/frontend/viewer/src/project/browse/EntriesList.svelte
+++ b/frontend/viewer/src/project/browse/EntriesList.svelte
@@ -2,7 +2,7 @@
   import type {IEntry} from '$lib/dotnet-types';
   import type {IQueryOptions} from '$lib/dotnet-types/generated-types/MiniLcm/IQueryOptions';
   import {SortField} from '$lib/dotnet-types/generated-types/MiniLcm/SortField';
-  import {resource, useDebounce} from 'runed';
+  import {Debounced, resource, useDebounce} from 'runed';
   import {useMiniLcmApi} from '$lib/services/service-provider';
   import EntryRow from './EntryRow.svelte';
   import Button from '$lib/components/ui/button/button.svelte';
@@ -58,9 +58,10 @@
     entriesResource.mutate(updatedEntries);
   }
 
-  let loading = $state(false);
+  let loadingUndebounced = $state(false);
+  const loading = new Debounced(() => loadingUndebounced, 50);
   const fetchCurrentEntries = useDebounce(async (silent = false) => {
-    if (!silent) loading = true;
+    if (!silent) loadingUndebounced = true;
     try {
       const queryOptions: IQueryOptions = {
         count: 10_000,
@@ -80,7 +81,7 @@
       }
       return await miniLcmApi.getEntries(queryOptions);
     } finally {
-      loading = false;
+      loadingUndebounced = false;
     }
   }, 300);
 
@@ -115,9 +116,9 @@
 <FabContainer>
   <DevContent>
     <Button
-      icon={loading ? 'i-mdi-loading' : 'i-mdi-refresh'}
+      icon={loading.current ? 'i-mdi-loading' : 'i-mdi-refresh'}
       variant="outline"
-      iconProps={{ class: cn(loading && 'animate-spin') }}
+      iconProps={{ class: cn(loading.current && 'animate-spin') }}
       size="icon"
       onclick={() => entriesResource.refetch()}
     />
@@ -133,7 +134,7 @@
     </div>
   {:else}
     <div class="h-full">
-      {#if loading}
+      {#if loading.current}
         <div class="md:pr-3 p-0.5">
           <!-- Show skeleton rows while loading -->
           {#each { length: skeletonRowCount }, _index}

--- a/frontend/viewer/src/project/browse/EntriesList.svelte
+++ b/frontend/viewer/src/project/browse/EntriesList.svelte
@@ -76,10 +76,11 @@
         },
       };
 
-      if (search) {
-        return await miniLcmApi.searchEntries(search, queryOptions);
-      }
-      return await miniLcmApi.getEntries(queryOptions);
+      const entries = search
+        ? miniLcmApi.searchEntries(search, queryOptions)
+        : miniLcmApi.getEntries(queryOptions);
+      await entries; // ensure the entries have arrived before toggling the loading flag
+      return entries;
     } finally {
       loadingUndebounced = false;
     }


### PR DESCRIPTION
Restores the load debouncing lost in [58bc9a2](https://github.com/sillsdev/languageforge-lexbox/pull/1714/commits/58bc9a2dd341b0d16851b6c6b8875185a0a4ba88)

Fixes [b315cef](https://github.com/sillsdev/languageforge-lexbox/pull/1721/commits/b315cefd918d924f9261b6612f2e552d28e9d1e8) adding a computed .net prop as a required property in TS.
