### PR TITLE
WIP: Allow admins (site or org) to download projects by code

### DIFF
--- a/backend/FwLite/FwLiteShared/Projects/LexboxProjectService.cs
+++ b/backend/FwLite/FwLiteShared/Projects/LexboxProjectService.cs
@@ -64,24 +64,24 @@ public class LexboxProjectService : IDisposable
         return Servers().FirstOrDefault(s => s.Id == projectData.ServerId);
     }
 
-    public async Task<FieldWorksLiteProject[]> GetLexboxProjects(LexboxServer server)
+    public async Task<ListProjectsResult> GetLexboxProjects(LexboxServer server)
     {
         return await cache.GetOrCreateAsync(CacheKey(server),
             async entry =>
             {
                 entry.AbsoluteExpirationRelativeToNow = TimeSpan.FromMinutes(5);
                 var httpClient = await clientFactory.GetClient(server).CreateHttpClient();
-                if (httpClient is null) return [];
+                if (httpClient is null) return new([], false);
                 try
                 {
-                    return await httpClient.GetFromJsonAsync<FieldWorksLiteProject[]>("api/crdt/listProjects") ?? [];
+                    return await httpClient.GetFromJsonAsync<ListProjectsResult>("api/crdt/listProjects") ?? new([], false);
                 }
                 catch (Exception e)
                 {
                     logger.LogError(e, "Error getting lexbox projects");
-                    return [];
+                    return new([], false);
                 }
-            }) ?? [];
+            }) ?? new([], false);
     }
 
     public async Task<LexboxUser?> GetLexboxUser(LexboxServer server)

--- a/backend/LexBoxApi/Controllers/CrdtController.cs
+++ b/backend/LexBoxApi/Controllers/CrdtController.cs
@@ -75,7 +75,7 @@ public class CrdtController(
     }
 
     [HttpGet("listProjects")]
-    public async Task<ActionResult<FieldWorksLiteProject[]>> ListProjects()
+    public async Task<ActionResult<ListProjectsResult>> ListProjects()
     {
         var myProjects = await projectService.UserProjects(loggedInContext.User.Id)
             .Where(p => p.Type == ProjectType.FLEx)
@@ -90,7 +90,7 @@ public class CrdtController(
         {
             await lexAuthService.RefreshUser(LexAuthConstants.ProjectsClaimType);
         }
-        return myProjects;
+        return new ListProjectsResult(myProjects, loggedInContext.User.CanDownloadProjectsWithoutMembership());
     }
 
     [HttpGet("lookupProjectId")]

--- a/backend/LexBoxApi/GraphQL/LexAuthUserCanDownloadProjectsExtensions.cs
+++ b/backend/LexBoxApi/GraphQL/LexAuthUserCanDownloadProjectsExtensions.cs
@@ -1,0 +1,14 @@
+using LexCore.Auth;
+using LexCore.Entities;
+
+namespace LexBoxApi.GraphQL;
+
+public static class LexAuthUserCanDownloadProjectsExtensions
+{
+    public static bool CanDownloadProjectsWithoutMembership(this LexAuthUser user)
+    {
+        if (user.IsAdmin) return true;
+        if (user.Orgs.Any(o => o.Role == OrgRole.Admin)) return true;
+        return false;
+    }
+}

--- a/backend/LexCore/Entities/ListProjectsResult.cs
+++ b/backend/LexCore/Entities/ListProjectsResult.cs
@@ -1,0 +1,7 @@
+namespace LexCore.Entities;
+
+// TODO: During code review, bikeshed where this record belongs. Needs to be referenceable from FwLiteShared
+
+public record ListProjectsResult(
+    FieldWorksLiteProject[] Projects,
+    bool CanDownloadProjectsWithoutMembership);

--- a/frontend/viewer/src/lib/dotnet-types/generated-types/FwLiteShared/Projects/ICombinedProjectsService.ts
+++ b/frontend/viewer/src/lib/dotnet-types/generated-types/FwLiteShared/Projects/ICombinedProjectsService.ts
@@ -10,7 +10,7 @@ export interface ICombinedProjectsService
 {
 	supportsFwData() : Promise<boolean>;
 	remoteProjects() : Promise<IServerProjects[]>;
-	serverProjects(serverId: string, forceRefresh: boolean) : Promise<IProjectModel[]>;
+	serverProjects(serverId: string, forceRefresh: boolean) : Promise<[IProjectModel[],boolean]>;
 	localProjects() : Promise<IProjectModel[]>;
 	downloadProject(project: IProjectModel) : Promise<void>;
 	createProject(name: string) : Promise<void>;

--- a/frontend/viewer/src/lib/dotnet-types/generated-types/FwLiteShared/Projects/IServerProjects.ts
+++ b/frontend/viewer/src/lib/dotnet-types/generated-types/FwLiteShared/Projects/IServerProjects.ts
@@ -10,5 +10,6 @@ export interface IServerProjects
 {
 	server: ILexboxServer;
 	projects: IProjectModel[];
+	canDownloadProjectsWithoutMembership: boolean;
 }
 /* eslint-enable */


### PR DESCRIPTION
WIP. Will fix #1707 when done.

Backend will now give frontend a project list for each server *and* whether the user is allowed to download arbitrary projects (by project code) from that server without being a member. This applies to site admins (who have rights to all projects) and org admins (who have rights to projects owned by their org). The latter case means the frontend still needs to handle "Well, turns out you're not authorized to download that project code" errors.

Backend work done, though it still need some minor tweaks. Next up will be frontend UI.