### PR TITLE
fix localization in prod

### DIFF
--- a/frontend/viewer/src/lib/components/lcm-rich-text-editor/editor-schema.ts
+++ b/frontend/viewer/src/lib/components/lcm-rich-text-editor/editor-schema.ts
@@ -1,0 +1,31 @@
+import {Schema} from 'prosemirror-model';
+import {gt} from 'svelte-i18n-lingui';
+import {cn} from '$lib/utils';
+
+export const textSchema = new Schema({
+  nodes: {
+    text: {},
+    /**
+     * Note: it seems that our spans likely should have been modeled as "marks" rather than "nodes".
+     * Conceptually our users "mark" up a text.
+     * I assume using marks would make delete and backspace behave more intuitively and automatically solve what our
+     * custom key bindings do.
+     * */
+    span: {
+      selectable: false,
+      content: 'text*',
+      whitespace: 'pre',
+      toDOM: (node) => {
+        return ['span', {
+          title: gt`Writing system: ${node.attrs.richSpan.ws}`,
+          class: cn(node.attrs.className),
+        }, 0];
+      },
+      parseDOM: [{tag: 'span'}],
+      //richSpan is used to track the original span which was modified
+      //this allows us to update the text property without having to map all the span properties into the schema
+      attrs: {richSpan: {default: {}}, className: {default: ''}}
+    },
+    doc: {content: 'span*', attrs: {}}
+  }
+});

--- a/frontend/viewer/src/lib/components/lcm-rich-text-editor/lcm-rich-text-editor.svelte
+++ b/frontend/viewer/src/lib/components/lcm-rich-text-editor/lcm-rich-text-editor.svelte
@@ -1,35 +1,7 @@
 ﻿<script lang="ts" module>
-  import {type Node, Schema} from 'prosemirror-model';
-  import {gt} from 'svelte-i18n-lingui';
+  import {type Node} from 'prosemirror-model';
   import {cn} from '$lib/utils';
-
-  const textSchema = new Schema({
-    nodes: {
-      text: {},
-      /**
-       * Note: it seems that our spans likely should have been modeled as "marks" rather than "nodes".
-       * Conceptually our users "mark" up a text.
-       * I assume using marks would make delete and backspace behave more intuitively and automatically solve what our
-       * custom key bindings do.
-       * */
-      span: {
-        selectable: false,
-        content: 'text*',
-        whitespace: 'pre',
-        toDOM: (node) => {
-          return ['span', {
-            title: gt`Writing system: ${node.attrs.richSpan.ws}`,
-            class: cn(node.attrs.className),
-          }, 0];
-        },
-        parseDOM: [{tag: 'span'}],
-        //richSpan is used to track the original span which was modified
-        //this allows us to update the text property without having to map all the span properties into the schema
-        attrs: {richSpan: {default: {}}, className: {default: ''}}
-      },
-      doc: {content: 'span*', attrs: {}}
-    }
-  });
+  import {textSchema} from './editor-schema';
 
   //matching the character used in FieldWorks
   //https://unicode-explorer.com/c/2028

--- a/frontend/viewer/src/lib/i18n/LocalizationPicker.svelte
+++ b/frontend/viewer/src/lib/i18n/LocalizationPicker.svelte
@@ -1,8 +1,17 @@
 ﻿<script lang="ts" module>
+  import {locale} from 'svelte-i18n-lingui';
   const hasSetLang = {value: false};
+
+  export async function setLanguage(lang: string) {
+    const wasDefault = lang === 'default';
+    if (!lang || wasDefault) lang = localStorage.getItem('locale') ?? 'en';
+    let {messages} = await import(`../../locales/${lang}.json?lingui`);
+    locale.set(lang, messages);
+    //only save when the user changes locale
+    if (!wasDefault) localStorage.setItem('locale', lang);
+  }
 </script>
 <script lang="ts">
