### PR TITLE
hide some UI elements when running as a paratext extension

### DIFF
--- a/backend/FwLite/FwLiteShared/Pages/CrdtProject.razor
+++ b/backend/FwLite/FwLiteShared/Pages/CrdtProject.razor
@@ -1,4 +1,5 @@
 ﻿@page "/project/{projectName}/{*path}"
+@page "/paratext/project/{projectName}/{*path}"
 @using FwLiteShared.Layout
 @layout SvelteLayout;
 

--- a/backend/FwLite/FwLiteShared/Pages/FwdataProject.razor
+++ b/backend/FwLite/FwLiteShared/Pages/FwdataProject.razor
@@ -1,4 +1,5 @@
 ﻿@page "/fwdata/{projectName}/{*path}"
+@page "/paratext/fwdata/{projectName}/{*path}"
 @using FwLiteShared.Layout
 @layout SvelteLayout;
 

--- a/frontend/viewer/src/App.svelte
+++ b/frontend/viewer/src/App.svelte
@@ -80,6 +80,20 @@
           {/key}
         </Router>
       </Route>
+      <Route path="/paratext/project/:code/*" let:params>
+        <Router {url} basepath="/project/{params.code}">
+          {#key params.code}
+            <DotnetProjectView code={params.code} type="crdt" paratext />
+          {/key}
+        </Router>
+      </Route>
+      <Route path="/paratext/fwdata/:name/*" let:params>
+        <Router {url} basepath="/fwdata/{params.name}">
+          {#key params.name}
+            <DotnetProjectView code={params.name} type="fwdata" paratext />
+          {/key}
+        </Router>
+      </Route>
       <Route path="/testing/project-view/*">
         <Router {url} basepath="/testing/project-view">
           <TestProjectView />

--- a/frontend/viewer/src/App.svelte
+++ b/frontend/viewer/src/App.svelte
@@ -67,35 +67,35 @@
   <div class="app">
     <Router {url}>
       <Route path="/project/:code/*" let:params>
-        <Router {url} basepath="/project/{params.code}">
+        <Router {url}>
           {#key params.code}
             <DotnetProjectView code={params.code} type="crdt" />
           {/key}
         </Router>
       </Route>
       <Route path="/fwdata/:name/*" let:params>
-        <Router {url} basepath="/fwdata/{params.name}">
+        <Router {url}>
           {#key params.name}
             <DotnetProjectView code={params.name} type="fwdata" />
           {/key}
         </Router>
       </Route>
       <Route path="/paratext/project/:code/*" let:params>
-        <Router {url} basepath="/project/{params.code}">
+        <Router {url}>
           {#key params.code}
             <DotnetProjectView code={params.code} type="crdt" paratext />
           {/key}
         </Router>
       </Route>
       <Route path="/paratext/fwdata/:name/*" let:params>
-        <Router {url} basepath="/fwdata/{params.name}">
+        <Router {url}>
           {#key params.name}
             <DotnetProjectView code={params.name} type="fwdata" paratext />
           {/key}
         </Router>
       </Route>
       <Route path="/testing/project-view/*">
-        <Router {url} basepath="/testing/project-view">
+        <Router {url}>
           <TestProjectView />
         </Router>
       </Route>

--- a/frontend/viewer/src/DotnetProjectView.svelte
+++ b/frontend/viewer/src/DotnetProjectView.svelte
@@ -17,9 +17,10 @@
   const projectServicesProvider = useProjectServicesProvider();
   const projectContext = initProjectContext();
 
-  const {code, type: projectType}: {
+  const {code, type: projectType, paratext = false}: {
     code: string; // Code for CRDTs, project-name for FWData
-    type: 'fwdata' | 'crdt'
+    type: 'fwdata' | 'crdt';
+    paratext?: boolean;
   } = $props();
 
 
@@ -60,7 +61,8 @@
       projectCode: code,
       projectType,
       server: projectScope.server,
-      projectData: projectScope.projectData
+      projectData: projectScope.projectData,
+      paratext
     });
     serviceLoaded = true;
   });
@@ -79,8 +81,7 @@
   }
 </script>
 
-<div data-paratext={paratext} class="contents">
-  <ProjectLoader readyToLoadProject={serviceLoaded} {loading} {projectName}>
-      <ProjectView isConnected onloaded={() => loading = false}></ProjectView>
-  </ProjectLoader>
-</div>
+<ProjectLoader readyToLoadProject={serviceLoaded} {loading} {projectName}>
+  <ProjectView onloaded={() => loading = false} data-paratext={paratext}></ProjectView>
+</ProjectLoader>
+

--- a/frontend/viewer/src/DotnetProjectView.svelte
+++ b/frontend/viewer/src/DotnetProjectView.svelte
@@ -27,6 +27,7 @@
   let projectName = $state<string>(code);
   let projectScope: IProjectScope;
   let serviceLoaded = $state(false);
+  let loading = $state(true);
   let destroyed = false;
   onMount(async () => {
     console.debug('ProjectView mounted');
@@ -78,6 +79,8 @@
   }
 </script>
 
-<ProjectLoader readyToLoadProject={serviceLoaded} {projectName} let:onProjectLoaded>
-  <ProjectView isConnected onloaded={onProjectLoaded}></ProjectView>
-</ProjectLoader>
+<div data-paratext={paratext} class="contents">
+  <ProjectLoader readyToLoadProject={serviceLoaded} {loading} {projectName}>
+      <ProjectView isConnected onloaded={() => loading = false}></ProjectView>
+  </ProjectLoader>
+</div>

--- a/frontend/viewer/src/ProjectLoader.svelte
+++ b/frontend/viewer/src/ProjectLoader.svelte
@@ -1,13 +1,16 @@
 <script lang="ts">
-  import {writable} from 'svelte/store';
   import {fade} from 'svelte/transition';
   import Loading from '$lib/components/Loading.svelte';
+  import type {Snippet} from 'svelte';
 
-  export let readyToLoadProject = true;
-  export let projectName: string;
+  interface Props {
+    readyToLoadProject?: boolean;
+    projectName: string;
+    loading: boolean;
+    children: Snippet;
+  }
 
-  let projectLoaded = writable(false);
-  $: loading = !readyToLoadProject || !$projectLoaded;
+  let {readyToLoadProject = true, projectName, children, loading}: Props = $props();
 </script>
 
 {#if loading}
@@ -20,7 +23,7 @@
 {/if}
 
 {#if readyToLoadProject}
-  <div class:hidden={!$projectLoaded} class:contents={$projectLoaded}>
-    <slot onProjectLoaded={projectLoaded.set} />
+  <div class:hidden={loading} class:contents={!loading}>
+    {@render children()}
   </div>
 {/if}

--- a/frontend/viewer/src/ProjectView.svelte
+++ b/frontend/viewer/src/ProjectView.svelte
@@ -1,17 +1,13 @@
 <script lang="ts">
   import ShadcnProjectView from './ShadcnProjectView.svelte';
+  import type {HTMLAttributes} from 'svelte/elements';
 
   const {
     onloaded,
-    isConnected,
-    showHomeButton = true,
-    about = undefined,
+    ...rest
   }: {
     onloaded: (loaded: boolean) => void;
-    about?: string | undefined;
-    isConnected: boolean;
-    showHomeButton?: boolean;
-  } = $props();
+  } & HTMLAttributes<HTMLDivElement> = $props();
 </script>
 
-<ShadcnProjectView {onloaded} {about} {isConnected} {showHomeButton}/>
+<ShadcnProjectView {onloaded} {...rest}/>

--- a/frontend/viewer/src/ShadcnProjectView.svelte
+++ b/frontend/viewer/src/ShadcnProjectView.svelte
@@ -60,17 +60,20 @@
   <Sidebar.Provider bind:open>
     <ProjectSidebar/>
     <Sidebar.Inset class="flex-1 relative">
-      <Route path="browse">
+      <Route path="/browse">
         <BrowseView/>
       </Route>
-      <Route path="tasks">
+      <Route path="/tasks">
         <TasksView/>
       </Route>
-      <Route path="activity">
+      <Route path="/activity">
         <ActivityView />
       </Route>
-      <Route default>
+      <Route path="/">
         {setTimeout(() => navigate(`${$base.uri}/browse`, {replace: true}))}
+      </Route>
+      <Route path="/*">
+        Unknown route
       </Route>
     </Sidebar.Inset>
   </Sidebar.Provider>

--- a/frontend/viewer/src/ShadcnProjectView.svelte
+++ b/frontend/viewer/src/ShadcnProjectView.svelte
@@ -60,20 +60,17 @@
   <Sidebar.Provider bind:open>
     <ProjectSidebar/>
     <Sidebar.Inset class="flex-1 relative">
-      <Route path="/browse">
+      <Route path="browse">
         <BrowseView/>
       </Route>
-      <Route path="/tasks">
+      <Route path="tasks">
         <TasksView/>
       </Route>
-      <Route path="/activity">
+      <Route path="activity">
         <ActivityView />
       </Route>
-      <Route path="/">
+      <Route default>
         {setTimeout(() => navigate(`${$base.uri}/browse`, {replace: true}))}
-      </Route>
-      <Route path="/*">
-        Unknown route
       </Route>
     </Sidebar.Inset>
   </Sidebar.Provider>

--- a/frontend/viewer/src/ShadcnProjectView.svelte
+++ b/frontend/viewer/src/ShadcnProjectView.svelte
@@ -22,18 +22,14 @@
   import {navigate, Route, useRouter} from 'svelte-routing';
   import ActivityView from '$lib/activity/ActivityView.svelte';
   import {AppNotification} from '$lib/notifications/notifications';
+  import type {HTMLAttributes} from 'svelte/elements';
 
   const {
     onloaded,
-    // isConnected,
-    // showHomeButton = true,
-    // about = undefined,
+    ...rest
   }: {
     onloaded: (loaded: boolean) => void;
-    about?: string | undefined;
-    isConnected: boolean;
-    showHomeButton?: boolean;
-  } = $props();
+  } & HTMLAttributes<HTMLDivElement> = $props();
 
   initView();
   initViewSettings();
@@ -60,7 +56,7 @@
 </script>
 <svelte:window on:message={onMessage}/>
 <DialogsProvider/>
-<div class="h-screen flex PortalTarget overflow-hidden shadcn-root">
+<div class="h-screen flex PortalTarget overflow-hidden shadcn-root" {...rest}>
   <Sidebar.Provider bind:open>
     <ProjectSidebar/>
     <Sidebar.Inset class="flex-1 relative">

--- a/frontend/viewer/src/TestProjectView.svelte
+++ b/frontend/viewer/src/TestProjectView.svelte
@@ -4,8 +4,9 @@ import {InMemoryApiService} from '$lib/in-memory-api-service';
 import ProjectLoader from './ProjectLoader.svelte';
 
 const projectName = InMemoryApiService.setup().projectName;
+let loading = $state(true);
 </script>
 
-<ProjectLoader {projectName} let:onProjectLoaded>
-  <ProjectView isConnected onloaded={onProjectLoaded}></ProjectView>
+<ProjectLoader {projectName} {loading}>
+  <ProjectView isConnected onloaded={() => loading = false}></ProjectView>
 </ProjectLoader>

--- a/frontend/viewer/src/TestProjectView.svelte
+++ b/frontend/viewer/src/TestProjectView.svelte
@@ -8,5 +8,5 @@ let loading = $state(true);
 </script>
 
 <ProjectLoader {projectName} {loading}>
-  <ProjectView isConnected onloaded={() => loading = false}></ProjectView>
+  <ProjectView onloaded={() => loading = false}></ProjectView>
 </ProjectLoader>

--- a/frontend/viewer/src/WebComponent.svelte
+++ b/frontend/viewer/src/WebComponent.svelte
@@ -14,6 +14,7 @@
   import {mockFwLiteConfig} from '$lib/in-memory-api-service';
   import type {IFwEvent} from '$lib/dotnet-types/generated-types/FwLiteShared/Events/IFwEvent';
 
+  let connecting = true;
   let loading = true;
 
   export let projectName: string;
@@ -39,7 +40,7 @@
       signal: abortController.signal,
     });
 
-    loading = false;
+    connecting = false;
 
     return () => {
       abortController.abort();
@@ -60,7 +61,7 @@
 </svelte:element>
 
 <div class="app contents" class:dark={mode.current === 'dark'} data-theme={theme.current}>
-  <ProjectLoader readyToLoadProject={!loading} {projectName} let:onProjectLoaded>
-    <ProjectView isConnected showHomeButton={false} {about}  onloaded={onProjectLoaded} />
+  <ProjectLoader readyToLoadProject={!connecting} {loading} {projectName}>
+    <ProjectView isConnected showHomeButton={false} {about}  onloaded={() => loading = false} />
   </ProjectLoader>
 </div>

--- a/frontend/viewer/src/WebComponent.svelte
+++ b/frontend/viewer/src/WebComponent.svelte
@@ -62,6 +62,6 @@
 
 <div class="app contents" class:dark={mode.current === 'dark'} data-theme={theme.current}>
   <ProjectLoader readyToLoadProject={!connecting} {loading} {projectName}>
-    <ProjectView isConnected showHomeButton={false} {about}  onloaded={() => loading = false} />
+    <ProjectView onloaded={() => loading = false} />
   </ProjectLoader>
 </div>

--- a/frontend/viewer/src/lib/project-context.svelte.ts
+++ b/frontend/viewer/src/lib/project-context.svelte.ts
@@ -23,6 +23,7 @@ interface ProjectContextSetup {
   projectType?: 'crdt' | 'fwdata';
   server?: ILexboxServer;
   projectData?: IProjectData;
+  paratext?: boolean;
 }
 export function initProjectContext(args?: ProjectContextSetup) {
   const context = new ProjectContext(args);
@@ -42,6 +43,7 @@ export class ProjectContext {
   #projectData = $state<IProjectData>();
   #historyService: IHistoryServiceJsInvokable | undefined = $state(undefined);
   #syncService: ISyncServiceJsInvokable | undefined = $state(undefined);
+  #paratext = $state(false);
   #features = resource(() => this.#api, (api) => {
     if (!api) return Promise.resolve({} satisfies IMiniLcmFeatures);
     return api.supportedFeatures();
@@ -79,16 +81,12 @@ export class ProjectContext {
   public get syncService(): ISyncServiceJsInvokable | undefined {
     return this.#syncService;
   }
+  public get inParatext(): boolean {
+    return this.#paratext;
+  }
 
   constructor(args?: ProjectContextSetup) {
-    this.#api = args?.api;
-    this.#historyService = args?.historyService;
-    this.#syncService = args?.syncService;
-    this.#projectName = args?.projectName;
-    this.#projectCode = args?.projectCode;
-    this.#projectType = args?.projectType;
-    this.#server = args?.server;
-    this.#projectData = args?.projectData;
+    if (args) this.setup(args);
   }
 
   public setup(args: ProjectContextSetup) {
@@ -100,6 +98,7 @@ export class ProjectContext {
     this.#projectType = args.projectType;
     this.#server = args.server;
     this.#projectData = args.projectData;
+    this.#paratext = args.paratext ?? false;
   }
 
   public getOrAddAsync<T>(key: symbol, initialValue: T, factory: (api: IMiniLcmJsInvokable) => Promise<T>, options?: GetOrAddAsyncOptions<T>): ResourceReturn<T, unknown, true> {

--- a/frontend/viewer/src/project/ProjectDropdown.svelte
+++ b/frontend/viewer/src/project/ProjectDropdown.svelte
@@ -77,7 +77,8 @@
         variant="ghost"
         role="combobox"
         aria-expanded={open}
-        class="w-full justify-between overflow-hidden gap-0"
+        class="w-full justify-between overflow-hidden gap-0 paratext:!opacity-100"
+        disabled={projectContext.inParatext}
         {...props}
       >
         <div class="flex items-center gap-2 overflow-hidden">
@@ -88,7 +89,7 @@
         </div>
         <Icon
           icon="i-mdi-chevron-down"
-          class={cn('ml-2 size-4 shrink-0 opacity-50', open && 'rotate-180')}
+          class={cn('ml-2 size-4 shrink-0 opacity-50 paratext:hidden', open && 'rotate-180')}
         />
       </Button>
     {/snippet}

--- a/frontend/viewer/src/project/ProjectSidebar.svelte
+++ b/frontend/viewer/src/project/ProjectSidebar.svelte
@@ -147,7 +147,7 @@
         </Sidebar.GroupContent>
       </Sidebar.Group>
 
-    <Sidebar.Group>
+    <Sidebar.Group class="paratext:hidden">
       <Sidebar.Menu>
         <Sidebar.MenuItem>
           <Sidebar.MenuButton onclick={() => navigate('/')}>

--- a/frontend/viewer/tailwind.config.ts
+++ b/frontend/viewer/tailwind.config.ts
@@ -23,6 +23,11 @@ export default {
     extend: {},
   },
   plugins: [
+    {
+      handler: (api) => {
+        api.addVariant('paratext', '[data-paratext="true"] &');
+      }
+    },
     iconsPlugin({
       // Root source: https://github.com/Templarian/MaterialDesign
       // Our source (that pulls from ☝️): https://www.npmjs.com/package/@iconify-json/mdi


### PR DESCRIPTION
closes #1813 by introducing a tailwind variant `paratext` which allows adding styles like `paratext:hidden` which will hide the element when in paratext mode.

In order to use this the extension will need to be updated to set the URL to `[base url]/paratext/[project type]/[project code]`, I didn't make that change in this PR because right now it just opens the home page for picking a project.