### PR TITLE
move work off UI thread

### DIFF
--- a/backend/FwLite/FwLiteShared/Projects/CombinedProjectsService.cs
+++ b/backend/FwLite/FwLiteShared/Projects/CombinedProjectsService.cs
@@ -157,7 +157,7 @@ public class CombinedProjectsService(LexboxProjectService lexboxProjectService,
         var server = project.Server ?? throw new ArgumentNullException($"{nameof(project.Server)} is null for project {project.Code}");
         var projectId = project.Id ?? throw new ArgumentNullException($"{nameof(project.Id)} is null for project {project.Code}");
         var currentUser = await oAuthClientFactory.GetClient(server).GetCurrentUser();
-        await crdtProjectsService.CreateProject(new(project.Name,
+        await Task.Run(async () => await crdtProjectsService.CreateProject(new(project.Name,
             project.Code,
             projectId,
             server.Authority,
@@ -168,7 +168,7 @@ public class CombinedProjectsService(LexboxProjectService lexboxProjectService,
             SeedNewProjectData: false,
             AuthenticatedUser: currentUser?.Name,
             AuthenticatedUserId: currentUser?.Id,
-            Role: ToRole(project.Role)));
+            Role: ToRole(project.Role))));
     }
 
     [JSInvokable]

--- a/backend/FwLite/FwLiteShared/Services/MiniLcmJsInvokable.cs
+++ b/backend/FwLite/FwLiteShared/Services/MiniLcmJsInvokable.cs
@@ -62,9 +62,9 @@ public class MiniLcmJsInvokable(
     }
 
     [JSInvokable]
-    public ValueTask<SemanticDomain[]> GetSemanticDomains()
+    public Task<SemanticDomain[]> GetSemanticDomains()
     {
-        return _wrappedApi.GetSemanticDomains().ToArrayAsync();
+        return Task.Run(async () => await _wrappedApi.GetSemanticDomains().ToArrayAsync());
     }
 
     [JSInvokable]
@@ -83,26 +83,26 @@ public class MiniLcmJsInvokable(
     [JSInvokable]
     public Task<int> CountEntries(string? query, FilterQueryOptions? options)
     {
-        return _wrappedApi.CountEntries(query, options);
+        return Task.Run(() => _wrappedApi.CountEntries(query, options));
     }
 
     [JSInvokable]
-    public ValueTask<Entry[]> GetEntries(QueryOptions? options = null)
+    public Task<Entry[]> GetEntries(QueryOptions? options = null)
     {
-        return _wrappedApi.GetEntries(options).ToArrayAsync();
+        return Task.Run(async () => await _wrappedApi.GetEntries(options).ToArrayAsync());
     }
 
     [JSInvokable]
-    public ValueTask<Entry[]> SearchEntries(string query, QueryOptions? options = null)
+    public Task<Entry[]> SearchEntries(string query, QueryOptions? options = null)
     {
-        return _wrappedApi.SearchEntries(query, options).ToArrayAsync();
+        return Task.Run(async () => await _wrappedApi.SearchEntries(query, options).ToArrayAsync());
     }
 
     [JSInvokable]
     [TsFunction(Type = "Promise<IEntry | null>")]
     public Task<Entry?> GetEntry(Guid id)
     {
-        return _wrappedApi.GetEntry(id);
+        return Task.Run(async () => await _wrappedApi.GetEntry(id));
     }
 
     [JSInvokable]
@@ -227,7 +227,7 @@ public class MiniLcmJsInvokable(
     [JSInvokable]
     public async Task<Entry> UpdateEntry(Entry before, Entry after)
     {
-        var result = await _wrappedApi.UpdateEntry(before, after);
+        var result = await Task.Run(async () => await _wrappedApi.UpdateEntry(before, after));
         OnDataChanged();
         return result;
     }

--- a/backend/FwLite/FwLiteShared/Sync/SyncService.cs
+++ b/backend/FwLite/FwLiteShared/Sync/SyncService.cs
@@ -28,7 +28,7 @@ public class SyncService(
     IMiniLcmApi lexboxApi,
     IOptions<AuthConfig> authOptions,
     ILogger<SyncService> logger,
-    LcmCrdtDbContext dbContext)
+    IDbContextFactory<LcmCrdtDbContext> dbContextFactory)
 {
     public async Task<SyncResults> SafeExecuteSync(bool skipNotifications = false)
     {
@@ -204,6 +204,7 @@ public class SyncService(
         {
             //the prop name is hardcoded into the sql so we just want to assert it's what we expect
             Debug.Assert(CommitHelpers.SyncDateProp == "SyncDate");
+            await using var dbContext = await dbContextFactory.CreateDbContextAsync();
             await dbContext.Database.ExecuteSqlAsync(
                 $"""
                  UPDATE Commits
@@ -223,6 +224,7 @@ public class SyncService(
         {
             // Assert sync date prop for same reason as in UpdateSyncDate
             Debug.Assert(CommitHelpers.SyncDateProp == "SyncDate");
+            await using var dbContext = await dbContextFactory.CreateDbContextAsync();
             int count = await dbContext.Database.SqlQuery<int>(
                 $"""
                  SELECT COUNT(*) AS Value FROM Commits
@@ -243,6 +245,7 @@ public class SyncService(
         {
             // Assert sync date prop for same reason as in UpdateSyncDate
             Debug.Assert(CommitHelpers.SyncDateProp == "SyncDate");
+            await using var dbContext = await dbContextFactory.CreateDbContextAsync();
             var date = await dbContext.Database.SqlQuery<DateTimeOffset>(
                 $"""
                  SELECT MAX(json_extract(Metadata, '$.ExtraMetadata.SyncDate')) AS Value FROM Commits

--- a/backend/FwLite/LcmCrdt.Tests/Data/MigrationTests.cs
+++ b/backend/FwLite/LcmCrdt.Tests/Data/MigrationTests.cs
@@ -22,8 +22,6 @@ public class MigrationTests: IAsyncLifetime
     [Fact]
     public async Task GetEntries_WorksAfterMigrationFromScriptedDb()
     {
-        //manually open the connection, this prevents a race condition where the entries query runs before the collations are created.
-        await _helper.Services.GetRequiredService<LcmCrdtDbContext>().Database.OpenConnectionAsync();
         var api = _helper.Services.GetRequiredService<IMiniLcmApi>();
         var hasEntries = false;
         await foreach (var entry in api.GetEntries(new(Count: 100)))

--- a/backend/FwLite/LcmCrdt.Tests/Data/RegressionTestHelper.cs
+++ b/backend/FwLite/LcmCrdt.Tests/Data/RegressionTestHelper.cs
@@ -18,7 +18,7 @@ public class RegressionTestHelper(string dbName): IAsyncLifetime
         var crdtProject = new CrdtProject(dbName, $"{dbName}.sqlite");
         if (File.Exists(crdtProject.DbPath)) File.Delete(crdtProject.DbPath);
         projectsService.SetupProjectContextForNewDb(crdtProject);
-        var lcmCrdtDbContext = _asyncScope.ServiceProvider.GetRequiredService<LcmCrdtDbContext>();
+        await using var lcmCrdtDbContext = await _asyncScope.ServiceProvider.GetRequiredService<IDbContextFactory<LcmCrdtDbContext>>().CreateDbContextAsync();
         var sql = await File.ReadAllTextAsync(initialSqlFile);
         var dbConnection = lcmCrdtDbContext.Database.GetDbConnection();
         await dbConnection.OpenAsync();

--- a/backend/FwLite/LcmCrdt.Tests/DataModelSnapshotTests.cs
+++ b/backend/FwLite/LcmCrdt.Tests/DataModelSnapshotTests.cs
@@ -32,7 +32,7 @@ public class DataModelSnapshotTests : IAsyncLifetime
             .AddLogging(builder => builder.AddDebug())
             .BuildServiceProvider();
         _services = services.CreateAsyncScope();
-        _crdtDbContext = _services.ServiceProvider.GetRequiredService<LcmCrdtDbContext>();
+        _crdtDbContext = _services.ServiceProvider.GetRequiredService<IDbContextFactory<LcmCrdtDbContext>>().CreateDbContext();
         _crdtConfig = _services.ServiceProvider.GetRequiredService<IOptions<CrdtConfig>>().Value;
     }
 
@@ -50,6 +50,7 @@ public class DataModelSnapshotTests : IAsyncLifetime
     {
         await _crdtDbContext.Database.CloseConnectionAsync();
         await _crdtDbContext.Database.EnsureDeletedAsync();
+        await _crdtDbContext.DisposeAsync();
         await _services.DisposeAsync();
     }
 

--- a/backend/FwLite/LcmCrdt.Tests/FullTextSearch/EntrySearchServiceTests.cs
+++ b/backend/FwLite/LcmCrdt.Tests/FullTextSearch/EntrySearchServiceTests.cs
@@ -40,8 +40,8 @@ public class EntrySearchServiceTests : IAsyncLifetime
             Exemplars = ["a", "b"],
             Type = WritingSystemType.Analysis
         });
-        _context = fixture.GetService<LcmCrdtDbContext>();
-        _service = fixture.GetService<EntrySearchService>();
+        _context = await fixture.GetService<IDbContextFactory<LcmCrdtDbContext>>().CreateDbContextAsync();
+        _service = fixture.GetService<EntrySearchServiceFactory>().CreateSearchService(_context);
     }
 
     [Fact]
@@ -242,6 +242,7 @@ public class EntrySearchServiceTests : IAsyncLifetime
 
     public async Task DisposeAsync()
     {
+        await _context.DisposeAsync();
         await fixture.DisposeAsync();
     }
 }

--- a/backend/FwLite/LcmCrdt.Tests/OpenProjectTests.cs
+++ b/backend/FwLite/LcmCrdt.Tests/OpenProjectTests.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.Extensions.DependencyInjection;
+﻿using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using static LcmCrdt.CrdtProjectsService;
 
@@ -68,6 +69,7 @@ public class OpenProjectTests
         var miniLcmApi = (CrdtMiniLcmApi)await asyncScope.ServiceProvider.OpenCrdtProject(crdtProject);
         miniLcmApi.ProjectData.Name.Should().Be("OpeningAProjectWorks");
 
-        await asyncScope.ServiceProvider.GetRequiredService<LcmCrdtDbContext>().Database.EnsureDeletedAsync();
+        await using var dbContext = await asyncScope.ServiceProvider.GetRequiredService<IDbContextFactory<LcmCrdtDbContext>>().CreateDbContextAsync();
+        await dbContext.Database.EnsureDeletedAsync();
     }
 }

--- a/backend/FwLite/LcmCrdt/CrdtMiniLcmApi.cs
+++ b/backend/FwLite/LcmCrdt/CrdtMiniLcmApi.cs
@@ -54,28 +54,14 @@ public class CrdtMiniLcmApi(
 
     private async Task AddChanges(IEnumerable<IChange> changes)
     {
-        await AddChanges(changes.Chunk(100));
+        AssertWritable();
+        await dataModel.AddManyChanges(ClientId, changes, commitMetadata: NewMetadata);
     }
 
     private void AssertWritable()
     {
         if (ProjectData.IsReadonly)
             throw new ReadOnlyException($"project is readonly because you are logged in with the {ProjectData.Role} role. If your role recently changed, try refreshing the server project list on the home page.");
-    }
-
-    /// <summary>
-    /// use when making a large number of changes at once
-    /// </summary>
-    /// <param name="changeChunks"></param>
-    private async Task AddChanges(IEnumerable<IReadOnlyCollection<IChange>> changeChunks)
-    {
-        AssertWritable();
-        foreach (var chunk in changeChunks)
-        {
-            await dataModel.AddChanges(ClientId, chunk, commitMetadata: NewMetadata(), deferCommit: true);
-        }
-
-        await dataModel.FlushDeferredCommits();
     }
 
     public async Task<WritingSystems> GetWritingSystems()

--- a/backend/FwLite/LcmCrdt/CrdtMiniLcmApi.cs
+++ b/backend/FwLite/LcmCrdt/CrdtMiniLcmApi.cs
@@ -1,5 +1,4 @@
 using System.Data;
-using FluentValidation;
 using Gridify;
 using SIL.Harmony;
 using SIL.Harmony.Changes;
@@ -11,16 +10,13 @@ using LcmCrdt.Objects;
 using LcmCrdt.Utils;
 using LinqToDB;
 using LinqToDB.EntityFrameworkCore;
-using Microsoft.Data.Sqlite;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using MiniLcm.Exceptions;
 using MiniLcm.SyncHelpers;
 using MiniLcm.Validators;
 using SIL.Harmony.Core;
-using SIL.Harmony.Db;
 using MiniLcm.Culture;
-using MiniLcm.Filtering;
 
 namespace LcmCrdt;
 
@@ -29,7 +25,7 @@ public class CrdtMiniLcmApi(
     CurrentProjectService projectService,
     IMiniLcmCultureProvider cultureProvider,
     MiniLcmValidators validators,
-    LcmCrdtDbContext dbContext,
+    MiniLcmRepositoryFactory repoFactory,
     IOptions<LcmCrdtConfig> config,
     ILogger<CrdtMiniLcmApi> logger,
     EntrySearchService? entrySearchService = null) : IMiniLcmApi
@@ -37,16 +33,6 @@ public class CrdtMiniLcmApi(
     private Guid ClientId { get; } = projectService.ProjectData.ClientId;
     public ProjectData ProjectData => projectService.ProjectData;
     private LcmCrdtConfig LcmConfig => config.Value;
-
-    private IQueryable<Entry> Entries => dataModel.QueryLatest<Entry>();
-    private IQueryable<ComplexFormComponent> ComplexFormComponents => dataModel.QueryLatest<ComplexFormComponent>();
-    private IQueryable<ComplexFormType> ComplexFormTypes => dataModel.QueryLatest<ComplexFormType>();
-    private IQueryable<Sense> Senses => dataModel.QueryLatest<Sense>();
-    private IQueryable<ExampleSentence> ExampleSentences => dataModel.QueryLatest<ExampleSentence>();
-    private IQueryable<WritingSystem> WritingSystems => dataModel.QueryLatest<WritingSystem>();
-    private IQueryable<SemanticDomain> SemanticDomains => dataModel.QueryLatest<SemanticDomain>();
-    private IQueryable<PartOfSpeech> PartsOfSpeech => dataModel.QueryLatest<PartOfSpeech>();
-    private IQueryable<Publication> Publications => dataModel.QueryLatest<Publication>();
 
     private CommitMetadata NewMetadata()
     {
@@ -84,19 +70,18 @@ public class CrdtMiniLcmApi(
     private async Task AddChanges(IEnumerable<IReadOnlyCollection<IChange>> changeChunks)
     {
         AssertWritable();
-        await using var transaction = await dbContext.Database.BeginTransactionAsync();
         foreach (var chunk in changeChunks)
         {
             await dataModel.AddChanges(ClientId, chunk, commitMetadata: NewMetadata(), deferCommit: true);
         }
 
         await dataModel.FlushDeferredCommits();
-        await transaction.CommitAsync();
     }
 
     public async Task<WritingSystems> GetWritingSystems()
     {
-        var systems = await WritingSystems.ToArrayAsync();
+        await using var repo = await repoFactory.CreateRepoAsync();
+        var systems = await repo.WritingSystems.ToArrayAsync();
         return new WritingSystems
         {
             Analysis = systems.Where(ws => ws.Type == WritingSystemType.Analysis)
@@ -109,22 +94,24 @@ public class CrdtMiniLcmApi(
     public async Task<WritingSystem> CreateWritingSystem(WritingSystem writingSystem)
     {
         await validators.ValidateAndThrow(writingSystem);
+        await using var repo = await repoFactory.CreateRepoAsync();
         var entityId = Guid.NewGuid();
-        var exists = await WritingSystems.AnyAsync(ws => ws.WsId == writingSystem.WsId && ws.Type == writingSystem.Type);
+        var exists = await repo.WritingSystems.AnyAsync(ws => ws.WsId == writingSystem.WsId && ws.Type == writingSystem.Type);
         if (exists) throw new DuplicateObjectException($"Writing system {writingSystem.WsId.Code} already exists");
-        var wsCount = await WritingSystems.CountAsync(ws => ws.Type == writingSystem.Type);
+        var wsCount = await repo.WritingSystems.CountAsync(ws => ws.Type == writingSystem.Type);
         await AddChange(new CreateWritingSystemChange(writingSystem, entityId, wsCount));
-        return await GetWritingSystem(writingSystem.WsId, writingSystem.Type) ?? throw new NullReferenceException();
+        return await repo.GetWritingSystem(writingSystem.WsId, writingSystem.Type) ?? throw new NullReferenceException();
     }
 
     public async Task<WritingSystem> UpdateWritingSystem(WritingSystemId id, WritingSystemType type, UpdateObjectInput<WritingSystem> update)
     {
+        await using var repo = await repoFactory.CreateRepoAsync();
         await validators.ValidateAndThrow(update);
-        var ws = await GetWritingSystem(id, type);
+        var ws = await repo.GetWritingSystem(id, type);
         if (ws is null) throw new NullReferenceException($"unable to find writing system with id {id}");
         var patchChange = new JsonPatchChange<WritingSystem>(ws.Id, update.Patch);
         await AddChange(patchChange);
-        return await GetWritingSystem(id, type) ?? throw new NullReferenceException();
+        return await repo.GetWritingSystem(id, type) ?? throw new NullReferenceException();
     }
 
     public async Task<WritingSystem> UpdateWritingSystem(WritingSystem before, WritingSystem after, IMiniLcmApi? api = null)
@@ -134,40 +121,40 @@ public class CrdtMiniLcmApi(
         return await GetWritingSystem(after.WsId, after.Type) ?? throw new NullReferenceException("unable to find writing system with id " + after.WsId);
     }
 
-    private WritingSystem? _defaultVernacularWs;
-    private WritingSystem? _defaultAnalysisWs;
     private async ValueTask<WritingSystem?> GetWritingSystem(WritingSystemId id, WritingSystemType type)
     {
-        if (id.Code == "default")
+        await using var repo = await repoFactory.CreateRepoAsync();
+        return await repo.GetWritingSystem(id, type);
+    }
+
+    public async IAsyncEnumerable<PartOfSpeech> GetPartsOfSpeech()
+    {
+        await using var repo = await repoFactory.CreateRepoAsync();
+        await foreach (var partOfSpeech in repo.PartsOfSpeech.AsAsyncEnumerable())
         {
-            return type switch
-            {
-                WritingSystemType.Analysis => _defaultAnalysisWs ??= await WritingSystems.FirstOrDefaultAsync(ws => ws.Type == type),
-                WritingSystemType.Vernacular => _defaultVernacularWs ??= await WritingSystems.FirstOrDefaultAsync(ws => ws.Type == type),
-                _ => throw new ArgumentOutOfRangeException(nameof(type), type, null)
-            } ?? throw new NullReferenceException($"Unable to find a default writing system of type {type}");
+            yield return partOfSpeech;
         }
-        return await WritingSystems.FirstOrDefaultAsync(ws => ws.WsId == id && ws.Type == type);
     }
 
-    public IAsyncEnumerable<PartOfSpeech> GetPartsOfSpeech()
+    public async IAsyncEnumerable<Publication> GetPublications()
     {
-        return PartsOfSpeech.AsAsyncEnumerable();
-    }
-
-    public IAsyncEnumerable<Publication> GetPublications()
-    {
-        return Publications.AsAsyncEnumerable();
+        await using var repo = await repoFactory.CreateRepoAsync();
+        await foreach (var publication in repo.Publications.AsAsyncEnumerable())
+        {
+            yield return publication;
+        }
     }
 
     public async Task<PartOfSpeech?> GetPartOfSpeech(Guid id)
     {
-        return await PartsOfSpeech.SingleOrDefaultAsync(pos => pos.Id == id);
+        await using var repo = await repoFactory.CreateRepoAsync();
+        return await repo.PartsOfSpeech.SingleOrDefaultAsync(pos => pos.Id == id);
     }
 
     public async Task<Publication?> GetPublication(Guid id)
     {
-        return await Publications.SingleOrDefaultAsync(p => p.Id == id);
+        await using var repo = await repoFactory.CreateRepoAsync();
+        return await repo.Publications.SingleOrDefaultAsync(p => p.Id == id);
     }
 
     public async Task<PartOfSpeech> CreatePartOfSpeech(PartOfSpeech partOfSpeech)
@@ -234,14 +221,19 @@ public class CrdtMiniLcmApi(
         throw new NotImplementedException();
     }
 
-    public IAsyncEnumerable<MiniLcm.Models.SemanticDomain> GetSemanticDomains()
+    public async IAsyncEnumerable<MiniLcm.Models.SemanticDomain> GetSemanticDomains()
     {
-        return SemanticDomains.AsAsyncEnumerable();
+        await using var repo = await repoFactory.CreateRepoAsync();
+        await foreach (var semanticDomain in repo.SemanticDomains.AsAsyncEnumerable())
+        {
+            yield return semanticDomain;
+        }
     }
 
-    public Task<MiniLcm.Models.SemanticDomain?> GetSemanticDomain(Guid id)
+    public async Task<SemanticDomain?> GetSemanticDomain(Guid id)
     {
-        return SemanticDomains.FirstOrDefaultAsync(semdom => semdom.Id == id);
+        await using var repo = await repoFactory.CreateRepoAsync();
+        return await repo.SemanticDomains.FirstOrDefaultAsync(semdom => semdom.Id == id);
     }
 
     public async Task<MiniLcm.Models.SemanticDomain> CreateSemanticDomain(MiniLcm.Models.SemanticDomain semanticDomain)
@@ -277,22 +269,28 @@ public class CrdtMiniLcmApi(
         await AddChanges(await semanticDomains.Select(sd => new CreateSemanticDomainChange(sd.Id, sd.Name, sd.Code, sd.Predefined)).ToArrayAsync());
     }
 
-    public IAsyncEnumerable<ComplexFormType> GetComplexFormTypes()
+    public async IAsyncEnumerable<ComplexFormType> GetComplexFormTypes()
     {
-        return ComplexFormTypes.AsAsyncEnumerable();
+        await using var repo = await repoFactory.CreateRepoAsync();
+        await foreach (var complexFormType in repo.ComplexFormTypes.AsAsyncEnumerable())
+        {
+            yield return complexFormType;
+        }
     }
 
     public async Task<ComplexFormType?> GetComplexFormType(Guid id)
     {
-        return await ComplexFormTypes.SingleOrDefaultAsync(c => c.Id == id);
+        await using var repo = await repoFactory.CreateRepoAsync();
+        return await repo.ComplexFormTypes.SingleOrDefaultAsync(c => c.Id == id);
     }
 
     public async Task<ComplexFormType> CreateComplexFormType(ComplexFormType complexFormType)
     {
         await validators.ValidateAndThrow(complexFormType);
+        await using var repo = await repoFactory.CreateRepoAsync();
         if (complexFormType.Id == default) complexFormType.Id = Guid.NewGuid();
         await AddChange(new CreateComplexFormType(complexFormType.Id, complexFormType.Name));
-        return await ComplexFormTypes.SingleAsync(c => c.Id == complexFormType.Id);
+        return await repo.ComplexFormTypes.SingleAsync(c => c.Id == complexFormType.Id);
     }
 
     public async Task<ComplexFormType> UpdateComplexFormType(Guid id, UpdateObjectInput<ComplexFormType> update)
@@ -313,28 +311,20 @@ public class CrdtMiniLcmApi(
         await AddChange(new DeleteChange<ComplexFormType>(id));
     }
 
-    private async Task<AddEntryComponentChange> CreateComplexFormComponentChange(ComplexFormComponent complexFormComponent, BetweenPosition? between = null)
-    {
-        complexFormComponent.Order = await OrderPicker.PickOrder(ComplexFormComponents.Where(c => c.ComplexFormEntryId == complexFormComponent.ComplexFormEntryId), between);
-        return new AddEntryComponentChange(complexFormComponent);
-    }
-
     public async Task<ComplexFormComponent> CreateComplexFormComponent(ComplexFormComponent complexFormComponent, BetweenPosition<ComplexFormComponent>? between = null)
     {
+        await using var repo = await repoFactory.CreateRepoAsync();
         // tests in seperate PR:
         // 1: call create with the same ID should throw.
         // 2: change a propertyId => should result in a new ID (in Crdt test not base).
         // 3: "normal" create also changes provided ID.
-        var existing = await ComplexFormComponents.SingleOrDefaultAsync(c =>
-            c.ComplexFormEntryId == complexFormComponent.ComplexFormEntryId
-            && c.ComponentEntryId == complexFormComponent.ComponentEntryId
-            && c.ComponentSenseId == complexFormComponent.ComponentSenseId);
+        var existing = await repo.FindComplexFormComponent(complexFormComponent);
         if (existing is null)
         {
             var betweenIds = between is null ? null : new BetweenPosition(between.Previous?.Id, between.Next?.Id);
-            var addEntryComponentChange = await CreateComplexFormComponentChange(complexFormComponent, betweenIds);
+            var addEntryComponentChange = await repo.CreateComplexFormComponentChange(complexFormComponent, betweenIds);
             await AddChange(addEntryComponentChange);
-            return (await ComplexFormComponents.SingleOrDefaultAsync(c => c.Id == addEntryComponentChange.EntityId)) ?? throw NotFoundException.ForType<ComplexFormComponent>();
+            return await repo.FindComplexFormComponent(addEntryComponentChange.EntityId);
         }
         else if (between is not null)
         {
@@ -345,8 +335,9 @@ public class CrdtMiniLcmApi(
 
     public async Task MoveComplexFormComponent(ComplexFormComponent component, BetweenPosition<ComplexFormComponent> between)
     {
+        await using var repo = await repoFactory.CreateRepoAsync();
         var betweenIds = new BetweenPosition(between.Previous?.Id, between.Next?.Id);
-        var order = await OrderPicker.PickOrder(ComplexFormComponents.Where(s => s.ComplexFormEntryId == component.ComplexFormEntryId), betweenIds);
+        var order = await OrderPicker.PickOrder(repo.ComplexFormComponents.Where(s => s.ComplexFormEntryId == component.ComplexFormEntryId), betweenIds);
         await AddChange(new Changes.SetOrderChange<ComplexFormComponent>(component.Id, order));
     }
 
@@ -357,7 +348,8 @@ public class CrdtMiniLcmApi(
 
     public async Task AddComplexFormType(Guid entryId, Guid complexFormTypeId)
     {
-        await AddChange(new AddComplexFormTypeChange(entryId, await ComplexFormTypes.SingleAsync(ct => ct.Id == complexFormTypeId)));
+        await using var repo = await repoFactory.CreateRepoAsync();
+        await AddChange(new AddComplexFormTypeChange(entryId, await repo.ComplexFormTypes.SingleAsync(ct => ct.Id == complexFormTypeId)));
     }
 
     public async Task RemoveComplexFormType(Guid entryId, Guid complexFormTypeId)
@@ -367,9 +359,8 @@ public class CrdtMiniLcmApi(
 
     public async Task<int> CountEntries(string? query = null, FilterQueryOptions? options = null)
     {
-        options ??= FilterQueryOptions.Default;
-        var (queryable, _) = await FilterEntries(Entries, query, options);
-        return await queryable.CountAsync();
+        await using var repo = await repoFactory.CreateRepoAsync();
+        return await repo.CountEntries(query, options);
     }
 
     public IAsyncEnumerable<Entry> GetEntries(QueryOptions? options = null)
@@ -377,122 +368,29 @@ public class CrdtMiniLcmApi(
         return SearchEntries(null, options);
     }
 
-    public IAsyncEnumerable<Entry> SearchEntries(string? query, QueryOptions? options = null)
+    public async IAsyncEnumerable<Entry> SearchEntries(string? query, QueryOptions? options = null)
     {
-        return GetEntries(Entries, query, options);
-    }
-
-    private async IAsyncEnumerable<Entry> GetEntries(IQueryable<Entry> queryable,
-        string? query = null,
-        QueryOptions? options = null)
-    {
-        options ??= QueryOptions.Default;
-        (queryable, var sortingHandled) = await FilterEntries(queryable, query, options);
-        if (!sortingHandled)
-            queryable = await ApplySorting(queryable, options, query);
-
-        queryable = queryable
-            .LoadWith(e => e.Senses)
-            .ThenLoad(s => s.ExampleSentences)
-            .LoadWith(e => e.Senses).ThenLoad(s => s.PartOfSpeech)
-            .LoadWith(e => e.ComplexForms)
-            .LoadWith(e => e.Components)
-            .AsQueryable();
-
-        queryable = options.ApplyPaging(queryable);
-        var complexFormComparer = cultureProvider.GetCompareInfo(await GetWritingSystem(default, WritingSystemType.Vernacular))
-            .AsComplexFormComparer();
-        var entries = queryable.AsAsyncEnumerable();
-        await foreach (var entry in EfExtensions.SafeIterate(entries))
+        await using var repo = await repoFactory.CreateRepoAsync();
+        await foreach (var entry in repo.GetEntries(query, options))
         {
-            entry.ApplySortOrder(complexFormComparer);
             yield return entry;
-        }
-    }
-
-    private async Task<(IQueryable<Entry> queryable, bool sortingHandled)> FilterEntries(IQueryable<Entry> queryable,
-        string? query,
-        FilterQueryOptions options)
-    {
-        bool sortingHandled = false;
-        if (!string.IsNullOrEmpty(query))
-        {
-            if (entrySearchService is not null && entrySearchService.ValidSearchTerm(query))
-            {
-                var queryOptions = options as QueryOptions;
-                //ranking must be done at the same time as part of the full-text search, so we can't use normal sorting
-                sortingHandled = queryOptions?.Order.Field == SortField.SearchRelevance;
-                queryable = entrySearchService.FilterAndRank(queryable,
-                    query,
-                    sortingHandled,
-                    queryOptions?.Order.Ascending == true);
-            }
-            else
-            {
-                queryable = queryable.Where(Filtering.SearchFilter(query));
-            }
-        }
-
-        if (options.Exemplar is not null)
-        {
-            var ws = (await GetWritingSystem(options.Exemplar.WritingSystem, WritingSystemType.Vernacular))?.WsId;
-            if (ws is null)
-                throw new NullReferenceException($"writing system {options.Exemplar.WritingSystem} not found");
-            queryable = queryable.WhereExemplar(ws.Value, options.Exemplar.Value);
-        }
-
-        if (options.Filter?.GridifyFilter != null)
-        {
-            queryable = queryable.ApplyFiltering(options.Filter.GridifyFilter, LcmConfig.Mapper);
-        }
-        return (queryable, sortingHandled);
-    }
-
-    private async ValueTask<IQueryable<Entry>> ApplySorting(IQueryable<Entry> queryable, QueryOptions options, string? query = null)
-    {
-        var sortWs = await GetWritingSystem(options.Order.WritingSystem, WritingSystemType.Vernacular);
-        if (sortWs is null)
-            throw new NullReferenceException($"sort writing system {options.Order.WritingSystem} not found");
-
-        switch (options.Order.Field)
-        {
-            case SortField.SearchRelevance:
-                return queryable.ApplyRoughBestMatchOrder(options.Order with { WritingSystem = sortWs.WsId }, query);
-            case SortField.Headword:
-                var ordered = options.ApplyOrder(queryable, e => e.Headword(sortWs.WsId).CollateUnicode(sortWs));
-                return ordered.ThenBy(e => e.Id);
-            default:
-                throw new ArgumentOutOfRangeException(nameof(options), "sort field unknown " + options.Order.Field);
         }
     }
 
     public async Task<Entry?> GetEntry(Guid id)
     {
-        var entry = await Entries
-            .LoadWith(e => e.Senses)
-            .ThenLoad(s => s.ExampleSentences)
-            .LoadWith(e => e.Senses).ThenLoad(s => s.PartOfSpeech)
-            .LoadWith(e => e.ComplexForms)
-            .LoadWith(e => e.Components)
-            .AsQueryable()
-            .SingleOrDefaultAsync(e => e.Id == id);
-        if (entry is not null)
-        {
-            var sortWs = await GetWritingSystem(WritingSystemId.Default, WritingSystemType.Vernacular);
-            var complexFormComparer = cultureProvider.GetCompareInfo(sortWs)
-                .AsComplexFormComparer();
-            entry.ApplySortOrder(complexFormComparer);
-        }
-        return entry;
+        await using var repo = await repoFactory.CreateRepoAsync();
+        return await repo.GetEntry(id);
     }
 
     public async Task BulkCreateEntries(IAsyncEnumerable<Entry> entries)
     {
-        var semanticDomains = await SemanticDomains.ToDictionaryAsync(sd => sd.Id, sd => sd);
+        await using var repo = await repoFactory.CreateRepoAsync();
+        var semanticDomains = await repo.SemanticDomains.ToDictionaryAsync(sd => sd.Id, sd => sd);
         //we're using this change list to ensure that we partially commit in case of an error
         //this lets us attempt an import again skipping the entries that were already imported
         var changeList = new List<IChange>(1300);
-        var createdEntryIds = await Entries.Select(e => e.Id).ToAsyncEnumerable().ToHashSetAsync();
+        var createdEntryIds = await repo.Entries.Select(e => e.Id).ToAsyncEnumerable().ToHashSetAsync();
         int entryCount = 0;
         await foreach (var entry in entries)
         {
@@ -559,20 +457,21 @@ public class CrdtMiniLcmApi(
     public async Task<Entry> CreateEntry(Entry entry)
     {
         await validators.ValidateAndThrow(entry);
+        await using var repo = await repoFactory.CreateRepoAsync();
         await AddChanges([
             new CreateEntryChange(entry),
             ..await entry.Senses.ToAsyncEnumerable()
                 .SelectMany((s, i) =>
                 {
                     s.Order = i + 1;
-                    return CreateSenseChanges(entry.Id, s);
+                    return CreateSenseChanges(entry.Id, s, repo.SemanticDomains);
                 })
                 .ToArrayAsync(),
             ..await ToComplexFormComponents(entry.Components).ToArrayAsync(),
             ..await ToComplexFormComponents(entry.ComplexForms).ToArrayAsync(),
             ..await ToComplexFormTypes(entry.ComplexFormTypes).ToArrayAsync()
         ]);
-        return await GetEntry(entry.Id) ?? throw new NullReferenceException();
+        return await repo.GetEntry(entry.Id) ?? throw new NullReferenceException();
 
         async IAsyncEnumerable<AddEntryComponentChange> ToComplexFormComponents(IList<ComplexFormComponent> complexFormComponents)
         {
@@ -612,7 +511,7 @@ public class CrdtMiniLcmApi(
                 else
                 {
                     // the entry is a component, so we let its complex-form pick the order
-                    yield return await CreateComplexFormComponentChange(complexFormComponent);
+                    yield return await repo.CreateComplexFormComponentChange(complexFormComponent);
                 }
             }
         }
@@ -626,28 +525,24 @@ public class CrdtMiniLcmApi(
                     throw new InvalidOperationException("Complex form type must have an id");
                 }
 
-                if (!await ComplexFormTypes.AnyAsyncEF(t => t.Id == complexFormType.Id))
+                if (!await repo.ComplexFormTypes.AnyAsyncEF(t => t.Id == complexFormType.Id))
                 {
                     throw new InvalidOperationException($"Complex form type {complexFormType} does not exist");
                 }
                 yield return new AddComplexFormTypeChange(entry.Id, complexFormType);
             }
         }
-            }
-
-    private async ValueTask<bool> IsEntryDeleted(Guid id)
-    {
-        return !await Entries.AnyAsyncEF(e => e.Id == id);
     }
 
     public async Task<Entry> UpdateEntry(Guid id,
         UpdateObjectInput<Entry> update)
     {
-        var entry = await GetEntry(id);
+        await using var repo = await repoFactory.CreateRepoAsync();
+        var entry = await repo.GetEntry(id);
         if (entry is null) throw new NullReferenceException($"unable to find entry with id {id}");
 
         await AddChanges(entry.ToChanges(update.Patch));
-        var updatedEntry = await GetEntry(id) ?? throw new NullReferenceException("unable to find entry with id " + id);
+        var updatedEntry = await repo.GetEntry(id) ?? throw new NullReferenceException("unable to find entry with id " + id);
         return updatedEntry;
     }
 
@@ -664,9 +559,11 @@ public class CrdtMiniLcmApi(
         await AddChange(new DeleteChange<Entry>(id));
     }
 
-    private async IAsyncEnumerable<IChange> CreateSenseChanges(Guid entryId, Sense sense)
+    private async IAsyncEnumerable<IChange> CreateSenseChanges(Guid entryId,
+        Sense sense,
+        IQueryable<SemanticDomain> semanticDomains)
     {
-        sense.SemanticDomains = await SemanticDomains
+        sense.SemanticDomains = await semanticDomains
             .Where(sd => sense.SemanticDomains.Select(s => s.Id).Contains(sd.Id))
             .ToListAsync();
 
@@ -681,32 +578,31 @@ public class CrdtMiniLcmApi(
 
     public async Task<Sense?> GetSense(Guid entryId, Guid senseId)
     {
-        var sense = await Senses.LoadWith(s => s.PartOfSpeech)
-            .AsQueryable()
-            .SingleOrDefaultAsync(e => e.Id == senseId);
-        sense?.ApplySortOrder();
-        return sense;
+        await using var repo = await repoFactory.CreateRepoAsync();
+        return await repo.GetSense(entryId, senseId);
     }
 
     public async Task<Sense> CreateSense(Guid entryId, Sense sense, BetweenPosition? between = null)
     {
         await validators.ValidateAndThrow(sense);
+        await using var repo = await repoFactory.CreateRepoAsync();
         if (sense.PartOfSpeechId.HasValue && await GetPartOfSpeech(sense.PartOfSpeechId.Value) is null)
             throw new InvalidOperationException($"Part of speech must exist when creating a sense (could not find GUID {sense.PartOfSpeechId.Value})");
 
-        sense.Order = await OrderPicker.PickOrder(Senses.Where(s => s.EntryId == entryId), between);
-        await AddChanges(await CreateSenseChanges(entryId, sense).ToArrayAsync());
-        return await GetSense(entryId, sense.Id) ?? throw new NullReferenceException("unable to find sense " + sense.Id);
+        sense.Order = await OrderPicker.PickOrder(repo.Senses.Where(s => s.EntryId == entryId), between);
+        await AddChanges(await CreateSenseChanges(entryId, sense, repo.SemanticDomains).ToArrayAsync());
+        return await repo.GetSense(entryId, sense.Id) ?? throw new NullReferenceException("unable to find sense " + sense.Id);
     }
 
     public async Task<Sense> UpdateSense(Guid entryId,
         Guid senseId,
         UpdateObjectInput<Sense> update)
     {
-        var sense = await GetSense(entryId, senseId);
+        await using var repo = await repoFactory.CreateRepoAsync();
+        var sense = await repo.GetSense(entryId, senseId);
         if (sense is null) throw new NullReferenceException($"unable to find sense with id {senseId}");
         await AddChanges([..sense.ToChanges(update.Patch)]);
-        return await GetSense(entryId, senseId) ?? throw new NullReferenceException("unable to find sense with id " + senseId);
+        return await repo.GetSense(entryId, senseId) ?? throw new NullReferenceException("unable to find sense with id " + senseId);
     }
 
     public async Task<Sense> UpdateSense(Guid entryId, Sense before, Sense after, IMiniLcmApi? api = null)
@@ -718,7 +614,8 @@ public class CrdtMiniLcmApi(
 
     public async Task MoveSense(Guid entryId, Guid senseId, BetweenPosition between)
     {
-        var order = await OrderPicker.PickOrder(Senses.Where(s => s.EntryId == entryId), between);
+        await using var repo = await repoFactory.CreateRepoAsync();
+        var order = await OrderPicker.PickOrder(repo.Senses.Where(s => s.EntryId == entryId), between);
         await AddChange(new Changes.SetOrderChange<Sense>(senseId, order));
     }
 
@@ -743,17 +640,16 @@ public class CrdtMiniLcmApi(
         BetweenPosition? between = null)
     {
         await validators.ValidateAndThrow(exampleSentence);
-        exampleSentence.Order = await OrderPicker.PickOrder(ExampleSentences.Where(s => s.SenseId == senseId), between);
+        await using var repo = await repoFactory.CreateRepoAsync();
+        exampleSentence.Order = await OrderPicker.PickOrder(repo.ExampleSentences.Where(s => s.SenseId == senseId), between);
         await AddChange(new CreateExampleSentenceChange(exampleSentence, senseId));
-        return await GetExampleSentence(entryId, senseId, exampleSentence.Id) ?? throw new NullReferenceException();
+        return await repo.GetExampleSentence(entryId, senseId, exampleSentence.Id) ?? throw new NullReferenceException();
     }
 
     public async Task<ExampleSentence?> GetExampleSentence(Guid entryId, Guid senseId, Guid id)
     {
-        var exampleSentence = await ExampleSentences
-            .AsQueryable()
-            .SingleOrDefaultAsync(e => e.Id == id);
-        return exampleSentence;
+        await using var repo = await repoFactory.CreateRepoAsync();
+        return await repo.GetExampleSentence(entryId, senseId, id);
     }
 
     public async Task<ExampleSentence> UpdateExampleSentence(Guid entryId,
@@ -780,7 +676,8 @@ public class CrdtMiniLcmApi(
 
     public async Task MoveExampleSentence(Guid entryId, Guid senseId, Guid exampleId, BetweenPosition between)
     {
-        var order = await OrderPicker.PickOrder(ExampleSentences.Where(s => s.SenseId == senseId), between);
+        await using var repo = await repoFactory.CreateRepoAsync();
+        var order = await OrderPicker.PickOrder(repo.ExampleSentences.Where(s => s.SenseId == senseId), between);
         await AddChange(new Changes.SetOrderChange<ExampleSentence>(exampleId, order));
     }
 

--- a/backend/FwLite/LcmCrdt/CrdtProjectsService.cs
+++ b/backend/FwLite/LcmCrdt/CrdtProjectsService.cs
@@ -130,7 +130,7 @@ public partial class CrdtProjectsService(IServiceProvider provider, ILogger<Crdt
         await using var serviceScope = provider.CreateAsyncScope();
         var currentProjectService = serviceScope.ServiceProvider.GetRequiredService<CurrentProjectService>();
         currentProjectService.SetupProjectContextForNewDb(crdtProject);
-        var db = serviceScope.ServiceProvider.GetRequiredService<LcmCrdtDbContext>();
+        await using var db = await serviceScope.ServiceProvider.GetRequiredService<IDbContextFactory<LcmCrdtDbContext>>().CreateDbContextAsync();
         try
         {
             var projectData = new ProjectData(request.Name,

--- a/backend/FwLite/LcmCrdt/Data/MiniLcmRepository.cs
+++ b/backend/FwLite/LcmCrdt/Data/MiniLcmRepository.cs
@@ -1,0 +1,239 @@
+using Gridify;
+using LcmCrdt.Changes.Entries;
+using LcmCrdt.FullTextSearch;
+using LcmCrdt.Utils;
+using LinqToDB;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using MiniLcm.Culture;
+using MiniLcm.Exceptions;
+using MiniLcm.SyncHelpers;
+
+namespace LcmCrdt.Data;
+
+public class MiniLcmRepositoryFactory(
+    Microsoft.EntityFrameworkCore.IDbContextFactory<LcmCrdtDbContext> dbContextFactory,
+    IServiceProvider serviceProvider,
+    EntrySearchServiceFactory? entrySearchServiceFactory = null)
+{
+    public MiniLcmRepository CreateRepo()
+    {
+        return CreateRepoInternal(dbContextFactory.CreateDbContext());
+    }
+
+    public async Task<MiniLcmRepository> CreateRepoAsync(CancellationToken cancellationToken = new CancellationToken())
+    {
+        return CreateRepoInternal(await dbContextFactory.CreateDbContextAsync(cancellationToken));
+    }
+
+    private MiniLcmRepository CreateRepoInternal(LcmCrdtDbContext dbContext)
+    {
+        if (entrySearchServiceFactory is null) return ActivatorUtilities.CreateInstance<MiniLcmRepository>(serviceProvider, dbContext);
+        return ActivatorUtilities.CreateInstance<MiniLcmRepository>(serviceProvider, dbContext, entrySearchServiceFactory.CreateSearchService(dbContext));
+    }
+}
+
+public class MiniLcmRepository(
+    LcmCrdtDbContext dbContext,
+    IMiniLcmCultureProvider cultureProvider,
+    IOptions<LcmCrdtConfig> config,
+    EntrySearchService? entrySearchService = null
+) : IAsyncDisposable, IDisposable
+{
+    public EntrySearchService? SearchService { get; } = entrySearchService;
+
+    public ValueTask DisposeAsync()
+    {
+        return dbContext.DisposeAsync();
+    }
+
+    public void Dispose()
+    {
+        dbContext.Dispose();
+    }
+
+
+    public IQueryable<Entry> Entries => dbContext.Entries;
+    public IQueryable<ComplexFormComponent> ComplexFormComponents => dbContext.ComplexFormComponents;
+    public IQueryable<ComplexFormType> ComplexFormTypes => dbContext.ComplexFormTypes;
+    public IQueryable<Sense> Senses => dbContext.Senses;
+    public IQueryable<ExampleSentence> ExampleSentences => dbContext.ExampleSentences;
+    public IQueryable<WritingSystem> WritingSystems => dbContext.WritingSystems;
+    public IQueryable<SemanticDomain> SemanticDomains => dbContext.SemanticDomains;
+    public IQueryable<PartOfSpeech> PartsOfSpeech => dbContext.PartsOfSpeech;
+    public IQueryable<Publication> Publications => dbContext.Publications;
+
+
+    private WritingSystem? _defaultVernacularWs;
+    private WritingSystem? _defaultAnalysisWs;
+    public async ValueTask<WritingSystem?> GetWritingSystem(WritingSystemId id, WritingSystemType type)
+    {
+        if (id.Code == "default")
+        {
+            return type switch
+            {
+                WritingSystemType.Analysis => _defaultAnalysisWs ??=
+                    await dbContext.WritingSystems.FirstOrDefaultAsync(ws => ws.Type == type),
+                WritingSystemType.Vernacular => _defaultVernacularWs ??=
+                    await dbContext.WritingSystems.FirstOrDefaultAsync(ws => ws.Type == type),
+                _ => throw new ArgumentOutOfRangeException(nameof(type), type, null)
+            } ?? throw new NullReferenceException($"Unable to find a default writing system of type {type}");
+        }
+
+        return await dbContext.WritingSystems.FirstOrDefaultAsync(ws => ws.WsId == id && ws.Type == type);
+    }
+
+    public async Task<AddEntryComponentChange> CreateComplexFormComponentChange(
+        ComplexFormComponent complexFormComponent,
+        BetweenPosition? between = null)
+    {
+        complexFormComponent.Order = await OrderPicker.PickOrder(
+            dbContext.ComplexFormComponents.Where(c => c.ComplexFormEntryId == complexFormComponent.ComplexFormEntryId),
+            between);
+        return new AddEntryComponentChange(complexFormComponent);
+    }
+
+    public async Task<ComplexFormComponent?> FindComplexFormComponent(ComplexFormComponent complexFormComponent)
+    {
+        return await ComplexFormComponents.SingleOrDefaultAsync(c =>
+            c.ComplexFormEntryId == complexFormComponent.ComplexFormEntryId
+            && c.ComponentEntryId == complexFormComponent.ComponentEntryId
+            && c.ComponentSenseId == complexFormComponent.ComponentSenseId);
+    }
+
+    public async Task<ComplexFormComponent> FindComplexFormComponent(Guid objectId)
+    {
+        return (await ComplexFormComponents.SingleOrDefaultAsync(c => c.Id == objectId)) ??
+               throw NotFoundException.ForType<ComplexFormComponent>();
+    }
+
+    public async Task<int> CountEntries(string? query = null, FilterQueryOptions? options = null)
+    {
+        options ??= FilterQueryOptions.Default;
+        var (queryable, _) = await FilterEntries(Entries, query, options);
+        return await queryable.CountAsync();
+    }
+
+    public async IAsyncEnumerable<Entry> GetEntries(
+        string? query = null,
+        QueryOptions? options = null)
+    {
+        options ??= QueryOptions.Default;
+        var queryable = Entries;
+        (queryable, var sortingHandled) = await FilterEntries(queryable, query, options);
+        if (!sortingHandled)
+            queryable = await ApplySorting(queryable, options, query);
+
+        queryable = queryable
+            .LoadWith(e => e.Senses)
+            .ThenLoad(s => s.ExampleSentences)
+            .LoadWith(e => e.Senses).ThenLoad(s => s.PartOfSpeech)
+            .LoadWith(e => e.ComplexForms)
+            .LoadWith(e => e.Components)
+            .AsQueryable();
+
+        queryable = options.ApplyPaging(queryable);
+        var complexFormComparer = cultureProvider.GetCompareInfo(await GetWritingSystem(default, WritingSystemType.Vernacular))
+            .AsComplexFormComparer();
+        var entries = queryable.AsAsyncEnumerable();
+        await foreach (var entry in EfExtensions.SafeIterate(entries))
+        {
+            entry.ApplySortOrder(complexFormComparer);
+            yield return entry;
+        }
+    }
+
+    private async Task<(IQueryable<Entry> queryable, bool sortingHandled)> FilterEntries(IQueryable<Entry> queryable,
+        string? query,
+        FilterQueryOptions options)
+    {
+        bool sortingHandled = false;
+        if (!string.IsNullOrEmpty(query))
+        {
+            if (SearchService is not null && SearchService.ValidSearchTerm(query))
+            {
+                var queryOptions = options as QueryOptions;
+                //ranking must be done at the same time as part of the full-text search, so we can't use normal sorting
+                sortingHandled = queryOptions?.Order.Field == SortField.SearchRelevance;
+                queryable = SearchService.FilterAndRank(queryable,
+                    query,
+                    sortingHandled,
+                    queryOptions?.Order.Ascending == true);
+            }
+            else
+            {
+                queryable = queryable.Where(Filtering.SearchFilter(query));
+            }
+        }
+
+        if (options.Exemplar is not null)
+        {
+            var ws = (await GetWritingSystem(options.Exemplar.WritingSystem, WritingSystemType.Vernacular))?.WsId;
+            if (ws is null)
+                throw new NullReferenceException($"writing system {options.Exemplar.WritingSystem} not found");
+            queryable = queryable.WhereExemplar(ws.Value, options.Exemplar.Value);
+        }
+
+        if (options.Filter?.GridifyFilter != null)
+        {
+            queryable = queryable.ApplyFiltering(options.Filter.GridifyFilter, config.Value.Mapper);
+        }
+        return (queryable, sortingHandled);
+    }
+
+    private async ValueTask<IQueryable<Entry>> ApplySorting(IQueryable<Entry> queryable, QueryOptions options, string? query = null)
+    {
+        var sortWs = await GetWritingSystem(options.Order.WritingSystem, WritingSystemType.Vernacular);
+        if (sortWs is null)
+            throw new NullReferenceException($"sort writing system {options.Order.WritingSystem} not found");
+
+        switch (options.Order.Field)
+        {
+            case SortField.SearchRelevance:
+                return queryable.ApplyRoughBestMatchOrder(options.Order with { WritingSystem = sortWs.WsId }, query);
+            case SortField.Headword:
+                var ordered = options.ApplyOrder(queryable, e => e.Headword(sortWs.WsId).CollateUnicode(sortWs));
+                return ordered.ThenBy(e => e.Id);
+            default:
+                throw new ArgumentOutOfRangeException(nameof(options), "sort field unknown " + options.Order.Field);
+        }
+    }
+
+    public async Task<Entry?> GetEntry(Guid id)
+    {
+        var entry = await Entries
+            .LoadWith(e => e.Senses)
+            .ThenLoad(s => s.ExampleSentences)
+            .LoadWith(e => e.Senses).ThenLoad(s => s.PartOfSpeech)
+            .LoadWith(e => e.ComplexForms)
+            .LoadWith(e => e.Components)
+            .AsQueryable()
+            .SingleOrDefaultAsync(e => e.Id == id);
+        if (entry is not null)
+        {
+            var sortWs = await GetWritingSystem(WritingSystemId.Default, WritingSystemType.Vernacular);
+            var complexFormComparer = cultureProvider.GetCompareInfo(sortWs)
+                .AsComplexFormComparer();
+            entry.ApplySortOrder(complexFormComparer);
+        }
+
+        return entry;
+    }
+
+    public async Task<Sense?> GetSense(Guid entryId, Guid senseId)
+    {
+        var sense = await Senses.LoadWith(s => s.PartOfSpeech)
+            .AsQueryable()
+            .SingleOrDefaultAsync(e => e.Id == senseId);
+        sense?.ApplySortOrder();
+        return sense;
+    }
+
+    public async Task<ExampleSentence?> GetExampleSentence(Guid entryId, Guid senseId, Guid id)
+    {
+        var exampleSentence = await ExampleSentences
+            .AsQueryable()
+            .SingleOrDefaultAsync(e => e.Id == id);
+        return exampleSentence;
+    }
+}

--- a/backend/FwLite/LcmCrdt/LcmCrdtDbContext.cs
+++ b/backend/FwLite/LcmCrdt/LcmCrdtDbContext.cs
@@ -19,6 +19,14 @@ public class LcmCrdtDbContext(
 {
     public DbSet<ProjectData> ProjectData => Set<ProjectData>();
     public IQueryable<WritingSystem> WritingSystems => Set<WritingSystem>().AsNoTracking();
+    public IQueryable<Entry> Entries => Set<Entry>().AsNoTracking();
+    public IQueryable<ComplexFormComponent> ComplexFormComponents => Set<ComplexFormComponent>().AsNoTracking();
+    public IQueryable<ComplexFormType> ComplexFormTypes => Set<ComplexFormType>().AsNoTracking();
+    public IQueryable<Sense> Senses => Set<Sense>().AsNoTracking();
+    public IQueryable<ExampleSentence> ExampleSentences => Set<ExampleSentence>().AsNoTracking();
+    public IQueryable<SemanticDomain> SemanticDomains => Set<SemanticDomain>().AsNoTracking();
+    public IQueryable<PartOfSpeech> PartsOfSpeech => Set<PartOfSpeech>().AsNoTracking();
+    public IQueryable<Publication> Publications => Set<Publication>().AsNoTracking();
     protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
     {
         optionsBuilder.AddInterceptors(setupCollationInterceptor, new CustomSqliteFunctionInterceptor());

--- a/backend/FwLite/LcmCrdt/LcmCrdtDbContext.cs
+++ b/backend/FwLite/LcmCrdt/LcmCrdtDbContext.cs
@@ -11,9 +11,7 @@ namespace LcmCrdt;
 
 public class LcmCrdtDbContext(
     DbContextOptions<LcmCrdtDbContext> dbContextOptions,
-    IOptions<CrdtConfig> options,
-    SetupCollationInterceptor setupCollationInterceptor,
-    UpdateEntrySearchTableInterceptor? updateEntrySearchTableInterceptor = null
+    IOptions<CrdtConfig> options
     )
     : DbContext(dbContextOptions), ICrdtDbContext
 {
@@ -27,14 +25,6 @@ public class LcmCrdtDbContext(
     public IQueryable<SemanticDomain> SemanticDomains => Set<SemanticDomain>().AsNoTracking();
     public IQueryable<PartOfSpeech> PartsOfSpeech => Set<PartOfSpeech>().AsNoTracking();
     public IQueryable<Publication> Publications => Set<Publication>().AsNoTracking();
-    protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
-    {
-        optionsBuilder.AddInterceptors(setupCollationInterceptor, new CustomSqliteFunctionInterceptor());
-        if (updateEntrySearchTableInterceptor is not null)
-        {
-            optionsBuilder.AddInterceptors(updateEntrySearchTableInterceptor);
-        }
-    }
 
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {

--- a/backend/FwLite/LcmCrdt/LcmCrdtKernel.cs
+++ b/backend/FwLite/LcmCrdt/LcmCrdtKernel.cs
@@ -36,7 +36,7 @@ public static class LcmCrdtKernel
     {
         services.AddLcmCrdtClientCore();
         services.AddScoped<UpdateEntrySearchTableInterceptor>();
-        services.AddScoped<EntrySearchService>();
+        services.AddScoped<EntrySearchServiceFactory>();
         return services;
     }
 
@@ -49,13 +49,14 @@ public static class LcmCrdtKernel
         services.AddMemoryCache();
         services.AddSingleton<IMiniLcmCultureProvider, LcmCrdtCultureProvider>();
         services.AddSingleton<SetupCollationInterceptor>();
-        services.AddDbContext<LcmCrdtDbContext>(ConfigureDbOptions);
+        services.AddPooledDbContextFactory<LcmCrdtDbContext>(ConfigureDbOptions);
         services.AddOptions<LcmCrdtConfig>().BindConfiguration("LcmCrdt");
 
         services.AddCrdtData<LcmCrdtDbContext>(
             ConfigureCrdt
         );
         services.AddScoped<IMiniLcmApi, CrdtMiniLcmApi>();
+        services.AddScoped<MiniLcmRepositoryFactory>();
         services.AddMiniLcmValidators();
         services.AddScoped<CurrentProjectService>();
         services.AddScoped<HistoryService>();


### PR DESCRIPTION
this should fix the majority of our UI stuttering particularly on mobile. This does require a shift in how we use the db context. Before we could just return queryables and not worry about anything. Now we need to create the db context and use the queryable in the same context. For example this:
```C#
await using ICrdtDbContext dbContext = await dbContextFactory.CreateDbContextAsync();
return await dbContext.Snapshots.SingleOrDefaultAsync(s => s.Id == snapshotId);
```
but not this:
```C#
await using ICrdtDbContext dbContext = await dbContextFactory.CreateDbContextAsync();
return await dbContext.Snapshots.Where(s => s.TypeName == name);
```
because the IQuerable is returned from the method the dbContext will get cleaned up before the query is actually executed. Depending on the method you could just call `ToArrayAsync` or something similar. However this makes querying stuff difficult, to make this better I've introduced `MiniLcmRepository` and `MiniLcmRepositoryFactory`, for the users of these classes they follow similar rules as above. However internally to the repo it doesn't need to worry as there's only one instance of the dbContext to use. 

One last example is for `IAsyncEnumerable<T>` you can't do this:
```C#
await using var repo = await repoFactory.CreateRepoAsync();
return repo.PartsOfSpeech.AsAsyncEnumerable();
```
because the similar to IQuerable the query won't be executed until the function has returned and cleaned up the repo. However there's a different option here:
```C#
await using var repo = await repoFactory.CreateRepoAsync();
await foreach (var partOfSpeech in repo.PartsOfSpeech.AsAsyncEnumerable())
{
    yield return partOfSpeech;
}
```
this works just fine because the repo isn't disposed until the `foreach` finishes and returns, at which point the query is done anyway. You only need to use this trick in the same method where the repo/context is created. In any methods calling this one they don't have to worry about it.