-import {locale} from 'svelte-i18n-lingui';
 import {onMount} from 'svelte';
 import * as DropdownMenu from '$lib/components/ui/dropdown-menu';
 import {Button} from '$lib/components/ui/button';
@@ -15,14 +24,7 @@ const languages: Record<string, string> = {
   'es': 'Español'
 };
 const currentLanguage = $derived(languages[$locale] ?? 'Unknown: ' + $locale);
-async function setLanguage(lang: string) {
-  const wasDefault = lang === 'default';
-  if (!lang || wasDefault) lang = localStorage.getItem('locale') ?? 'en';
-  let {messages} = await import(`../../locales/${lang}.json?lingui`);
-  locale.set(lang, messages);
-  //only save when the user changes locale
-  if (!wasDefault) localStorage.setItem('locale', lang);
-}
+
 onMount(() => {
   if (!hasSetLang.value) {
     void setLanguage($locale);

--- a/frontend/viewer/src/locales/en.json
+++ b/frontend/viewer/src/locales/en.json
@@ -238,7 +238,7 @@
     "origin": [
       [
         "src/lib/history/HistoryView.svelte",
-        76
+        83
       ],
       [
         "src/lib/activity/ActivityView.svelte",
@@ -294,7 +294,7 @@
     "origin": [
       [
         "src/lib/history/HistoryView.svelte",
-        88
+        95
       ],
       [
         "src/lib/activity/ActivityView.svelte",
@@ -334,7 +334,7 @@
     "origin": [
       [
         "src/lib/history/HistoryView.svelte",
-        73
+        80
       ],
       [
         "src/lib/activity/ActivityView.svelte",
@@ -342,6 +342,18 @@
       ]
     ],
     "translation": "before"
+  },
+  "3qtIhN": {
+    "message": "Best match",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/project/browse/SortMenu.svelte",
+        9
+      ]
+    ],
+    "translation": "Best match"
   },
   "O2UpM1": {
     "message": "Browse",
@@ -1107,6 +1119,18 @@
     ],
     "translation": "Grammatical info."
   },
+  "X5C2hm": {
+    "message": "Headword",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/project/browse/SortMenu.svelte",
+        10
+      ]
+    ],
+    "translation": "Headword"
+  },
   "vLyv1R": {
     "message": "Hide",
     "placeholders": {},
@@ -1130,7 +1154,7 @@
       ],
       [
         "src/lib/history/HistoryView.svelte",
-        52
+        59
       ]
     ],
     "translation": "History"
@@ -1294,7 +1318,7 @@
       ],
       [
         "src/lib/auth/LoginButton.svelte",
-        78
+        79
       ]
     ],
     "translation": "Login to see projects"
@@ -1474,7 +1498,7 @@
     "origin": [
       [
         "src/lib/history/HistoryView.svelte",
-        64
+        71
       ]
     ],
     "translation": "No change name"
@@ -1514,7 +1538,7 @@
     "origin": [
       [
         "src/lib/history/HistoryView.svelte",
-        59
+        66
       ]
     ],
     "translation": "No history found"
@@ -2214,7 +2238,7 @@
       ],
       [
         "src/lib/history/HistoryView.svelte",
-        92
+        99
       ],
       [
         "src/lib/activity/ActivityView.svelte",
@@ -2350,5 +2374,17 @@
       ]
     ],
     "translation": "Word or meaning:"
+  },
+  "cDHTt1": {
+    "message": "Writing system: {0}",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/lib/components/lcm-rich-text-editor/editor-schema.ts",
+        20
+      ]
+    ],
+    "translation": "Writing system: {0}"
   }
 }

