### PR TITLE
Turn off @typescript-eslint/no-redundant-type-constituents

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -38,3 +38,16 @@ To run an end-to-end test in the frontend folder:
 ```bash
 pnpm test
 ```
+
+#### Linting
+
+Linting depends partially on generated code, so first:
+
+```bash
+pnpm run -r build
+```
+
+And then:
+```bash
+pnpm run -r lint
+```

--- a/frontend/eslint.config.js
+++ b/frontend/eslint.config.js
@@ -38,11 +38,12 @@ export default [
     files: ['**/*.svelte'],
     rules: {
       // The Svelte plugin doesn't seem to have typing quite figured out
-      '@typescript-eslint/no-unsafe-assignment': 'off',
-      '@typescript-eslint/no-unsafe-member-access': 'off',
-      '@typescript-eslint/no-unsafe-call': 'off',
-      '@typescript-eslint/no-unsafe-return': 'off',
+      '@typescript-eslint/no-redundant-type-constituents': 'off',
       '@typescript-eslint/no-unsafe-argument': 'off',
+      '@typescript-eslint/no-unsafe-assignment': 'off',
+      '@typescript-eslint/no-unsafe-call': 'off',
+      '@typescript-eslint/no-unsafe-member-access': 'off',
+      '@typescript-eslint/no-unsafe-return': 'off',
     },
   },
   ...svelte.configs.recommended,

--- a/frontend/src/lib/components/FilterBar/FilterBar.svelte
+++ b/frontend/src/lib/components/FilterBar/FilterBar.svelte
@@ -22,7 +22,6 @@
   import { DEFAULT_DEBOUNCE_TIME } from '$lib/util/time';
 
   type DumbFilters = $$Generic<Record<string, unknown>>;
-  // eslint-disable-next-line @typescript-eslint/no-redundant-type-constituents
   type Filters = DumbFilters & Record<typeof searchKey, string>;
 
   let searchInput: PlainInput | undefined = $state();

--- a/frontend/src/lib/components/Projects/ProjectConfidentialityFilterSelect.svelte
+++ b/frontend/src/lib/components/Projects/ProjectConfidentialityFilterSelect.svelte
@@ -6,7 +6,6 @@
   import type { Confidentiality } from './ProjectFilter.svelte';
 
   interface Props extends Omit<SelectProps, 'label'> {
-    // eslint-disable-next-line @typescript-eslint/no-redundant-type-constituents -- false positive
     value: Confidentiality | undefined;
   }
 

--- a/frontend/src/lib/components/modals/ConfirmDeleteModal.svelte
+++ b/frontend/src/lib/components/modals/ConfirmDeleteModal.svelte
@@ -41,7 +41,6 @@
 
   type Schema = typeof verify;
 
-  // eslint-disable-next-line @typescript-eslint/no-redundant-type-constituents
   let deletionFormModal: FormModal<Schema> | undefined = $state();
   let deletionForm = $derived(deletionFormModal?.form());
 </script>

