### PR TITLE
Set username on hg and Harmony commits

### DIFF
--- a/backend/FwHeadless/Services/SendReceiveHelpers.cs
+++ b/backend/FwHeadless/Services/SendReceiveHelpers.cs
@@ -100,7 +100,7 @@ public static class SendReceiveHelpers
             { "languageDepotRepoName", "LexBox" },
             { "languageDepotRepoUri", repoUrl.AbsoluteUri },
             { "deleteRepoIfNoSuchBranch", "false" },
-            { "user", "Fieldworks Lite" }, // Not necessary if username was set at clone time, but why not
+            { "user", "FieldWorks Lite" }, // Not necessary if username was set at clone time, but why not
         };
         if (commitMessage is not null) flexBridgeOptions["commitMessage"] = commitMessage;
         return await CallLfMergeBridge("Language_Forge_Send_Receive", flexBridgeOptions, progress);

--- a/backend/FwHeadless/Services/SendReceiveHelpers.cs
+++ b/backend/FwHeadless/Services/SendReceiveHelpers.cs
@@ -100,7 +100,7 @@ public static class SendReceiveHelpers
             { "languageDepotRepoName", "LexBox" },
             { "languageDepotRepoUri", repoUrl.AbsoluteUri },
             { "deleteRepoIfNoSuchBranch", "false" },
-            { "user", "LexBox" },
+            { "user", "Fieldworks Lite" }, // Not necessary if username was set at clone time, but why not
         };
         if (commitMessage is not null) flexBridgeOptions["commitMessage"] = commitMessage;
         return await CallLfMergeBridge("Language_Forge_Send_Receive", flexBridgeOptions, progress);
@@ -123,6 +123,7 @@ public static class SendReceiveHelpers
             { "languageDepotRepoName", "LexBox" },
             { "languageDepotRepoUri", repoUrl.ToString() },
             { "deleteRepoIfNoSuchBranch", "false" },
+            { "user", "FieldWorks Lite" }
         };
         return await CallLfMergeBridge("Language_Forge_Clone", flexBridgeOptions, progress);
     }

--- a/backend/FwHeadless/appsettings.json
+++ b/backend/FwHeadless/appsettings.json
@@ -9,6 +9,9 @@
       "SendReceive": "Information"
     }
   },
+  "LcmCrdt": {
+    "DefaultAuthorForCommits": "FieldWorks"
+  },
   "AllowedHosts": "*",
   "OTEL_SERVICE_NAME": "fw-headless"
 }

--- a/backend/FwLite/FwLiteShared/Sync/SyncService.cs
+++ b/backend/FwLite/FwLiteShared/Sync/SyncService.cs
@@ -66,7 +66,7 @@ public class SyncService(
             return new SyncResults([], [], false);
         }
         var currentUser = await oAuthClient.GetCurrentUser();
-        await currentProjectService.UpdateLastUser(currentUser?.Name ?? "FieldWorks", currentUser?.Id);
+        await currentProjectService.UpdateLastUser(currentUser?.Name, currentUser?.Id);
 
         var remoteModel = await remoteSyncServiceServer.CreateProjectSyncable(project, httpClient);
         if (!await remoteModel.ShouldSync())

--- a/backend/FwLite/FwLiteShared/Sync/SyncService.cs
+++ b/backend/FwLite/FwLiteShared/Sync/SyncService.cs
@@ -66,7 +66,7 @@ public class SyncService(
             return new SyncResults([], [], false);
         }
         var currentUser = await oAuthClient.GetCurrentUser();
-        await currentProjectService.UpdateLastUser(currentUser?.Name, currentUser?.Id);
+        await currentProjectService.UpdateLastUser(currentUser?.Name ?? "FieldWorks", currentUser?.Id);
 
         var remoteModel = await remoteSyncServiceServer.CreateProjectSyncable(project, httpClient);
         if (!await remoteModel.ShouldSync())

--- a/backend/FwLite/LcmCrdt/CrdtMiniLcmApi.cs
+++ b/backend/FwLite/LcmCrdt/CrdtMiniLcmApi.cs
@@ -51,7 +51,7 @@ public class CrdtMiniLcmApi(
         {
             ClientVersion = AppVersion.Version,
             //todo, if a user logs out and in with another account, this will be out of date until the next sync
-            AuthorName = ProjectData.LastUserName,
+            AuthorName = ProjectData.LastUserName ?? config.Value.DefaultAuthorForCommits,
             AuthorId = ProjectData.LastUserId
         };
         return metadata;

--- a/backend/FwLite/LcmCrdt/LcmCrdtConfig.cs
+++ b/backend/FwLite/LcmCrdt/LcmCrdtConfig.cs
@@ -6,6 +6,6 @@ namespace LcmCrdt;
 public class LcmCrdtConfig
 {
     public string ProjectPath { get; set; } = Path.GetFullPath(".");
-    public string DefaultAuthorForCommits { get; set; } = "FieldWorks";
+    public string? DefaultAuthorForCommits { get; set; } = null;
     public GridifyMapper<Entry> Mapper { get; set; } = EntryFilter.NewMapper(new EntryFilterMapProvider());
 }

--- a/backend/FwLite/LcmCrdt/LcmCrdtConfig.cs
+++ b/backend/FwLite/LcmCrdt/LcmCrdtConfig.cs
@@ -6,5 +6,6 @@ namespace LcmCrdt;
 public class LcmCrdtConfig
 {
     public string ProjectPath { get; set; } = Path.GetFullPath(".");
+    public string DefaultAuthorForCommits { get; set; } = "FieldWorks";
     public GridifyMapper<Entry> Mapper { get; set; } = EntryFilter.NewMapper(new EntryFilterMapProvider());
 }


### PR DESCRIPTION
Fixes #1706.

Set username on hg commits to "FieldWorks Lite". Set it on Harmony commits to "FieldWorks" if user's name is not available from the OAuth token.