### PR TITLE
Roll over log files based on file size

### DIFF
--- a/backend/FwLite/FwLiteMaui/FwLiteMauiConfig.cs
+++ b/backend/FwLite/FwLiteMaui/FwLiteMauiConfig.cs
@@ -20,6 +20,10 @@ public class FwLiteMauiConfig
         set => field = Path.GetFullPath(value);
     }
 
+    public int MaxLogFileSize = 50 * 1024 * 1024;
+    public int MaxLogFileCount = 2;
+
     public string AppLogFilePath => Path.Combine(BaseDataDir, "app.log");
+    public string AppLogAlternateFilePath => Path.Combine(BaseDataDir, "app1.log");
     public string AuthCacheFilePath => Path.Combine(BaseDataDir, "msal.cache");
 }

--- a/backend/FwLite/FwLiteMaui/FwLiteMauiKernel.cs
+++ b/backend/FwLite/FwLiteMaui/FwLiteMauiKernel.cs
@@ -115,7 +115,12 @@ public static class FwLiteMauiKernel
             config.LocalResourceCachePath = Path.Combine(baseDataPath, "localResourcesCache");
         });
 
-        logging.AddFile(fwLiteMauiConfig.AppLogFilePath);
+        logging.AddFile(fwLiteMauiConfig.AppLogFilePath, options =>
+        {
+            options.RollingFilesConvention = FileLoggerOptions.FileRollingConvention.Descending;
+            options.FileSizeLimitBytes = fwLiteMauiConfig.MaxLogFileSize;
+            options.MaxRollingFiles = fwLiteMauiConfig.MaxLogFileCount;
+        });
         services.AddSingleton<IPreferences>(Preferences.Default);
         services.AddSingleton<IVersionTracking>(VersionTracking.Default);
         services.AddSingleton<IConnectivity>(Connectivity.Current);

--- a/backend/FwLite/FwLiteMaui/Services/MauiTroubleshootingService.cs
+++ b/backend/FwLite/FwLiteMaui/Services/MauiTroubleshootingService.cs
@@ -43,6 +43,18 @@ public class MauiTroubleshootingService(IOptions<FwLiteMauiConfig> config, ILogg
     [JSInvokable]
     public async Task ShareLogFile()
     {
-        await _share.RequestAsync(new ShareFileRequest("FieldWorks Lite logs", new ShareFile(Config.AppLogFilePath, "text/plain")));
+        if (File.Exists(Config.AppLogAlternateFilePath))
+        {
+            var mainLogFile = new ShareFile(Config.AppLogFilePath, "text/plain");
+            var secondLogFile = new ShareFile(Config.AppLogAlternateFilePath, "text/plain");
+            var shareRequest = new ShareMultipleFilesRequest("FieldWorks Lite logs", [mainLogFile, secondLogFile]);
+            await _share.RequestAsync(shareRequest);
+        }
+        else
+        {
+            var shareRequest =
+                new ShareFileRequest("FieldWorks Lite logs", new ShareFile(Config.AppLogFilePath, "text/plain"));
+            await _share.RequestAsync(shareRequest);
+        }
     }
 }


### PR DESCRIPTION
Fixes #1748.

File size and max log count can be set in configuration, default to max of 2 files of 50 megabytes each so that if config not set we don't end up using up too much space for logs.

Also set up sharing log files so that if the logs have rolled over at least once, it will grab the latest *and* previous log files to share, so that we don't end up in a situation where the log rollover just happened and we shared a log file with only 5 lines in it.