### PR TITLE
Allow overriding LinkedFiles subfolder via form

### DIFF
--- a/backend/FwHeadless/Controllers/MediaFileController.cs
+++ b/backend/FwHeadless/Controllers/MediaFileController.cs
@@ -156,8 +156,7 @@ public static class MediaFileController
         var responseBody = new PostFileResult(mediaFile.Id);
         if (newFile)
         {
-            // TODO: Put "/api/media" into a constant so if it changes in MediaFileRoutes it will change here as well
-            var newLocation = $"/api/media/{fileId}";
+            var newLocation = $"{Routes.MediaFileRoutes.RootRoute}/{fileId}";
             return TypedResults.Created(newLocation, responseBody);
         }
         else

--- a/backend/FwHeadless/Controllers/MediaFileController.cs
+++ b/backend/FwHeadless/Controllers/MediaFileController.cs
@@ -343,11 +343,11 @@ public static class MediaFileController
         var project = await lexBoxDb.Projects.FindAsync(projectId);
         if (project is null) throw new NotFoundException();
         var projectFolder = config.Value.GetFwDataProject(project.Code, projectId).ProjectFolder;
-        await WriteFileAndUpdateMediaFileMetadata(lexBoxDb, mediaFile, projectFolder, subfolderOverride, file, config.Value.MaxUploadFileSizeBytes);
+        await WriteFileAndUpdateMediaFileMetadata(lexBoxDb, mediaFile, projectFolder, file, config.Value.MaxUploadFileSizeBytes);
         return (mediaFile, newFile);
     }
 
-    private static async Task WriteFileAndUpdateMediaFileMetadata(LexBoxDbContext lexBoxDb, MediaFile mediaFile, string projectFolder, string? subfolderOverride, IFormFile file, long maxUploadSize)
+    private static async Task WriteFileAndUpdateMediaFileMetadata(LexBoxDbContext lexBoxDb, MediaFile mediaFile, string projectFolder, IFormFile file, long maxUploadSize)
     {
         if (!Directory.Exists(projectFolder))
         {

--- a/backend/FwHeadless/Controllers/MediaFileController.cs
+++ b/backend/FwHeadless/Controllers/MediaFileController.cs
@@ -87,12 +87,12 @@ public static class MediaFileController
         [FromForm] string? filename,
         [FromForm] IFormFile file,
         [FromForm] FileMetadata? metadata,
-        [FromForm] string? LinkedFilesSubfolderOverride,
+        [FromForm] string? linkedFilesSubfolderOverride,
         HttpContext httpContext,
         IOptions<FwHeadlessConfig> config,
         LexBoxDbContext lexBoxDb)
     {
-        var result = await HandleFileUpload(fileId, projectId, filename, file, metadata, LinkedFilesSubfolderOverride, httpContext, config, lexBoxDb, newFilesAllowed: false);
+        var result = await HandleFileUpload(fileId, projectId, filename, file, metadata, linkedFilesSubfolderOverride, httpContext, config, lexBoxDb, newFilesAllowed: false);
         return result;
     }
 
@@ -103,12 +103,12 @@ public static class MediaFileController
         [FromForm] string? filename,
         [FromForm] IFormFile file,
         [FromForm] FileMetadata? metadata,
-        [FromForm] string? LinkedFilesSubfolderOverride,
+        [FromForm] string? linkedFilesSubfolderOverride,
         HttpContext httpContext,
         IOptions<FwHeadlessConfig> config,
         LexBoxDbContext lexBoxDb)
     {
-        var result = await HandleFileUpload(fileId, projectId, filename, file, metadata, LinkedFilesSubfolderOverride, httpContext, config, lexBoxDb, newFilesAllowed: true);
+        var result = await HandleFileUpload(fileId, projectId, filename, file, metadata, linkedFilesSubfolderOverride, httpContext, config, lexBoxDb, newFilesAllowed: true);
         return result;
     }
 
@@ -118,7 +118,7 @@ public static class MediaFileController
         string? filename,
         IFormFile file,
         FileMetadata? metadata,
-        string? LinkedFilesSubfolderOverride,
+        string? linkedFilesSubfolderOverride,
         HttpContext httpContext,
         IOptions<FwHeadlessConfig> config,
         LexBoxDbContext lexBoxDb,
@@ -135,7 +135,7 @@ public static class MediaFileController
                 filename,
                 file,
                 metadata,
-                LinkedFilesSubfolderOverride,
+                linkedFilesSubfolderOverride,
                 newFilesAllowed,
                 httpContext,
                 config);

--- a/backend/FwHeadless/Controllers/MediaFileController.cs
+++ b/backend/FwHeadless/Controllers/MediaFileController.cs
@@ -29,7 +29,7 @@ public static class MediaFileController
             // This will also fail for any requests with ".." in the name of a directory, but that's an acceptable loss
             return TypedResults.BadRequest();
         }
-        var path = Path.Join(projectFolder, relativePath); // Do NOT use Path.Combine here
+        var path = Path.Join(projectFolder, "LinkedFiles", relativePath); // Do NOT use Path.Combine here
         var files =
             Directory.EnumerateFiles(path, "*", new EnumerationOptions() { RecurseSubdirectories = true })
                 .Select(file => Path.GetRelativePath(path, file))

--- a/backend/FwHeadless/Controllers/MediaFileController.cs
+++ b/backend/FwHeadless/Controllers/MediaFileController.cs
@@ -388,6 +388,8 @@ public static class MediaFileController
         if (mimeType.StartsWith("image/")) return "Pictures";
         if (mimeType.StartsWith("audio/")) return "AudioVisual";
         if (mimeType.StartsWith("video/")) return "AudioVisual";
+        // Special cases
+        if (mimeType == "application/mp4") return "AudioVisual"; // Some apps don't want to commit to audio/ or video/, but we don't care which it is
         return null;
     }
 