--- a/frontend/viewer/src/locales/es.json
+++ b/frontend/viewer/src/locales/es.json
@@ -238,7 +238,7 @@
     "origin": [
       [
         "src/lib/history/HistoryView.svelte",
-        76
+        83
       ],
       [
         "src/lib/activity/ActivityView.svelte",
@@ -294,7 +294,7 @@
     "origin": [
       [
         "src/lib/history/HistoryView.svelte",
-        88
+        95
       ],
       [
         "src/lib/activity/ActivityView.svelte",
@@ -334,11 +334,23 @@
     "origin": [
       [
         "src/lib/history/HistoryView.svelte",
-        73
+        80
       ],
       [
         "src/lib/activity/ActivityView.svelte",
         75
+      ]
+    ],
+    "translation": ""
+  },
+  "3qtIhN": {
+    "message": "Best match",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/project/browse/SortMenu.svelte",
+        9
       ]
     ],
     "translation": ""
@@ -1107,6 +1119,18 @@
     ],
     "translation": ""
   },
+  "X5C2hm": {
+    "message": "Headword",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/project/browse/SortMenu.svelte",
+        10
+      ]
+    ],
+    "translation": ""
+  },
   "vLyv1R": {
     "message": "Hide",
     "placeholders": {},
@@ -1130,7 +1154,7 @@
       ],
       [
         "src/lib/history/HistoryView.svelte",
-        52
+        59
       ]
     ],
     "translation": ""
@@ -1294,7 +1318,7 @@
       ],
       [
         "src/lib/auth/LoginButton.svelte",
-        78
+        79
       ]
     ],
     "translation": "Inicie sesión para ver proyectos"
@@ -1474,7 +1498,7 @@
     "origin": [
       [
         "src/lib/history/HistoryView.svelte",
-        64
+        71
       ]
     ],
     "translation": ""
@@ -1514,7 +1538,7 @@
     "origin": [
       [
         "src/lib/history/HistoryView.svelte",
-        59
+        66
       ]
     ],
     "translation": ""
@@ -2214,7 +2238,7 @@
       ],
       [
         "src/lib/history/HistoryView.svelte",
-        92
+        99
       ],
       [
         "src/lib/activity/ActivityView.svelte",
@@ -2347,6 +2371,18 @@
       [
         "src/lib/entry-editor/EntryOrSensePicker.svelte",
         204
+      ]
+    ],
+    "translation": ""
+  },
+  "cDHTt1": {
+    "message": "Writing system: {0}",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/lib/components/lcm-rich-text-editor/editor-schema.ts",
+        20
       ]
     ],
     "translation": ""

--- a/frontend/viewer/src/locales/fr.json
+++ b/frontend/viewer/src/locales/fr.json
@@ -238,7 +238,7 @@
     "origin": [
       [
         "src/lib/history/HistoryView.svelte",
-        76
+        83
       ],
       [
         "src/lib/activity/ActivityView.svelte",
@@ -294,7 +294,7 @@
     "origin": [
       [
         "src/lib/history/HistoryView.svelte",
-        88
+        95
       ],
       [
         "src/lib/activity/ActivityView.svelte",
@@ -334,11 +334,23 @@
     "origin": [
       [
         "src/lib/history/HistoryView.svelte",
-        73
+        80
       ],
       [
         "src/lib/activity/ActivityView.svelte",
         75
+      ]
+    ],
+    "translation": ""
+  },
+  "3qtIhN": {
+    "message": "Best match",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/project/browse/SortMenu.svelte",
+        9
       ]
     ],
     "translation": ""
@@ -1107,6 +1119,18 @@
     ],
     "translation": ""
   },
+  "X5C2hm": {
+    "message": "Headword",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/project/browse/SortMenu.svelte",
+        10
+      ]
+    ],
+    "translation": ""
+  },
   "vLyv1R": {
     "message": "Hide",
     "placeholders": {},
@@ -1130,7 +1154,7 @@
       ],
       [
         "src/lib/history/HistoryView.svelte",
-        52
+        59
       ]
     ],
     "translation": ""
@@ -1294,7 +1318,7 @@
       ],
       [
         "src/lib/auth/LoginButton.svelte",
-        78
+        79
       ]
     ],
     "translation": "Connectez-vous pour voir les projets"
