### PR TITLE
Hopefully avoid more race conditions

### DIFF
--- a/backend/FwLite/FwLiteProjectSync.Tests/Fixtures/SyncFixture.cs
+++ b/backend/FwLite/FwLiteProjectSync.Tests/Fixtures/SyncFixture.cs
@@ -4,9 +4,9 @@ using FwDataMiniLcmBridge.Api;
 using FwDataMiniLcmBridge.LcmUtils;
 using LcmCrdt;
 using LexCore.Utils;
+using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
-using MiniLcm.Models;
 
 namespace FwLiteProjectSync.Tests.Fixtures;
 
@@ -67,7 +67,10 @@ public class SyncFixture : IAsyncLifetime
         Directory.CreateDirectory(crdtProjectsFolder);
         var crdtProject = await _services.ServiceProvider.GetRequiredService<CrdtProjectsService>()
             .CreateProject(new(_projectName, _projectName, FwProjectId: FwDataApi.ProjectId, SeedNewProjectData: false));
-        CrdtApi = (CrdtMiniLcmApi) await _services.ServiceProvider.OpenCrdtProject(crdtProject);
+        CrdtApi = (CrdtMiniLcmApi)await _services.ServiceProvider.OpenCrdtProject(crdtProject);
+
+        //hopefully avoid race conditions where linq2db uses it's own connection
+        Services.GetRequiredService<LcmCrdtDbContext>().Database.OpenConnection();
     }
 
     public async Task DisposeAsync()

--- a/backend/FwLite/FwLiteProjectSync.Tests/Import/ImportTests.cs
+++ b/backend/FwLite/FwLiteProjectSync.Tests/Import/ImportTests.cs
@@ -1,6 +1,4 @@
 using FwLiteProjectSync.Tests.Fixtures;
-using LcmCrdt;
-using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 using MiniLcm.Models;
 
@@ -14,8 +12,6 @@ public class ImportTests : IClassFixture<SyncFixture>
     public ImportTests(SyncFixture fixture)
     {
         _fixture = fixture;
-        //hopefully avoid race conditions where linq2db uses it's own connection
-        _fixture.Services.GetRequiredService<LcmCrdtDbContext>().Database.OpenConnection();
     }
 
     [Fact]


### PR DESCRIPTION
See "no such collation" test failures in e.g.
https://github.com/sillsdev/languageforge-lexbox/actions/runs/15965792089/job/45025854312?pr=1760
https://github.com/sillsdev/languageforge-lexbox/actions/runs/15991984806/job/45106882732?pr=1791

The code that is currently in `ImportTests` did seem to prevent failures in that class.