--- a/backend/FwHeadless/Controllers/MediaFileController.cs
+++ b/backend/FwHeadless/Controllers/MediaFileController.cs
@@ -13,6 +13,8 @@ namespace FwHeadless.Controllers;
 
 public static class MediaFileController
 {
+    public const string LinkedFiles = "LinkedFiles";
+
     public static async Task<Results<Ok<FileListing>, NotFound, BadRequest>> ListFiles(
         Guid projectId,
         IOptions<FwHeadlessConfig> config,
@@ -29,7 +31,7 @@ public static class MediaFileController
             // This will also fail for any requests with ".." in the name of a directory, but that's an acceptable loss
             return TypedResults.BadRequest();
         }
-        var path = Path.Join(projectFolder, "LinkedFiles", relativePath); // Do NOT use Path.Combine here
+        var path = Path.Join(projectFolder, LinkedFiles, relativePath); // Do NOT use Path.Combine here
         var files =
             Directory.EnumerateFiles(path, "*", new EnumerationOptions() { RecurseSubdirectories = true })
                 .Select(file => Path.GetRelativePath(path, file))
@@ -322,7 +324,7 @@ public static class MediaFileController
             mediaFile = new MediaFile()
             {
                 Id = fileId.Value,
-                Filename = Path.Join("LinkedFiles", subfolder, fileId.ToString(), filename),
+                Filename = Path.Join(LinkedFiles, subfolder, fileId.ToString(), filename),
                 ProjectId = projectId,
                 Metadata = metadata,
             };
@@ -334,7 +336,7 @@ public static class MediaFileController
             {
                 throw new UploadedFilesCannotBeMovedToNewProjects();
             }
-            if (subfolderOverride is not null && !mediaFile.Filename.StartsWith(Path.Join("LinkedFiles", subfolderOverride)))
+            if (subfolderOverride is not null && !mediaFile.Filename.StartsWith(Path.Join(LinkedFiles, subfolderOverride)))
             {
                 throw new UploadedFilesCannotBeMovedToDifferentLinkedFilesSubfolders();
             }

--- a/backend/FwHeadless/Controllers/MediaFileController.cs
+++ b/backend/FwHeadless/Controllers/MediaFileController.cs
@@ -192,7 +192,9 @@ public static class MediaFileController
         string tempFile = "";
         try
         {
-            tempFile = Path.Join(Path.GetDirectoryName(filePath), Path.GetRandomFileName());
+            var dirName = Path.GetDirectoryName(filePath);
+            if (dirName is not null) Directory.CreateDirectory(dirName);
+            tempFile = Path.Join(dirName, Path.GetRandomFileName());
             await using (var writeStream = File.Open(tempFile, FileMode.CreateNew, FileAccess.Write, FileShare.ReadWrite))
             {
                 await contents.CopyToAsync(writeStream);
@@ -355,7 +357,6 @@ public static class MediaFileController
         }
 
         var filePath = Path.Join(projectFolder, mediaFile.Filename);
-        Directory.CreateDirectory(Path.GetDirectoryName(filePath) ?? "");
         if (mediaFile.Metadata is not null) mediaFile.Metadata.SizeInBytes = (int)file.Length;
         long writtenLength = 0;
         await using (var readStream = file.OpenReadStream())

--- a/backend/FwHeadless/Models/MediaFileModels.cs
+++ b/backend/FwHeadless/Models/MediaFileModels.cs
@@ -8,6 +8,7 @@ public record PostFileResult(Guid guid);
 public enum FileUploadErrorMessage
 {
     UploadedFilesCannotBeMovedToNewProjects,
+    UploadedFilesCannotBeMovedToDifferentLinkedFilesSubfolders,
     ProjectFolderNotFoundInFwHeadless,
 }
 

--- a/backend/FwHeadless/Routes/MediaFileRoutes.cs
+++ b/backend/FwHeadless/Routes/MediaFileRoutes.cs
@@ -4,9 +4,10 @@ namespace FwHeadless.Routes;
 
 public static class MediaFileRoutes
 {
+    public const string RootRoute = "/api/media";
     public static IEndpointConventionBuilder MapMediaFileRoutes(this WebApplication app)
     {
-        var group = app.MapGroup("/api/media").WithOpenApi();
+        var group = app.MapGroup(RootRoute).WithOpenApi();
         group.MapGet("/list/{projectId:guid}", MediaFileController.ListFiles);
         group.MapGet("/metadata/{fileId:guid}", MediaFileMetadataController.GetFileMetadata);
         group.MapGet("/{fileId:guid}", MediaFileController.GetFile);

--- a/backend/LexCore/Entities/MediaFile.cs
+++ b/backend/LexCore/Entities/MediaFile.cs
@@ -37,6 +37,7 @@ public class FileMetadata
     public int? SizeInBytes { get; set; }
     public string? FileFormat { get; set; }
     public string? MimeType { get; set; }
+    public string? LinkedFilesSubfolder { get; set; }
     public string? Author { get; set; }
     public DateTimeOffset? UploadDate { get; set; }
     public MediaFileLicense? License { get; set; }
@@ -51,6 +52,7 @@ public class FileMetadata
         if (other.SizeInBytes is not null && other.SizeInBytes.Value > 0) this.SizeInBytes = other.SizeInBytes;
         if (!string.IsNullOrEmpty(other.FileFormat)) this.FileFormat = other.FileFormat;
         if (!string.IsNullOrEmpty(other.MimeType)) this.MimeType = other.MimeType;
+        if (!string.IsNullOrEmpty(other.LinkedFilesSubfolder)) this.LinkedFilesSubfolder = other.LinkedFilesSubfolder;
         if (!string.IsNullOrEmpty(other.Author)) this.Author = other.Author;
         if (other.UploadDate is not null) this.UploadDate = other.UploadDate;
         if (other.License is not null) this.License = other.License;

--- a/backend/LexCore/Entities/MediaFile.cs
+++ b/backend/LexCore/Entities/MediaFile.cs
@@ -37,7 +37,6 @@ public class FileMetadata
     public int? SizeInBytes { get; set; }
     public string? FileFormat { get; set; }
     public string? MimeType { get; set; }
-    public string? LinkedFilesSubfolder { get; set; }
     public string? Author { get; set; }
     public DateTimeOffset? UploadDate { get; set; }
     public MediaFileLicense? License { get; set; }
@@ -52,7 +51,6 @@ public class FileMetadata
         if (other.SizeInBytes is not null && other.SizeInBytes.Value > 0) this.SizeInBytes = other.SizeInBytes;
         if (!string.IsNullOrEmpty(other.FileFormat)) this.FileFormat = other.FileFormat;
         if (!string.IsNullOrEmpty(other.MimeType)) this.MimeType = other.MimeType;
-        if (!string.IsNullOrEmpty(other.LinkedFilesSubfolder)) this.LinkedFilesSubfolder = other.LinkedFilesSubfolder;
         if (!string.IsNullOrEmpty(other.Author)) this.Author = other.Author;
         if (other.UploadDate is not null) this.UploadDate = other.UploadDate;
         if (other.License is not null) this.License = other.License;

--- a/backend/Testing/FwHeadless/MediaFileTestFixture.cs
+++ b/backend/Testing/FwHeadless/MediaFileTestFixture.cs
@@ -60,7 +60,7 @@ public class MediaFileTestFixture : ApiTestBase, IAsyncLifetime
         return (await result.Content.ReadFromJsonAsync<FileListing>(), result);
     }
 
-    public async Task<(Guid, HttpResponseMessage)> PostFile(string localPath, string? overrideFilename = null, FileMetadata? metadata = null, string loginAs = "admin", IDictionary<string, string>? extraFields = null)
+    public async Task<(Guid, HttpResponseMessage)> PostFile(string localPath, string? overrideFilename = null, string? overrideSubfolder = null, FileMetadata? metadata = null, string loginAs = "admin", IDictionary<string, string>? extraFields = null)
     {
         await LoginIfNeeded(loginAs);
         var filename = Path.GetFileName(localPath);
@@ -69,6 +69,10 @@ public class MediaFileTestFixture : ApiTestBase, IAsyncLifetime
             if (overrideFilename is not null)
             {
                 formData.Add(new StringContent(overrideFilename), name: "filename");
+            }
+            if (overrideSubfolder is not null)
+            {
+                formData.Add(new StringContent(overrideSubfolder), name: "LinkedFilesSubfolderOverride");
             }
             if (metadata is not null)
             {
@@ -98,7 +102,7 @@ public class MediaFileTestFixture : ApiTestBase, IAsyncLifetime
         }
     }
 
-    public async Task<HttpResponseMessage> PutFile(string localPath, Guid fileId, string? overrideFilename = null, FileMetadata? metadata = null, string loginAs = "admin")
+    public async Task<HttpResponseMessage> PutFile(string localPath, Guid fileId, string? overrideFilename = null, string? overrideSubfolder = null, FileMetadata? metadata = null, string loginAs = "admin")
     {
         await LoginIfNeeded(loginAs);
         var filename = Path.GetFileName(localPath);
@@ -107,6 +111,10 @@ public class MediaFileTestFixture : ApiTestBase, IAsyncLifetime
             if (overrideFilename is not null)
             {
                 formData.Add(new StringContent(overrideFilename), name: "filename");
+            }
+            if (overrideSubfolder is not null)
+            {
+                formData.Add(new StringContent(overrideSubfolder), name: "LinkedFilesSubfolderOverride");
             }
             if (metadata is not null)
             {

--- a/backend/Testing/FwHeadless/MediaFileTestFixture.cs
+++ b/backend/Testing/FwHeadless/MediaFileTestFixture.cs
@@ -60,7 +60,7 @@ public class MediaFileTestFixture : ApiTestBase, IAsyncLifetime
         return (await result.Content.ReadFromJsonAsync<FileListing>(), result);
     }
 
-    public async Task<(Guid, HttpResponseMessage)> PostFile(string localPath, string? overrideFilename = null, string? overrideSubfolder = null, FileMetadata? metadata = null, string loginAs = "admin", IDictionary<string, string>? extraFields = null)
+    public async Task<(Guid, HttpResponseMessage)> PostFile(string localPath, string? overrideFilename = null, string? overrideSubfolder = null, bool deleteContentLengthHeader = false, FileMetadata? metadata = null, string loginAs = "admin", IDictionary<string, string>? extraFields = null)
     {
         await LoginIfNeeded(loginAs);
         var filename = Path.GetFileName(localPath);
@@ -96,13 +96,14 @@ public class MediaFileTestFixture : ApiTestBase, IAsyncLifetime
             formData.Add(stream, name: "file", fileName: filename);
             var request = new HttpRequestMessage(HttpMethod.Post, $"api/media/?projectId={ProjectId}");
             request.Content = formData;
+            if (deleteContentLengthHeader) request.Content.Headers.ContentLength = null;
             var result = await HttpClient.SendAsync(request);
             var obj = await result.Content.ReadFromJsonAsync<PostFileResult>();
             return (obj?.guid ?? Guid.Empty, result);
         }
     }
 
-    public async Task<HttpResponseMessage> PutFile(string localPath, Guid fileId, string? overrideFilename = null, string? overrideSubfolder = null, FileMetadata? metadata = null, string loginAs = "admin")
+    public async Task<HttpResponseMessage> PutFile(string localPath, Guid fileId, string? overrideFilename = null, string? overrideSubfolder = null, bool deleteContentLengthHeader = false, FileMetadata? metadata = null, string loginAs = "admin")
     {
         await LoginIfNeeded(loginAs);
         var filename = Path.GetFileName(localPath);
@@ -125,6 +126,7 @@ public class MediaFileTestFixture : ApiTestBase, IAsyncLifetime
             formData.Add(stream, name: "file", fileName: filename);
             var request = new HttpRequestMessage(HttpMethod.Put, $"api/media/{fileId}");
             request.Content = formData;
+            if (deleteContentLengthHeader) request.Content.Headers.ContentLength = null;
             var result = await HttpClient.SendAsync(request);
             return result;
         }

--- a/backend/Testing/FwHeadless/MediaFileTestFixture.cs
+++ b/backend/Testing/FwHeadless/MediaFileTestFixture.cs
@@ -72,7 +72,7 @@ public class MediaFileTestFixture : ApiTestBase, IAsyncLifetime
             }
             if (overrideSubfolder is not null)
             {
-                formData.Add(new StringContent(overrideSubfolder), name: "LinkedFilesSubfolderOverride");
+                formData.Add(new StringContent(overrideSubfolder), name: "linkedFilesSubfolderOverride");
             }
             if (metadata is not null)
             {
@@ -116,7 +116,7 @@ public class MediaFileTestFixture : ApiTestBase, IAsyncLifetime
             }
             if (overrideSubfolder is not null)
             {
-                formData.Add(new StringContent(overrideSubfolder), name: "LinkedFilesSubfolderOverride");
+                formData.Add(new StringContent(overrideSubfolder), name: "linkedFilesSubfolderOverride");
             }
             if (metadata is not null)
             {

--- a/backend/Testing/FwHeadless/MediaFileTestFixture.cs
+++ b/backend/Testing/FwHeadless/MediaFileTestFixture.cs
@@ -60,7 +60,7 @@ public class MediaFileTestFixture : ApiTestBase, IAsyncLifetime
         return (await result.Content.ReadFromJsonAsync<FileListing>(), result);
     }
 
-    public async Task<(Guid, HttpResponseMessage)> PostFile(string localPath, string? overrideFilename = null, string? overrideSubfolder = null, bool deleteContentLengthHeader = false, FileMetadata? metadata = null, string loginAs = "admin", IDictionary<string, string>? extraFields = null)
+    public async Task<(Guid, HttpResponseMessage)> PostFile(string localPath, string? overrideFilename = null, string? overrideSubfolder = null, string? contentType = null, bool deleteContentLengthHeader = false, FileMetadata? metadata = null, string loginAs = "admin", IDictionary<string, string>? extraFields = null)
     {
         await LoginIfNeeded(loginAs);
         var filename = Path.GetFileName(localPath);
@@ -93,6 +93,7 @@ public class MediaFileTestFixture : ApiTestBase, IAsyncLifetime
                 }
             }
             var stream = new StreamContent(File.OpenRead(localPath));
+            if (contentType is not null) stream.Headers.ContentType = new(contentType);
             formData.Add(stream, name: "file", fileName: filename);
             var request = new HttpRequestMessage(HttpMethod.Post, $"api/media/?projectId={ProjectId}");
             request.Content = formData;
@@ -103,7 +104,7 @@ public class MediaFileTestFixture : ApiTestBase, IAsyncLifetime
         }
     }
 
