### PR TITLE
Tell browsers not to spellcheck HTML input fields

### DIFF
--- a/frontend/viewer/src/lib/components/lcm-rich-text-editor/lcm-rich-text-editor.svelte
+++ b/frontend/viewer/src/lib/components/lcm-rich-text-editor/lcm-rich-text-editor.svelte
@@ -107,6 +107,7 @@
         ...(ariaLabelledby ? {'aria-labelledby': ariaLabelledby} : {}),
         ...(ariaLabel ? {'aria-label': ariaLabel} : {}),
         role: 'textbox',
+        spellcheck: 'false',
       },
       editable() {
         return !readonly;

--- a/frontend/viewer/src/lib/components/ui/input/input.svelte
+++ b/frontend/viewer/src/lib/components/ui/input/input.svelte
@@ -60,6 +60,7 @@
     class={cn(inputVariants({ variant }), className)}
     {type}
     bind:value
+    spellcheck="false"
     {...restProps}
   />
 {/if}


### PR DESCRIPTION
Fixes #1761.

We could do this on each individual field editor that uses the `Input` component, if we wanted to ever have spellcheck turned on for any fields. But since I think we want to turn spellcheck off globally, let's just do it on the `Input` component itself and have that apply everywhere the component is used.