### PR TITLE
fix error displayed when playing audio

### DIFF
--- a/frontend/viewer/src/lib/components/field-editors/audio-input.svelte
+++ b/frontend/viewer/src/lib/components/field-editors/audio-input.svelte
@@ -29,6 +29,10 @@
     fractionalDigits: 2,
   }));
 
+  function isNotFoundAudioId(audioId: string) {
+    return audioId === 'sil-media://not-found/00000000-0000-0000-0000-000000000000';
+  }
+
   const missingDuration = $derived(zeroDuration.replaceAll('0', '‒')); // <=  this "figure dash" is supposed to be the dash closest to the width of a number
 </script>
 <script lang="ts">
@@ -152,7 +156,15 @@
   let smallestUnit = $derived(totalLength.minutes > 0 ? 'seconds' as const : 'milliseconds' as const);
 </script>
 {#if supportsAudio}
-  {#if audioId}
+  {#if !audioId}
+    <div class="text-muted-foreground p-1">
+      {$t`No audio`}
+    </div>
+  {:else if isNotFoundAudioId(audioId)}
+    <div class="text-muted-foreground p-1">
+      {$t`Audio file not included in Send & Receive`}
+    </div>
+  {:else}
     <div class="flex space-x-3 items-center">
       {#if loading}
         <!--for some reason using the same button for loading, play and pause doesn't work and pause is never shown-->
@@ -165,31 +177,29 @@
                 class="pl-2"
                 value={sliderValue}
                 onValueChange={(value) => {
-                  // store the value, because !playing is not necessarrily up to date when a drag starts
-                  lastEmittedSliderValue = value;
-                  // keep displayed time up to date while dragging
-                  if (!playing) audioRuned.currentTime = sliderValue = value;
-                }}
+                    // store the value, because !playing is not necessarrily up to date when a drag starts
+                    lastEmittedSliderValue = value;
+                    // keep displayed time up to date while dragging
+                    if (!playing) audioRuned.currentTime = sliderValue = value;
+                  }}
                 onValueCommit={(value) => {
-                  // sometimes all value change events are fired before pausedViaDragging === true
-                  // then we need this
-                  audioRuned.currentTime = sliderValue = value;
-                }}
+                    // sometimes all value change events are fired before pausedViaDragging === true
+                    // then we need this
+                    audioRuned.currentTime = sliderValue = value;
+                  }}
                 {onDraggingChange}
                 max={audioRuned?.duration}
-                step={0.01} />
-          <span class="break-keep text-nowrap pr-2 flex flex-nowrap gap-1">
-            {#if !isNaN(audioRuned.duration)}
-              <time>{formatDuration({seconds: sliderValue}, smallestUnit, formatOpts)}</time> / <time>{formatDuration(totalLength, smallestUnit, formatOpts)}</time>
-            {:else}
-              <time>{zeroDuration}</time> / <time class="text-muted-foreground">{missingDuration}</time>
-            {/if}
-        </span>
+                step={0.01}/>
+        <span class="break-keep text-nowrap pr-2 flex flex-nowrap gap-1">
+              {#if !isNaN(audioRuned.duration)}
+                <time>{formatDuration({seconds: sliderValue}, smallestUnit, formatOpts)}</time> / <time>{formatDuration(totalLength, smallestUnit, formatOpts)}</time>
+              {:else}
+                <time>{zeroDuration}</time> / <time class="text-muted-foreground">{missingDuration}</time>
+              {/if}
+          </span>
       {/if}
       <audio bind:this={audio} onplay={load}>
       </audio>
     </div>
-  {:else}
-    <div class="text-muted-foreground p-1">{$t`No audio`}</div>
   {/if}
 {/if}

--- a/frontend/viewer/src/lib/components/ui/format/format-duration.ts
+++ b/frontend/viewer/src/lib/components/ui/format/format-duration.ts
@@ -1,5 +1,6 @@
 import {fromStore} from 'svelte/store';
 import {locale} from 'svelte-i18n-lingui';
+import '@formatjs/intl-durationformat/polyfill';
 
 const currentLocale = fromStore(locale);
 type Duration = Pick<Intl.DurationLike, 'hours' | 'minutes' | 'seconds' | 'milliseconds'>;
@@ -18,17 +19,17 @@ export function normalizeDuration(value: Duration, smallestUnit?: 'hours' | 'min
   const msPerSecond = 1_000;
   let distanceMs = (value.hours ?? 0) * msPerHour + (value.minutes ?? 0) * msPerMinute + (value.seconds ?? 0) * msPerSecond + (value.milliseconds ?? 0);
   let hours = distanceMs / msPerHour;
-  if (smallestUnit === 'hours') return {hours};
   hours = Math.floor(hours);
+  if (smallestUnit === 'hours') return {hours};
   distanceMs -= hours * msPerHour;
   let minutes = distanceMs / msPerMinute;
-  if (smallestUnit === 'minutes') return {hours, minutes};
   minutes = Math.floor(minutes);
+  if (smallestUnit === 'minutes') return {hours, minutes};
   distanceMs -= minutes * msPerMinute;
   let seconds = distanceMs / msPerSecond;
-  if (smallestUnit === 'seconds') return {hours, minutes, seconds};
   seconds = Math.floor(seconds);
+  if (smallestUnit === 'seconds') return {hours, minutes, seconds};
   distanceMs -= seconds * msPerSecond;
-  const milliseconds = distanceMs;
+  const milliseconds = Math.floor(distanceMs);
   return {hours, minutes, seconds, milliseconds};
 }

--- a/frontend/viewer/src/lib/writing-system-service.svelte.ts
+++ b/frontend/viewer/src/lib/writing-system-service.svelte.ts
@@ -55,6 +55,14 @@ export class WritingSystemService {
     return this.pickWritingSystems('vernacular');
   }
 
+  get analysisNoAudio(): IWritingSystem[] {
+    return this.analysis.filter(ws => !ws.isAudio);
+  }
+
+  get vernacularNoAudio(): IWritingSystem[] {
+    return this.vernacular.filter(ws => !ws.isAudio);
+  }
+
   get defaultVernacular(): IWritingSystem | undefined {
     return this.writingSystems.vernacular[0];
   }
@@ -94,7 +102,7 @@ export class WritingSystemService {
       return WritingSystemService.headword(entry, ws) || '';
     }
 
-    return firstTruthy(this.vernacular, ws => WritingSystemService.headword(entry, ws.wsId)) || '';
+    return firstTruthy(this.vernacularNoAudio, ws => WritingSystemService.headword(entry, ws.wsId)) || '';
   }
 
   private static headword(entry: IEntry, ws: string): string | undefined {


### PR DESCRIPTION
Looks like this got missed in our audio PR. This also changes how normalize works.

We now display a message when a file isn't found
![image](https://github.com/user-attachments/assets/b6f7f19a-c5f0-4b07-9d55-ddf50f3ff0c8)
previously we would show the audio player. This differs from when there's no file.