-    public async Task<HttpResponseMessage> PutFile(string localPath, Guid fileId, string? overrideFilename = null, string? overrideSubfolder = null, bool deleteContentLengthHeader = false, FileMetadata? metadata = null, string loginAs = "admin")
+    public async Task<HttpResponseMessage> PutFile(string localPath, Guid fileId, string? overrideFilename = null, string? overrideSubfolder = null, string? contentType = null, bool deleteContentLengthHeader = false, FileMetadata? metadata = null, string loginAs = "admin")
     {
         await LoginIfNeeded(loginAs);
         var filename = Path.GetFileName(localPath);
@@ -123,6 +124,7 @@ public class MediaFileTestFixture : ApiTestBase, IAsyncLifetime
             }
             formData.Add(new StringContent(ProjectId.ToString()), name: "projectId");
             var stream = new StreamContent(File.OpenRead(localPath));
+            if (contentType is not null) stream.Headers.ContentType = new(contentType);
             formData.Add(stream, name: "file", fileName: filename);
             var request = new HttpRequestMessage(HttpMethod.Put, $"api/media/{fileId}");
             request.Content = formData;

--- a/backend/Testing/FwHeadless/MediaFileTests.cs
+++ b/backend/Testing/FwHeadless/MediaFileTests.cs
@@ -25,12 +25,12 @@ public class MediaFileTests : IClassFixture<MediaFileTestFixture>
         var (guid, result) = await Fixture.PostFile(TestRepoZipPath);
         result.StatusCode.Should().Be(HttpStatusCode.Created);
         guid.Should().NotBe(Guid.Empty);
