### PR TITLE
make project import resumable

### DIFF
--- a/backend/FwHeadless/Services/SyncHostedService.cs
+++ b/backend/FwHeadless/Services/SyncHostedService.cs
@@ -153,7 +153,12 @@ public class SyncWorker(
 
         var miniLcmApi = await services.OpenCrdtProject(crdtProject);
         var crdtSyncService = services.GetRequiredService<CrdtSyncService>();
-        await crdtSyncService.SyncHarmonyProject();
+
+        // If the last merge was successful, we can sync the Harmony project, otherwise we risk pushing a partial sync
+        if (CrdtFwdataProjectSyncService.HasSyncedSuccessfully(fwDataProject))
+        {
+            await crdtSyncService.SyncHarmonyProject();
+        }
 
         var result = await syncService.Sync(miniLcmApi, fwdataApi);
         logger.LogInformation("Sync result, CrdtChanges: {CrdtChanges}, FwdataChanges: {FwdataChanges}",

--- a/backend/FwLite/FwLiteProjectSync.Tests/FwLiteProjectSync.Tests.csproj
+++ b/backend/FwLite/FwLiteProjectSync.Tests/FwLiteProjectSync.Tests.csproj
@@ -34,6 +34,7 @@
     <ProjectReference Include="..\FwDataMiniLcmBridge.Tests\FwDataMiniLcmBridge.Tests.csproj" />
     <ProjectReference Include="..\FwLiteProjectSync\FwLiteProjectSync.csproj" />
     <ProjectReference Include="..\FwLiteWeb\FwLiteWeb.csproj" />
+    <ProjectReference Include="..\LcmCrdt.Tests\LcmCrdt.Tests.csproj" />
   </ItemGroup>
   <ItemGroup>
     <!-- json files get imported by default in web projects, so exclude those here so they aren't imported again below -->

--- a/backend/FwLite/FwLiteProjectSync.Tests/Import/ResumableTests.cs
+++ b/backend/FwLite/FwLiteProjectSync.Tests/Import/ResumableTests.cs
@@ -26,7 +26,27 @@ public class ResumableTests : IAsyncLifetime
             random
         );
 
-        mockFrom.Setup(f => f.GetWritingSystems()).ReturnsAsync(new WritingSystems());
+        mockFrom.Setup(f => f.GetWritingSystems()).ReturnsAsync(new WritingSystems()
+        {
+            Vernacular = [new()
+            {
+                Id = Guid.NewGuid(),
+                WsId = new() { Code = "en" },
+                Type = WritingSystemType.Vernacular,
+                Name = "English",
+                Abbreviation = "EN",
+                Font = "Arial",
+            }],
+            Analysis = [new()
+            {
+                Id = Guid.NewGuid(),
+                WsId = new() { Code = "en" },
+                Type = WritingSystemType.Analysis,
+                Name = "English",
+                Abbreviation = "EN",
+                Font = "Arial",
+            }]
+        });
         mockFrom.Setup(f => f.GetPartsOfSpeech())
             .Returns(MockAsyncEnumerable(expectedPartsOfSpeech));
         mockFrom.Setup(f => f.GetEntries(It.IsAny<QueryOptions>()))

--- a/backend/FwLite/FwLiteProjectSync.Tests/Import/ResumableTests.cs
+++ b/backend/FwLite/FwLiteProjectSync.Tests/Import/ResumableTests.cs
@@ -1,0 +1,108 @@
+using LcmCrdt.Tests;
+using Microsoft.Extensions.Logging.Abstractions;
+using MiniLcm;
+using MiniLcm.Models;
+using Moq;
+
+namespace FwLiteProjectSync.Tests.Import;
+
+public class ResumableTests : IAsyncLifetime
+{
+    private readonly MiniLcmApiFixture _fixture = new();
+    [Fact]
+    public async Task ImportProject_IsResumable_AcrossRandomFailures()
+    {
+        // Arrange
+        var random = new Random(42); // deterministic!
+        var expectedEntries = Enumerable.Range(1, 10)
+            .Select(i => new Entry() { Id = Guid.NewGuid(), LexemeForm = { ["en"] = $"entry{i}" } }).ToList();
+        var expectedPartsOfSpeech = Enumerable.Range(1, 10)
+            .Select(i => new PartOfSpeech { Id = Guid.NewGuid(), Name = { ["en"] = $"pos{i}" } }).ToList();
+
+        var mockFrom = new Mock<IMiniLcmApi>();
+        IMiniLcmApi mockTo = new UnreliableApi(
+            api: _fixture.Api,
+            random
+        );
+
+        mockFrom.Setup(f => f.GetWritingSystems()).ReturnsAsync(new WritingSystems());
+        mockFrom.Setup(f => f.GetPartsOfSpeech())
+            .Returns(MockAsyncEnumerable(expectedPartsOfSpeech));
+        mockFrom.Setup(f => f.GetEntries(It.IsAny<QueryOptions>()))
+            .Returns(MockAsyncEnumerable(expectedEntries));
+
+        var import = new MiniLcmImport(
+            logger: NullLogger<MiniLcmImport>.Instance,
+            fwDataFactory: null!,
+            crdtProjectsService: null!
+        );
+
+        // Act: retry until all are imported
+        var maxTries = 20;
+        for (var attempt = 0; attempt < maxTries; attempt++)
+        {
+            try
+            {
+                await import.ImportProject(mockTo, mockFrom.Object, expectedEntries.Count);
+            }
+            catch (SimulatedException)
+            {
+                // Suppress, simulate server crash.
+            }
+            if (await mockTo.CountEntries() == expectedEntries.Count) break;
+        }
+
+        var createdEntries = await mockTo.GetAllEntries().ToArrayAsync();
+        var createdPartsOfSpeech = await mockTo.GetPartsOfSpeech().ToArrayAsync();
+
+        // Assert
+        createdPartsOfSpeech.Select(pos => pos.Name["en"]).Should().BeEquivalentTo(expectedPartsOfSpeech.Select(p => p.Name["en"]));
+        createdEntries.Select(e => e.LexemeForm["en"]).Should().BeEquivalentTo(expectedEntries.Select(e => e.LexemeForm["en"]));
+    }
+
+
+
+    internal static void MaybeThrowRandom(Random random, double probability)
+    {
+        if (random.NextDouble() < probability)
+            throw new SimulatedException("Injected random failure!");
+    }
+
+    private class SimulatedException(string message) : Exception(message);
+
+    private static async IAsyncEnumerable<T> MockAsyncEnumerable<T>(IEnumerable<T> items)
+    {
+        foreach (var item in items)
+        {
+            await Task.Delay(1);
+            yield return item;
+        }
+    }
+
+    public async Task InitializeAsync()
+    {
+        await _fixture.InitializeAsync();
+    }
+
+    public async Task DisposeAsync()
+    {
+        await _fixture.DisposeAsync();
+    }
+}
+internal partial class UnreliableApi(IMiniLcmApi api, Random random) : IMiniLcmApi
+{
+
+    [BeaKona.AutoInterface(IncludeBaseInterfaces = true)]
+    private readonly IMiniLcmApi _api = api;
+
+    Task<PartOfSpeech> IMiniLcmWriteApi.CreatePartOfSpeech(PartOfSpeech partOfSpeech)
+    {
+        ResumableTests.MaybeThrowRandom(random, 0.2);
+        return _api.CreatePartOfSpeech(partOfSpeech);
+    }
+    Task<Entry> IMiniLcmWriteApi.CreateEntry(Entry entry)
+    {
+        ResumableTests.MaybeThrowRandom(random, 0.2);
+        return _api.CreateEntry(entry);
+    }
+}

--- a/backend/FwLite/FwLiteProjectSync.Tests/Import/ResumableTests.cs
+++ b/backend/FwLite/FwLiteProjectSync.Tests/Import/ResumableTests.cs
@@ -2,6 +2,7 @@ using LcmCrdt.Tests;
 using Microsoft.Extensions.Logging.Abstractions;
 using MiniLcm;
 using MiniLcm.Models;
+using MiniLcm.SyncHelpers;
 using Moq;
 
 namespace FwLiteProjectSync.Tests.Import;
@@ -30,6 +31,23 @@ public class ResumableTests : IAsyncLifetime
             .Returns(MockAsyncEnumerable(expectedPartsOfSpeech));
         mockFrom.Setup(f => f.GetEntries(It.IsAny<QueryOptions>()))
             .Returns(MockAsyncEnumerable(expectedEntries));
+        mockFrom.Setup(f => f.GetPublications()).Returns(MockAsyncEnumerable([new Publication(){
+                Id = Guid.NewGuid(),
+                Name = { ["en"] = "Test Publication" },
+            }]));
+        mockFrom.Setup(f => f.GetComplexFormTypes())
+            .Returns(MockAsyncEnumerable([new ComplexFormType()
+            {
+                Id = Guid.NewGuid(),
+                Name = new(){ ["en"] = "Test Complex Form Type" }
+            }]));
+        mockFrom.Setup(f => f.GetSemanticDomains())
+            .Returns(MockAsyncEnumerable([new SemanticDomain()
+            {
+                Id = Guid.NewGuid(),
+                Name = new() { ["en"] = "Test Semantic Domain" },
+                Code = "TSD"
+            }]));
 
         var import = new MiniLcmImport(
             logger: NullLogger<MiniLcmImport>.Instance,
@@ -104,5 +122,30 @@ internal partial class UnreliableApi(IMiniLcmApi api, Random random) : IMiniLcmA
     {
         ResumableTests.MaybeThrowRandom(random, 0.2);
         return _api.CreateEntry(entry);
+    }
+    Task<ComplexFormComponent> IMiniLcmWriteApi.CreateComplexFormComponent(ComplexFormComponent complexFormComponent, BetweenPosition<ComplexFormComponent>? position)
+    {
+        ResumableTests.MaybeThrowRandom(random, 0.2);
+        return _api.CreateComplexFormComponent(complexFormComponent, position);
+    }
+    Task<ComplexFormType> IMiniLcmWriteApi.CreateComplexFormType(ComplexFormType complexFormType)
+    {
+        ResumableTests.MaybeThrowRandom(random, 0.2);
+        return _api.CreateComplexFormType(complexFormType);
+    }
+    Task<SemanticDomain> IMiniLcmWriteApi.CreateSemanticDomain(SemanticDomain semanticDomain)
+    {
+        ResumableTests.MaybeThrowRandom(random, 0.2);
+        return _api.CreateSemanticDomain(semanticDomain);
+    }
+    Task<Publication> IMiniLcmWriteApi.CreatePublication(Publication publication)
+    {
+        ResumableTests.MaybeThrowRandom(random, 0.2);
+        return _api.CreatePublication(publication);
+    }
+    Task<WritingSystem> IMiniLcmWriteApi.CreateWritingSystem(WritingSystem writingSystems)
+    {
+        ResumableTests.MaybeThrowRandom(random, 0.2);
+        return _api.CreateWritingSystem(writingSystems);
     }
 }

--- a/backend/FwLite/FwLiteProjectSync/CrdtFwdataProjectSyncService.cs
+++ b/backend/FwLite/FwLiteProjectSync/CrdtFwdataProjectSyncService.cs
@@ -23,7 +23,7 @@ public class CrdtFwdataProjectSyncService(MiniLcmImport miniLcmImport, ILogger<C
 
     public async Task<DryRunSyncResult> SyncDryRun(IMiniLcmApi crdtApi, FwDataMiniLcmApi fwdataApi)
     {
-        return (DryRunSyncResult) await Sync(crdtApi, fwdataApi, true);
+        return (DryRunSyncResult)await Sync(crdtApi, fwdataApi, true);
     }
 
     public async Task<SyncResult> Sync(IMiniLcmApi crdtApi, FwDataMiniLcmApi fwdataApi, bool dryRun = false)
@@ -143,5 +143,12 @@ public class CrdtFwdataProjectSyncService(MiniLcmImport miniLcmImport, ILogger<C
         var projectPath = project.ProjectsPath;
         var snapshotPath = Path.Combine(projectPath, $"{project.Name}_snapshot.json");
         return snapshotPath;
+    }
+
+    public static bool HasSyncedSuccessfully(FwDataProject project)
+    {
+        var snapshotPath = SnapshotPath(project);
+        if (!File.Exists(snapshotPath)) return false;
+        return new FileInfo(snapshotPath).Length > 0;
     }
 }

--- a/backend/FwLite/FwLiteProjectSync/Import/ResumableImportApi.cs
+++ b/backend/FwLite/FwLiteProjectSync/Import/ResumableImportApi.cs
@@ -1,0 +1,69 @@
+using System.Runtime.CompilerServices;
+using MiniLcm;
+using MiniLcm.Models;
+
+namespace FwLiteProjectSync.Import;
+
+public partial class ResumableImportApi(IMiniLcmApi api) : IMiniLcmApi
+{
+    [BeaKona.AutoInterface(IncludeBaseInterfaces = true)]
+    private readonly IMiniLcmApi _api = api;
+    private readonly Dictionary<string, Dictionary<Guid, object>> _createdObjects = new();
+    private async ValueTask<T> HasCreated<T>(T value, IAsyncEnumerable<T> values, Func<Task<T>> create, [CallerMemberName] string typeName = "")
+        where T : class, IObjectWithId
+    {
+        if (!_createdObjects.TryGetValue(typeName, out var created))
+        {
+            created = await values.ToDictionaryAsync(v => v.Id, v => (object)v);
+            _createdObjects[typeName] = created;
+        }
+        if (created.TryGetValue(value.Id, out var existing))
+        {
+            return (T)existing;
+        }
+        var createdValue = await create();
+        created[value.Id] = createdValue;
+        return createdValue;
+    }
+
+    // ********** Overrides go here **********
+
+    async Task<Entry> IMiniLcmWriteApi.CreateEntry(Entry entry)
+    {
+        return await HasCreated(entry, _api.GetAllEntries(), () => _api.CreateEntry(entry));
+    }
+
+    async Task<PartOfSpeech> IMiniLcmWriteApi.CreatePartOfSpeech(PartOfSpeech partOfSpeech)
+    {
+        return await HasCreated(partOfSpeech, _api.GetPartsOfSpeech(), () => _api.CreatePartOfSpeech(partOfSpeech));
+    }
+    async Task<ComplexFormType> IMiniLcmWriteApi.CreateComplexFormType(ComplexFormType complexFormType)
+    {
+        return await HasCreated(complexFormType, _api.GetComplexFormTypes(), () => _api.CreateComplexFormType(complexFormType));
+    }
+    async Task<SemanticDomain> IMiniLcmWriteApi.CreateSemanticDomain(SemanticDomain semanticDomain)
+    {
+        return await HasCreated(semanticDomain, _api.GetSemanticDomains(), () => _api.CreateSemanticDomain(semanticDomain));
+    }
+    async Task<Publication> IMiniLcmWriteApi.CreatePublication(Publication publication)
+    {
+        return await HasCreated(publication, _api.GetPublications(), () => _api.CreatePublication(publication));
+    }
+    async Task<WritingSystem> IMiniLcmWriteApi.CreateWritingSystem(WritingSystem writingSystem)
+    {
+        return await HasCreated(writingSystem, AsyncWs(), () => _api.CreateWritingSystem(writingSystem));
+    }
+
+    async IAsyncEnumerable<WritingSystem> AsyncWs()
+    {
+        var wss = await _api.GetWritingSystems();
+        foreach (var ws in wss.Analysis)
+        {
+            yield return ws;
+        }
+        foreach (var ws in wss.Vernacular)
+        {
+            yield return ws;
+        }
+    }
+}

--- a/backend/FwLite/FwLiteProjectSync/MiniLcmImport.cs
+++ b/backend/FwLite/FwLiteProjectSync/MiniLcmImport.cs
@@ -73,10 +73,10 @@ public class MiniLcmImport(
 
         var semanticDomains = importFrom.GetSemanticDomains();
         var entries = importFrom.GetAllEntries();
-        if (importTo is CrdtMiniLcmApi crdtLexboxApi)
+        if (importTo is IMiniLcmBulkImportApi crdtLexboxApi)
         {
             logger.LogInformation("Importing semantic domains");
-            await crdtLexboxApi.BulkImportSemanticDomains(semanticDomains.ToBlockingEnumerable());
+            await crdtLexboxApi.BulkImportSemanticDomains(semanticDomains);
             logger.LogInformation("Importing {Count} entries", entryCount);
             await crdtLexboxApi.BulkCreateEntries(entries);
         }

--- a/backend/FwLite/FwLiteProjectSync/MiniLcmImport.cs
+++ b/backend/FwLite/FwLiteProjectSync/MiniLcmImport.cs
@@ -1,5 +1,6 @@
 using System.Diagnostics;
 using FwDataMiniLcmBridge;
+using FwLiteProjectSync.Import;
 using Humanizer;
 using LcmCrdt;
 using Microsoft.Extensions.DependencyInjection;
@@ -48,6 +49,7 @@ public class MiniLcmImport(
     public async Task ImportProject(IMiniLcmApi importTo, IMiniLcmApi importFrom, int entryCount)
     {
         using var activity = FwLiteProjectSyncActivitySource.Value.StartActivity();
+        importTo = new ResumableImportApi(importTo);
         await ImportWritingSystems(importTo, importFrom);
 
         await foreach (var partOfSpeech in importFrom.GetPartsOfSpeech())

--- a/backend/FwLite/LcmCrdt/CrdtMiniLcmApi.cs
+++ b/backend/FwLite/LcmCrdt/CrdtMiniLcmApi.cs
@@ -29,7 +29,7 @@ public class CrdtMiniLcmApi(
     IMiniLcmCultureProvider cultureProvider,
     MiniLcmValidators validators,
     LcmCrdtDbContext dbContext,
-    IOptions<LcmCrdtConfig> config) : IMiniLcmApi
+    IOptions<LcmCrdtConfig> config) : IMiniLcmApi, IMiniLcmBulkImportApi
 {
     private Guid ClientId { get; } = projectService.ProjectData.ClientId;
     public ProjectData ProjectData => projectService.ProjectData;
@@ -265,12 +265,12 @@ public class CrdtMiniLcmApi(
 
     public async Task DeleteSemanticDomain(Guid id)
     {
-        await AddChange( new DeleteChange<SemanticDomain>(id));
+        await AddChange(new DeleteChange<SemanticDomain>(id));
     }
 
-    public async Task BulkImportSemanticDomains(IEnumerable<MiniLcm.Models.SemanticDomain> semanticDomains)
+    public async Task BulkImportSemanticDomains(IAsyncEnumerable<SemanticDomain> semanticDomains)
     {
-        await AddChanges(semanticDomains.Select(sd => new CreateSemanticDomainChange(sd.Id, sd.Name, sd.Code, sd.Predefined)));
+        await AddChanges(await semanticDomains.Select(sd => new CreateSemanticDomainChange(sd.Id, sd.Name, sd.Code, sd.Predefined)).ToArrayAsync());
     }
 
     public IAsyncEnumerable<ComplexFormType> GetComplexFormTypes()

--- a/backend/FwLite/MiniLcm/IMiniLcmWriteApi.cs
+++ b/backend/FwLite/MiniLcm/IMiniLcmWriteApi.cs
@@ -105,6 +105,21 @@ public interface IMiniLcmSaveApi
     void Save();
 }
 
+public interface IMiniLcmBulkImportApi : IMiniLcmWriteApi
+{
+    /// <summary>
+    /// Imports the provided semantic domains in bulk.
+    /// </summary>
+    /// <param name="semanticDomains">The semantic domains to import.</param>
+    Task BulkImportSemanticDomains(IAsyncEnumerable<SemanticDomain> semanticDomains);
+
+    /// <summary>
+    /// Imports the provided entries in bulk.
+    /// </summary>
+    /// <param name="entries">The entries to import.</param>
+    Task BulkCreateEntries(IAsyncEnumerable<Entry> entries);
+}
+
 /// <summary>
 /// wrapper around JsonPatchDocument that allows for fluent updates
 /// </summary>


### PR DESCRIPTION
makes the project import process handle resuming after a failure. It does this by introducing `ResumableImportApi` which will check to see if the thing it's being requested to create has already been created, if it has then it's a no-op.

Also introduced a new interface `IMiniLcmBulkImportApi` which does exactly what you think.

Finally, I skip running a harmony sync if the last merge didn't succeed (indicated by the snapshot not existing)