### PR TITLE
Only show loading in entry view if switching entries

### DIFF
--- a/frontend/viewer/src/project/browse/EntryView.svelte
+++ b/frontend/viewer/src/project/browse/EntryView.svelte
@@ -108,7 +108,7 @@
       </div>
     </ScrollArea>
   {/if}
-  {#if loadingDebounced.current}
+  {#if loadingDebounced.current && entryResource.current?.id !== entryId}
     <div
       class="absolute inset-0 opacity-50 bg-background z-10"
       transition:fade={{ duration: 150 }}>


### PR DESCRIPTION
Without this the screen easily flickers while editing an entry if the saves are super fast.