-        var (files, listResult) = await Fixture.ListFiles(Fixture.ProjectId, relativePath: "LinkedFiles");
+        var (files, listResult) = await Fixture.ListFiles(Fixture.ProjectId);
         listResult.StatusCode.Should().Be(HttpStatusCode.OK);
         files.Should().NotBeNull();
         files.Files.Should().Contain(Path.Join(guid.ToString(), TestRepoZipFilename));
         await Fixture.PutFile(TestRepoZipPath, guid);
-        (files, listResult) = await Fixture.ListFiles(Fixture.ProjectId, relativePath: "LinkedFiles");
+        (files, listResult) = await Fixture.ListFiles(Fixture.ProjectId);
         listResult.StatusCode.Should().Be(HttpStatusCode.OK);
         files.Should().NotBeNull();
         files.Files.Should().Contain(Path.Join(guid.ToString(), TestRepoZipFilename));
@@ -42,7 +42,7 @@ public class MediaFileTests : IClassFixture<MediaFileTestFixture>
         var (guid, result) = await Fixture.PostFile(TestRepoZipPath, loginAs: "user");
         guid.Should().Be(Guid.Empty);
         result.StatusCode.Should().Be(HttpStatusCode.Forbidden);
-        var (files, listResult) = await Fixture.ListFiles(Fixture.ProjectId, relativePath: "LinkedFiles", loginAs: "user");
+        var (files, listResult) = await Fixture.ListFiles(Fixture.ProjectId, loginAs: "user");
         listResult.StatusCode.Should().Be(HttpStatusCode.Forbidden);
         (files?.Files ?? []).Should().NotContain(Path.Join(guid.ToString(), TestRepoZipFilename));
     }
@@ -54,7 +54,7 @@ public class MediaFileTests : IClassFixture<MediaFileTestFixture>
     {
         var (guid, result) = await Fixture.PostFile(TestRepoZipPath, loginAs: loginAs);
         result.StatusCode.Should().Be(HttpStatusCode.Created);
-        var (files, listResult) = await Fixture.ListFiles(Fixture.ProjectId, relativePath: "LinkedFiles", loginAs: loginAs);
+        var (files, listResult) = await Fixture.ListFiles(Fixture.ProjectId, loginAs: loginAs);
         listResult.StatusCode.Should().Be(HttpStatusCode.OK);
         (files?.Files ?? []).Should().Contain(Path.Join(guid.ToString(), TestRepoZipFilename));
     }
@@ -106,7 +106,7 @@ public class MediaFileTests : IClassFixture<MediaFileTestFixture>
         mResult.StatusCode.Should().Be(HttpStatusCode.OK);
         metadata.Should().NotBeNull();
         metadata.Filename.Should().Be(overrideFilename);
-        var (files, listResult) = await Fixture.ListFiles(Fixture.ProjectId, relativePath: "LinkedFiles");
+        var (files, listResult) = await Fixture.ListFiles(Fixture.ProjectId);
         listResult.StatusCode.Should().Be(HttpStatusCode.OK);
         files.Should().NotBeNull();
         files.Files.Should().Contain(Path.Join(fileId.ToString(), overrideFilename));
