### PR TITLE
Remove README line about .env.example

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -19,8 +19,6 @@ pnpm run dev -- --open
 
 The app will be running at [http://localhost:3000](http://localhost:3000) by default.
 
-> In order to configure the robot protection in forms, you'll need to `cp .env.example .env`
-
 #### Building
 
 To create a production version of the app:


### PR DESCRIPTION
This line became irrelevant in #54