--- a/frontend/src/lib/components/modals/FormModal.svelte
+++ b/frontend/src/lib/components/modals/FormModal.svelte
@@ -58,12 +58,12 @@
   let done = $state(false);
 
   export async function open(
-    value: Partial<FormType> | undefined, //eslint-disable-line @typescript-eslint/no-redundant-type-constituents
+    value: Partial<FormType> | undefined,
     onSubmit: SubmitCallback,
   ): Promise<FormModalResult<Schema>>;
   export async function open(onSubmit: SubmitCallback): Promise<FormModalResult<Schema>>;
   export async function open(
-    valueOrOnSubmit: Partial<FormType> | SubmitCallback | undefined, //eslint-disable-line @typescript-eslint/no-redundant-type-constituents
+    valueOrOnSubmit: Partial<FormType> | SubmitCallback | undefined,
     _onSubmit?: SubmitCallback,
   ): Promise<FormModalResult<Schema>> {
     done = false;

--- a/frontend/src/routes/(authenticated)/admin/+page.svelte
+++ b/frontend/src/routes/(authenticated)/admin/+page.svelte
@@ -41,7 +41,6 @@
     showDeletedProjects: queryParam.boolean<boolean>(false),
     hideDraftProjects: queryParam.boolean<boolean>(false),
     emptyProjects: queryParam.boolean<boolean>(false),
-    // eslint-disable-next-line @typescript-eslint/no-redundant-type-constituents -- false positive?
     confidential: queryParam.string<Confidentiality | undefined>(undefined),
     projectType: queryParam.string<ProjectType | undefined>(undefined),
     memberSearch: queryParam.string(undefined),

--- a/frontend/src/routes/(authenticated)/admin/EditUserAccount.svelte
+++ b/frontend/src/routes/(authenticated)/admin/EditUserAccount.svelte
@@ -39,7 +39,6 @@
 
   type Schema = typeof schema;
   type RefinedSchema = typeof refinedSchema;
-  // eslint-disable-next-line @typescript-eslint/no-redundant-type-constituents
   let formModal: FormModal<RefinedSchema> | undefined = $state();
 
   export function close(): void {

--- a/frontend/src/routes/(authenticated)/org/[org_id]/AddMyProjectsToOrgModal.svelte
+++ b/frontend/src/routes/(authenticated)/org/[org_id]/AddMyProjectsToOrgModal.svelte
@@ -21,7 +21,6 @@
 
   const schema = z.object({});
 
-  // eslint-disable-next-line @typescript-eslint/no-redundant-type-constituents
   let formModal: FormModal<typeof schema> | undefined = $state();
   let newProjects: Project[] = $state([]);
   let alreadyAddedProjects: number = $state(0);

--- a/frontend/src/routes/(authenticated)/org/[org_id]/AddOrgMemberModal.svelte
+++ b/frontend/src/routes/(authenticated)/org/[org_id]/AddOrgMemberModal.svelte
@@ -28,7 +28,6 @@
     role: z.enum([OrgRole.User, OrgRole.Admin]).default(OrgRole.User),
     canInvite: z.boolean().default(false),
   });
-  // eslint-disable-next-line @typescript-eslint/no-redundant-type-constituents
   let formModal: FormModal<typeof schema> | undefined = $state();
   let form = $derived(formModal?.form());
 

--- a/frontend/src/routes/(authenticated)/org/[org_id]/BulkAddOrgMembers.svelte
+++ b/frontend/src/routes/(authenticated)/org/[org_id]/BulkAddOrgMembers.svelte
@@ -31,7 +31,6 @@
     usernamesText: z.string().trim().min(1, $t('org_page.bulk_add_members.empty_user_field')),
   });
 
-  // eslint-disable-next-line @typescript-eslint/no-redundant-type-constituents
   let formModal: FormModal<typeof schema> | undefined = $state();
   let form = $derived(formModal?.form());
 

--- a/frontend/src/routes/(authenticated)/org/[org_id]/ChangeOrgMemberRoleModal.svelte
+++ b/frontend/src/routes/(authenticated)/org/[org_id]/ChangeOrgMemberRoleModal.svelte
@@ -16,7 +16,6 @@
     role: z.enum([OrgRole.User, OrgRole.Admin]),
   });
   type Schema = typeof schema;
-  // eslint-disable-next-line @typescript-eslint/no-redundant-type-constituents
   let formModal: FormModal<Schema> | undefined = $state();
   let form = $derived(formModal?.form());
 

--- a/frontend/src/routes/(authenticated)/project/[project_code]/+page.ts
+++ b/frontend/src/routes/(authenticated)/project/[project_code]/+page.ts
@@ -136,6 +136,7 @@ export async function load(event: PageLoadEvent) {
       { projectCode }
     );
 
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
   const nonNullableProject = tryMakeNonNullable(projectResult.projectByCode);
   if (!nonNullableProject) {
     error(404);

--- a/frontend/src/routes/(authenticated)/project/[project_code]/+page.ts
+++ b/frontend/src/routes/(authenticated)/project/[project_code]/+page.ts
@@ -136,7 +136,6 @@ export async function load(event: PageLoadEvent) {
       { projectCode }
     );
 
-  // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
   const nonNullableProject = tryMakeNonNullable(projectResult.projectByCode);
   if (!nonNullableProject) {
     error(404);

--- a/frontend/src/routes/(authenticated)/project/[project_code]/AddOrganization.svelte
+++ b/frontend/src/routes/(authenticated)/project/[project_code]/AddOrganization.svelte
@@ -21,7 +21,6 @@
   });
 
   type Schema = typeof schema;