@@ -1474,7 +1498,7 @@
     "origin": [
       [
         "src/lib/history/HistoryView.svelte",
-        64
+        71
       ]
     ],
     "translation": ""
@@ -1514,7 +1538,7 @@
     "origin": [
       [
         "src/lib/history/HistoryView.svelte",
-        59
+        66
       ]
     ],
     "translation": ""
@@ -2214,7 +2238,7 @@
       ],
       [
         "src/lib/history/HistoryView.svelte",
-        92
+        99
       ],
       [
         "src/lib/activity/ActivityView.svelte",
@@ -2347,6 +2371,18 @@
       [
         "src/lib/entry-editor/EntryOrSensePicker.svelte",
         204
+      ]
+    ],
+    "translation": ""
+  },
+  "cDHTt1": {
+    "message": "Writing system: {0}",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/lib/components/lcm-rich-text-editor/editor-schema.ts",
+        20
       ]
     ],
     "translation": ""

--- a/frontend/viewer/src/main.ts
+++ b/frontend/viewer/src/main.ts
@@ -9,11 +9,16 @@ import {mount} from 'svelte';
 import {setupDotnetServiceProvider} from './lib/services/service-provider-dotnet';
 import {setupServiceProvider} from '$lib/services/service-provider';
 import {useEventBus} from '$lib/services/event-bus';
+import {setLanguage} from '$lib/i18n/LocalizationPicker.svelte';
 
 setupServiceProvider();
 setupDotnetServiceProvider();
 useEventBus();
 
-mount(App, {
-  target: document.getElementById('svelte-app')!,
-});
+//dont mount the app until after we've loaded the local
+void setLanguage('default')
+  .then(() => {
+    mount(App, {
+      target: document.getElementById('svelte-app')!,
+    });
+  });

--- a/frontend/viewer/src/project/browse/SortMenu.svelte
+++ b/frontend/viewer/src/project/browse/SortMenu.svelte
@@ -1,13 +1,13 @@
 <script lang="ts" module>
   import {SortField} from '$lib/dotnet-types';
-  import {gt, t} from 'svelte-i18n-lingui';
+  import {msg, t} from 'svelte-i18n-lingui';
   import type {IconClass} from '$lib/icon-class';
 
   export type SortDirection = 'asc' | 'desc';
 
   const sortLabels = {
-    [SortField.SearchRelevance]: gt`Best match`,
-    [SortField.Headword]: gt`Headword`
+    [SortField.SearchRelevance]: msg`Best match`,
+    [SortField.Headword]: msg`Headword`
   } as const;
 
   const sortIcons: Partial<Record<SortField, Record<SortDirection, IconClass>>> = {
@@ -58,7 +58,7 @@
     {#snippet child({props})}
       <button {...props}>
         <Icon icon={sortIcons[sortField]?.[direction] ?? 'i-mdi-arrow-down'} class="size-4 mr-1" />
-        {sortLabels[sortField]}
+        {$t(sortLabels[sortField])}
       </button>
     {/snippet}
   </ResponsiveMenu.Trigger>
@@ -72,7 +72,7 @@
         >
         {$t`Auto`}
         <span class="text-muted-foreground ml-auto">
-          ({sortLabels[autoSort]})
+          ({$t(sortLabels[autoSort])})
         </span>
     </ResponsiveMenu.Item>
     {#each sortOptions as option}
@@ -87,7 +87,7 @@
         {#if icon}
           <Icon {icon} />
         {/if}
-        {sortLabels[option.field]}
+        {$t(sortLabels[option.field])}
       </ResponsiveMenu.Item>
     {/each}
   </ResponsiveMenu.Content>


### PR DESCRIPTION
closes #1678 

There were actually 2 problems. One is that the message extracter does not match `gt"text"` in svelte files, only in ts files.

The second was that our UI was loading and rendering before our local had been loaded and so there was a race condition. We're now loading it on app startup before we mount the App to the dom.