@@ -169,7 +169,7 @@ public class MediaFileTests : IClassFixture<MediaFileTestFixture>
         mResult.StatusCode.Should().Be(HttpStatusCode.OK);
         metadata.Should().NotBeNull();
         metadata.Filename.Should().Be(TestRepoZipFilename);
-        var (fileListing, listResult) = await Fixture.ListFiles(Fixture.ProjectId, relativePath: "LinkedFiles", loginAs: "admin");
+        var (fileListing, listResult) = await Fixture.ListFiles(Fixture.ProjectId, loginAs: "admin");
         listResult.StatusCode.Should().Be(HttpStatusCode.OK);
         var files = fileListing?.Files ?? [];
         files.Should().Contain(Path.Join(fileId.ToString(), TestRepoZipFilename));
@@ -197,7 +197,7 @@ public class MediaFileTests : IClassFixture<MediaFileTestFixture>
     {
         var (fileId, result) = await Fixture.PostFile(TestRepoZipPath, overrideSubfolder: "Pictures");
         result.StatusCode.Should().Be(HttpStatusCode.Created);
-        var (fileListing, listResult) = await Fixture.ListFiles(Fixture.ProjectId, relativePath: "LinkedFiles");
+        var (fileListing, listResult) = await Fixture.ListFiles(Fixture.ProjectId);
         listResult.StatusCode.Should().Be(HttpStatusCode.OK);
         var files = fileListing?.Files ?? [];
         files.Should().Contain(Path.Join("Pictures", fileId.ToString(), TestRepoZipFilename));
@@ -217,7 +217,7 @@ public class MediaFileTests : IClassFixture<MediaFileTestFixture>
         result.StatusCode.Should().Be(HttpStatusCode.Created);
         result = await Fixture.PutFile(TestRepoZipPath, fileId, overrideSubfolder: "AudioVisual");
         result.StatusCode.Should().Be(HttpStatusCode.BadRequest);
-        var (fileListing, listResult) = await Fixture.ListFiles(Fixture.ProjectId, relativePath: "LinkedFiles");
+        var (fileListing, listResult) = await Fixture.ListFiles(Fixture.ProjectId);
         listResult.StatusCode.Should().Be(HttpStatusCode.OK);
         var files = fileListing?.Files ?? [];
         files.Should().Contain(Path.Join("Pictures", fileId.ToString(), TestRepoZipFilename));
@@ -232,7 +232,7 @@ public class MediaFileTests : IClassFixture<MediaFileTestFixture>
         result.StatusCode.Should().Be(HttpStatusCode.Created);
         result = await Fixture.PutFile(TestRepoZipPath, fileId);
         result.StatusCode.Should().Be(HttpStatusCode.OK);
-        var (fileListing, listResult) = await Fixture.ListFiles(Fixture.ProjectId, relativePath: "LinkedFiles");
+        var (fileListing, listResult) = await Fixture.ListFiles(Fixture.ProjectId);
         listResult.StatusCode.Should().Be(HttpStatusCode.OK);
         var files = fileListing?.Files ?? [];
         files.Should().Contain(Path.Join("Pictures", fileId.ToString(), TestRepoZipFilename));
@@ -245,7 +245,7 @@ public class MediaFileTests : IClassFixture<MediaFileTestFixture>
     {
         var (fileId, result) = await Fixture.PostFile(TestRepoZipPath); // MIME type "application/zip" will go into LinkedFiles, no subfolder
         result.StatusCode.Should().Be(HttpStatusCode.Created);
-        var (fileListing, listResult) = await Fixture.ListFiles(Fixture.ProjectId, relativePath: "LinkedFiles");
+        var (fileListing, listResult) = await Fixture.ListFiles(Fixture.ProjectId);
         listResult.StatusCode.Should().Be(HttpStatusCode.OK);
         var files = fileListing?.Files ?? [];
         files.Should().Contain(Path.Join(fileId.ToString(), TestRepoZipFilename));
@@ -253,7 +253,7 @@ public class MediaFileTests : IClassFixture<MediaFileTestFixture>
         files.Should().NotContain(Path.Join("AudioVisual", fileId.ToString(), TestRepoZipFilename));
         result = await Fixture.PutFile(TestRepoZipPath, fileId, overrideSubfolder: "Pictures");
         result.StatusCode.Should().Be(HttpStatusCode.BadRequest);
-        var (fileListing2, listResult2) = await Fixture.ListFiles(Fixture.ProjectId, relativePath: "LinkedFiles");
+        var (fileListing2, listResult2) = await Fixture.ListFiles(Fixture.ProjectId);
         listResult2.StatusCode.Should().Be(HttpStatusCode.OK);
         var files2 = fileListing2?.Files ?? [];
         files2.Should().Contain(Path.Join(fileId.ToString(), TestRepoZipFilename));
@@ -281,7 +281,7 @@ public class MediaFileTests : IClassFixture<MediaFileTestFixture>
             File.Copy(TestRepoZipPath, otherPath, overwrite: true);
             var (fileId, result) = await Fixture.PostFile(otherPath);
             result.StatusCode.Should().Be(HttpStatusCode.Created);
-            var (fileListing, listResult) = await Fixture.ListFiles(Fixture.ProjectId, relativePath: "LinkedFiles");
+            var (fileListing, listResult) = await Fixture.ListFiles(Fixture.ProjectId);
             listResult.StatusCode.Should().Be(HttpStatusCode.OK);
             var files = fileListing?.Files ?? [];
             files.Should().NotContain(Path.Join(wrongFolder, fileId.ToString(), otherFilename));
@@ -310,7 +310,7 @@ public class MediaFileTests : IClassFixture<MediaFileTestFixture>
             File.Copy(TestRepoZipPath, otherPath, overwrite: true);
             var (fileId, result) = await Fixture.PostFile(otherPath, contentType: mimeType);
             result.StatusCode.Should().Be(HttpStatusCode.Created);
-            var (fileListing, listResult) = await Fixture.ListFiles(Fixture.ProjectId, relativePath: "LinkedFiles");
+            var (fileListing, listResult) = await Fixture.ListFiles(Fixture.ProjectId);
             listResult.StatusCode.Should().Be(HttpStatusCode.OK);
             var files = fileListing?.Files ?? [];
             files.Should().NotContain(Path.Join(wrongFolder, fileId.ToString(), otherFilename));

--- a/backend/Testing/FwHeadless/MediaFileTests.cs
+++ b/backend/Testing/FwHeadless/MediaFileTests.cs
@@ -327,7 +327,7 @@ public class MediaFileTests : IClassFixture<MediaFileTestFixture>
         try
         {
             if (File.Exists(dummyPath)) File.Delete(dummyPath);
-            Fixture.CreateDummyFile(dummyPath, 1024 * 1024 * 10 - 1); // 10 MB minus one byte, file is not too large but Content-Length will be too large
+            Fixture.CreateDummyFile(dummyPath, 1024 * 1024 * 10 - 64); // 10 MB minus 64 bytes, file is not too large but Content-Length will be too large
             var (guid, result) = await Fixture.PostFile(dummyPath);
             result.StatusCode.Should().Be(HttpStatusCode.RequestEntityTooLarge);
             guid.Should().BeEmpty();
@@ -345,7 +345,7 @@ public class MediaFileTests : IClassFixture<MediaFileTestFixture>
         try
         {
             if (File.Exists(dummyPath)) File.Delete(dummyPath);
-            Fixture.CreateDummyFile(dummyPath, 1024 * 1024 * 10 - 1); // 10 MB minus one byte, file is not too large but Content-Length would be too large if included
+            Fixture.CreateDummyFile(dummyPath, 1024 * 1024 * 10 - 64); // 10 MB minus 64 bytes, file is not too large but Content-Length would be too large if included
             var (guid, result) = await Fixture.PostFile(dummyPath, deleteContentLengthHeader: true);
             result.StatusCode.Should().Be(HttpStatusCode.Created);
             guid.Should().NotBeEmpty();
@@ -365,7 +365,7 @@ public class MediaFileTests : IClassFixture<MediaFileTestFixture>
         try
         {
             if (File.Exists(dummyPath)) File.Delete(dummyPath);
-            Fixture.CreateDummyFile(dummyPath, 1024 * 1024 * 10 + 1); // 10 MB plus one byte, file is too large
+            Fixture.CreateDummyFile(dummyPath, 1024 * 1024 * 10 + 64); // 10 MB plus 64 bytes, file is too large
             var (guid, result) = await Fixture.PostFile(dummyPath, deleteContentLengthHeader: true);
             result.StatusCode.Should().Be(HttpStatusCode.RequestEntityTooLarge);
             guid.Should().BeEmpty();
@@ -383,12 +383,12 @@ public class MediaFileTests : IClassFixture<MediaFileTestFixture>
         try
         {
             if (File.Exists(dummyPath)) File.Delete(dummyPath);
-            Fixture.CreateDummyFile(dummyPath, 1024 * 1024 * 10 - 1); // 10 MB minus one byte, file is not too large but Content-Length would be too large if included
+            Fixture.CreateDummyFile(dummyPath, 1024 * 1024 * 10 - 64); // 10 MB minus 64 bytes, file is not too large but Content-Length would be too large if included
             var (guid, result) = await Fixture.PostFile(dummyPath, deleteContentLengthHeader: true);
             result.StatusCode.Should().Be(HttpStatusCode.Created);
             guid.Should().NotBeEmpty();
             if (File.Exists(dummyPath)) File.Delete(dummyPath);
-            Fixture.CreateDummyFile(dummyPath, 1024 * 1024 * 10 + 1); // 10 MB plus one byte, file is too large
+            Fixture.CreateDummyFile(dummyPath, 1024 * 1024 * 10 + 64); // 10 MB plus 64 bytes, file is too large
             result = await Fixture.PutFile(dummyPath, guid, deleteContentLengthHeader: true);
             result.StatusCode.Should().Be(HttpStatusCode.RequestEntityTooLarge);
         }

--- a/backend/Testing/FwHeadless/MediaFileTests.cs
+++ b/backend/Testing/FwHeadless/MediaFileTests.cs
@@ -224,7 +224,7 @@ public class MediaFileTests : IClassFixture<MediaFileTestFixture>
     }
 
     [Fact]
-    public async Task UploadFile_OverridingLinkedPathSubfolder_ThenReplacingWithoutOverriding_PutsReplacementInOriginalLocation()
+    public async Task UploadFile_OverridingLinkedPathSubfolder_SecondUploadsDoNotMoveFile()
     {
         var (fileId, result) = await Fixture.PostFile(TestRepoZipPath, overrideSubfolder: "Pictures");
         result.StatusCode.Should().Be(HttpStatusCode.Created);
@@ -238,7 +238,7 @@ public class MediaFileTests : IClassFixture<MediaFileTestFixture>
     }
 
     [Fact]
-    public async Task UploadFile_WithoutOverridingLinkedPathSubfolderFirst_ThenReplacingWithOverride_Fails()
+    public async Task UploadFile_WithoutSubfolder_ThenTryingToOverride_Fails()
     {
         var (fileId, result) = await Fixture.PostFile(TestRepoZipPath); // MIME type "application/zip" will go into LinkedFiles, no subfolder
         result.StatusCode.Should().Be(HttpStatusCode.Created);
@@ -248,7 +248,7 @@ public class MediaFileTests : IClassFixture<MediaFileTestFixture>
         (files?.Files ?? []).Should().NotContain(Path.Join("Pictures", fileId.ToString(), TestRepoZipFilename));
         (files?.Files ?? []).Should().NotContain(Path.Join("AudioVisual", fileId.ToString(), TestRepoZipFilename));
         result = await Fixture.PutFile(TestRepoZipPath, fileId, overrideSubfolder: "Pictures");
-        // result.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+        result.StatusCode.Should().Be(HttpStatusCode.BadRequest);
         var (files2, listResult2) = await Fixture.ListFiles(Fixture.ProjectId, relativePath: "LinkedFiles");
         listResult2.StatusCode.Should().Be(HttpStatusCode.OK);
         (files2?.Files ?? []).Should().Contain(Path.Join(fileId.ToString(), TestRepoZipFilename));

--- a/backend/Testing/FwHeadless/MediaFileTests.cs
+++ b/backend/Testing/FwHeadless/MediaFileTests.cs
@@ -1,5 +1,4 @@
 ﻿using LexCore.Entities;
-using Testing.ApiTests;
 using Testing.Fixtures;
 using System.Net;
 using System.Security.Cryptography;
@@ -170,10 +169,11 @@ public class MediaFileTests : IClassFixture<MediaFileTestFixture>
         mResult.StatusCode.Should().Be(HttpStatusCode.OK);
         metadata.Should().NotBeNull();
         metadata.Filename.Should().Be(TestRepoZipFilename);
-        var (files, listResult) = await Fixture.ListFiles(Fixture.ProjectId, relativePath: "LinkedFiles", loginAs: "admin");
+        var (fileListing, listResult) = await Fixture.ListFiles(Fixture.ProjectId, relativePath: "LinkedFiles", loginAs: "admin");
         listResult.StatusCode.Should().Be(HttpStatusCode.OK);
-        (files?.Files ?? []).Should().Contain(Path.Join(fileId.ToString(), TestRepoZipFilename));
-        (files?.Files ?? []).Should().NotContain(Path.Join(fileId.ToString(), secondPath));
+        var files = fileListing?.Files ?? [];
+        files.Should().Contain(Path.Join(fileId.ToString(), TestRepoZipFilename));
+        files.Should().NotContain(Path.Join(fileId.ToString(), secondPath));
     }
 
     [Fact]
@@ -197,11 +197,12 @@ public class MediaFileTests : IClassFixture<MediaFileTestFixture>
     {
         var (fileId, result) = await Fixture.PostFile(TestRepoZipPath, overrideSubfolder: "Pictures");
         result.StatusCode.Should().Be(HttpStatusCode.Created);
-        var (files, listResult) = await Fixture.ListFiles(Fixture.ProjectId, relativePath: "LinkedFiles");
+        var (fileListing, listResult) = await Fixture.ListFiles(Fixture.ProjectId, relativePath: "LinkedFiles");
         listResult.StatusCode.Should().Be(HttpStatusCode.OK);
-        (files?.Files ?? []).Should().Contain(Path.Join("Pictures", fileId.ToString(), TestRepoZipFilename));
-        (files?.Files ?? []).Should().NotContain(Path.Join("AudioVisual", fileId.ToString(), TestRepoZipFilename));
-        (files?.Files ?? []).Should().NotContain(Path.Join(fileId.ToString(), TestRepoZipFilename));
+        var files = fileListing?.Files ?? [];
+        files.Should().Contain(Path.Join("Pictures", fileId.ToString(), TestRepoZipFilename));
+        files.Should().NotContain(Path.Join("AudioVisual", fileId.ToString(), TestRepoZipFilename));
+        files.Should().NotContain(Path.Join(fileId.ToString(), TestRepoZipFilename));
         // LinkedFiles subfolder must NOT be part of filename returned by metadata endpoint
         var (metadata, mResult) = await Fixture.GetFileMetadata(fileId);
         mResult.StatusCode.Should().Be(HttpStatusCode.OK);
@@ -216,11 +217,12 @@ public class MediaFileTests : IClassFixture<MediaFileTestFixture>
         result.StatusCode.Should().Be(HttpStatusCode.Created);
         result = await Fixture.PutFile(TestRepoZipPath, fileId, overrideSubfolder: "AudioVisual");
         result.StatusCode.Should().Be(HttpStatusCode.BadRequest);
-        var (files, listResult) = await Fixture.ListFiles(Fixture.ProjectId, relativePath: "LinkedFiles");
+        var (fileListing, listResult) = await Fixture.ListFiles(Fixture.ProjectId, relativePath: "LinkedFiles");
         listResult.StatusCode.Should().Be(HttpStatusCode.OK);
-        (files?.Files ?? []).Should().Contain(Path.Join("Pictures", fileId.ToString(), TestRepoZipFilename));
-        (files?.Files ?? []).Should().NotContain(Path.Join("AudioVisual", fileId.ToString(), TestRepoZipFilename));
-        (files?.Files ?? []).Should().NotContain(Path.Join(fileId.ToString(), TestRepoZipFilename));
+        var files = fileListing?.Files ?? [];
+        files.Should().Contain(Path.Join("Pictures", fileId.ToString(), TestRepoZipFilename));
+        files.Should().NotContain(Path.Join("AudioVisual", fileId.ToString(), TestRepoZipFilename));
+        files.Should().NotContain(Path.Join(fileId.ToString(), TestRepoZipFilename));
     }
 
     [Fact]
@@ -230,11 +232,12 @@ public class MediaFileTests : IClassFixture<MediaFileTestFixture>
         result.StatusCode.Should().Be(HttpStatusCode.Created);
         result = await Fixture.PutFile(TestRepoZipPath, fileId);
         result.StatusCode.Should().Be(HttpStatusCode.OK);
-        var (files, listResult) = await Fixture.ListFiles(Fixture.ProjectId, relativePath: "LinkedFiles");
+        var (fileListing, listResult) = await Fixture.ListFiles(Fixture.ProjectId, relativePath: "LinkedFiles");
         listResult.StatusCode.Should().Be(HttpStatusCode.OK);
-        (files?.Files ?? []).Should().Contain(Path.Join("Pictures", fileId.ToString(), TestRepoZipFilename));
-        (files?.Files ?? []).Should().NotContain(Path.Join("AudioVisual", fileId.ToString(), TestRepoZipFilename));
-        (files?.Files ?? []).Should().NotContain(Path.Join(fileId.ToString(), TestRepoZipFilename));
+        var files = fileListing?.Files ?? [];
+        files.Should().Contain(Path.Join("Pictures", fileId.ToString(), TestRepoZipFilename));
+        files.Should().NotContain(Path.Join("AudioVisual", fileId.ToString(), TestRepoZipFilename));
+        files.Should().NotContain(Path.Join(fileId.ToString(), TestRepoZipFilename));
     }
 
     [Fact]
@@ -242,19 +245,79 @@ public class MediaFileTests : IClassFixture<MediaFileTestFixture>
     {
         var (fileId, result) = await Fixture.PostFile(TestRepoZipPath); // MIME type "application/zip" will go into LinkedFiles, no subfolder
         result.StatusCode.Should().Be(HttpStatusCode.Created);
-        var (files, listResult) = await Fixture.ListFiles(Fixture.ProjectId, relativePath: "LinkedFiles");
+        var (fileListing, listResult) = await Fixture.ListFiles(Fixture.ProjectId, relativePath: "LinkedFiles");
         listResult.StatusCode.Should().Be(HttpStatusCode.OK);
-        (files?.Files ?? []).Should().Contain(Path.Join(fileId.ToString(), TestRepoZipFilename));
-        (files?.Files ?? []).Should().NotContain(Path.Join("Pictures", fileId.ToString(), TestRepoZipFilename));
-        (files?.Files ?? []).Should().NotContain(Path.Join("AudioVisual", fileId.ToString(), TestRepoZipFilename));
+        var files = fileListing?.Files ?? [];
+        files.Should().Contain(Path.Join(fileId.ToString(), TestRepoZipFilename));
+        files.Should().NotContain(Path.Join("Pictures", fileId.ToString(), TestRepoZipFilename));
+        files.Should().NotContain(Path.Join("AudioVisual", fileId.ToString(), TestRepoZipFilename));
         result = await Fixture.PutFile(TestRepoZipPath, fileId, overrideSubfolder: "Pictures");
         result.StatusCode.Should().Be(HttpStatusCode.BadRequest);
-        var (files2, listResult2) = await Fixture.ListFiles(Fixture.ProjectId, relativePath: "LinkedFiles");
+        var (fileListing2, listResult2) = await Fixture.ListFiles(Fixture.ProjectId, relativePath: "LinkedFiles");
         listResult2.StatusCode.Should().Be(HttpStatusCode.OK);
-        (files2?.Files ?? []).Should().Contain(Path.Join(fileId.ToString(), TestRepoZipFilename));
-        (files2?.Files ?? []).Should().NotContain(Path.Join("Pictures", fileId.ToString(), TestRepoZipFilename));
-        (files2?.Files ?? []).Should().NotContain(Path.Join("AudioVisual", fileId.ToString(), TestRepoZipFilename));
-        (files2?.Files ?? []).Should().BeEquivalentTo(files?.Files ?? []);
+        var files2 = fileListing2?.Files ?? [];
+        files2.Should().Contain(Path.Join(fileId.ToString(), TestRepoZipFilename));
+        files2.Should().NotContain(Path.Join("Pictures", fileId.ToString(), TestRepoZipFilename));
+        files2.Should().NotContain(Path.Join("AudioVisual", fileId.ToString(), TestRepoZipFilename));
+        files2.Should().BeEquivalentTo(files);
+    }
+
+    [Theory]
+    [InlineData(".mp3", "AudioVisual")]
+    [InlineData(".wav", "AudioVisual")]
+    [InlineData(".mp4", "AudioVisual")]
+    [InlineData(".mkv", "AudioVisual")]
+    [InlineData(".jpg", "Pictures")]
+    [InlineData(".jpeg", "Pictures")]
+    [InlineData(".gif", "Pictures")]
+    [InlineData(".png", "Pictures")]
+    public async Task UploadFile_WithoutContentType_GuessesFromFilename(string extension, string expectedFolder)
+    {
+        var otherPath = TestRepoZipPath.Replace(".zip", extension);
+        var otherFilename = TestRepoZipFilename.Replace(".zip", extension);
+        var wrongFolder = expectedFolder == "Pictures" ? "AudioVisual" : "Pictures";
+        try
+        {
+            File.Copy(TestRepoZipPath, otherPath, overwrite: true);
+            var (fileId, result) = await Fixture.PostFile(otherPath);
+            result.StatusCode.Should().Be(HttpStatusCode.Created);
+            var (fileListing, listResult) = await Fixture.ListFiles(Fixture.ProjectId, relativePath: "LinkedFiles");
+            listResult.StatusCode.Should().Be(HttpStatusCode.OK);
+            var files = fileListing?.Files ?? [];
+            files.Should().NotContain(Path.Join(wrongFolder, fileId.ToString(), otherFilename));
+            files.Should().NotContain(Path.Join(fileId.ToString(), otherFilename));
+            files.Should().Contain(Path.Join(expectedFolder, fileId.ToString(), otherFilename));
+        }
+        finally { if (File.Exists(otherPath)) File.Delete(otherPath); }
+    }
+
+    [Theory]
+    [InlineData(".mp3", "image/jpeg", "Pictures")]
+    [InlineData(".wav", "image/png", "Pictures")]
+    [InlineData(".mp4", "image/tiff", "Pictures")]
+    [InlineData(".mkv", "image/gif", "Pictures")]
+    [InlineData(".jpg", "audio/mp3", "AudioVisual")]
+    [InlineData(".jpeg", "audio/wav", "AudioVisual")]
+    [InlineData(".gif", "video/mp4", "AudioVisual")]
+    [InlineData(".png", "video/x-matroska", "AudioVisual")]
+    public async Task UploadFile_WithContentType_GuessesFromContentTypeAndNotFilename(string extension, string mimeType, string expectedFolder)
+    {
+        var otherPath = TestRepoZipPath.Replace(".zip", extension);
+        var otherFilename = TestRepoZipFilename.Replace(".zip", extension);
+        var wrongFolder = expectedFolder == "Pictures" ? "AudioVisual" : "Pictures";
+        try
+        {
+            File.Copy(TestRepoZipPath, otherPath, overwrite: true);
+            var (fileId, result) = await Fixture.PostFile(otherPath, contentType: mimeType);
+            result.StatusCode.Should().Be(HttpStatusCode.Created);
+            var (fileListing, listResult) = await Fixture.ListFiles(Fixture.ProjectId, relativePath: "LinkedFiles");
+            listResult.StatusCode.Should().Be(HttpStatusCode.OK);
+            var files = fileListing?.Files ?? [];
+            files.Should().NotContain(Path.Join(wrongFolder, fileId.ToString(), otherFilename));
+            files.Should().NotContain(Path.Join(fileId.ToString(), otherFilename));
+            files.Should().Contain(Path.Join(expectedFolder, fileId.ToString(), otherFilename));
+        }
+        finally { if (File.Exists(otherPath)) File.Delete(otherPath); }
     }
 
     [Fact]


### PR DESCRIPTION
Fixes #1790.

Rules for overriding LinkedFiles subfolder:
- If not overridden, subfolder is guessed via MIME type
- Subfolder guess can be overridden via LinkedFilesSubfolder form value
- Once file is put in place, cannot be moved later (for FW's sake)

Also include more tests for rejecting too-large uploads, ensuring that if Content-Length header is missing we'll still reject uploads that are too large.