### PR TITLE
Display beta requester's email

### DIFF
--- a/frontend/src/lib/email/JoinFwLiteBetaRequest.svelte
+++ b/frontend/src/lib/email/JoinFwLiteBetaRequest.svelte
@@ -9,6 +9,6 @@
 </script>
 
 <Email subject={$t('emails.join_fw_lite_beta_request_email.subject', { name })}>
-  <mj-text>{$t('emails.join_fw_lite_beta_request_email.body', { name })}</mj-text>
+  <mj-text>{$t('emails.join_fw_lite_beta_request_email.body', { name, email })}</mj-text>
   <mj-button href={approveUrl}>{$t('emails.join_fw_lite_beta_request_email.approve_button')}</mj-button>
 </Email>

--- a/frontend/src/lib/i18n/locales/en.json
+++ b/frontend/src/lib/i18n/locales/en.json
@@ -752,7 +752,7 @@ Click the button below to request to join the early access program. It may take 
     },
     "join_fw_lite_beta_request_email": {
       "subject": "FW Lite Beta join request: {name}",
-      "body": "User {name} requested to join the FW Lite beta. Click below to approve this request.",
+      "body": "User {name} ({email}) requested to join the FW Lite beta. Click below to approve this request.",
       "approve_button": "Approve Request"
     },
     "user_added": {


### PR DESCRIPTION
Resolves #1771

I realize now that the email was encoded in the Approval link (oops), but this is still nice.

![image](https://github.com/user-attachments/assets/d8512b77-b8b0-48e6-9245-2bbbba4e48cc)
