### PR TITLE
Disable synchronize button for observers

### DIFF
--- a/frontend/viewer/src/project/SyncDialog.svelte
+++ b/frontend/viewer/src/project/SyncDialog.svelte
@@ -15,8 +15,10 @@
   import { fade } from 'svelte/transition';
   import { delay } from '$lib/utils/time';
   import { cn } from '$lib/utils';
+  import {useFeatures} from '$lib/services/feature-service';
 
   const service = useSyncStatusService();
+  const features = useFeatures();
   let remoteStatus: IProjectSyncStatus | undefined = $state();
   let localStatus: ISyncResult | undefined = $state();
   let server: ILexboxServer | undefined = $state();
@@ -206,7 +208,7 @@
         <div class="content-center text-center">
           <Button
             loading={loadingSyncLexboxToFlex}
-            disabled={loadingSyncLexboxToLocal}
+            disabled={loadingSyncLexboxToLocal || !features.write}
             onclick={syncLexboxToFlex}
             icon="i-mdi-sync"
             iconProps={{ class: 'size-5' }}>


### PR DESCRIPTION
I also considered:
- hiding the outgoing changes, but meh 🤷 
- disabling the crdt sync button, but they're allowed to sync, just not send/author changes