### PR TITLE
create project snapshot from crdt project when missing

### DIFF
--- a/backend/FwLite/FwLiteProjectSync/CrdtFwdataProjectSyncService.cs
+++ b/backend/FwLite/FwLiteProjectSync/CrdtFwdataProjectSyncService.cs
@@ -40,16 +40,21 @@ public class CrdtFwdataProjectSyncService(MiniLcmImport miniLcmImport, ILogger<C
 
         if (!dryRun)
         {
-            await SaveProjectSnapshot(fwdataApi.Project,
-                new ProjectSnapshot(
-                    await fwdataApi.GetAllEntries().ToArrayAsync(),
-                    await fwdataApi.GetPartsOfSpeech().ToArrayAsync(),
-                    await fwdataApi.GetPublications().ToArrayAsync(),
-                    await fwdataApi.GetSemanticDomains().ToArrayAsync(),
-                    await fwdataApi.GetComplexFormTypes().ToArrayAsync(),
-                    await fwdataApi.GetWritingSystems()));
+            await SaveProjectSnapshot(fwdataApi.Project, fwdataApi);
         }
         return result;
+    }
+
+    public async Task SaveProjectSnapshot(FwDataProject project, IMiniLcmApi miniLcmApi)
+    {
+        await SaveProjectSnapshot(project,
+            new ProjectSnapshot(
+                await miniLcmApi.GetAllEntries().ToArrayAsync(),
+                await miniLcmApi.GetPartsOfSpeech().ToArrayAsync(),
+                await miniLcmApi.GetPublications().ToArrayAsync(),
+                await miniLcmApi.GetSemanticDomains().ToArrayAsync(),
+                await miniLcmApi.GetComplexFormTypes().ToArrayAsync(),
+                await miniLcmApi.GetWritingSystems()));
     }
 
     private async Task<SyncResult> Sync(IMiniLcmApi crdtApi, IMiniLcmApi fwdataApi, bool dryRun, int entryCount, ProjectSnapshot? projectSnapshot)

--- a/backend/FwLite/FwLiteProjectSync/CrdtFwdataProjectSyncService.cs
+++ b/backend/FwLite/FwLiteProjectSync/CrdtFwdataProjectSyncService.cs
@@ -144,4 +144,10 @@ public class CrdtFwdataProjectSyncService(MiniLcmImport miniLcmImport, ILogger<C
         var snapshotPath = Path.Combine(projectPath, $"{project.Name}_snapshot.json");
         return snapshotPath;
     }
+
+    public static bool IsSnapshotAvailable(FwDataProject project)
+    {
+        var snapshotPath = SnapshotPath(project);
+        return File.Exists(snapshotPath) && new FileInfo(snapshotPath).Length > 0;
+    }
 }


### PR DESCRIPTION
closes #1735 

Changes FW Headless so that if the previous sync failed to create a snapshot (OOM, restart, or bug) then we will create a snapshot based on what's in the CRDT db. Then when the sync executes it will be able to resume where it left off, instead of trying to import again.