### PR TITLE
Don't underline rich-text if no ws

### DIFF
--- a/frontend/viewer/src/lib/components/lcm-rich-text-editor/lcm-rich-text-editor.svelte
+++ b/frontend/viewer/src/lib/components/lcm-rich-text-editor/lcm-rich-text-editor.svelte
@@ -186,7 +186,7 @@
     //ProseMirror will keep the text up to date itself, if we store it on the richSpan attr then it will become out of date
     let {text, ...rest} = s;
     //if the ws doesn't match expected, or there's more than just the ws key in props
-    const isCustomized = (!!normalWs && normalWs !== s.ws) || Object.keys(rest).length > 1;
+    const isCustomized = (!!s.ws && !!normalWs && normalWs !== s.ws) || Object.keys(rest).length > 1;
     return textSchema.node('span', {richSpan: rest, className: cn(isCustomized && 'customized')}, [textSchema.text(replaceLineSeparatorWithNewLine(text))]);
   }
 


### PR DESCRIPTION
This prevents rich-spans that don't have a ws from being underlined. That's the case for:
1) new spans that are created when a user starts typing in an empty rich-text field
2) non-multi rich-strings for which we could not/cannot assign a WS when we migrate to rich-strings