-  // eslint-disable-next-line @typescript-eslint/no-redundant-type-constituents
   let formModal: FormModal<Schema> | undefined = $state();
   let form = $derived(formModal?.form());
 

--- a/frontend/src/routes/(authenticated)/project/[project_code]/AddProjectMember.svelte
+++ b/frontend/src/routes/(authenticated)/project/[project_code]/AddProjectMember.svelte
@@ -25,7 +25,6 @@
     role: z.enum([ProjectRole.Editor, ProjectRole.Manager, ProjectRole.Observer]).default(ProjectRole.Editor),
     canInvite: z.boolean().default(false),
   });
-  // eslint-disable-next-line @typescript-eslint/no-redundant-type-constituents
   let formModal: FormModal<typeof schema> | undefined = $state();
   let form = $derived(formModal?.form());
   let selectedUserId: string | undefined = $state(undefined);

--- a/frontend/src/routes/(authenticated)/project/[project_code]/AddPurpose.svelte
+++ b/frontend/src/routes/(authenticated)/project/[project_code]/AddPurpose.svelte
@@ -20,7 +20,6 @@
   });
 
   type Schema = typeof schema;
-  // eslint-disable-next-line @typescript-eslint/no-redundant-type-constituents
   let formModal: FormModal<Schema> | undefined = $state();
   let form = $derived(formModal?.form());
 

--- a/frontend/src/routes/(authenticated)/project/[project_code]/BulkAddProjectMembers.svelte
+++ b/frontend/src/routes/(authenticated)/project/[project_code]/BulkAddProjectMembers.svelte
@@ -33,7 +33,6 @@
     password: passwordFormRules($t),
   });
 
-  // eslint-disable-next-line @typescript-eslint/no-redundant-type-constituents
   let formModal: FormModal<typeof schema> | undefined = $state();
   let form = $derived(formModal?.form());
 

--- a/frontend/src/routes/(authenticated)/project/[project_code]/ChangeMemberRoleModal.svelte
+++ b/frontend/src/routes/(authenticated)/project/[project_code]/ChangeMemberRoleModal.svelte
@@ -18,7 +18,6 @@
     role: z.enum([ProjectRole.Editor, ProjectRole.Manager, ProjectRole.Observer]),
   });
   type Schema = typeof schema;
-  // eslint-disable-next-line @typescript-eslint/no-redundant-type-constituents
   let formModal: FormModal<Schema> | undefined = $state();
   let form = $derived(formModal?.form());
 

--- a/frontend/src/routes/(authenticated)/project/[project_code]/ProjectConfidentialityModal.svelte
+++ b/frontend/src/routes/(authenticated)/project/[project_code]/ProjectConfidentialityModal.svelte
@@ -16,7 +16,6 @@
   const schema = z.object({
     isConfidential: z.boolean(),
   });
-  // eslint-disable-next-line @typescript-eslint/no-redundant-type-constituents
   let formModal: FormModal<typeof schema> | undefined = $state();
   let form = $derived(formModal?.form());
 

--- a/frontend/src/routes/(authenticated)/project/[project_code]/ResetProjectModal.svelte
+++ b/frontend/src/routes/(authenticated)/project/[project_code]/ResetProjectModal.svelte
@@ -109,7 +109,6 @@
   }
 
   let tusUpload: TusUpload | undefined = $state();
-  // eslint-disable-next-line @typescript-eslint/no-redundant-type-constituents
   let uploadStatus: UploadStatus | undefined = $state();
 </script>
 

