### PR TITLE
 use GITHUB_TOKEN during tests calling the release api

### DIFF
--- a/.github/workflows/lexbox-api.yaml
+++ b/.github/workflows/lexbox-api.yaml
@@ -60,6 +60,8 @@ jobs:
         run: task api:has-pending-model-changes
 
       - name: Unit tests
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} #used for the FwLiteReleaseServiceTests so they don't get rate limited
         run: dotnet test LexBoxOnly.slnf --logger:"xunit;LogFileName={assembly}.results.xml" --results-directory ./test-results --filter "Category!=Integration&Category!=FlakyIntegration" --blame-hang-timeout 10m
       - name: Publish unit test results
         uses: EnricoMi/publish-unit-test-result-action@8885e273a4343cd7b48eaa72428dea0c3067ea98 # v2.14.0

--- a/backend/LexBoxApi/Services/FwLiteReleases/FwLiteReleaseService.cs
+++ b/backend/LexBoxApi/Services/FwLiteReleases/FwLiteReleaseService.cs
@@ -9,6 +9,7 @@ namespace LexBoxApi.Services.FwLiteReleases;
 
 public class FwLiteReleaseService(IHttpClientFactory factory, HybridCache cache, IOptions<FwLiteReleaseConfig> config)
 {
+    public const string HttpClientName = "Github";
     private const string GithubLatestRelease = "GithubLatestRelease";
     public const string FwLiteClientVersionTag = "app.fw-lite.client.version";
     public const string FwLiteEditionTag = "app.fw-lite.edition";
@@ -55,7 +56,7 @@ public class FwLiteReleaseService(IHttpClientFactory factory, HybridCache cache,
         }
         using var activity = LexBoxActivitySource.Get().StartActivity();
         activity?.AddTag(FwLiteEditionTag, edition.ToString());
-        var response = await factory.CreateClient("Github")
+        var response = await factory.CreateClient(HttpClientName)
             .SendAsync(new HttpRequestMessage(HttpMethod.Get,
                     "https://api.github.com/repos/sillsdev/languageforge-lexbox/releases")
                 {

--- a/backend/Testing/LexCore/Services/FwLiteReleaseServiceTests.cs
+++ b/backend/Testing/LexCore/Services/FwLiteReleaseServiceTests.cs
@@ -1,4 +1,5 @@
-﻿using FluentAssertions;
+﻿using System.Net.Http.Headers;
+using FluentAssertions;
 using LexBoxApi;
 using LexBoxApi.Config;
 using LexBoxApi.Services.FwLiteReleases;
@@ -18,7 +19,16 @@ public class FwLiteReleaseServiceTests
 #pragma warning disable EXTEXP0018
         var services = new ServiceCollection()
             .AddSingleton<FwLiteReleaseService>()
-            .AddHttpClient()
+            .AddHttpClient(FwLiteReleaseService.HttpClientName,
+                client =>
+                {
+                    var githubToken = Environment.GetEnvironmentVariable("GITHUB_TOKEN");
+                    if (githubToken is not null)
+                    {
+                        client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", githubToken);
+                    }
+                })
+            .Services
             .AddOptions<FwLiteReleaseConfig>().Configure(config =>
             {
                 config.Editions.Add(FwLiteEdition.Windows, new FwLiteEditionConfig() { FileNameRegex = "(?i)\\.msixbundle$" });


### PR DESCRIPTION
we've been having failures when running tests in CI due to calling the github api and getting rate limited, one way to have a much higher and seperate limit is to use the token provided in the action.