### PR TITLE
Fix NPEs when using gridify in fw-data projects

### DIFF
--- a/backend/FwLite/FwDataMiniLcmBridge/Api/LcmHelpers.cs
+++ b/backend/FwLite/FwDataMiniLcmBridge/Api/LcmHelpers.cs
@@ -145,7 +145,7 @@ internal static class LcmHelpers
     internal static string? PickText(this ICmObject obj, ITsMultiString multiString, string ws)
     {
         var wsHandle = obj.Cache.GetWritingSystemHandle(ws);
-        return multiString.get_String(wsHandle)?.Text ?? null;
+        return multiString.get_String(wsHandle)?.Text ?? "";
     }
 
     internal static IMoStemAllomorph CreateLexemeForm(this LcmCache cache)

--- a/backend/FwLite/MiniLcm.Tests/QueryEntryTestsBase.cs
+++ b/backend/FwLite/MiniLcm.Tests/QueryEntryTestsBase.cs
@@ -10,6 +10,7 @@ public abstract class QueryEntryTestsBase : MiniLcmTestBase
     private readonly string Peach = "Peach";
     private readonly string Banana = "Banana";
     private readonly string Kiwi = "Kiwi";
+    private readonly string Null_LexemeForm = "";
 
     private static readonly AutoFaker Faker = new(AutoFakerDefault.Config);
 
@@ -87,13 +88,14 @@ public abstract class QueryEntryTestsBase : MiniLcmTestBase
                 }
             ]
         });
+        await Api.CreateEntry(new Entry());
     }
 
     [Fact]
     public async Task CanFilterToMissingSenses()
     {
         var results = await Api.GetEntries(new(Filter: new() { GridifyFilter = "Senses=null" })).ToArrayAsync();
-        results.Select(e => e.LexemeForm["en"]).Should().BeEquivalentTo(Apple);
+        results.Select(e => e.LexemeForm["en"]).Should().BeEquivalentTo(Apple, Null_LexemeForm);
     }
 
     [Fact]
@@ -145,14 +147,14 @@ public abstract class QueryEntryTestsBase : MiniLcmTestBase
     public async Task CanFilterToMissingComplexFormTypes()
     {
         var results = await Api.GetEntries(new(Filter: new() { GridifyFilter = "ComplexFormTypes=null" })).ToArrayAsync();
-        results.Select(e => e.LexemeForm["en"]).Should().BeEquivalentTo(Apple, Banana, Kiwi);
+        results.Select(e => e.LexemeForm["en"]).Should().BeEquivalentTo(Apple, Banana, Kiwi, Null_LexemeForm);
     }
 
     [Fact]
     public async Task CanFilterToMissingComplexFormTypesWithEmptyArray()
     {
         var results = await Api.GetEntries(new(Filter: new() { GridifyFilter = "ComplexFormTypes=[]" })).ToArrayAsync();
-        results.Select(e => e.LexemeForm["en"]).Should().BeEquivalentTo(Apple, Banana, Kiwi);
+        results.Select(e => e.LexemeForm["en"]).Should().BeEquivalentTo(Apple, Banana, Kiwi, Null_LexemeForm);
     }
 
     [Fact]
@@ -184,16 +186,16 @@ public abstract class QueryEntryTestsBase : MiniLcmTestBase
     }
 
     [Fact]
-    public async Task CanFilterGlossNull()
+    public async Task CanFilterGlossEmptyOrNull()
     {
-        var results = await Api.GetEntries(new(Filter: new() { GridifyFilter = "Senses.Gloss[en]=null" })).ToArrayAsync();
+        var results = await Api.GetEntries(new(Filter: new() { GridifyFilter = "Senses.Gloss[en]=" })).ToArrayAsync();
         results.Select(e => e.LexemeForm["en"]).Should().BeEquivalentTo(Peach);
     }
 
-    [Fact]
-    public async Task CanFilterGlossEmpty()
+    [Fact] // this is equivalent to CanFilterGlossEmptyOrNull() because we normalize null to the empty string
+    public async Task CanFilterGlossEmptyOrNull2()
     {
-        var results = await Api.GetEntries(new(Filter: new() { GridifyFilter = "Senses.Gloss[en]=" })).ToArrayAsync();
+        var results = await Api.GetEntries(new(Filter: new() { GridifyFilter = "Senses.Gloss[en]=null" })).ToArrayAsync();
         results.Select(e => e.LexemeForm["en"]).Should().BeEquivalentTo(Peach);
     }
 

