### PR TITLE
Create new MiniLcmApi wrapper for normalizing strings

### DIFF
--- a/backend/FwLite/FwLiteProjectSync.Tests/Import/ResumableTests.cs
+++ b/backend/FwLite/FwLiteProjectSync.Tests/Import/ResumableTests.cs
@@ -149,7 +149,7 @@ public class ResumableTests : IAsyncLifetime
 internal partial class UnreliableApi(IMiniLcmApi api, Random random) : IMiniLcmApi
 {
 
-    [BeaKona.AutoInterface(IncludeBaseInterfaces = true)]
+    [BeaKona.AutoInterface(IncludeBaseInterfaces = true, MemberMatch = BeaKona.MemberMatchTypes.Any)]
     private readonly IMiniLcmApi _api = api;
 
     Task<PartOfSpeech> IMiniLcmWriteApi.CreatePartOfSpeech(PartOfSpeech partOfSpeech)

--- a/backend/FwLite/FwLiteProjectSync/CrdtFwdataProjectSyncService.cs
+++ b/backend/FwLite/FwLiteProjectSync/CrdtFwdataProjectSyncService.cs
@@ -14,7 +14,7 @@ using SystemTextJsonPatch.Operations;
 namespace FwLiteProjectSync;
 
 public class CrdtFwdataProjectSyncService(MiniLcmImport miniLcmImport, ILogger<CrdtFwdataProjectSyncService> logger,
-    MiniLcmApiValidationWrapperFactory validationWrapperFactory)
+    MiniLcmApiValidationWrapperFactory validationWrapperFactory, MiniLcmApiStringNormalizationWrapperFactory normalizationWrapperFactory)
 {
     public record DryRunSyncResult(
         int CrdtChanges,
@@ -51,8 +51,8 @@ public class CrdtFwdataProjectSyncService(MiniLcmImport miniLcmImport, ILogger<C
 
     private async Task<SyncResult> Sync(IMiniLcmApi crdtApi, IMiniLcmApi fwdataApi, bool dryRun, int entryCount, ProjectSnapshot? projectSnapshot)
     {
-        crdtApi = validationWrapperFactory.Create(crdtApi);
-        fwdataApi = validationWrapperFactory.Create(fwdataApi);
+        crdtApi = normalizationWrapperFactory.Create(validationWrapperFactory.Create(crdtApi));
+        fwdataApi = normalizationWrapperFactory.Create(validationWrapperFactory.Create(fwdataApi));
 
         if (dryRun)
         {

--- a/backend/FwLite/FwLiteProjectSync/DryRunMiniLcmApi.cs
+++ b/backend/FwLite/FwLiteProjectSync/DryRunMiniLcmApi.cs
@@ -7,7 +7,7 @@ namespace FwLiteProjectSync;
 
 public partial class DryRunMiniLcmApi(IMiniLcmApi api) : IMiniLcmApi
 {
-    [BeaKona.AutoInterface(typeof(IMiniLcmReadApi))]
+    [BeaKona.AutoInterface(typeof(IMiniLcmReadApi), MemberMatch = BeaKona.MemberMatchTypes.Any)]
     private readonly IMiniLcmApi _api = api;
 
     public void Dispose()

--- a/backend/FwLite/FwLiteProjectSync/Import/ResumableImportApi.cs
+++ b/backend/FwLite/FwLiteProjectSync/Import/ResumableImportApi.cs
@@ -6,7 +6,7 @@ namespace FwLiteProjectSync.Import;
 
 public partial class ResumableImportApi(IMiniLcmApi api) : IMiniLcmApi
 {
-    [BeaKona.AutoInterface(IncludeBaseInterfaces = true)]
+    [BeaKona.AutoInterface(IncludeBaseInterfaces = true, MemberMatch = BeaKona.MemberMatchTypes.Any)]
     private readonly IMiniLcmApi _api = api;
     private readonly Dictionary<string, Dictionary<string, object>> _createdObjects = new();
     private async ValueTask<T> HasCreated<T>(T value, IAsyncEnumerable<T> values, Func<Task<T>> create, [CallerMemberName] string typeName = "")

--- a/backend/FwLite/FwLiteShared/Services/MiniLcmApiNotifyWrapper.cs
+++ b/backend/FwLite/FwLiteShared/Services/MiniLcmApiNotifyWrapper.cs
@@ -3,10 +3,11 @@ using LexCore.Utils;
 using MiniLcm;
 using MiniLcm.Models;
 using MiniLcm.SyncHelpers;
+using MiniLcm.Wrappers;
 
 namespace FwLiteShared.Services;
 
-public class MiniLcmApiNotifyWrapperFactory(ProjectEventBus bus)
+public class MiniLcmApiNotifyWrapperFactory(ProjectEventBus bus) : IMiniLcmWrapperFactory
 {
     public IMiniLcmApi Create(IMiniLcmApi api, IProjectIdentifier project)
     {

--- a/backend/FwLite/FwLiteShared/Services/MiniLcmApiNotifyWrapper.cs
+++ b/backend/FwLite/FwLiteShared/Services/MiniLcmApiNotifyWrapper.cs
@@ -20,7 +20,7 @@ public partial class MiniLcmApiNotifyWrapper(
     ProjectEventBus bus,
     IProjectIdentifier project) : IMiniLcmApi
 {
-    [BeaKona.AutoInterface(IncludeBaseInterfaces = true)]
+    [BeaKona.AutoInterface(IncludeBaseInterfaces = true, MemberMatch = BeaKona.MemberMatchTypes.Any)]
     private readonly IMiniLcmApi _api = api;
 
     private PendingChangeNotifications? _pendingChanges;

--- a/backend/FwLite/FwLiteShared/Services/MiniLcmJsInvokable.cs
+++ b/backend/FwLite/FwLiteShared/Services/MiniLcmJsInvokable.cs
@@ -6,6 +6,7 @@ using MiniLcm;
 using MiniLcm.Media;
 using MiniLcm.Models;
 using MiniLcm.Validators;
+using MiniLcm.Wrappers;
 using Reinforced.Typings.Attributes;
 
 namespace FwLiteShared.Services;
@@ -18,7 +19,7 @@ public class MiniLcmJsInvokable(
     MiniLcmApiNotifyWrapperFactory notificationWrapperFactory,
     MiniLcmApiValidationWrapperFactory validationWrapperFactory) : IDisposable
 {
-    private readonly IMiniLcmApi _wrappedApi = validationWrapperFactory.Create(notificationWrapperFactory.Create(api, project));
+    private readonly IMiniLcmApi _wrappedApi = api.WrapWith([validationWrapperFactory, notificationWrapperFactory], project);
 
     public record MiniLcmFeatures(bool? History, bool? Write, bool? OpenWithFlex, bool? Feedback, bool? Sync, bool? Audio);
     private bool SupportsSync => project.DataFormat == ProjectDataFormat.Harmony && api is CrdtMiniLcmApi;

--- a/backend/FwLite/MiniLcm.Tests/NormalizationTests.cs
+++ b/backend/FwLite/MiniLcm.Tests/NormalizationTests.cs
@@ -1,0 +1,87 @@
+using MiniLcm.Validators;
+using Moq;
+using Xunit.Abstractions;
+using Xunit.Sdk;
+
+namespace MiniLcm.Tests;
+
+public class NormalizationTests
+{
+    public IMiniLcmApi MockApi { get; init; }
+    public IMiniLcmApi NormalizingApi { get; init; }
+
+    public const string NFCString = "naïve"; // U+00EF LATIN SMALL LETTER I WITH DIAERESIS
+    public const string NFDString = "naïve"; // U+0069 LATIN SMALL LETTER I + U+0308 COMBINING DIAERESIS
+
+    public FilterQueryOptions NFCOptions = new()
+    {
+        Exemplar = new ExemplarOptions(NFCString, "en"),
+        Filter = new Filtering.EntryFilter { GridifyFilter = NFCString },
+    };
+
+    public QueryOptions NFCQueryOptions = new()
+    {
+        Exemplar = new ExemplarOptions(NFCString, "en"),
+        Filter = new Filtering.EntryFilter { GridifyFilter = NFCString },
+    };
+
+    public FilterQueryOptions NFDOptions = new()
+    {
+        Exemplar = new ExemplarOptions(NFDString, "en"),
+        Filter = new Filtering.EntryFilter { GridifyFilter = NFDString },
+    };
+
+    public NormalizationTests()
+    {
+        MockApi = Mock.Of<IMiniLcmApi>();
+        // Mock.Get(MockApi).Setup(api => api.SearchEntries(It.IsAny<string>(), null)).Returns(new List<Entry>().ToAsyncEnumerable());
+        var factory = new MiniLcmApiStringNormalizationWrapperFactory();
+        NormalizingApi = factory.Create(MockApi);
+    }
+
+    [Fact]
+    public void SearchEntriesIsNormalized()
+    {
+        NormalizingApi.Should().BeOfType<MiniLcmApiStringNormalizationWrapper>();
+        var results = NormalizingApi.SearchEntries(NFCString, null);
+        Mock.Get(MockApi).Verify(api => api.SearchEntries(NFDString, null));
+    }
+
+    [Fact]
+    public void SearchEntriesWithQueryOptionsAreNormalized()
+    {
+        NormalizingApi.Should().BeOfType<MiniLcmApiStringNormalizationWrapper>();
+        var results = NormalizingApi.SearchEntries(NFCString, NFCQueryOptions);
+        Mock.Get(MockApi).Verify(api => api.SearchEntries(NFDString, It.Is<QueryOptions>(
+            opt => opt.Exemplar!.Value == NFDOptions.Exemplar!.Value &&
+                   opt.Filter!.GridifyFilter == NFDOptions.Filter!.GridifyFilter)));
+    }
+
+    [Fact]
+    public void CountEntriesIsNormalized()
+    {
+        NormalizingApi.Should().BeOfType<MiniLcmApiStringNormalizationWrapper>();
+        var results = NormalizingApi.CountEntries(NFCString, null);
+        Mock.Get(MockApi).Verify(api => api.CountEntries(NFDString, null));
+    }
+
+    [Fact]
+    public void CountEntriesWithFilterQueryOptionsIsNormalized()
+    {
+        NormalizingApi.Should().BeOfType<MiniLcmApiStringNormalizationWrapper>();
+        var results = NormalizingApi.CountEntries(NFCString, NFCOptions);
+        Mock.Get(MockApi).Verify(api => api.CountEntries(NFDString, It.Is<FilterQueryOptions>(
+            opt => opt.Exemplar!.Value == NFDOptions.Exemplar!.Value &&
+                   opt.Filter!.GridifyFilter == NFDOptions.Filter!.GridifyFilter)));
+    }
+
+    [Fact]
+    public void GetEntriesIsNormalized()
+    {
+        NormalizingApi.Should().BeOfType<MiniLcmApiStringNormalizationWrapper>();
+        var results = NormalizingApi.GetEntries(NFCQueryOptions);
+        Mock.Get(MockApi).Verify(api => api.GetEntries(It.Is<QueryOptions>(
+            opt => opt.Exemplar!.Value == NFDOptions.Exemplar!.Value &&
+                   opt.Filter!.GridifyFilter == NFDOptions.Filter!.GridifyFilter)));
+    }
+}

--- a/backend/FwLite/MiniLcm.Tests/NormalizationTests.cs
+++ b/backend/FwLite/MiniLcm.Tests/NormalizationTests.cs
@@ -1,7 +1,5 @@
 using MiniLcm.Validators;
 using Moq;
-using Xunit.Abstractions;
-using Xunit.Sdk;
 
 namespace MiniLcm.Tests;
 
@@ -10,8 +8,8 @@ public class NormalizationTests
     public IMiniLcmApi MockApi { get; init; }
     public IMiniLcmApi NormalizingApi { get; init; }
 
-    public const string NFCString = "naïve"; // U+00EF LATIN SMALL LETTER I WITH DIAERESIS
-    public const string NFDString = "naïve"; // U+0069 LATIN SMALL LETTER I + U+0308 COMBINING DIAERESIS
+    public const string NFCString = "na\u00efve"; // "naïve" with U+00EF LATIN SMALL LETTER I WITH DIAERESIS
+    public const string NFDString = "na\u0069\u0308ve"; // "naïve" with U+0069 LATIN SMALL LETTER I + U+0308 COMBINING DIAERESIS
 
     public FilterQueryOptions NFCOptions = new()
     {

--- a/backend/FwLite/MiniLcm/Filtering/EntryFilter.cs
+++ b/backend/FwLite/MiniLcm/Filtering/EntryFilter.cs
@@ -1,4 +1,7 @@
-﻿using Gridify;
+using System.Linq.Expressions;
+using System.Text;
+using Gridify;
+using Gridify.Syntax;
 using MiniLcm.Models;
 
 namespace MiniLcm.Filtering;
@@ -53,4 +56,8 @@ public class EntryFilter
 
     public string? GridifyFilter { get; set; }
 
+    public EntryFilter Normalized(NormalizationForm form)
+    {
+        return new() { GridifyFilter = GridifyFilter?.Normalize(form) };
+    }
 }

--- a/backend/FwLite/MiniLcm/IMiniLcmReadApi.cs
+++ b/backend/FwLite/MiniLcm/IMiniLcmReadApi.cs
@@ -1,4 +1,5 @@
 using System.Linq.Expressions;
+using System.Text;
 using System.Text.Json.Serialization;
 using MiniLcm.Filtering;
 using MiniLcm.Media;
@@ -38,6 +39,10 @@ public record FilterQueryOptions(
 {
     public static FilterQueryOptions Default { get; } = new();
     public bool HasFilter => Filter is {GridifyFilter.Length: > 0 } || Exemplar is {Value.Length: > 0};
+    public FilterQueryOptions Normalized(NormalizationForm form)
+    {
+        return new(Exemplar?.Normalized(form), Filter?.Normalized(form));
+    }
 }
 
 public record QueryOptions(
@@ -51,6 +56,11 @@ public record QueryOptions(
     public const int QueryAll = -1;
     public const int DefaultCount = 1000;
     public SortOptions Order { get; init; } = Order ?? SortOptions.Default;
+
+    public QueryOptions Normalized(NormalizationForm form)
+    {
+        return new(Order, Exemplar?.Normalized(form), Count, Offset, Filter?.Normalized(form));
+    }
 
     public IEnumerable<T> ApplyPaging<T>(IEnumerable<T> enumerable)
     {
@@ -99,7 +109,13 @@ public record SortOptions(SortField Field, WritingSystemId WritingSystem = defau
     public static SortOptions Default { get; } = new(SortField.Headword, DefaultWritingSystem);
 }
 
-public record ExemplarOptions(string Value, WritingSystemId WritingSystem);
+public record ExemplarOptions(string Value, WritingSystemId WritingSystem)
+{
+    public ExemplarOptions Normalized(NormalizationForm form)
+    {
+        return new(Value.Normalize(form), WritingSystem);
+    }
+}
 
 [JsonConverter(typeof(JsonStringEnumConverter))]
 public enum SortField

--- a/backend/FwLite/MiniLcm/IMiniLcmReadApi.cs
+++ b/backend/FwLite/MiniLcm/IMiniLcmReadApi.cs
@@ -39,7 +39,7 @@ public record FilterQueryOptions(
 {
     public static FilterQueryOptions Default { get; } = new();
     public bool HasFilter => Filter is {GridifyFilter.Length: > 0 } || Exemplar is {Value.Length: > 0};
-    public FilterQueryOptions Normalized(NormalizationForm form)
+    public virtual FilterQueryOptions Normalized(NormalizationForm form)
     {
         return new(Exemplar?.Normalized(form), Filter?.Normalized(form));
     }
@@ -57,7 +57,7 @@ public record QueryOptions(
     public const int DefaultCount = 1000;
     public SortOptions Order { get; init; } = Order ?? SortOptions.Default;
 
-    public QueryOptions Normalized(NormalizationForm form)
+    public override QueryOptions Normalized(NormalizationForm form)
     {
         return new(Order, Exemplar?.Normalized(form), Count, Offset, Filter?.Normalized(form));
     }

--- a/backend/FwLite/MiniLcm/Normalization/MiniLcmApiStringNormalizationWrapper.cs
+++ b/backend/FwLite/MiniLcm/Normalization/MiniLcmApiStringNormalizationWrapper.cs
@@ -1,0 +1,46 @@
+using System.Text;
+using MiniLcm;
+using MiniLcm.Models;
+using MiniLcm.SyncHelpers;
+using MiniLcm.Wrappers;
+
+namespace MiniLcm.Validators;
+
+public class MiniLcmApiStringNormalizationWrapperFactory(NormalizationForm normalization = NormalizationForm.FormD) : IMiniLcmWrapperFactory
+{
+    public IMiniLcmApi Create(IMiniLcmApi api, IProjectIdentifier _unused) => Create(api);
+
+    public IMiniLcmApi Create(IMiniLcmApi api)
+    {
+        return new MiniLcmApiStringNormalizationWrapper(api, normalization);
+    }
+}
+
+public partial class MiniLcmApiStringNormalizationWrapper(
+    IMiniLcmApi api,
+    NormalizationForm form) : IMiniLcmApi
+{
+    [BeaKona.AutoInterface(IncludeBaseInterfaces = true)]
+    private readonly IMiniLcmApi _api = api;
+
+    // ********** Overrides go here **********
+
+    public IAsyncEnumerable<Entry> SearchEntries(string query, QueryOptions? options = null)
+    {
+        return _api.SearchEntries(query.Normalize(form), options?.Normalized(form));
+    }
+
+    public Task<int> CountEntries(string? query = null, FilterQueryOptions? options = null)
+    {
+        return _api.CountEntries(query?.Normalize(form), options?.Normalized(form));
+    }
+
+    public IAsyncEnumerable<Entry> GetEntries(QueryOptions? options = null)
+    {
+        return _api.GetEntries(options?.Normalized(form));
+    }
+
+    void IDisposable.Dispose()
+    {
+    }
+}

--- a/backend/FwLite/MiniLcm/Normalization/MiniLcmApiStringNormalizationWrapper.cs
+++ b/backend/FwLite/MiniLcm/Normalization/MiniLcmApiStringNormalizationWrapper.cs
@@ -6,38 +6,39 @@ using MiniLcm.Wrappers;
 
 namespace MiniLcm.Validators;
 
-public class MiniLcmApiStringNormalizationWrapperFactory(NormalizationForm normalization = NormalizationForm.FormD) : IMiniLcmWrapperFactory
+public class MiniLcmApiStringNormalizationWrapperFactory() : IMiniLcmWrapperFactory
 {
     public IMiniLcmApi Create(IMiniLcmApi api, IProjectIdentifier _unused) => Create(api);
 
     public IMiniLcmApi Create(IMiniLcmApi api)
     {
-        return new MiniLcmApiStringNormalizationWrapper(api, normalization);
+        return new MiniLcmApiStringNormalizationWrapper(api);
     }
 }
 
 public partial class MiniLcmApiStringNormalizationWrapper(
-    IMiniLcmApi api,
-    NormalizationForm form) : IMiniLcmApi
+    IMiniLcmApi api) : IMiniLcmApi
 {
-    [BeaKona.AutoInterface(IncludeBaseInterfaces = true)]
+    public const NormalizationForm Form = NormalizationForm.FormD;
+
+    [BeaKona.AutoInterface(IncludeBaseInterfaces = true, MemberMatch = BeaKona.MemberMatchTypes.Any)]
     private readonly IMiniLcmApi _api = api;
 
     // ********** Overrides go here **********
 
     public IAsyncEnumerable<Entry> SearchEntries(string query, QueryOptions? options = null)
     {
-        return _api.SearchEntries(query.Normalize(form), options?.Normalized(form));
+        return _api.SearchEntries(query.Normalize(Form), options?.Normalized(Form));
     }
 
     public Task<int> CountEntries(string? query = null, FilterQueryOptions? options = null)
     {
-        return _api.CountEntries(query?.Normalize(form), options?.Normalized(form));
+        return _api.CountEntries(query?.Normalize(Form), options?.Normalized(Form));
     }
 
     public IAsyncEnumerable<Entry> GetEntries(QueryOptions? options = null)
     {
-        return _api.GetEntries(options?.Normalized(form));
+        return _api.GetEntries(options?.Normalized(Form));
     }
 
     void IDisposable.Dispose()

--- a/backend/FwLite/MiniLcm/Validators/MiniLcmApiValidationWrapper.cs
+++ b/backend/FwLite/MiniLcm/Validators/MiniLcmApiValidationWrapper.cs
@@ -7,7 +7,9 @@ namespace MiniLcm.Validators;
 
 public class MiniLcmApiValidationWrapperFactory(MiniLcmValidators validators) : IMiniLcmWrapperFactory
 {
-    public IMiniLcmApi Create(IMiniLcmApi api, IProjectIdentifier _unused)
+    public IMiniLcmApi Create(IMiniLcmApi api, IProjectIdentifier _unused) => Create(api);
+
+    public IMiniLcmApi Create(IMiniLcmApi api)
     {
         return new MiniLcmApiValidationWrapper(api, validators);
     }

--- a/backend/FwLite/MiniLcm/Validators/MiniLcmApiValidationWrapper.cs
+++ b/backend/FwLite/MiniLcm/Validators/MiniLcmApiValidationWrapper.cs
@@ -1,12 +1,13 @@
 using MiniLcm;
 using MiniLcm.Models;
 using MiniLcm.SyncHelpers;
+using MiniLcm.Wrappers;
 
 namespace MiniLcm.Validators;
 
-public class MiniLcmApiValidationWrapperFactory(MiniLcmValidators validators)
+public class MiniLcmApiValidationWrapperFactory(MiniLcmValidators validators) : IMiniLcmWrapperFactory
 {
-    public IMiniLcmApi Create(IMiniLcmApi api)
+    public IMiniLcmApi Create(IMiniLcmApi api, IProjectIdentifier _unused)
     {
         return new MiniLcmApiValidationWrapper(api, validators);
     }

--- a/backend/FwLite/MiniLcm/Validators/MiniLcmApiValidationWrapper.cs
+++ b/backend/FwLite/MiniLcm/Validators/MiniLcmApiValidationWrapper.cs
@@ -19,7 +19,7 @@ public partial class MiniLcmApiValidationWrapper(
     IMiniLcmApi api,
     MiniLcmValidators validators) : IMiniLcmApi
 {
-    [BeaKona.AutoInterface(IncludeBaseInterfaces = true)]
+    [BeaKona.AutoInterface(IncludeBaseInterfaces = true, MemberMatch = BeaKona.MemberMatchTypes.Any)]
     private readonly IMiniLcmApi _api = api;
 
     // ********** Overrides go here **********

--- a/backend/FwLite/MiniLcm/Validators/MiniLcmValidators.cs
+++ b/backend/FwLite/MiniLcm/Validators/MiniLcmValidators.cs
@@ -76,6 +76,7 @@ public static class MiniLcmValidatorsExtensions
         services.AddTransient<IValidator<SemanticDomain>, SemanticDomainValidator>();
         services.AddTransient<IValidator<Publication>, PublicationValidator>();
         services.AddTransient<IValidator<UpdateObjectInput<WritingSystem>>, WritingSystemUpdateValidator>();
+        services.AddTransient<MiniLcmApiStringNormalizationWrapperFactory>();
         return services;
     }
 }

--- a/backend/FwLite/MiniLcm/Wrappers/MiniLcmWrappers.cs
+++ b/backend/FwLite/MiniLcm/Wrappers/MiniLcmWrappers.cs
@@ -1,0 +1,21 @@
+using MiniLcm.Models;
+
+namespace MiniLcm.Wrappers;
+
+public interface IMiniLcmWrapperFactory
+{
+    IMiniLcmApi Create(IMiniLcmApi api, IProjectIdentifier project);
+}
+
+public static class MiniLcmWrapperExtensions
+{
+    public static IMiniLcmApi WrapWith(this IMiniLcmApi api, IEnumerable<IMiniLcmWrapperFactory> factories, IProjectIdentifier project)
+    {
+        var wrappedApi = api;
+        foreach (var factory in factories.Reverse())
+        {
+            wrappedApi = factory.Create(wrappedApi, project);
+        }
+        return wrappedApi;
+    }
+}


### PR DESCRIPTION
Fixes #1860.

Currently this normalizes parameters for the search APIs: SearchEntries, CountEntries, and GetEntries. Normalizing the APIs that take MiniLcm objects such as the CreateFoo, UpdateFoo, etc. methods is out of scope for this PR.