### PR TITLE
Fix feedback link in drawer

### DIFF
--- a/frontend/viewer/src/home/HomeView.svelte
+++ b/frontend/viewer/src/home/HomeView.svelte
@@ -122,7 +122,7 @@
     <ResponsiveMenu.Root>
       <ResponsiveMenu.Trigger />
       <ResponsiveMenu.Content>
-        <ResponsiveMenu.Item href={fwLiteConfig.feedbackUrl} icon="i-mdi-chat-question">
+        <ResponsiveMenu.Item href={fwLiteConfig.feedbackUrl} target="_blank" icon="i-mdi-chat-question">
           {$t`Feedback`}
         </ResponsiveMenu.Item>
         {#if supportsTroubleshooting}

--- a/frontend/viewer/src/lib/components/responsive-menu/responsive-menu-item.svelte
+++ b/frontend/viewer/src/lib/components/responsive-menu/responsive-menu-item.svelte
@@ -11,12 +11,14 @@
   import type {DrawerCloseProps} from 'vaul-svelte';
   import {cn} from '$lib/utils';
   import {DrawerClose} from '../ui/drawer';
+  import type {HTMLAnchorAttributes} from 'svelte/elements';
 
   type Props = {
     children?: Snippet;
     icon?: IconClass;
     onSelect?: () => void;
     href?: string;
+    target?: HTMLAnchorAttributes['target'];
   } & Omit<ContextMenuItemProps & DrawerCloseProps, 'onclick'>;
 
   let {
@@ -58,6 +60,7 @@
   <DrawerClose
     class={cn(buttonVariants({ variant: 'ghost', class: 'w-full justify-start gap-2' }), className)}
     onclick={onSelect}
+    child={rest.href ? anchorChild : undefined}
     {...rest}
     bind:ref>
     {@render content()}


### PR DESCRIPTION
I'm not entirely sure why, but this prevents DrawerClose's onclick handling from preventing opening the link.
We also **want** it to open in a new tab 👍 