--- a/backend/FwLite/MiniLcm/Filtering/EntryFilter.cs
+++ b/backend/FwLite/MiniLcm/Filtering/EntryFilter.cs
@@ -13,17 +13,17 @@ public class EntryFilter
         mapper.Configuration.DisableCollectionNullChecks = true;
         mapper.AddMap(nameof(Entry.Senses), provider.EntrySenses);
         mapper.AddMap($"{nameof(Entry.Senses)}.{nameof(Sense.SemanticDomains)}", provider.EntrySensesSemanticDomains, provider.EntrySensesSemanticDomainsConverter);
-        mapper.AddMap($"{nameof(Entry.Senses)}.{nameof(Sense.SemanticDomains)}.{nameof(SemanticDomain.Code)}", provider.EntrySensesSemanticDomainsCode);
-        mapper.AddMap($"{nameof(Entry.Senses)}.{nameof(Sense.PartOfSpeechId)}", provider.EntrySensesPartOfSpeechId);
-        mapper.AddMap($"{nameof(Entry.Senses)}.{nameof(Sense.Gloss)}", provider.EntrySensesGloss);
-        mapper.AddMap($"{nameof(Entry.Senses)}.{nameof(Sense.Definition)}", provider.EntrySensesDefinition);
+        mapper.AddMap($"{nameof(Entry.Senses)}.{nameof(Sense.SemanticDomains)}.{nameof(SemanticDomain.Code)}", provider.EntrySensesSemanticDomainsCode, NormalizeNullToEmptyString);
+        mapper.AddMap($"{nameof(Entry.Senses)}.{nameof(Sense.PartOfSpeechId)}", provider.EntrySensesPartOfSpeechId, NormalizeNullToEmptyString);
+        mapper.AddMap($"{nameof(Entry.Senses)}.{nameof(Sense.Gloss)}", provider.EntrySensesGloss, NormalizeNullToEmptyString);
+        mapper.AddMap($"{nameof(Entry.Senses)}.{nameof(Sense.Definition)}", provider.EntrySensesDefinition, NormalizeNullToEmptyString);
         mapper.AddMap($"{nameof(Entry.Senses)}.{nameof(Sense.ExampleSentences)}", provider.EntrySensesExampleSentences);
-        mapper.AddMap($"{nameof(Entry.Senses)}.{nameof(Sense.ExampleSentences)}.{nameof(ExampleSentence.Sentence)}", provider.EntrySensesExampleSentencesSentence);
+        mapper.AddMap($"{nameof(Entry.Senses)}.{nameof(Sense.ExampleSentences)}.{nameof(ExampleSentence.Sentence)}", provider.EntrySensesExampleSentencesSentence, NormalizeNullToEmptyString);
 
-        mapper.AddMap(nameof(Entry.Note), provider.EntryNote);
-        mapper.AddMap(nameof(Entry.LexemeForm), provider.EntryLexemeForm);
-        mapper.AddMap(nameof(Entry.CitationForm), provider.EntryCitationForm);
-        mapper.AddMap(nameof(Entry.LiteralMeaning), provider.EntryLiteralMeaning);
+        mapper.AddMap(nameof(Entry.Note), provider.EntryNote, NormalizeNullToEmptyString);
+        mapper.AddMap(nameof(Entry.LexemeForm), provider.EntryLexemeForm, NormalizeNullToEmptyString);
+        mapper.AddMap(nameof(Entry.CitationForm), provider.EntryCitationForm, NormalizeNullToEmptyString);
+        mapper.AddMap(nameof(Entry.LiteralMeaning), provider.EntryLiteralMeaning, NormalizeNullToEmptyString);
         mapper.AddMap(nameof(Entry.ComplexFormTypes), provider.EntryComplexFormTypes, provider.EntryComplexFormTypesConverter);
         return mapper;
     }
@@ -39,6 +39,13 @@ public class EntryFilter
     {
         if (value is "null" or "" or "[]") return "null";
         throw new Exception($"Invalid value {value} for {typeof(T).Name}");
+    }
+
+    //Removes the distinction between null and empty string, so that we don't have to add null checks to prevent NPE's when using string contains (and similar) operators.
+    public static object NormalizeNullToEmptyString(string value)
+    {
+        if (value is "null" or "") return string.Empty;
+        return value;
     }
 
     public string? GridifyFilter { get; set; }


### PR DESCRIPTION
Resolves #1874

Map nulls to empty string and normalize filtering for null to null or empty.

For why I took this approach see: https://github.com/sillsdev/languageforge-lexbox/issues/1874#issuecomment-3160397861 
I'm open to taking an entirely different route.