### PR TITLE
Add FWLite Viewer Indonesian localization file from Gemini

### DIFF
--- a/frontend/viewer/README.md
+++ b/frontend/viewer/README.md
@@ -13,17 +13,14 @@ for the english text 'Logout'. Then to make localization files run:
 ```bash
 pnpm run i18n:extract
 ```
-this will update the files under `/src/locales/`
-if you want you can then feed those files to an AI and it'll translate them for you.
+This will update the files under `/src/locales/`. If you want, you can then feed those files to an AI and it will translate them for you.
 
+#### Adding a new language
+The `/src/locales/` folder contains one file per language, named using its language code (e.g. `es.json` for Spanish).
+To add a new language, copy `en.json`, rename it, translate the `"translation"` fields, and commit the changes.
+You must also update `frontend/viewer/lingui.config.ts` with the additional language code.
 
-#### Adding a new langauge
-The `/src/locales/` folder contains one file per language, named appropriately using its language code e.g. es.json for Spanish
-
-To add a new language for localization, copy the existing en.json file in the folder above and name it for the new language.  Ask AI to translate the "translation" strings into the language you want, and then commit those changes.
-You also need to update the `frontend/viewer/lingui.config.ts` with the additional language code
-
-#### advanced usage
+#### Advanced Usage
 
 for formatted values you can do this:
 ```sveltehtml

--- a/frontend/viewer/README.md
+++ b/frontend/viewer/README.md
@@ -13,8 +13,15 @@ for the english text 'Logout'. Then to make localization files run:
 ```bash
 pnpm run i18n:extract
 ```
-this will update the files under /src/locales/
+this will update the files under `/src/locales/`
 if you want you can then feed those files to an AI and it'll translate them for you.
+
+
+#### Adding a new langauge
+The `/src/locales/` folder contains one file per language, named appropriately using its language code e.g. es.json for Spanish
+
+To add a new language for localization, copy the existing en.json file in the folder above and name it for the new language.  Ask AI to translate the "translation" strings into the language you want, and then commit those changes.
+You also need to update the `frontend/viewer/lingui.config.ts` with the additional language code
 
 #### advanced usage
 

--- a/frontend/viewer/lingui.config.ts
+++ b/frontend/viewer/lingui.config.ts
@@ -5,7 +5,7 @@ import {formatter} from '@lingui/format-json';
 
 export default defineConfig({
   format: formatter({style: 'lingui'}),
-  locales: ['en', 'es', 'fr'],
+  locales: ['en', 'es', 'fr', 'ko'],
   sourceLocale: 'en',
   catalogs: [
     {

--- a/frontend/viewer/lingui.config.ts
+++ b/frontend/viewer/lingui.config.ts
@@ -5,7 +5,7 @@ import {formatter} from '@lingui/format-json';
 
 export default defineConfig({
   format: formatter({style: 'lingui'}),
-  locales: ['en', 'es', 'fr', 'ko'],
+  locales: ['en', 'es', 'fr', 'ko', 'id'],
   sourceLocale: 'en',
   catalogs: [
     {

--- a/frontend/viewer/src/locales/id.json
+++ b/frontend/viewer/src/locales/id.json
@@ -1,0 +1,2390 @@
+{
+  "rwLRCA": {
+    "message": "– ({0} changes)",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/lib/activity/ActivityView.svelte",
+        99
+      ]
+    ],
+    "translation": "– ({0} perubahan)"
+  },
+  "mpbC3j": {
+    "message": "{0} - FieldWorks",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/project/SyncDialog.svelte",
+        239
+      ]
+    ],
+    "translation": "{0} - FieldWorks"
+  },
+  "35GcOB": {
+    "message": "{0} - FieldWorks Lite",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/project/SyncDialog.svelte",
+        200
+      ]
+    ],
+    "translation": "{0} - FieldWorks Lite"
+  },
+  "0jQasM": {
+    "message": "{0} (FieldWorks Lite)",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/lib/components/editor/field/field-title.svelte",
+        22
+      ]
+    ],
+    "translation": "{0} (FieldWorks Lite)"
+  },
+  "Bi6Xst": {
+    "message": "{0} (FieldWorks)",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/lib/components/editor/field/field-title.svelte",
+        23
+      ]
+    ],
+    "translation": "{0} (FieldWorks)"
+  },
+  "dhBPPx": {
+    "message": "{0} Server",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/home/Server.svelte",
+        54
+      ]
+    ],
+    "translation": "Server {0}"
+  },
+  "tgUNp+": {
+    "message": "{0} synced to FieldWorks. {1} synced to FieldWorks Lite.",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/project/SyncDialog.svelte",
+        95
+      ]
+    ],
+    "translation": "{0} disinkronkan ke FieldWorks. {1} disinkronkan ke FieldWorks Lite."
+  },
+  "ubuwKa": {
+    "message": "{num, plural, one {# change} other {# changes}}",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/project/SyncDialog.svelte",
+        92
+      ],
+      [
+        "src/project/SyncDialog.svelte",
+        93
+      ]
+    ],
+    "translation": "{num, plural, one {# perubahan} other {# perubahan}}"
+  },
+  "UuldxO": {
+    "message": "A new version of FieldWorks lite is available.",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/lib/notifications/NotificationOutlet.svelte",
+        24
+      ]
+    ],
+    "translation": "Versi baru FieldWorks lite tersedia."
+  },
+  "fhKYsI": {
+    "message": "a word",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/project/browse/BrowseView.svelte",
+        102
+      ]
+    ],
+    "translation": "sebuah kata"
+  },
+  "uyJsf6": {
+    "message": "About",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/lib/about/AboutDialog.svelte",
+        22
+      ]
+    ],
+    "translation": "Tentang"
+  },
+  "AeXO77": {
+    "message": "Account",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/project/ProjectSidebar.svelte",
+        136
+      ]
+    ],
+    "translation": "Akun"
+  },
+  "XJOV1Y": {
+    "message": "Activity",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/project/ProjectSidebar.svelte",
+        93
+      ]
+    ],
+    "translation": "Aktivitas"
+  },
+  "KdJj3U": {
+    "message": "Add component",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/lib/entry-editor/field-editors/ComplexForms.svelte",
+        51
+      ],
+      [
+        "src/lib/entry-editor/field-editors/ComplexFormComponents.svelte",
+        57
+      ]
+    ],
+    "translation": "Tambah komponen"
+  },
+  "nI3A8B": {
+    "message": "Add Example",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/lib/entry-editor/object-editors/EntryEditor.svelte",
+        211
+      ]
+    ],
+    "translation": "Tambah Contoh"
+  },
+  "dt7w9L": {
+    "message": "Add Meaning",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/lib/entry-editor/object-editors/EntryEditor.svelte",
+        226
+      ],
+      [
+        "src/lib/entry-editor/object-editors/EntryEditor.svelte",
+        226
+      ]
+    ],
+    "translation": "Tambah Arti"
+  },
+  "uvBQSU": {
+    "message": "Add part of",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/lib/entry-editor/field-editors/ComplexForms.svelte",
+        51
+      ]
+    ],
+    "translation": "Tambahkan bagian dari"
+  },
+  "0YSbah": {
+    "message": "Add Sense",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/lib/entry-editor/object-editors/EntryEditor.svelte",
+        226
+      ],
+      [
+        "src/lib/entry-editor/object-editors/EntryEditor.svelte",
+        226
+      ]
+    ],
+    "translation": "Tambah Makna"
+  },
+  "XeIoU/": {
+    "message": "ago",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/lib/history/HistoryView.svelte",
+        83
+      ],
+      [
+        "src/lib/activity/ActivityView.svelte",
+        78
+      ],
+      [
+        "src/lib/activity/ActivityView.svelte",
+        105
+      ]
+    ],
+    "translation": "yang lalu"
+  },
+  "iPthvs": {
+    "message": "an entry",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/project/browse/BrowseView.svelte",
+        102
+      ]
+    ],
+    "translation": "sebuah entri"
+  },
+  "ZYimak": {
+    "message": "Application version",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/lib/troubleshoot/TroubleshootDialog.svelte",
+        33
+      ]
+    ],
+    "translation": "Versi aplikasi"
+  },
+  "GKJXpX": {
+    "message": "Are you sure you want to delete {0}?",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/lib/entry-editor/DeleteDialog.svelte",
+        55
+      ]
+    ],
+    "translation": "Apakah Anda yakin ingin menghapus {0}?"
+  },
+  "6QeoeO": {
+    "message": "Author:",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/lib/history/HistoryView.svelte",
+        95
+      ],
+      [
+        "src/lib/activity/ActivityView.svelte",
+        91
+      ]
+    ],
+    "translation": "Penulis:"
+  },
+  "R9Khdg": {
+    "message": "Auto",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/project/browse/SortMenu.svelte",
+        73
+      ]
+    ],
+    "translation": "Otomatis"
+  },
+  "VmDOAV": {
+    "message": "Auto synchronizing",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/project/SyncDialog.svelte",
+        176
+      ]
+    ],
+    "translation": "Sinkronisasi otomatis"
+  },
+  "CI9Ae4": {
+    "message": "before",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/lib/history/HistoryView.svelte",
+        80
+      ],
+      [
+        "src/lib/activity/ActivityView.svelte",
+        75
+      ]
+    ],
+    "translation": "sebelum"
+  },
+  "3qtIhN": {
+    "message": "Best match",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/project/browse/SortMenu.svelte",
+        9
+      ]
+    ],
+    "translation": "Kecocokan terbaik"
+  },
+  "O2UpM1": {
+    "message": "Browse",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/project/ProjectSidebar.svelte",
+        88
+      ]
+    ],
+    "translation": "Jelajahi"
+  },
+  "dEgA5A": {
+    "message": "Cancel",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/lib/entry-editor/NewEntryDialog.svelte",
+        110
+      ],
+      [
+        "src/lib/entry-editor/EntryOrSensePicker.svelte",
+        245
+      ],
+      [
+        "src/lib/components/field-editors/select.svelte",
+        164
+      ],
+      [
+        "src/lib/components/field-editors/multi-select.svelte",
+        280
+      ]
+    ],
+    "translation": "Batal"
+  },
+  "7Esn9Y": {
+    "message": "Citation form",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/lib/entry-editor/object-editors/EntryEditorPrimitive.svelte",
+        55
+      ]
+    ],
+    "translation": "Bentuk kutipan"
+  },
+  "Q01cKL": {
+    "message": "Classic FieldWorks Projects",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/home/HomeView.svelte",
+        225
+      ]
+    ],
+    "translation": "Proyek FieldWorks Klasik"
+  },
+  "K0PCkZ": {
+    "message": "clear",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/lib/components/field-editors/select.svelte",
+        116
+      ],
+      [
+        "src/lib/components/field-editors/multi-select.svelte",
+        205
+      ]
+    ],
+    "translation": "hapus"
+  },
+  "yz7wBu": {
+    "message": "Close",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/lib/components/ui/button/x-button.svelte",
+        14
+      ],
+      [
+        "src/lib/components/field-editors/multi-select.svelte",
+        215
+      ],
+      [
+        "src/lib/about/AboutDialog.svelte",
+        28
+      ]
+    ],
+    "translation": "Tutup"
+  },
+  "Iy+nsd": {
+    "message": "Close Dictionary",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/project/ProjectSidebar.svelte",
+        155
+      ]
+    ],
+    "translation": "Tutup Kamus"
+  },
+  "jZlrte": {
+    "message": "Color",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/lib/ThemePicker.svelte",
+        32
+      ]
+    ],
+    "translation": "Warna"
+  },
+  "PkH7DZ": {
+    "message": "Complex Form",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/lib/entry-editor/field-editors/ComplexForms.svelte",
+        55
+      ],
+      [
+        "src/lib/entry-editor/field-editors/ComplexForms.svelte",
+        44
+      ],
+      [
+        "src/lib/entry-editor/field-editors/ComplexFormComponents.svelte",
+        45
+      ]
+    ],
+    "translation": "Bentuk Kompleks"
+  },
+  "W+5v9T": {
+    "message": "Complex form types",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/lib/entry-editor/object-editors/EntryEditorPrimitive.svelte",
+        88
+      ]
+    ],
+    "translation": "Jenis bentuk kompleks"
+  },
+  "j6HACU": {
+    "message": "Complex forms",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/lib/entry-editor/object-editors/EntryEditorPrimitive.svelte",
+        67
+      ]
+    ],
+    "translation": "Bentuk-bentuk kompleks"
+  },
+  "dK3Z9j": {
+    "message": "Component",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/lib/entry-editor/field-editors/ComplexForms.svelte",
+        43
+      ],
+      [
+        "src/lib/entry-editor/field-editors/ComplexFormComponents.svelte",
+        61
+      ],
+      [
+        "src/lib/entry-editor/field-editors/ComplexFormComponents.svelte",
+        44
+      ],
+      [
+        "src/lib/entry-editor/field-editors/ComplexFormComponents.svelte",
+        50
+      ]
+    ],
+    "translation": "Komponen"
+  },
+  "RRa/CR": {
+    "message": "Components",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/lib/entry-editor/object-editors/EntryEditorPrimitive.svelte",
+        77
+      ]
+    ],
+    "translation": "Komponen"
+  },
+  "b9XOHo": {
+    "message": "Create {0}",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/lib/entry-editor/NewEntryDialog.svelte",
+        112
+      ]
+    ],
+    "translation": "Buat {0}"
+  },
+  "sYP6Ef": {
+    "message": "Create entry",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/lib/entry-editor/NewEntryButton.svelte",
+        12
+      ]
+    ],
+    "translation": "Buat entri"
+  },
+  "0widty": {
+    "message": "Create Example Project",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/home/HomeView.svelte",
+        203
+      ]
+    ],
+    "translation": "Buat Proyek Contoh"
+  },
+  "OVriW/": {
+    "message": "Create word",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/lib/entry-editor/NewEntryButton.svelte",
+        12
+      ]
+    ],
+    "translation": "Buat kata"
+  },
+  "Jxxmun": {
+    "message": "Current Entry",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/lib/entry-editor/field-editors/ComplexForms.svelte",
+        42
+      ],
+      [
+        "src/lib/entry-editor/field-editors/ComplexFormComponents.svelte",
+        43
+      ]
+    ],
+    "translation": "Entri Saat Ini"
+  },
+  "e2n436": {
+    "message": "Current Word",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/lib/entry-editor/field-editors/ComplexForms.svelte",
+        42
+      ],
+      [
+        "src/lib/entry-editor/field-editors/ComplexFormComponents.svelte",
+        43
+      ]
+    ],
+    "translation": "Kata Saat Ini"
+  },
+  "7p5kLi": {
+    "message": "Dashboard",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/project/ProjectSidebar.svelte",
+        86
+      ]
+    ],
+    "translation": "Dasbor"
+  },
+  "yX4qgn": {
+    "message": "Data Directory",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/lib/troubleshoot/TroubleshootDialog.svelte",
+        35
+      ]
+    ],
+    "translation": "Direktori Data"
+  },
+  "MbRyzp": {
+    "message": "Definition",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/lib/entry-editor/object-editors/SenseEditorPrimitive.svelte",
+        52
+      ]
+    ],
+    "translation": "Definisi"
+  },
+  "cnGeoo": {
+    "message": "Delete",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/home/HomeView.svelte",
+        177
+      ]
+    ],
+    "translation": "Hapus"
+  },
+  "Y2tU6I": {
+    "message": "Delete {0}",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/lib/entry-editor/DeleteDialog.svelte",
+        52
+      ],
+      [
+        "src/lib/entry-editor/DeleteDialog.svelte",
+        59
+      ]
+    ],
+    "translation": "Hapus {0}"
+  },
+  "P0mjNu": {
+    "message": "Delete Entry",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/project/browse/EntryMenu.svelte",
+        55
+      ]
+    ],
+    "translation": "Hapus Entri"
+  },
+  "i/7SVG": {
+    "message": "Delete Word",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/project/browse/EntryMenu.svelte",
+        55
+      ]
+    ],
+    "translation": "Hapus Kata"
+  },
+  "RY27RL": {
+    "message": "Dictionaries",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/home/HomeView.svelte",
+        107
+      ],
+      [
+        "src/home/HomeView.svelte",
+        110
+      ]
+    ],
+    "translation": "Kamus"
+  },
+  "VrH1k+": {
+    "message": "Dictionary",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/project/ProjectSidebar.svelte",
+        82
+      ]
+    ],
+    "translation": "Kamus"
+  },
+  "OVGpil": {
+    "message": "Dictionary Preview",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/project/browse/ViewPicker.svelte",
+        38
+      ]
+    ],
+    "translation": "Pratinjau Kamus"
+  },
+  "NagCcF": {
+    "message": "Display as",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/lib/entry-editor/object-editors/EntryEditorPrimitive.svelte",
+        55
+      ]
+    ],
+    "translation": "Tampilkan sebagai"
+  },
+  "z9VIKz": {
+    "message": "Don't delete",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/lib/entry-editor/DeleteDialog.svelte",
+        58
+      ]
+    ],
+    "translation": "Jangan hapus"
+  },
+  "mzI/c+": {
+    "message": "Download",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/lib/notifications/NotificationOutlet.svelte",
+        30
+      ],
+      [
+        "src/home/Server.svelte",
+        119
+      ]
+    ],
+    "translation": "Unduh"
+  },
+  "VIwCaD": {
+    "message": "Entry",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/project/browse/EntryMenu.svelte",
+        37
+      ],
+      [
+        "src/lib/entry-editor/NewEntryDialog.svelte",
+        84
+      ],
+      [
+        "src/lib/entry-editor/EntryOrSensePicker.svelte",
+        250
+      ]
+    ],
+    "translation": "Entri"
+  },
+  "byQjNm": {
+    "message": "Entry Only",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/lib/entry-editor/EntryOrSensePicker.svelte",
+        211
+      ]
+    ],
+    "translation": "Hanya Entri"
+  },
+  "bQ8ysI": {
+    "message": "Entry or sense:",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/lib/entry-editor/EntryOrSensePicker.svelte",
+        204
+      ]
+    ],
+    "translation": "Entri atau makna:"
+  },
+  "yeYJfy": {
+    "message": "Error getting sync status",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/project/ProjectSidebar.svelte",
+        117
+      ]
+    ],
+    "translation": "Kesalahan saat mendapatkan status sinkronisasi"
+  },
+  "ggzvfk": {
+    "message": "Error getting sync status.",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/project/SyncDialog.svelte",
+        186
+      ]
+    ],
+    "translation": "Kesalahan saat mendapatkan status sinkronisasi."
+  },
+  "TpqeIh": {
+    "message": "Error: {0}",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/project/SyncDialog.svelte",
+        250
+      ]
+    ],
+    "translation": "Kesalahan: {0}"
+  },
+  "HmI5oK": {
+    "message": "Example",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/lib/entry-editor/object-editors/EntryEditor.svelte",
+        183
+      ]
+    ],
+    "translation": "Contoh"
+  },
+  "BGP/S1": {
+    "message": "Example sentence",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/lib/entry-editor/object-editors/EntryEditor.svelte",
+        90
+      ]
+    ],
+    "translation": "Contoh kalimat"
+  },
+  "9QXzjh": {
+    "message": "Failed to load entries",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/project/browse/EntriesList.svelte",
+        134
+      ]
+    ],
+    "translation": "Gagal memuat entri"
+  },
+  "MS0/dh": {
+    "message": "Failed to open data directory, use the path in the text field instead",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/lib/troubleshoot/TroubleshootDialog.svelte",
+        22
+      ]
+    ],
+    "translation": "Gagal membuka direktori data, gunakan path di bidang teks sebagai gantinya"
+  },
+  "yPkUF+": {
+    "message": "Failed to synchronize",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/project/SyncDialog.svelte",
+        89
+      ],
+      [
+        "src/project/SyncDialog.svelte",
+        119
+      ]
+    ],
+    "translation": "Gagal menyinkronkan"
+  },
+  "YirHq7": {
+    "message": "Feedback",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/project/ProjectSidebar.svelte",
+        177
+      ],
+      [
+        "src/home/HomeView.svelte",
+        126
+      ]
+    ],
+    "translation": "Umpan Balik"
+  },
+  "jI2ZOA": {
+    "message": "Field Labels",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/project/browse/ViewPicker.svelte",
+        32
+      ]
+    ],
+    "translation": "Label Bidang"
+  },
+  "uKNYWn": {
+    "message": "FieldWorks logo",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/project/ProjectDropdown.svelte",
+        69
+      ],
+      [
+        "src/lib/OpenInFieldWorksButton.svelte",
+        56
+      ],
+      [
+        "src/home/HomeView.svelte",
+        231
+      ]
+    ],
+    "translation": "Logo FieldWorks"
+  },
+  "LwjKwe": {
+    "message": "Filter # entries",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/project/browse/SearchFilter.svelte",
+        53
+      ]
+    ],
+    "translation": "Filter # entri"
+  },
+  "zGI/cf": {
+    "message": "Filter # words",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/project/browse/SearchFilter.svelte",
+        53
+      ]
+    ],
+    "translation": "Filter # kata"
+  },
+  "ctQd0R": {
+    "message": "Filter entries",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/project/browse/SearchFilter.svelte",
+        59
+      ]
+    ],
+    "translation": "Filter entri"
+  },
+  "IrEBhq": {
+    "message": "Filter words",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/project/browse/SearchFilter.svelte",
+        59
+      ]
+    ],
+    "translation": "Filter kata"
+  },
+  "6HLTEb": {
+    "message": "Filter...",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/lib/components/field-editors/select.svelte",
+        112
+      ],
+      [
+        "src/lib/components/field-editors/multi-select.svelte",
+        201
+      ]
+    ],
+    "translation": "Filter..."
+  },
+  "0KYzFS": {
+    "message": "Find entry...",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/lib/entry-editor/EntryOrSensePicker.svelte",
+        140
+      ]
+    ],
+    "translation": "Temukan entri..."
+  },
+  "gotGzB": {
+    "message": "Find word...",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/lib/entry-editor/EntryOrSensePicker.svelte",
+        140
+      ]
+    ],
+    "translation": "Temukan kata..."
+  },
+  "F7GHkf": {
+    "message": "Gloss",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/lib/entry-editor/object-editors/SenseEditorPrimitive.svelte",
+        41
+      ]
+    ],
+    "translation": "Glos"
+  },
+  "u8+PAt": {
+    "message": "Go to {0}",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/lib/entry-editor/EntryOrSenseItemList.svelte",
+        26
+      ]
+    ],
+    "translation": "Pergi ke {0}"
+  },
+  "Ks+qfd": {
+    "message": "Grammatical info.",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/lib/entry-editor/object-editors/SenseEditorPrimitive.svelte",
+        63
+      ]
+    ],
+    "translation": "Info tata bahasa."
+  },
+  "X5C2hm": {
+    "message": "Headword",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/project/browse/SortMenu.svelte",
+        10
+      ]
+    ],
+    "translation": "Kata kepala"
+  },
+  "vLyv1R": {
+    "message": "Hide",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/project/browse/ViewPicker.svelte",
+        40
+      ]
+    ],
+    "translation": "Sembunyikan"
+  },
+  "0caMy7": {
+    "message": "History",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/project/browse/EntryMenu.svelte",
+        60
+      ],
+      [
+        "src/lib/history/HistoryView.svelte",
+        59
+      ]
+    ],
+    "translation": "Riwayat"
+  },
+  "E8KyPm": {
+    "message": "I don't see my project",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/home/Server.svelte",
+        129
+      ]
+    ],
+    "translation": "Saya tidak melihat proyek saya"
+  },
+  "l3s5ri": {
+    "message": "Import",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/home/HomeView.svelte",
+        237
+      ]
+    ],
+    "translation": "Impor"
+  },
+  "rZkl7/": {
+    "message": "Last change: {0}",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/project/SyncDialog.svelte",
+        203
+      ],
+      [
+        "src/project/SyncDialog.svelte",
+        242
+      ]
+    ],
+    "translation": "Perubahan terakhir: {0}"
+  },
+  "Cb8zzH": {
+    "message": "Lexbox logo",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/home/HomeView.svelte",
+        109
+      ]
+    ],
+    "translation": "Logo Lexbox"
+  },
+  "vSL95+": {
+    "message": "Lexeme form",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/lib/entry-editor/object-editors/EntryEditorPrimitive.svelte",
+        43
+      ]
+    ],
+    "translation": "Bentuk leksem"
+  },
+  "8oegWV": {
+    "message": "List mode",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/project/browse/BrowseView.svelte",
+        63
+      ]
+    ],
+    "translation": "Mode daftar"
+  },
+  "2kUuXE": {
+    "message": "Literal meaning",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/lib/entry-editor/object-editors/EntryEditorPrimitive.svelte",
+        103
+      ]
+    ],
+    "translation": "Arti harfiah"
+  },
+  "4PN67S": {
+    "message": "Loading Dictionaries...",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/project/ProjectDropdown.svelte",
+        104
+      ]
+    ],
+    "translation": "Memuat Kamus..."
+  },
+  "+yD+Wu": {
+    "message": "loading...",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/home/HomeView.svelte",
+        146
+      ]
+    ],
+    "translation": "memuat..."
+  },
+  "d5zxa4": {
+    "message": "Local",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/home/HomeView.svelte",
+        151
+      ]
+    ],
+    "translation": "Lokal"
+  },
+  "OgyJSr": {
+    "message": "Local only",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/home/HomeView.svelte",
+        168
+      ]
+    ],
+    "translation": "Hanya lokal"
+  },
+  "z0t9bb": {
+    "message": "Login",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/project/SyncDialog.svelte",
+        182
+      ]
+    ],
+    "translation": "Masuk"
+  },
+  "z7IcPF": {
+    "message": "Login to see projects",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/lib/auth/LoginButton.svelte",
+        71
+      ],
+      [
+        "src/lib/auth/LoginButton.svelte",
+        79
+      ]
+    ],
+    "translation": "Masuk untuk melihat proyek"
+  },
+  "nOhz3x": {
+    "message": "Logout",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/lib/auth/LoginButton.svelte",
+        61
+      ]
+    ],
+    "translation": "Keluar"
+  },
+  "nK30Fy": {
+    "message": "Made with ❤️ from 🇦🇹 🇹🇭 🇺🇸",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/project/ProjectSidebar.svelte",
+        188
+      ]
+    ],
+    "translation": "Dibuat dengan ❤️ dari 🇦🇹 🇹🇭 🇺🇸"
+  },
+  "6URaYg": {
+    "message": "Meaning",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/lib/entry-editor/EntryOrSensePicker.svelte",
+        250
+      ],
+      [
+        "src/lib/entry-editor/object-editors/EntryEditor.svelte",
+        165
+      ],
+      [
+        "src/lib/entry-editor/object-editors/EntryEditor.svelte",
+        72
+      ],
+      [
+        "src/lib/entry-editor/object-editors/AddSenseFab.svelte",
+        15
+      ]
+    ],
+    "translation": "Arti"
+  },
+  "oPBJ/O": {
+    "message": "Missing Examples",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/project/browse/SearchFilter.svelte",
+        81
+      ]
+    ],
+    "translation": "Contoh yang Hilang"
+  },
+  "sb65UQ": {
+    "message": "Missing Part of Speech",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/project/browse/SearchFilter.svelte",
+        83
+      ]
+    ],
+    "translation": "Bagian Ucapan yang Hilang"
+  },
+  "XOUmTu": {
+    "message": "Missing Semantic Domains",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/project/browse/SearchFilter.svelte",
+        84
+      ]
+    ],
+    "translation": "Domain Semantik yang Hilang"
+  },
+  "1H/nm7": {
+    "message": "Missing Senses",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/project/browse/SearchFilter.svelte",
+        82
+      ]
+    ],
+    "translation": "Makna yang Hilang"
+  },
+  "QWdKwH": {
+    "message": "Move",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/lib/entry-editor/ItemListItem.svelte",
+        61
+      ]
+    ],
+    "translation": "Pindahkan"
+  },
+  "qqeAJM": {
+    "message": "Never",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/project/SyncDialog.svelte",
+        243
+      ]
+    ],
+    "translation": "Tidak pernah"
+  },
+  "isRobC": {
+    "message": "New",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/project/NewEntryButton.svelte",
+        48
+      ]
+    ],
+    "translation": "Baru"
+  },
+  "6WSYbN": {
+    "message": "New {0}",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/lib/entry-editor/NewEntryDialog.svelte",
+        97
+      ]
+    ],
+    "translation": "Baru {0}"
+  },
+  "eL8osE": {
+    "message": "New Entry",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/project/NewEntryButton.svelte",
+        50
+      ]
+    ],
+    "translation": "Entri Baru"
+  },
+  "QUaH5J": {
+    "message": "No activity found",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/lib/activity/ActivityView.svelte",
+        61
+      ]
+    ],
+    "translation": "Tidak ada aktivitas yang ditemukan"
+  },
+  "cJKxGt": {
+    "message": "No change name",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/lib/history/HistoryView.svelte",
+        71
+      ]
+    ],
+    "translation": "Tidak ada nama perubahan"
+  },
+  "hcFut8": {
+    "message": "No Dictionaries found",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/project/ProjectDropdown.svelte",
+        108
+      ]
+    ],
+    "translation": "Tidak ada Kamus yang ditemukan"
+  },
+  "bakDdy": {
+    "message": "No entries found",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/project/browse/EntriesList.svelte",
+        160
+      ],
+      [
+        "src/lib/entry-editor/EntryOrSensePicker.svelte",
+        174
+      ]
+    ],
+    "translation": "Tidak ada entri yang ditemukan"
+  },
+  "7elymg": {
+    "message": "No history found",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/lib/history/HistoryView.svelte",
+        66
+      ]
+    ],
+    "translation": "Tidak ada riwayat yang ditemukan"
+  },
+  "V9PAEu": {
+    "message": "No items found",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/lib/components/field-editors/select.svelte",
+        124
+      ],
+      [
+        "src/lib/components/field-editors/multi-select.svelte",
+        220
+      ]
+    ],
+    "translation": "Tidak ada item yang ditemukan"
+  },
+  "ylgAlG": {
+    "message": "No server configured",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/project/SyncDialog.svelte",
+        184
+      ],
+      [
+        "src/project/ProjectSidebar.svelte",
+        113
+      ]
+    ],
+    "translation": "Tidak ada server yang dikonfigurasi"
+  },
+  "qdJypF": {
+    "message": "No words found",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/lib/entry-editor/EntryOrSensePicker.svelte",
+        174
+      ]
+    ],
+    "translation": "Tidak ada kata yang ditemukan"
+  },
+  "EdQY6l": {
+    "message": "None",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/lib/components/field-editors/select.svelte",
+        99
+      ],
+      [
+        "src/lib/components/field-editors/multi-select.svelte",
+        176
+      ]
+    ],
+    "translation": "Tidak ada"
+  },
+  "wMP6DT": {
+    "message": "Not logged in",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/project/SyncDialog.svelte",
+        247
+      ],
+      [
+        "src/project/ProjectSidebar.svelte",
+        111
+      ]
+    ],
+    "translation": "Belum masuk"
+  },
+  "KiJn9B": {
+    "message": "Note",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/lib/entry-editor/object-editors/EntryEditorPrimitive.svelte",
+        114
+      ]
+    ],
+    "translation": "Catatan"
+  },
+  "6Aih4U": {
+    "message": "Offline",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/project/SyncDialog.svelte",
+        180
+      ],
+      [
+        "src/project/ProjectSidebar.svelte",
+        109
+      ]
+    ],
+    "translation": "Luring"
+  },
+  "LqMYkh": {
+    "message": "Open Data Directory",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/lib/troubleshoot/TroubleshootDialog.svelte",
+        40
+      ]
+    ],
+    "translation": "Buka Direktori Data"
+  },
+  "Y4BKCd": {
+    "message": "Open in FieldWorks",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/lib/OpenInFieldWorksButton.svelte",
+        57
+      ]
+    ],
+    "translation": "Buka di FieldWorks"
+  },
+  "OsAKOS": {
+    "message": "Open in new Window",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/project/browse/EntryMenu.svelte",
+        65
+      ]
+    ],
+    "translation": "Buka di Jendela baru"
+  },
+  "sccXTS": {
+    "message": "Open Log file",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/lib/troubleshoot/TroubleshootDialog.svelte",
+        46
+      ]
+    ],
+    "translation": "Buka file Log"
+  },
+  "vgP+9p": {
+    "message": "Part",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/lib/entry-editor/field-editors/ComplexForms.svelte",
+        43
+      ],
+      [
+        "src/lib/entry-editor/field-editors/ComplexFormComponents.svelte",
+        44
+      ]
+    ],
+    "translation": "Bagian"
+  },
+  "qW3eh2": {
+    "message": "Part of",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/lib/entry-editor/object-editors/EntryEditorPrimitive.svelte",
+        67
+      ],
+      [
+        "src/lib/entry-editor/field-editors/ComplexForms.svelte",
+        55
+      ],
+      [
+        "src/lib/entry-editor/field-editors/ComplexForms.svelte",
+        44
+      ],
+      [
+        "src/lib/entry-editor/field-editors/ComplexFormComponents.svelte",
+        45
+      ],
+      [
+        "src/lib/entry-editor/field-editors/ComplexFormComponents.svelte",
+        50
+      ]
+    ],
+    "translation": "Bagian dari"
+  },
+  "h6kyNd": {
+    "message": "Part of speech",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/lib/entry-editor/object-editors/SenseEditorPrimitive.svelte",
+        63
+      ]
+    ],
+    "translation": "Kelas kata"
+  },
+  "kNiQp6": {
+    "message": "Pinned",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/project/browse/ViewPicker.svelte",
+        41
+      ]
+    ],
+    "translation": "Disematkan"
+  },
+  "rdUucN": {
+    "message": "Preview",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/project/browse/BrowseView.svelte",
+        76
+      ]
+    ],
+    "translation": "Pratinjau"
+  },
+  "Xp1CO/": {
+    "message": "Project name...",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/home/HomeView.svelte",
+        211
+      ]
+    ],
+    "translation": "Nama proyek..."
+  },
+  "N2C89m": {
+    "message": "Reference",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/lib/entry-editor/object-editors/ExampleEditorPrimitive.svelte",
+        60
+      ]
+    ],
+    "translation": "Referensi"
+  },
+  "4mRsmF": {
+    "message": "Refine your filter to see more...",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/lib/components/field-editors/select.svelte",
+        144
+      ],
+      [
+        "src/lib/components/field-editors/multi-select.svelte",
+        256
+      ]
+    ],
+    "translation": "Saring filter Anda untuk melihat lebih banyak..."
+  },
+  "TG4hr2": {
+    "message": "Refresh Projects",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/home/Server.svelte",
+        62
+      ],
+      [
+        "src/home/HomeView.svelte",
+        155
+      ]
+    ],
+    "translation": "Segarkan Proyek"
+  },
+  "t/YqKh": {
+    "message": "Remove",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/lib/entry-editor/ItemListItem.svelte",
+        73
+      ]
+    ],
+    "translation": "Hapus"
+  },
+  "M7SqjM": {
+    "message": "Reopen",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/lib/OpenInFieldWorksButton.svelte",
+        41
+      ]
+    ],
+    "translation": "Buka kembali"
+  },
+  "aKuPxK": {
+    "message": "Search # or #",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/lib/entry-editor/EntryOrSensePicker.svelte",
+        null
+      ]
+    ],
+    "translation": "Cari # atau #"
+  },
+  "3NdSH7": {
+    "message": "Search Dictionaries",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/project/ProjectDropdown.svelte",
+        98
+      ]
+    ],
+    "translation": "Cari Kamus"
+  },
+  "02ePaq": {
+    "message": "Select {0}",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/lib/entry-editor/EntryOrSensePicker.svelte",
+        250
+      ]
+    ],
+    "translation": "Pilih {0}"
+  },
+  "bbTYV2": {
+    "message": "Select {0} to view details",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/project/browse/BrowseView.svelte",
+        102
+      ]
+    ],
+    "translation": "Pilih {0} untuk melihat detail"
+  },
+  "mEtszZ": {
+    "message": "Semantic domains",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/lib/entry-editor/object-editors/SenseEditorPrimitive.svelte",
+        79
+      ]
+    ],
+    "translation": "Domain semantik"
+  },
+  "Ivc0e8": {
+    "message": "Sense",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/lib/entry-editor/EntryOrSensePicker.svelte",
+        250
+      ],
+      [
+        "src/lib/entry-editor/object-editors/EntryEditor.svelte",
+        165
+      ],
+      [
+        "src/lib/entry-editor/object-editors/EntryEditor.svelte",
+        72
+      ],
+      [
+        "src/lib/entry-editor/object-editors/AddSenseFab.svelte",
+        15
+      ]
+    ],
+    "translation": "Makna"
+  },
+  "FDpH/H": {
+    "message": "Sentence",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/lib/entry-editor/object-editors/ExampleEditorPrimitive.svelte",
+        37
+      ]
+    ],
+    "translation": "Kalimat"
+  },
+  "Tz0i8g": {
+    "message": "Settings",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/project/ProjectSidebar.svelte",
+        142
+      ]
+    ],
+    "translation": "Pengaturan"
+  },
+  "+drua4": {
+    "message": "Shadcn Sandbox # #",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/lib/sandbox/Sandbox.svelte",
+        null
+      ]
+    ],
+    "translation": "Shadcn Sandbox # #"
+  },
+  "mFKqBL": {
+    "message": "Share Log file",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/lib/troubleshoot/TroubleshootDialog.svelte",
+        50
+      ]
+    ],
+    "translation": "Bagikan file Log"
+  },
+  "8vETh9": {
+    "message": "Show",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/project/browse/ViewPicker.svelte",
+        39
+      ]
+    ],
+    "translation": "Tampilkan"
+  },
+  "0IaUwR": {
+    "message": "Show {0} more...",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/lib/entry-editor/EntryOrSensePicker.svelte",
+        191
+      ]
+    ],
+    "translation": "Tampilkan {0} lagi..."
+  },
+  "AQK14J": {
+    "message": "Simple",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/project/browse/BrowseView.svelte",
+        72
+      ]
+    ],
+    "translation": "Sederhana"
+  },
+  "hQRttt": {
+    "message": "Submit",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/lib/components/field-editors/multi-select.svelte",
+        210
+      ],
+      [
+        "src/lib/components/field-editors/multi-select.svelte",
+        211
+      ],
+      [
+        "src/lib/components/field-editors/multi-select.svelte",
+        283
+      ]
+    ],
+    "translation": "Kirim"
+  },
+  "N2FcBE": {
+    "message": "Synced",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/lib/activity/ActivityView.svelte",
+        103
+      ],
+      [
+        "src/home/Server.svelte",
+        105
+      ]
+    ],
+    "translation": "Tersinkronisasi"
+  },
+  "JXRN33": {
+    "message": "Synced with {0}",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/home/HomeView.svelte",
+        168
+      ]
+    ],
+    "translation": "Tersinkronisasi dengan {0}"
+  },
+  "UNnBU9": {
+    "message": "Synchronize",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/project/SyncDialog.svelte",
+        142
+      ],
+      [
+        "src/project/SyncDialog.svelte",
+        224
+      ],
+      [
+        "src/project/ProjectSidebar.svelte",
+        122
+      ]
+    ],
+    "translation": "Sinkronkan"
+  },
+  "ivpwMF": {
+    "message": "Synchronizing...",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/project/SyncDialog.svelte",
+        174
+      ],
+      [
+        "src/project/SyncDialog.svelte",
+        222
+      ]
+    ],
+    "translation": "Menyinkronkan..."
+  },
+  "GtycJ/": {
+    "message": "Tasks",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/project/ProjectSidebar.svelte",
+        90
+      ]
+    ],
+    "translation": "Tugas"
+  },
+  "/OCqal": {
+    "message": "Test Project",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/home/HomeView.svelte",
+        192
+      ]
+    ],
+    "translation": "Proyek Uji Coba"
+  },
+  "qYgnDa": {
+    "message": "This date # and this emoji # are snippets",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/stories/i18n/i18n.stories.svelte",
+        null
+      ]
+    ],
+    "translation": "Tanggal ini # dan emoji ini # adalah cuplikan"
+  },
+  "f233G3": {
+    "message": "This project is now open in FieldWorks. To continue working in FieldWorks Lite, close the project in FieldWorks and click Reopen.",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/lib/OpenInFieldWorksButton.svelte",
+        40
+      ]
+    ],
+    "translation": "Proyek ini sekarang terbuka di FieldWorks. Untuk melanjutkan bekerja di FieldWorks Lite, tutup proyek di FieldWorks dan klik Buka Kembali."
+  },
+  "L2twOB": {
+    "message": "Toggle filters",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/project/browse/SearchFilter.svelte",
+        72
+      ]
+    ],
+    "translation": "Beralih filter"
+  },
+  "2N0C4b": {
+    "message": "Toggle theme",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/lib/ThemePicker.svelte",
+        24
+      ]
+    ],
+    "translation": "Beralih tema"
+  },
+  "wFcvZJ": {
+    "message": "Translation",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/lib/entry-editor/object-editors/ExampleEditorPrimitive.svelte",
+        48
+      ]
+    ],
+    "translation": "Terjemahan"
+  },
+  "et+mIi": {
+    "message": "Troubleshoot",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/project/ProjectSidebar.svelte",
+        168
+      ],
+      [
+        "src/lib/troubleshoot/TroubleshootDialog.svelte",
+        30
+      ],
+      [
+        "src/home/HomeView.svelte",
+        132
+      ]
+    ],
+    "translation": "Penyelesaian Masalah"
+  },
+  "amlaqM": {
+    "message": "Unable to open in FieldWorks",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/lib/OpenInFieldWorksButton.svelte",
+        45
+      ]
+    ],
+    "translation": "Tidak dapat membuka di FieldWorks"
+  },
+  "Ef7StM": {
+    "message": "Unknown",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/project/SyncDialog.svelte",
+        243
+      ],
+      [
+        "src/project/SyncDialog.svelte",
+        250
+      ],
+      [
+        "src/lib/history/HistoryView.svelte",
+        99
+      ],
+      [
+        "src/lib/activity/ActivityView.svelte",
+        95
+      ]
+    ],
+    "translation": "Tidak diketahui"
+  },
+  "29VNqC": {
+    "message": "Unknown error",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/project/ProjectSidebar.svelte",
+        115
+      ]
+    ],
+    "translation": "Kesalahan yang tidak diketahui"
+  },
+  "wja8aL": {
+    "message": "Untitled",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/project/browse/EntryView.svelte",
+        49
+      ],
+      [
+        "src/project/browse/EntryRow.svelte",
+        57
+      ],
+      [
+        "src/project/browse/EntryMenu.svelte",
+        32
+      ]
+    ],
+    "translation": "Tanpa Judul"
+  },
+  "S/J67B": {
+    "message": "Uses components as",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/lib/entry-editor/object-editors/EntryEditorPrimitive.svelte",
+        88
+      ]
+    ],
+    "translation": "Menggunakan komponen sebagai"
+  },
+  "YYdC3A": {
+    "message": "Version {0}",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/project/ProjectSidebar.svelte",
+        187
+      ]
+    ],
+    "translation": "Versi {0}"
+  },
+  "yK+3LL": {
+    "message": "View Configuration",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/project/browse/ViewPicker.svelte",
+        26
+      ]
+    ],
+    "translation": "Lihat Konfigurasi"
+  },
+  "LhKBuY": {
+    "message": "Where are my projects?",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/home/Server.svelte",
+        86
+      ]
+    ],
+    "translation": "Di mana proyek saya?"
+  },
+  "dZiBrj": {
+    "message": "Word",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/project/browse/EntryMenu.svelte",
+        37
+      ],
+      [
+        "src/lib/entry-editor/NewEntryDialog.svelte",
+        84
+      ],
+      [
+        "src/lib/entry-editor/EntryOrSensePicker.svelte",
+        250
+      ],
+      [
+        "src/lib/entry-editor/object-editors/EntryEditorPrimitive.svelte",
+        43
+      ]
+    ],
+    "translation": "Kata"
+  },
+  "yRdLNW": {
+    "message": "Word only",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/lib/entry-editor/EntryOrSensePicker.svelte",
+        211
+      ]
+    ],
+    "translation": "Hanya kata"
+  },
+  "o0GO4i": {
+    "message": "Word or meaning:",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/lib/entry-editor/EntryOrSensePicker.svelte",
+        204
+      ]
+    ],
+    "translation": "Kata atau arti:"
+  },
+  "cDHTt1": {
+    "message": "Writing system: {0}",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/lib/components/lcm-rich-text-editor/editor-schema.ts",
+        20
+      ]
+    ],
+    "translation": "Sistem penulisan: {0}"
+  }
+}

--- a/frontend/viewer/src/locales/ko.json
+++ b/frontend/viewer/src/locales/ko.json
@@ -1,0 +1,2390 @@
+{
+  "rwLRCA": {
+    "message": "– ({0} changes)",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/lib/activity/ActivityView.svelte",
+        99
+      ]
+    ],
+    "translation": "– ({0} 변경)"
+  },
+  "mpbC3j": {
+    "message": "{0} - FieldWorks",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/project/SyncDialog.svelte",
+        239
+      ]
+    ],
+    "translation": "{0} - FieldWorks"
+  },
+  "35GcOB": {
+    "message": "{0} - FieldWorks Lite",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/project/SyncDialog.svelte",
+        200
+      ]
+    ],
+    "translation": "{0} - FieldWorks Lite"
+  },
+  "0jQasM": {
+    "message": "{0} (FieldWorks Lite)",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/lib/components/editor/field/field-title.svelte",
+        22
+      ]
+    ],
+    "translation": "{0} (FieldWorks Lite)"
+  },
+  "Bi6Xst": {
+    "message": "{0} (FieldWorks)",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/lib/components/editor/field/field-title.svelte",
+        23
+      ]
+    ],
+    "translation": "{0} (FieldWorks)"
+  },
+  "dhBPPx": {
+    "message": "{0} Server",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/home/Server.svelte",
+        54
+      ]
+    ],
+    "translation": "{0} 서버"
+  },
+  "tgUNp+": {
+    "message": "{0} synced to FieldWorks. {1} synced to FieldWorks Lite.",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/project/SyncDialog.svelte",
+        95
+      ]
+    ],
+    "translation": "{0}가 FieldWorks와 동기화되었습니다. {1}가 FieldWorks Lite와 동기화되었습니다."
+  },
+  "ubuwKa": {
+    "message": "{num, plural, one {# change} other {# changes}}",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/project/SyncDialog.svelte",
+        92
+      ],
+      [
+        "src/project/SyncDialog.svelte",
+        93
+      ]
+    ],
+    "translation": "{num, plural, one {# 변경} other {# 변경}}"
+  },
+  "UuldxO": {
+    "message": "A new version of FieldWorks lite is available.",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/lib/notifications/NotificationOutlet.svelte",
+        24
+      ]
+    ],
+    "translation": "FieldWorks lite의 새 버전을 사용할 수 있습니다."
+  },
+  "fhKYsI": {
+    "message": "a word",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/project/browse/BrowseView.svelte",
+        102
+      ]
+    ],
+    "translation": "단어"
+  },
+  "uyJsf6": {
+    "message": "About",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/lib/about/AboutDialog.svelte",
+        22
+      ]
+    ],
+    "translation": "정보"
+  },
+  "AeXO77": {
+    "message": "Account",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/project/ProjectSidebar.svelte",
+        136
+      ]
+    ],
+    "translation": "계정"
+  },
+  "XJOV1Y": {
+    "message": "Activity",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/project/ProjectSidebar.svelte",
+        93
+      ]
+    ],
+    "translation": "활동"
+  },
+  "KdJj3U": {
+    "message": "Add component",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/lib/entry-editor/field-editors/ComplexForms.svelte",
+        51
+      ],
+      [
+        "src/lib/entry-editor/field-editors/ComplexFormComponents.svelte",
+        57
+      ]
+    ],
+    "translation": "구성 요소 추가"
+  },
+  "nI3A8B": {
+    "message": "Add Example",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/lib/entry-editor/object-editors/EntryEditor.svelte",
+        211
+      ]
+    ],
+    "translation": "예제 추가"
+  },
+  "dt7w9L": {
+    "message": "Add Meaning",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/lib/entry-editor/object-editors/EntryEditor.svelte",
+        226
+      ],
+      [
+        "src/lib/entry-editor/object-editors/EntryEditor.svelte",
+        226
+      ]
+    ],
+    "translation": "의미 추가"
+  },
+  "uvBQSU": {
+    "message": "Add part of",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/lib/entry-editor/field-editors/ComplexForms.svelte",
+        51
+      ]
+    ],
+    "translation": "의 일부 추가"
+  },
+  "0YSbah": {
+    "message": "Add Sense",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/lib/entry-editor/object-editors/EntryEditor.svelte",
+        226
+      ],
+      [
+        "src/lib/entry-editor/object-editors/EntryEditor.svelte",
+        226
+      ]
+    ],
+    "translation": "의미 추가"
+  },
+  "XeIoU/": {
+    "message": "ago",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/lib/history/HistoryView.svelte",
+        83
+      ],
+      [
+        "src/lib/activity/ActivityView.svelte",
+        78
+      ],
+      [
+        "src/lib/activity/ActivityView.svelte",
+        105
+      ]
+    ],
+    "translation": "전"
+  },
+  "iPthvs": {
+    "message": "an entry",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/project/browse/BrowseView.svelte",
+        102
+      ]
+    ],
+    "translation": "항목"
+  },
+  "ZYimak": {
+    "message": "Application version",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/lib/troubleshoot/TroubleshootDialog.svelte",
+        33
+      ]
+    ],
+    "translation": "애플리케이션 버전"
+  },
+  "GKJXpX": {
+    "message": "Are you sure you want to delete {0}?",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/lib/entry-editor/DeleteDialog.svelte",
+        55
+      ]
+    ],
+    "translation": "{0}을(를) 삭제하시겠습니까?"
+  },
+  "6QeoeO": {
+    "message": "Author:",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/lib/history/HistoryView.svelte",
+        95
+      ],
+      [
+        "src/lib/activity/ActivityView.svelte",
+        91
+      ]
+    ],
+    "translation": "작성자:"
+  },
+  "R9Khdg": {
+    "message": "Auto",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/project/browse/SortMenu.svelte",
+        73
+      ]
+    ],
+    "translation": "자동"
+  },
+  "VmDOAV": {
+    "message": "Auto synchronizing",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/project/SyncDialog.svelte",
+        176
+      ]
+    ],
+    "translation": "자동 동기화 중"
+  },
+  "CI9Ae4": {
+    "message": "before",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/lib/history/HistoryView.svelte",
+        80
+      ],
+      [
+        "src/lib/activity/ActivityView.svelte",
+        75
+      ]
+    ],
+    "translation": "이전"
+  },
+  "3qtIhN": {
+    "message": "Best match",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/project/browse/SortMenu.svelte",
+        9
+      ]
+    ],
+    "translation": "가장 일치하는 항목"
+  },
+  "O2UpM1": {
+    "message": "Browse",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/project/ProjectSidebar.svelte",
+        88
+      ]
+    ],
+    "translation": "찾아보기"
+  },
+  "dEgA5A": {
+    "message": "Cancel",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/lib/entry-editor/NewEntryDialog.svelte",
+        110
+      ],
+      [
+        "src/lib/entry-editor/EntryOrSensePicker.svelte",
+        245
+      ],
+      [
+        "src/lib/components/field-editors/select.svelte",
+        164
+      ],
+      [
+        "src/lib/components/field-editors/multi-select.svelte",
+        280
+      ]
+    ],
+    "translation": "취소"
+  },
+  "7Esn9Y": {
+    "message": "Citation form",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/lib/entry-editor/object-editors/EntryEditorPrimitive.svelte",
+        55
+      ]
+    ],
+    "translation": "인용 형식"
+  },
+  "Q01cKL": {
+    "message": "Classic FieldWorks Projects",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/home/HomeView.svelte",
+        225
+      ]
+    ],
+    "translation": "클래식 FieldWorks 프로젝트"
+  },
+  "K0PCkZ": {
+    "message": "clear",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/lib/components/field-editors/select.svelte",
+        116
+      ],
+      [
+        "src/lib/components/field-editors/multi-select.svelte",
+        205
+      ]
+    ],
+    "translation": "지우기"
+  },
+  "yz7wBu": {
+    "message": "Close",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/lib/components/ui/button/x-button.svelte",
+        14
+      ],
+      [
+        "src/lib/components/field-editors/multi-select.svelte",
+        215
+      ],
+      [
+        "src/lib/about/AboutDialog.svelte",
+        28
+      ]
+    ],
+    "translation": "닫기"
+  },
+  "Iy+nsd": {
+    "message": "Close Dictionary",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/project/ProjectSidebar.svelte",
+        155
+      ]
+    ],
+    "translation": "사전 닫기"
+  },
+  "jZlrte": {
+    "message": "Color",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/lib/ThemePicker.svelte",
+        32
+      ]
+    ],
+    "translation": "색상"
+  },
+  "PkH7DZ": {
+    "message": "Complex Form",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/lib/entry-editor/field-editors/ComplexForms.svelte",
+        55
+      ],
+      [
+        "src/lib/entry-editor/field-editors/ComplexForms.svelte",
+        44
+      ],
+      [
+        "src/lib/entry-editor/field-editors/ComplexFormComponents.svelte",
+        45
+      ]
+    ],
+    "translation": "복합 형식"
+  },
+  "W+5v9T": {
+    "message": "Complex form types",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/lib/entry-editor/object-editors/EntryEditorPrimitive.svelte",
+        88
+      ]
+    ],
+    "translation": "복합 형식 유형"
+  },
+  "j6HACU": {
+    "message": "Complex forms",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/lib/entry-editor/object-editors/EntryEditorPrimitive.svelte",
+        67
+      ]
+    ],
+    "translation": "복합 형식"
+  },
+  "dK3Z9j": {
+    "message": "Component",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/lib/entry-editor/field-editors/ComplexForms.svelte",
+        43
+      ],
+      [
+        "src/lib/entry-editor/field-editors/ComplexFormComponents.svelte",
+        61
+      ],
+      [
+        "src/lib/entry-editor/field-editors/ComplexFormComponents.svelte",
+        44
+      ],
+      [
+        "src/lib/entry-editor/field-editors/ComplexFormComponents.svelte",
+        50
+      ]
+    ],
+    "translation": "구성 요소"
+  },
+  "RRa/CR": {
+    "message": "Components",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/lib/entry-editor/object-editors/EntryEditorPrimitive.svelte",
+        77
+      ]
+    ],
+    "translation": "구성 요소"
+  },
+  "b9XOHo": {
+    "message": "Create {0}",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/lib/entry-editor/NewEntryDialog.svelte",
+        112
+      ]
+    ],
+    "translation": "{0} 만들기"
+  },
+  "sYP6Ef": {
+    "message": "Create entry",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/lib/entry-editor/NewEntryButton.svelte",
+        12
+      ]
+    ],
+    "translation": "항목 만들기"
+  },
+  "0widty": {
+    "message": "Create Example Project",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/home/HomeView.svelte",
+        203
+      ]
+    ],
+    "translation": "예제 프로젝트 만들기"
+  },
+  "OVriW/": {
+    "message": "Create word",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/lib/entry-editor/NewEntryButton.svelte",
+        12
+      ]
+    ],
+    "translation": "단어 만들기"
+  },
+  "Jxxmun": {
+    "message": "Current Entry",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/lib/entry-editor/field-editors/ComplexForms.svelte",
+        42
+      ],
+      [
+        "src/lib/entry-editor/field-editors/ComplexFormComponents.svelte",
+        43
+      ]
+    ],
+    "translation": "현재 항목"
+  },
+  "e2n436": {
+    "message": "Current Word",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/lib/entry-editor/field-editors/ComplexForms.svelte",
+        42
+      ],
+      [
+        "src/lib/entry-editor/field-editors/ComplexFormComponents.svelte",
+        43
+      ]
+    ],
+    "translation": "현재 단어"
+  },
+  "7p5kLi": {
+    "message": "Dashboard",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/project/ProjectSidebar.svelte",
+        86
+      ]
+    ],
+    "translation": "대시보드"
+  },
+  "yX4qgn": {
+    "message": "Data Directory",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/lib/troubleshoot/TroubleshootDialog.svelte",
+        35
+      ]
+    ],
+    "translation": "데이터 디렉터리"
+  },
+  "MbRyzp": {
+    "message": "Definition",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/lib/entry-editor/object-editors/SenseEditorPrimitive.svelte",
+        52
+      ]
+    ],
+    "translation": "정의"
+  },
+  "cnGeoo": {
+    "message": "Delete",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/home/HomeView.svelte",
+        177
+      ]
+    ],
+    "translation": "삭제"
+  },
+  "Y2tU6I": {
+    "message": "Delete {0}",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/lib/entry-editor/DeleteDialog.svelte",
+        52
+      ],
+      [
+        "src/lib/entry-editor/DeleteDialog.svelte",
+        59
+      ]
+    ],
+    "translation": "{0} 삭제"
+  },
+  "P0mjNu": {
+    "message": "Delete Entry",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/project/browse/EntryMenu.svelte",
+        55
+      ]
+    ],
+    "translation": "항목 삭제"
+  },
+  "i/7SVG": {
+    "message": "Delete Word",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/project/browse/EntryMenu.svelte",
+        55
+      ]
+    ],
+    "translation": "단어 삭제"
+  },
+  "RY27RL": {
+    "message": "Dictionaries",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/home/HomeView.svelte",
+        107
+      ],
+      [
+        "src/home/HomeView.svelte",
+        110
+      ]
+    ],
+    "translation": "사전"
+  },
+  "VrH1k+": {
+    "message": "Dictionary",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/project/ProjectSidebar.svelte",
+        82
+      ]
+    ],
+    "translation": "사전"
+  },
+  "OVGpil": {
+    "message": "Dictionary Preview",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/project/browse/ViewPicker.svelte",
+        38
+      ]
+    ],
+    "translation": "사전 미리보기"
+  },
+  "NagCcF": {
+    "message": "Display as",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/lib/entry-editor/object-editors/EntryEditorPrimitive.svelte",
+        55
+      ]
+    ],
+    "translation": "표시 형식"
+  },
+  "z9VIKz": {
+    "message": "Don't delete",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/lib/entry-editor/DeleteDialog.svelte",
+        58
+      ]
+    ],
+    "translation": "삭제 안 함"
+  },
+  "mzI/c+": {
+    "message": "Download",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/lib/notifications/NotificationOutlet.svelte",
+        30
+      ],
+      [
+        "src/home/Server.svelte",
+        119
+      ]
+    ],
+    "translation": "다운로드"
+  },
+  "VIwCaD": {
+    "message": "Entry",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/project/browse/EntryMenu.svelte",
+        37
+      ],
+      [
+        "src/lib/entry-editor/NewEntryDialog.svelte",
+        84
+      ],
+      [
+        "src/lib/entry-editor/EntryOrSensePicker.svelte",
+        250
+      ]
+    ],
+    "translation": "항목"
+  },
+  "byQjNm": {
+    "message": "Entry Only",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/lib/entry-editor/EntryOrSensePicker.svelte",
+        211
+      ]
+    ],
+    "translation": "항목만"
+  },
+  "bQ8ysI": {
+    "message": "Entry or sense:",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/lib/entry-editor/EntryOrSensePicker.svelte",
+        204
+      ]
+    ],
+    "translation": "항목 또는 의미:"
+  },
+  "yeYJfy": {
+    "message": "Error getting sync status",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/project/ProjectSidebar.svelte",
+        117
+      ]
+    ],
+    "translation": "동기화 상태를 가져오는 중 오류 발생"
+  },
+  "ggzvfk": {
+    "message": "Error getting sync status.",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/project/SyncDialog.svelte",
+        186
+      ]
+    ],
+    "translation": "동기화 상태를 가져오는 중 오류가 발생했습니다."
+  },
+  "TpqeIh": {
+    "message": "Error: {0}",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/project/SyncDialog.svelte",
+        250
+      ]
+    ],
+    "translation": "오류: {0}"
+  },
+  "HmI5oK": {
+    "message": "Example",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/lib/entry-editor/object-editors/EntryEditor.svelte",
+        183
+      ]
+    ],
+    "translation": "예제"
+  },
+  "BGP/S1": {
+    "message": "Example sentence",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/lib/entry-editor/object-editors/EntryEditor.svelte",
+        90
+      ]
+    ],
+    "translation": "예문"
+  },
+  "9QXzjh": {
+    "message": "Failed to load entries",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/project/browse/EntriesList.svelte",
+        134
+      ]
+    ],
+    "translation": "항목을 로드하지 못했습니다"
+  },
+  "MS0/dh": {
+    "message": "Failed to open data directory, use the path in the text field instead",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/lib/troubleshoot/TroubleshootDialog.svelte",
+        22
+      ]
+    ],
+    "translation": "데이터 디렉터리를 열지 못했습니다. 대신 텍스트 필드의 경로를 사용하세요."
+  },
+  "yPkUF+": {
+    "message": "Failed to synchronize",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/project/SyncDialog.svelte",
+        89
+      ],
+      [
+        "src/project/SyncDialog.svelte",
+        119
+      ]
+    ],
+    "translation": "동기화하지 못했습니다"
+  },
+  "YirHq7": {
+    "message": "Feedback",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/project/ProjectSidebar.svelte",
+        177
+      ],
+      [
+        "src/home/HomeView.svelte",
+        126
+      ]
+    ],
+    "translation": "피드백"
+  },
+  "jI2ZOA": {
+    "message": "Field Labels",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/project/browse/ViewPicker.svelte",
+        32
+      ]
+    ],
+    "translation": "필드 레이블"
+  },
+  "uKNYWn": {
+    "message": "FieldWorks logo",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/project/ProjectDropdown.svelte",
+        69
+      ],
+      [
+        "src/lib/OpenInFieldWorksButton.svelte",
+        56
+      ],
+      [
+        "src/home/HomeView.svelte",
+        231
+      ]
+    ],
+    "translation": "FieldWorks 로고"
+  },
+  "LwjKwe": {
+    "message": "Filter # entries",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/project/browse/SearchFilter.svelte",
+        53
+      ]
+    ],
+    "translation": "#개 항목 필터링"
+  },
+  "zGI/cf": {
+    "message": "Filter # words",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/project/browse/SearchFilter.svelte",
+        53
+      ]
+    ],
+    "translation": "#개 단어 필터링"
+  },
+  "ctQd0R": {
+    "message": "Filter entries",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/project/browse/SearchFilter.svelte",
+        59
+      ]
+    ],
+    "translation": "항목 필터링"
+  },
+  "IrEBhq": {
+    "message": "Filter words",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/project/browse/SearchFilter.svelte",
+        59
+      ]
+    ],
+    "translation": "단어 필터링"
+  },
+  "6HLTEb": {
+    "message": "Filter...",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/lib/components/field-editors/select.svelte",
+        112
+      ],
+      [
+        "src/lib/components/field-editors/multi-select.svelte",
+        201
+      ]
+    ],
+    "translation": "필터..."
+  },
+  "0KYzFS": {
+    "message": "Find entry...",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/lib/entry-editor/EntryOrSensePicker.svelte",
+        140
+      ]
+    ],
+    "translation": "항목 찾기..."
+  },
+  "gotGzB": {
+    "message": "Find word...",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/lib/entry-editor/EntryOrSensePicker.svelte",
+        140
+      ]
+    ],
+    "translation": "단어 찾기..."
+  },
+  "F7GHkf": {
+    "message": "Gloss",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/lib/entry-editor/object-editors/SenseEditorPrimitive.svelte",
+        41
+      ]
+    ],
+    "translation": "주석"
+  },
+  "u8+PAt": {
+    "message": "Go to {0}",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/lib/entry-editor/EntryOrSenseItemList.svelte",
+        26
+      ]
+    ],
+    "translation": "{0}(으)로 이동"
+  },
+  "Ks+qfd": {
+    "message": "Grammatical info.",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/lib/entry-editor/object-editors/SenseEditorPrimitive.svelte",
+        63
+      ]
+    ],
+    "translation": "문법 정보."
+  },
+  "X5C2hm": {
+    "message": "Headword",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/project/browse/SortMenu.svelte",
+        10
+      ]
+    ],
+    "translation": "표제어"
+  },
+  "vLyv1R": {
+    "message": "Hide",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/project/browse/ViewPicker.svelte",
+        40
+      ]
+    ],
+    "translation": "숨기기"
+  },
+  "0caMy7": {
+    "message": "History",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/project/browse/EntryMenu.svelte",
+        60
+      ],
+      [
+        "src/lib/history/HistoryView.svelte",
+        59
+      ]
+    ],
+    "translation": "기록"
+  },
+  "E8KyPm": {
+    "message": "I don't see my project",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/home/Server.svelte",
+        129
+      ]
+    ],
+    "translation": "내 프로젝트가 보이지 않습니다"
+  },
+  "l3s5ri": {
+    "message": "Import",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/home/HomeView.svelte",
+        237
+      ]
+    ],
+    "translation": "가져오기"
+  },
+  "rZkl7/": {
+    "message": "Last change: {0}",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/project/SyncDialog.svelte",
+        203
+      ],
+      [
+        "src/project/SyncDialog.svelte",
+        242
+      ]
+    ],
+    "translation": "마지막 변경: {0}"
+  },
+  "Cb8zzH": {
+    "message": "Lexbox logo",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/home/HomeView.svelte",
+        109
+      ]
+    ],
+    "translation": "Lexbox 로고"
+  },
+  "vSL95+": {
+    "message": "Lexeme form",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/lib/entry-editor/object-editors/EntryEditorPrimitive.svelte",
+        43
+      ]
+    ],
+    "translation": "어휘소 형식"
+  },
+  "8oegWV": {
+    "message": "List mode",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/project/browse/BrowseView.svelte",
+        63
+      ]
+    ],
+    "translation": "목록 모드"
+  },
+  "2kUuXE": {
+    "message": "Literal meaning",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/lib/entry-editor/object-editors/EntryEditorPrimitive.svelte",
+        103
+      ]
+    ],
+    "translation": "글자 그대로의 의미"
+  },
+  "4PN67S": {
+    "message": "Loading Dictionaries...",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/project/ProjectDropdown.svelte",
+        104
+      ]
+    ],
+    "translation": "사전 로드 중..."
+  },
+  "+yD+Wu": {
+    "message": "loading...",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/home/HomeView.svelte",
+        146
+      ]
+    ],
+    "translation": "로드 중..."
+  },
+  "d5zxa4": {
+    "message": "Local",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/home/HomeView.svelte",
+        151
+      ]
+    ],
+    "translation": "로컬"
+  },
+  "OgyJSr": {
+    "message": "Local only",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/home/HomeView.svelte",
+        168
+      ]
+    ],
+    "translation": "로컬만"
+  },
+  "z0t9bb": {
+    "message": "Login",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/project/SyncDialog.svelte",
+        182
+      ]
+    ],
+    "translation": "로그인"
+  },
+  "z7IcPF": {
+    "message": "Login to see projects",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/lib/auth/LoginButton.svelte",
+        71
+      ],
+      [
+        "src/lib/auth/LoginButton.svelte",
+        79
+      ]
+    ],
+    "translation": "프로젝트를 보려면 로그인하세요"
+  },
+  "nOhz3x": {
+    "message": "Logout",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/lib/auth/LoginButton.svelte",
+        61
+      ]
+    ],
+    "translation": "로그아웃"
+  },
+  "nK30Fy": {
+    "message": "Made with ❤️ from 🇦🇹 🇹🇭 🇺🇸",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/project/ProjectSidebar.svelte",
+        188
+      ]
+    ],
+    "translation": "🇦🇹 🇹🇭 🇺🇸에서 ❤️로 만들었습니다"
+  },
+  "6URaYg": {
+    "message": "Meaning",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/lib/entry-editor/EntryOrSensePicker.svelte",
+        250
+      ],
+      [
+        "src/lib/entry-editor/object-editors/EntryEditor.svelte",
+        165
+      ],
+      [
+        "src/lib/entry-editor/object-editors/EntryEditor.svelte",
+        72
+      ],
+      [
+        "src/lib/entry-editor/object-editors/AddSenseFab.svelte",
+        15
+      ]
+    ],
+    "translation": "의미"
+  },
+  "oPBJ/O": {
+    "message": "Missing Examples",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/project/browse/SearchFilter.svelte",
+        81
+      ]
+    ],
+    "translation": "예제 없음"
+  },
+  "sb65UQ": {
+    "message": "Missing Part of Speech",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/project/browse/SearchFilter.svelte",
+        83
+      ]
+    ],
+    "translation": "품사 없음"
+  },
+  "XOUmTu": {
+    "message": "Missing Semantic Domains",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/project/browse/SearchFilter.svelte",
+        84
+      ]
+    ],
+    "translation": "의미 영역 없음"
+  },
+  "1H/nm7": {
+    "message": "Missing Senses",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/project/browse/SearchFilter.svelte",
+        82
+      ]
+    ],
+    "translation": "의미 없음"
+  },
+  "QWdKwH": {
+    "message": "Move",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/lib/entry-editor/ItemListItem.svelte",
+        61
+      ]
+    ],
+    "translation": "이동"
+  },
+  "qqeAJM": {
+    "message": "Never",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/project/SyncDialog.svelte",
+        243
+      ]
+    ],
+    "translation": "안 함"
+  },
+  "isRobC": {
+    "message": "New",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/project/NewEntryButton.svelte",
+        48
+      ]
+    ],
+    "translation": "새로 만들기"
+  },
+  "6WSYbN": {
+    "message": "New {0}",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/lib/entry-editor/NewEntryDialog.svelte",
+        97
+      ]
+    ],
+    "translation": "새 {0}"
+  },
+  "eL8osE": {
+    "message": "New Entry",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/project/NewEntryButton.svelte",
+        50
+      ]
+    ],
+    "translation": "새 항목"
+  },
+  "QUaH5J": {
+    "message": "No activity found",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/lib/activity/ActivityView.svelte",
+        61
+      ]
+    ],
+    "translation": "활동을 찾을 수 없음"
+  },
+  "cJKxGt": {
+    "message": "No change name",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/lib/history/HistoryView.svelte",
+        71
+      ]
+    ],
+    "translation": "변경 이름 없음"
+  },
+  "hcFut8": {
+    "message": "No Dictionaries found",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/project/ProjectDropdown.svelte",
+        108
+      ]
+    ],
+    "translation": "사전을 찾을 수 없음"
+  },
+  "bakDdy": {
+    "message": "No entries found",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/project/browse/EntriesList.svelte",
+        160
+      ],
+      [
+        "src/lib/entry-editor/EntryOrSensePicker.svelte",
+        174
+      ]
+    ],
+    "translation": "항목을 찾을 수 없음"
+  },
+  "7elymg": {
+    "message": "No history found",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/lib/history/HistoryView.svelte",
+        66
+      ]
+    ],
+    "translation": "기록을 찾을 수 없음"
+  },
+  "V9PAEu": {
+    "message": "No items found",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/lib/components/field-editors/select.svelte",
+        124
+      ],
+      [
+        "src/lib/components/field-editors/multi-select.svelte",
+        220
+      ]
+    ],
+    "translation": "항목을 찾을 수 없음"
+  },
+  "ylgAlG": {
+    "message": "No server configured",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/project/SyncDialog.svelte",
+        184
+      ],
+      [
+        "src/project/ProjectSidebar.svelte",
+        113
+      ]
+    ],
+    "translation": "서버가 구성되지 않음"
+  },
+  "qdJypF": {
+    "message": "No words found",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/lib/entry-editor/EntryOrSensePicker.svelte",
+        174
+      ]
+    ],
+    "translation": "단어를 찾을 수 없음"
+  },
+  "EdQY6l": {
+    "message": "None",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/lib/components/field-editors/select.svelte",
+        99
+      ],
+      [
+        "src/lib/components/field-editors/multi-select.svelte",
+        176
+      ]
+    ],
+    "translation": "없음"
+  },
+  "wMP6DT": {
+    "message": "Not logged in",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/project/SyncDialog.svelte",
+        247
+      ],
+      [
+        "src/project/ProjectSidebar.svelte",
+        111
+      ]
+    ],
+    "translation": "로그인하지 않음"
+  },
+  "KiJn9B": {
+    "message": "Note",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/lib/entry-editor/object-editors/EntryEditorPrimitive.svelte",
+        114
+      ]
+    ],
+    "translation": "참고"
+  },
+  "6Aih4U": {
+    "message": "Offline",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/project/SyncDialog.svelte",
+        180
+      ],
+      [
+        "src/project/ProjectSidebar.svelte",
+        109
+      ]
+    ],
+    "translation": "오프라인"
+  },
+  "LqMYkh": {
+    "message": "Open Data Directory",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/lib/troubleshoot/TroubleshootDialog.svelte",
+        40
+      ]
+    ],
+    "translation": "데이터 디렉터리 열기"
+  },
+  "Y4BKCd": {
+    "message": "Open in FieldWorks",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/lib/OpenInFieldWorksButton.svelte",
+        57
+      ]
+    ],
+    "translation": "FieldWorks에서 열기"
+  },
+  "OsAKOS": {
+    "message": "Open in new Window",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/project/browse/EntryMenu.svelte",
+        65
+      ]
+    ],
+    "translation": "새 창에서 열기"
+  },
+  "sccXTS": {
+    "message": "Open Log file",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/lib/troubleshoot/TroubleshootDialog.svelte",
+        46
+      ]
+    ],
+    "translation": "로그 파일 열기"
+  },
+  "vgP+9p": {
+    "message": "Part",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/lib/entry-editor/field-editors/ComplexForms.svelte",
+        43
+      ],
+      [
+        "src/lib/entry-editor/field-editors/ComplexFormComponents.svelte",
+        44
+      ]
+    ],
+    "translation": "부분"
+  },
+  "qW3eh2": {
+    "message": "Part of",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/lib/entry-editor/object-editors/EntryEditorPrimitive.svelte",
+        67
+      ],
+      [
+        "src/lib/entry-editor/field-editors/ComplexForms.svelte",
+        55
+      ],
+      [
+        "src/lib/entry-editor/field-editors/ComplexForms.svelte",
+        44
+      ],
+      [
+        "src/lib/entry-editor/field-editors/ComplexFormComponents.svelte",
+        45
+      ],
+      [
+        "src/lib/entry-editor/field-editors/ComplexFormComponents.svelte",
+        50
+      ]
+    ],
+    "translation": "~의 일부"
+  },
+  "h6kyNd": {
+    "message": "Part of speech",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/lib/entry-editor/object-editors/SenseEditorPrimitive.svelte",
+        63
+      ]
+    ],
+    "translation": "품사"
+  },
+  "kNiQp6": {
+    "message": "Pinned",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/project/browse/ViewPicker.svelte",
+        41
+      ]
+    ],
+    "translation": "고정됨"
+  },
+  "rdUucN": {
+    "message": "Preview",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/project/browse/BrowseView.svelte",
+        76
+      ]
+    ],
+    "translation": "미리보기"
+  },
+  "Xp1CO/": {
+    "message": "Project name...",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/home/HomeView.svelte",
+        211
+      ]
+    ],
+    "translation": "프로젝트 이름..."
+  },
+  "N2C89m": {
+    "message": "Reference",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/lib/entry-editor/object-editors/ExampleEditorPrimitive.svelte",
+        60
+      ]
+    ],
+    "translation": "참조"
+  },
+  "4mRsmF": {
+    "message": "Refine your filter to see more...",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/lib/components/field-editors/select.svelte",
+        144
+      ],
+      [
+        "src/lib/components/field-editors/multi-select.svelte",
+        256
+      ]
+    ],
+    "translation": "더 보려면 필터를 구체화하세요..."
+  },
+  "TG4hr2": {
+    "message": "Refresh Projects",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/home/Server.svelte",
+        62
+      ],
+      [
+        "src/home/HomeView.svelte",
+        155
+      ]
+    ],
+    "translation": "프로젝트 새로고침"
+  },
+  "t/YqKh": {
+    "message": "Remove",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/lib/entry-editor/ItemListItem.svelte",
+        73
+      ]
+    ],
+    "translation": "제거"
+  },
+  "M7SqjM": {
+    "message": "Reopen",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/lib/OpenInFieldWorksButton.svelte",
+        41
+      ]
+    ],
+    "translation": "다시 열기"
+  },
+  "aKuPxK": {
+    "message": "Search # or #",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/lib/entry-editor/EntryOrSensePicker.svelte",
+        null
+      ]
+    ],
+    "translation": "# 또는 # 검색"
+  },
+  "3NdSH7": {
+    "message": "Search Dictionaries",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/project/ProjectDropdown.svelte",
+        98
+      ]
+    ],
+    "translation": "사전 검색"
+  },
+  "02ePaq": {
+    "message": "Select {0}",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/lib/entry-editor/EntryOrSensePicker.svelte",
+        250
+      ]
+    ],
+    "translation": "{0} 선택"
+  },
+  "bbTYV2": {
+    "message": "Select {0} to view details",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/project/browse/BrowseView.svelte",
+        102
+      ]
+    ],
+    "translation": "자세히 보려면 {0}을(를) 선택하세요"
+  },
+  "mEtszZ": {
+    "message": "Semantic domains",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/lib/entry-editor/object-editors/SenseEditorPrimitive.svelte",
+        79
+      ]
+    ],
+    "translation": "의미 영역"
+  },
+  "Ivc0e8": {
+    "message": "Sense",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/lib/entry-editor/EntryOrSensePicker.svelte",
+        250
+      ],
+      [
+        "src/lib/entry-editor/object-editors/EntryEditor.svelte",
+        165
+      ],
+      [
+        "src/lib/entry-editor/object-editors/EntryEditor.svelte",
+        72
+      ],
+      [
+        "src/lib/entry-editor/object-editors/AddSenseFab.svelte",
+        15
+      ]
+    ],
+    "translation": "의미"
+  },
+  "FDpH/H": {
+    "message": "Sentence",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/lib/entry-editor/object-editors/ExampleEditorPrimitive.svelte",
+        37
+      ]
+    ],
+    "translation": "문장"
+  },
+  "Tz0i8g": {
+    "message": "Settings",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/project/ProjectSidebar.svelte",
+        142
+      ]
+    ],
+    "translation": "설정"
+  },
+  "+drua4": {
+    "message": "Shadcn Sandbox # #",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/lib/sandbox/Sandbox.svelte",
+        null
+      ]
+    ],
+    "translation": "Shadcn 샌드박스 # #"
+  },
+  "mFKqBL": {
+    "message": "Share Log file",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/lib/troubleshoot/TroubleshootDialog.svelte",
+        50
+      ]
+    ],
+    "translation": "로그 파일 공유"
+  },
+  "8vETh9": {
+    "message": "Show",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/project/browse/ViewPicker.svelte",
+        39
+      ]
+    ],
+    "translation": "표시"
+  },
+  "0IaUwR": {
+    "message": "Show {0} more...",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/lib/entry-editor/EntryOrSensePicker.svelte",
+        191
+      ]
+    ],
+    "translation": "{0}개 더 보기..."
+  },
+  "AQK14J": {
+    "message": "Simple",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/project/browse/BrowseView.svelte",
+        72
+      ]
+    ],
+    "translation": "단순"
+  },
+  "hQRttt": {
+    "message": "Submit",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/lib/components/field-editors/multi-select.svelte",
+        210
+      ],
+      [
+        "src/lib/components/field-editors/multi-select.svelte",
+        211
+      ],
+      [
+        "src/lib/components/field-editors/multi-select.svelte",
+        283
+      ]
+    ],
+    "translation": "제출"
+  },
+  "N2FcBE": {
+    "message": "Synced",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/lib/activity/ActivityView.svelte",
+        103
+      ],
+      [
+        "src/home/Server.svelte",
+        105
+      ]
+    ],
+    "translation": "동기화됨"
+  },
+  "JXRN33": {
+    "message": "Synced with {0}",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/home/HomeView.svelte",
+        168
+      ]
+    ],
+    "translation": "{0}와 동기화됨"
+  },
+  "UNnBU9": {
+    "message": "Synchronize",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/project/SyncDialog.svelte",
+        142
+      ],
+      [
+        "src/project/SyncDialog.svelte",
+        224
+      ],
+      [
+        "src/project/ProjectSidebar.svelte",
+        122
+      ]
+    ],
+    "translation": "동기화"
+  },
+  "ivpwMF": {
+    "message": "Synchronizing...",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/project/SyncDialog.svelte",
+        174
+      ],
+      [
+        "src/project/SyncDialog.svelte",
+        222
+      ]
+    ],
+    "translation": "동기화 중..."
+  },
+  "GtycJ/": {
+    "message": "Tasks",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/project/ProjectSidebar.svelte",
+        90
+      ]
+    ],
+    "translation": "작업"
+  },
+  "/OCqal": {
+    "message": "Test Project",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/home/HomeView.svelte",
+        192
+      ]
+    ],
+    "translation": "테스트 프로젝트"
+  },
+  "qYgnDa": {
+    "message": "This date # and this emoji # are snippets",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/stories/i18n/i18n.stories.svelte",
+        null
+      ]
+    ],
+    "translation": "이 날짜 #과 이 이모지 #은 스니펫입니다"
+  },
+  "f233G3": {
+    "message": "This project is now open in FieldWorks. To continue working in FieldWorks Lite, close the project in FieldWorks and click Reopen.",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/lib/OpenInFieldWorksButton.svelte",
+        40
+      ]
+    ],
+    "translation": "이 프로젝트는 이제 FieldWorks에서 열려 있습니다. FieldWorks Lite에서 계속 작업하려면 FieldWorks에서 프로젝트를 닫고 다시 열기를 클릭하십시오."
+  },
+  "L2twOB": {
+    "message": "Toggle filters",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/project/browse/SearchFilter.svelte",
+        72
+      ]
+    ],
+    "translation": "필터 전환"
+  },
+  "2N0C4b": {
+    "message": "Toggle theme",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/lib/ThemePicker.svelte",
+        24
+      ]
+    ],
+    "translation": "테마 전환"
+  },
+  "wFcvZJ": {
+    "message": "Translation",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/lib/entry-editor/object-editors/ExampleEditorPrimitive.svelte",
+        48
+      ]
+    ],
+    "translation": "번역"
+  },
+  "et+mIi": {
+    "message": "Troubleshoot",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/project/ProjectSidebar.svelte",
+        168
+      ],
+      [
+        "src/lib/troubleshoot/TroubleshootDialog.svelte",
+        30
+      ],
+      [
+        "src/home/HomeView.svelte",
+        132
+      ]
+    ],
+    "translation": "문제 해결"
+  },
+  "amlaqM": {
+    "message": "Unable to open in FieldWorks",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/lib/OpenInFieldWorksButton.svelte",
+        45
+      ]
+    ],
+    "translation": "FieldWorks에서 열 수 없음"
+  },
+  "Ef7StM": {
+    "message": "Unknown",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/project/SyncDialog.svelte",
+        243
+      ],
+      [
+        "src/project/SyncDialog.svelte",
+        250
+      ],
+      [
+        "src/lib/history/HistoryView.svelte",
+        99
+      ],
+      [
+        "src/lib/activity/ActivityView.svelte",
+        95
+      ]
+    ],
+    "translation": "알 수 없음"
+  },
+  "29VNqC": {
+    "message": "Unknown error",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/project/ProjectSidebar.svelte",
+        115
+      ]
+    ],
+    "translation": "알 수 없는 오류"
+  },
+  "wja8aL": {
+    "message": "Untitled",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/project/browse/EntryView.svelte",
+        49
+      ],
+      [
+        "src/project/browse/EntryRow.svelte",
+        57
+      ],
+      [
+        "src/project/browse/EntryMenu.svelte",
+        32
+      ]
+    ],
+    "translation": "무제"
+  },
+  "S/J67B": {
+    "message": "Uses components as",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/lib/entry-editor/object-editors/EntryEditorPrimitive.svelte",
+        88
+      ]
+    ],
+    "translation": "다음을 구성 요소로 사용합니다"
+  },
+  "YYdC3A": {
+    "message": "Version {0}",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/project/ProjectSidebar.svelte",
+        187
+      ]
+    ],
+    "translation": "버전 {0}"
+  },
+  "yK+3LL": {
+    "message": "View Configuration",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/project/browse/ViewPicker.svelte",
+        26
+      ]
+    ],
+    "translation": "구성 보기"
+  },
+  "LhKBuY": {
+    "message": "Where are my projects?",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/home/Server.svelte",
+        86
+      ]
+    ],
+    "translation": "내 프로젝트는 어디에 있습니까?"
+  },
+  "dZiBrj": {
+    "message": "Word",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/project/browse/EntryMenu.svelte",
+        37
+      ],
+      [
+        "src/lib/entry-editor/NewEntryDialog.svelte",
+        84
+      ],
+      [
+        "src/lib/entry-editor/EntryOrSensePicker.svelte",
+        250
+      ],
+      [
+        "src/lib/entry-editor/object-editors/EntryEditorPrimitive.svelte",
+        43
+      ]
+    ],
+    "translation": "단어"
+  },
+  "yRdLNW": {
+    "message": "Word only",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/lib/entry-editor/EntryOrSensePicker.svelte",
+        211
+      ]
+    ],
+    "translation": "단어만"
+  },
+  "o0GO4i": {
+    "message": "Word or meaning:",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/lib/entry-editor/EntryOrSensePicker.svelte",
+        204
+      ]
+    ],
+    "translation": "단어 또는 의미:"
+  },
+  "cDHTt1": {
+    "message": "Writing system: {0}",
+    "placeholders": {},
+    "comments": [],
+    "origin": [
+      [
+        "src/lib/components/lcm-rich-text-editor/editor-schema.ts",
+        20
+      ]
+    ],
+    "translation": "쓰기 시스템: {0}"
+  }
+}


### PR DESCRIPTION
This PR is based on the Korean localization PR for simplicity and to avoid merge conflicts - it can be rebased once #1811 is merged.

Gemini 2.5 Pro prompt:

I have attached the English en.json file that is used to create new translation files. In the en.json file, there is both a "message" and a "translation" key/value along with other keys for each lexical unit. Your task is to create a new json file that translates from English into another language and put the translation into the "translation" value, replacing the English text that is there. You should only be replacing the text in the "translation" key/value and leave all other existing fields intact. Just give me the json file for each language.

Translate into this language: Indonesian (id)