--- a/frontend/viewer/eslint.config.js
+++ b/frontend/viewer/eslint.config.js
@@ -37,11 +37,12 @@ export default [
     files: ['**/*.svelte'],
     rules: {
       // The Svelte plugin doesn't seem to have typing quite figured out
-      '@typescript-eslint/no-unsafe-assignment': 'off',
-      '@typescript-eslint/no-unsafe-member-access': 'off',
-      '@typescript-eslint/no-unsafe-call': 'off',
-      '@typescript-eslint/no-unsafe-return': 'off',
+      '@typescript-eslint/no-redundant-type-constituents': 'off',
       '@typescript-eslint/no-unsafe-argument': 'off',
+      '@typescript-eslint/no-unsafe-assignment': 'off',
+      '@typescript-eslint/no-unsafe-call': 'off',
+      '@typescript-eslint/no-unsafe-member-access': 'off',
+      '@typescript-eslint/no-unsafe-return': 'off',
     },
   },
   ...svelte.configs.recommended,

--- a/frontend/viewer/src/lib/OpenInFieldWorksButton.svelte
+++ b/frontend/viewer/src/lib/OpenInFieldWorksButton.svelte
@@ -12,7 +12,6 @@
 
   type Props = {
     entry: IEntry
-  // eslint-disable-next-line @typescript-eslint/no-redundant-type-constituents
   } & ButtonProps;
 
   const {

--- a/frontend/viewer/src/lib/components/field-editors/multi-select.svelte
+++ b/frontend/viewer/src/lib/components/field-editors/multi-select.svelte
@@ -25,10 +25,8 @@
     values: Value[];
     options: ReadonlyArray<Value>;
     readonly?: boolean;
-    /* eslint-disable @typescript-eslint/no-redundant-type-constituents */
     idSelector: ConditionalKeys<Value, Primitive> | ((value: Value) => Primitive);
     labelSelector: ConditionalKeys<Value, string> | ((value: Value) => string);
-    /* eslint-enable @typescript-eslint/no-redundant-type-constituents */
     placeholder?: string;
     filterPlaceholder?: string;
     emptyResultsPlaceholder?: string;
@@ -157,7 +155,6 @@
       }
   }
 
-  // eslint-disable-next-line @typescript-eslint/no-redundant-type-constituents
   function getHighlightedValue(): Value | undefined {
     const selectedItem = commandRef?.querySelector('[data-command-item][data-selected]');
     const index = selectedItem?.getAttribute('data-value-index');

--- a/frontend/viewer/src/lib/components/field-editors/select.svelte
+++ b/frontend/viewer/src/lib/components/field-editors/select.svelte
@@ -20,10 +20,8 @@
     value?: Value;
     options: ReadonlyArray<Value>;
     readonly?: boolean;
-    /* eslint-disable @typescript-eslint/no-redundant-type-constituents */
     idSelector: ConditionalKeys<Value, Primitive> | ((value: Value) => Primitive);
     labelSelector: ConditionalKeys<Value, string> | ((value: Value) => string);
-    /* eslint-enable @typescript-eslint/no-redundant-type-constituents */
     placeholder?: string;
     filterPlaceholder?: string;
     emptyResultsPlaceholder?: string;

--- a/frontend/viewer/src/lib/components/ui/icon/pinging-icon.svelte
+++ b/frontend/viewer/src/lib/components/ui/icon/pinging-icon.svelte
@@ -5,7 +5,6 @@
   import {cn} from '$lib/utils';
   import type {IconClass} from '$lib/icon-class';
 
-  // eslint-disable-next-line @typescript-eslint/no-redundant-type-constituents
   type Props = IconProps & {
     ping?: boolean;
     icon: IconClass;


### PR DESCRIPTION
The false positives for [`'@typescript-eslint/no-redundant-type-constituents'`](https://typescript-eslint.io/rules/no-redundant-type-constituents/) appear related to the other 5 rules disabled for `*.svelte` files.

~These 6 rules are also the source of most noise on the `improve-platform-extension` branch, so this pr prepares for re-enabling linting in `frontend/platform.bible-extension/` on that branch.~