### PR TITLE
Touch-up language-picker in side-bar

### DIFF
--- a/frontend/viewer/src/lib/i18n/LocalizationPicker.svelte
+++ b/frontend/viewer/src/lib/i18n/LocalizationPicker.svelte
@@ -5,6 +5,15 @@
   import {Icon} from '$lib/components/ui/icon';
   import {IsMobile} from '$lib/hooks/is-mobile.svelte';
   import {setLanguage} from '$lib/i18n';
+  import {SidebarMenuButton} from '$lib/components/ui/sidebar';
+
+  type Props = {
+    inSidebar?: boolean;
+  };
+
+  let {
+    inSidebar
+  }: Props = $props();
 
   const languages: Record<string, string> = {
     'en': 'English',
@@ -15,18 +24,28 @@
   };
   const currentLanguage = $derived(languages[$locale] ?? 'Unknown: ' + $locale);
 </script>
+
 <DropdownMenu.Root>
   <DropdownMenu.Trigger>
     {#snippet child({props})}
-      <Button {...props} icon="i-mdi-translate" size={IsMobile.value ? 'icon' : undefined} variant="ghost">
-        {#if !IsMobile.value}
-          {currentLanguage}
+      {#if inSidebar}
+        <SidebarMenuButton {...props}>
+          <Icon icon="i-mdi-translate" />
+          <span>{currentLanguage}</span>
+          <span class="grow"></span>
           <Icon icon="i-mdi-menu-down"/>
-        {/if}
-      </Button>
+        </SidebarMenuButton>
+      {:else}
+        <Button {...props} icon="i-mdi-translate" size={IsMobile.value ? 'icon' : undefined} variant="ghost">
+          {#if !IsMobile.value}
+            {currentLanguage}
+            <Icon icon="i-mdi-menu-down"/>
+          {/if}
+        </Button>
+      {/if}
     {/snippet}
   </DropdownMenu.Trigger>
-  <DropdownMenu.Content>
+  <DropdownMenu.Content align="end">
     <DropdownMenu.RadioGroup bind:value={() => $locale, l => setLanguage(l)}>
       {#each Object.entries(languages) as [lang, label] (lang)}
         <DropdownMenu.RadioItem class="cursor-pointer" value={lang}>{label}</DropdownMenu.RadioItem>

--- a/frontend/viewer/src/project/ProjectSidebar.svelte
+++ b/frontend/viewer/src/project/ProjectSidebar.svelte
@@ -182,7 +182,7 @@
           </Sidebar.MenuButton>
         </Sidebar.MenuItem>
         <Sidebar.MenuItem>
-          <LocalizationPicker/>
+          <LocalizationPicker inSidebar />
         </Sidebar.MenuItem>
       </Sidebar.Menu>
     </Sidebar.Group>


### PR DESCRIPTION
An "as rudimentary as it gets" approach to determining how to render the trigger.

<img width="448" height="884" alt="image" src="https://github.com/user-attachments/assets/55deba5a-77ee-417a-bb6c-000ecedcc8d3" />
<img width="343" height="361" alt="image" src="https://github.com/user-attachments/assets/25daef04-b460-4e5d-9f74-2f7a15ffce4d" />
<img width="429" height="373" alt="image" src="https://github.com/user-attachments/assets/f95342ce-a9b7-46df-8900-86113970170b" />
<img width="520" height="493" alt="image" src="https://github.com/user-attachments/assets/d6f8965c-2473-489a-a134-787e0dea775f" />
<img width="441" height="347" alt="image" src="https://github.com/user-attachments/assets/eac7bf86-735c-45ef-aab9-19174af711af" />
