### PR TITLE
Map UnauthorizedAccessExceptions to 401s

### DIFF
--- a/backend/LexBoxApi/Program.cs
+++ b/backend/LexBoxApi/Program.cs
@@ -90,9 +90,9 @@ builder.Services.AddHealthChecks();
 builder.Services.AddSingleton<IDeveloperPageExceptionFilter, AddExceptionFeatureDevExceptionFilter>();
 builder.Services.AddExceptionHandler((options) =>
 {
-    options.StatusCodeSelector = context =>
+    options.StatusCodeSelector = exception =>
     {
-        if (context is UnauthorizedAccessException)
+        if (exception is UnauthorizedAccessException)
             return StatusCodes.Status401Unauthorized;
         return StatusCodes.Status500InternalServerError;
     };


### PR DESCRIPTION
This should result in the permission assertions we do in e.g. controller methods to return 401's instead of 500's.
I didn't actually test this, because it's not super critical, but...it should do the trick.