### PR TITLE
Move and handle writing systems effectively

### DIFF
--- a/backend/FwLite/FwDataMiniLcmBridge/Api/FwDataMiniLcmApi.cs
+++ b/backend/FwLite/FwDataMiniLcmBridge/Api/FwDataMiniLcmApi.cs
@@ -117,7 +117,7 @@ public class FwDataMiniLcmApi(
         };
     }
 
-    public async Task<WritingSystem> GetWritingSystem(WritingSystemId id, WritingSystemType type)
+    public async Task<WritingSystem?> GetWritingSystem(WritingSystemId id, WritingSystemType type)
     {
         var writingSystems = await GetWritingSystems();
         return type switch
@@ -125,7 +125,7 @@ public class FwDataMiniLcmApi(
             WritingSystemType.Vernacular => writingSystems.Vernacular.FirstOrDefault(ws => ws.WsId == id),
             WritingSystemType.Analysis => writingSystems.Analysis.FirstOrDefault(ws => ws.WsId == id),
             _ => throw new ArgumentOutOfRangeException(nameof(type), type, null)
-        } ?? throw new NullReferenceException($"unable to find writing system with id {id}");
+        };
     }
 
     internal void CompleteExemplars(WritingSystems writingSystems)
@@ -205,7 +205,7 @@ public class FwDataMiniLcmApi(
                 update.Apply(updateProxy);
                 return ValueTask.CompletedTask;
             });
-        return await GetWritingSystem(id, type);
+        return await GetWritingSystem(id, type) ?? throw new NullReferenceException($"unable to find writing system with id {id}");
     }
 
     public async Task<WritingSystem> UpdateWritingSystem(WritingSystem before, WritingSystem after, IMiniLcmApi? api = null)
@@ -217,6 +217,10 @@ public class FwDataMiniLcmApi(
                 await WritingSystemSync.Sync(before, after, api ?? this);
             });
         return await GetWritingSystem(after.WsId, after.Type) ?? throw new NullReferenceException($"unable to find {after.Type} writing system with id {after.WsId}");
+    }
+
+    public async Task MoveWritingSystem(WritingSystemId id, WritingSystemType type, BetweenPosition<WritingSystemId?> between)
+    {
     }
 
     public IAsyncEnumerable<PartOfSpeech> GetPartsOfSpeech()

--- a/backend/FwLite/FwDataMiniLcmBridge/Api/FwDataMiniLcmApi.cs
+++ b/backend/FwLite/FwDataMiniLcmBridge/Api/FwDataMiniLcmApi.cs
@@ -247,17 +247,21 @@ public class FwDataMiniLcmApi(
                     CoreWritingSystemDefinition? next,
                     ICollection<CoreWritingSystemDefinition> list)
                 {
-                    int index;
+                    var index = -1;
                     if (previous is not null)
                     {
-                        index = CollectionExtensions.IndexOf(list, previous) + 1;
-                    } else if (next is not null)
+                        index = CollectionExtensions.IndexOf(list, previous);
+                        if (index >= 0) index++;
+                    }
+
+                    if (index < 0 && next is not null)
                     {
                         index = CollectionExtensions.IndexOf(list, next);
-                    } else
-                    {
-                        throw new InvalidOperationException("unable to find writing system with id " + between.Previous + " or " + between.Next);
                     }
+
+                    if (index < 0)
+                        throw new InvalidOperationException("unable to find writing system with id " + between.Previous + " or " + between.Next);
+
                     LcmHelpers.AddOrMoveInList(list, index, ws);
                 }
 

--- a/backend/FwLite/FwDataMiniLcmBridge/Api/LcmHelpers.cs
+++ b/backend/FwLite/FwDataMiniLcmBridge/Api/LcmHelpers.cs
@@ -202,17 +202,25 @@ internal static class LcmHelpers
         }
     }
 
-    //copy of method in SIL.FieldWorks.FwCoreDlgs.FwWritingSystemSetupModel
+    //mostly a copy of method in SIL.FieldWorks.FwCoreDlgs.FwWritingSystemSetupModel
     internal static void AddOrMoveInList(
         ICollection<CoreWritingSystemDefinition> allWritingSystems,
         int desiredIndex,
         CoreWritingSystemDefinition workingWs
     )
     {
+        if (desiredIndex < 0) throw new ArgumentOutOfRangeException(nameof(desiredIndex), desiredIndex, "desiredIndex must be >= 0");
+
         // copy original contents into a list
         var updatedList = new List<CoreWritingSystemDefinition>(allWritingSystems);
         var ws = updatedList.Find(listItem =>
-            listItem.Id == (string.IsNullOrEmpty(workingWs.Id) ? workingWs.LanguageTag : workingWs.Id));
+        {
+            if (ReferenceEquals(listItem, workingWs)) return true;
+            var workingTag = string.IsNullOrEmpty(workingWs.Id) ? workingWs.LanguageTag : workingWs.Id;
+            var listItemTag = string.IsNullOrEmpty(listItem.Id) ? listItem.LanguageTag : listItem.Id;
+            return string.Equals(listItemTag, workingTag);
+        });
+
         if (ws != null)
         {
             updatedList.Remove(ws);

--- a/backend/FwLite/FwDataMiniLcmBridge/Api/LcmHelpers.cs
+++ b/backend/FwLite/FwDataMiniLcmBridge/Api/LcmHelpers.cs
@@ -1,9 +1,11 @@
 using System.Globalization;
 using MiniLcm.Culture;
 using MiniLcm.Models;
+using SIL.Extensions;
 using SIL.LCModel;
 using SIL.LCModel.Core.KernelInterfaces;
 using SIL.LCModel.Core.Text;
+using SIL.LCModel.Core.WritingSystems;
 
 namespace FwDataMiniLcmBridge.Api;
 
@@ -198,5 +200,34 @@ internal static class LcmHelpers
             var tsString = TsStringUtils.MakeString(api.FromMediaUri(value.GetPlainText()), writingSystemHandle);
             multiString.set_String(writingSystemHandle, tsString);
         }
+    }
+
+    //copy of method in SIL.FieldWorks.FwCoreDlgs.FwWritingSystemSetupModel
+    internal static void AddOrMoveInList(
+        ICollection<CoreWritingSystemDefinition> allWritingSystems,
+        int desiredIndex,
+        CoreWritingSystemDefinition workingWs
+    )
+    {
+        // copy original contents into a list
+        var updatedList = new List<CoreWritingSystemDefinition>(allWritingSystems);
+        var ws = updatedList.Find(listItem =>
+            listItem.Id == (string.IsNullOrEmpty(workingWs.Id) ? workingWs.LanguageTag : workingWs.Id));
+        if (ws != null)
+        {
+            updatedList.Remove(ws);
+        }
+
+        if (desiredIndex > updatedList.Count)
+        {
+            updatedList.Add(workingWs);
+        }
+        else
+        {
+            updatedList.Insert(desiredIndex, workingWs);
+        }
+
+        allWritingSystems.Clear();
+        allWritingSystems.AddRange(updatedList);
     }
 }

--- a/backend/FwLite/FwLiteProjectSync.Tests/Import/ResumableTests.cs
+++ b/backend/FwLite/FwLiteProjectSync.Tests/Import/ResumableTests.cs
@@ -203,9 +203,9 @@ internal partial class UnreliableApi(IMiniLcmApi api, Random random) : IMiniLcmA
         ResumableTests.MaybeThrowRandom(random, 0.2);
         return _api.CreatePublication(publication);
     }
-    Task<WritingSystem> IMiniLcmWriteApi.CreateWritingSystem(WritingSystem writingSystems)
+    Task<WritingSystem> IMiniLcmWriteApi.CreateWritingSystem(WritingSystem writingSystems, BetweenPosition<WritingSystemId?>? between)
     {
         ResumableTests.MaybeThrowRandom(random, 0.2);
-        return _api.CreateWritingSystem(writingSystems);
+        return _api.CreateWritingSystem(writingSystems, between);
     }
 }

--- a/backend/FwLite/FwLiteProjectSync.Tests/WritingSystemSyncTests.cs
+++ b/backend/FwLite/FwLiteProjectSync.Tests/WritingSystemSyncTests.cs
@@ -1,0 +1,79 @@
+using FwLiteProjectSync.Tests.Fixtures;
+using MiniLcm.Models;
+
+namespace FwLiteProjectSync.Tests;
+
+public class WritingSystemSyncTests : IClassFixture<SyncFixture>, IAsyncLifetime
+{
+
+    private readonly SyncFixture _fixture;
+    private readonly CrdtFwdataProjectSyncService _syncService;
+
+    public WritingSystemSyncTests(SyncFixture fixture)
+    {
+        _fixture = fixture;
+        _syncService = _fixture.SyncService;
+    }
+
+    public async Task InitializeAsync()
+    {
+        await _fixture.FwDataApi.CreateEntry(new Entry()
+        {
+            Id = Guid.NewGuid(),
+            LexemeForm = { { "en", "Pineapple" } },
+        });
+        await _fixture.FwDataApi.CreateWritingSystem(new WritingSystem()
+        {
+            Id = Guid.NewGuid(),
+            Type = WritingSystemType.Vernacular,
+            WsId = new WritingSystemId("fr"),
+            Name = "French",
+            Abbreviation = "fr",
+            Font = "Arial"
+        });
+        await _syncService.Sync(_fixture.CrdtApi, _fixture.FwDataApi);
+    }
+
+    public async Task DisposeAsync()
+    {
+        await foreach (var entry in _fixture.FwDataApi.GetAllEntries())
+        {
+            await _fixture.FwDataApi.DeleteEntry(entry.Id);
+        }
+
+        foreach (var entry in await _fixture.CrdtApi.GetAllEntries().ToArrayAsync())
+        {
+            await _fixture.CrdtApi.DeleteEntry(entry.Id);
+        }
+    }
+
+    [Fact]
+    public async Task SyncWs_UpdatesOrder()
+    {
+        var en = await _fixture.FwDataApi.GetWritingSystem("en", WritingSystemType.Vernacular);
+        en.Should().NotBeNull();
+        en.Order.Should().Be(0);
+        var fr = await _fixture.FwDataApi.GetWritingSystem("fr", WritingSystemType.Vernacular);
+        fr.Should().NotBeNull();
+        fr.Order.Should().Be(1);
+        await _fixture.FwDataApi.MoveWritingSystem("fr", WritingSystemType.Vernacular, new(null, "en"));
+        fr = await _fixture.FwDataApi.GetWritingSystem("fr", WritingSystemType.Vernacular);
+        fr.Should().NotBeNull();
+        fr.Order.Should().Be(0);
+        var crdtFr = await _fixture.CrdtApi.GetWritingSystem("fr", WritingSystemType.Vernacular);
+        crdtFr.Should().NotBeNull();
+        crdtFr.Order.Should().Be(1);
+
+        await _syncService.Sync(_fixture.CrdtApi, _fixture.FwDataApi);
+
+        fr = await _fixture.FwDataApi.GetWritingSystem("fr", WritingSystemType.Vernacular);
+        fr.Should().NotBeNull();
+        fr.Order.Should().Be(0);
+
+        var crdtEn = await _fixture.CrdtApi.GetWritingSystem("en", WritingSystemType.Vernacular);
+        crdtEn.Should().NotBeNull();
+        var actualFr = await _fixture.CrdtApi.GetWritingSystem("fr", WritingSystemType.Vernacular);
+        actualFr.Should().NotBeNull();
+        actualFr.Order.Should().BeLessThan(crdtEn.Order);
+    }
+}

--- a/backend/FwLite/FwLiteProjectSync/DryRunMiniLcmApi.cs
+++ b/backend/FwLite/FwLiteProjectSync/DryRunMiniLcmApi.cs
@@ -18,9 +18,10 @@ public partial class DryRunMiniLcmApi(IMiniLcmApi api) : IMiniLcmApi
 
     public record DryRunRecord(string Method, string Description);
 
-    public Task<WritingSystem> CreateWritingSystem(WritingSystem writingSystem)
+    public Task<WritingSystem> CreateWritingSystem(WritingSystem writingSystem, BetweenPosition<WritingSystemId?>? position = null)
     {
-        DryRunRecords.Add(new DryRunRecord(nameof(CreateWritingSystem), $"Create writing system {writingSystem.Type}"));
+        DryRunRecords.Add(new DryRunRecord(nameof(CreateWritingSystem),
+        $"Create writing system {writingSystem.Type} between {position?.Previous} and {position?.Next}"));
         return Task.FromResult(writingSystem);
     }
 

--- a/backend/FwLite/FwLiteProjectSync/DryRunMiniLcmApi.cs
+++ b/backend/FwLite/FwLiteProjectSync/DryRunMiniLcmApi.cs
@@ -45,6 +45,12 @@ public partial class DryRunMiniLcmApi(IMiniLcmApi api) : IMiniLcmApi
         return Task.FromResult(after);
     }
 
+    public async Task MoveWritingSystem(WritingSystemId id, WritingSystemType type, BetweenPosition<WritingSystemId?> between)
+    {
+        DryRunRecords.Add(new DryRunRecord(nameof(MoveWritingSystem), $"Move writing system {id} between {between.Previous} and {between.Next}"));
+        await Task.CompletedTask;
+    }
+
     public Task<PartOfSpeech> CreatePartOfSpeech(PartOfSpeech partOfSpeech)
     {
         DryRunRecords.Add(new DryRunRecord(nameof(CreatePartOfSpeech), $"Create part of speech {partOfSpeech.Name}"));

--- a/backend/FwLite/FwLiteProjectSync/Import/ResumableImportApi.cs
+++ b/backend/FwLite/FwLiteProjectSync/Import/ResumableImportApi.cs
@@ -1,6 +1,7 @@
 using System.Runtime.CompilerServices;
 using MiniLcm;
 using MiniLcm.Models;
+using MiniLcm.SyncHelpers;
 
 namespace FwLiteProjectSync.Import;
 
@@ -65,9 +66,9 @@ public partial class ResumableImportApi(IMiniLcmApi api) : IMiniLcmApi
     {
         return await HasCreated(publication, _api.GetPublications(), () => _api.CreatePublication(publication));
     }
-    async Task<WritingSystem> IMiniLcmWriteApi.CreateWritingSystem(WritingSystem writingSystem)
+    async Task<WritingSystem> IMiniLcmWriteApi.CreateWritingSystem(WritingSystem writingSystem, BetweenPosition<WritingSystemId?>? between = null)
     {
-        return await HasCreated(writingSystem, AsyncWs(), () => _api.CreateWritingSystem(writingSystem), ws => ws.Type + ws.WsId.Code);
+        return await HasCreated(writingSystem, AsyncWs(), () => _api.CreateWritingSystem(writingSystem, between), ws => ws.Type + ws.WsId.Code);
     }
 
     private async IAsyncEnumerable<WritingSystem> AsyncWs()

--- a/backend/FwLite/LcmCrdt.Tests/Changes/RegressionDeserializationData.json
+++ b/backend/FwLite/LcmCrdt.Tests/Changes/RegressionDeserializationData.json
@@ -278,6 +278,11 @@
     "EntityId": "e03826fb-e6d2-6e3c-1f43-9fc6a0f6c4c6"
   },
   {
+    "$type": "SetOrderChange:WritingSystem",
+    "Order": 0.4870418422144669,
+    "EntityId": "9d3e9006-c4b4-4316-6628-faeede75af40"
+  },
+  {
     "$type": "SetOrderChange:Sense",
     "Order": 0.4870418422144669,
     "EntityId": "9d3e9006-c4b4-4316-6628-faeede75af40"

--- a/backend/FwLite/LcmCrdt.Tests/Changes/UseChangesTests.cs
+++ b/backend/FwLite/LcmCrdt.Tests/Changes/UseChangesTests.cs
@@ -199,6 +199,9 @@ public class UseChangesTests(MiniLcmApiFixture fixture) : IClassFixture<MiniLcmA
         var setComplexFormComponentOrderChange = new LcmCrdt.Changes.SetOrderChange<ComplexFormComponent>(complexFormComponent.Id, 10);
         yield return new ChangeWithDependencies(setComplexFormComponentOrderChange, [createComplexFormComponentChange]);
 
+        var setWritingSystemOrderChange = new LcmCrdt.Changes.SetOrderChange<WritingSystem>(writingSystem.Id, 10);
+        yield return new ChangeWithDependencies(setWritingSystemOrderChange, [createWritingSystemChange]);
+
         var publication = new Publication { Id = Guid.NewGuid(), Name = { { "en", "Main" } } };
         var createPublicationChange = new CreatePublicationChange(publication.Id, publication.Name);
         yield return new ChangeWithDependencies(createPublicationChange);

--- a/backend/FwLite/LcmCrdt.Tests/DataModelSnapshotTests.VerifyChangeModels.verified.txt
+++ b/backend/FwLite/LcmCrdt.Tests/DataModelSnapshotTests.VerifyChangeModels.verified.txt
@@ -171,6 +171,10 @@
     {
       DerivedType: SetOrderChange<ComplexFormComponent>,
       TypeDiscriminator: SetOrderChange:ComplexFormComponent
+    },
+    {
+      DerivedType: SetOrderChange<WritingSystem>,
+      TypeDiscriminator: SetOrderChange:WritingSystem
     }
   ],
   IgnoreUnrecognizedTypeDiscriminators: false,

--- a/backend/FwLite/LcmCrdt/Changes/SetOrderChange.cs
+++ b/backend/FwLite/LcmCrdt/Changes/SetOrderChange.cs
@@ -5,7 +5,7 @@ using SIL.Harmony.Entities;
 namespace LcmCrdt.Changes;
 
 public class SetOrderChange<T>(Guid entityId, double order) : EditChange<T>(entityId), IPolyType
-    where T : class, IOrderable
+    where T : class, IOrderableNoId
 {
     public static string TypeName => $"{nameof(SetOrderChange<T>)}:" + typeof(T).Name;
 

--- a/backend/FwLite/LcmCrdt/CrdtMiniLcmApi.cs
+++ b/backend/FwLite/LcmCrdt/CrdtMiniLcmApi.cs
@@ -105,7 +105,12 @@ public class CrdtMiniLcmApi(
         return await GetWritingSystem(after.WsId, after.Type) ?? throw new NullReferenceException("unable to find writing system with id " + after.WsId);
     }
 
-    private async ValueTask<WritingSystem?> GetWritingSystem(WritingSystemId id, WritingSystemType type)
+    public Task MoveWritingSystem(WritingSystemId id, WritingSystemType type, BetweenPosition<WritingSystemId?> between)
+    {
+        throw new NotSupportedException("MoveWritingSystem is not supported");
+    }
+
+    public async Task<WritingSystem?> GetWritingSystem(WritingSystemId id, WritingSystemType type)
     {
         await using var repo = await repoFactory.CreateRepoAsync();
         return await repo.GetWritingSystem(id, type);

--- a/backend/FwLite/LcmCrdt/CrdtMiniLcmApi.cs
+++ b/backend/FwLite/LcmCrdt/CrdtMiniLcmApi.cs
@@ -78,15 +78,17 @@ public class CrdtMiniLcmApi(
         };
     }
 
-    public async Task<WritingSystem> CreateWritingSystem(WritingSystem writingSystem)
+    public async Task<WritingSystem> CreateWritingSystem(WritingSystem writingSystem, BetweenPosition<WritingSystemId?>? between = null)
     {
         await using var repo = await repoFactory.CreateRepoAsync();
         var entityId = Guid.NewGuid();
-        var exists = await repo.WritingSystems.AnyAsync(ws => ws.WsId == writingSystem.WsId && ws.Type == writingSystem.Type);
+        var wsType = writingSystem.Type;
+        var exists = await repo.WritingSystems.AnyAsync(ws => ws.WsId == writingSystem.WsId && ws.Type == wsType);
         if (exists) throw new DuplicateObjectException($"Writing system {writingSystem.WsId.Code} already exists");
-        var wsCount = await repo.WritingSystems.CountAsync(ws => ws.Type == writingSystem.Type);
-        await AddChange(new CreateWritingSystemChange(writingSystem, entityId, wsCount));
-        return await repo.GetWritingSystem(writingSystem.WsId, writingSystem.Type) ?? throw new NullReferenceException();
+        var betweenIds = between is null ? null : await between.MapAsync(async wsId => wsId is null ? null : (await GetWritingSystem(wsId.Value, wsType))?.Id);
+        var order = await OrderPicker.PickOrder(repo.WritingSystems.Where(ws => ws.Type == wsType), betweenIds);
+        await AddChange(new CreateWritingSystemChange(writingSystem, entityId, order));
+        return await repo.GetWritingSystem(writingSystem.WsId, wsType) ?? throw new NullReferenceException();
     }
 
     public async Task<WritingSystem> UpdateWritingSystem(WritingSystemId id, WritingSystemType type, UpdateObjectInput<WritingSystem> update)

--- a/backend/FwLite/LcmCrdt/LcmCrdtKernel.cs
+++ b/backend/FwLite/LcmCrdt/LcmCrdtKernel.cs
@@ -259,6 +259,7 @@ public static class LcmCrdtKernel
             .Add<Changes.SetOrderChange<Sense>>()
             .Add<Changes.SetOrderChange<ExampleSentence>>()
             .Add<Changes.SetOrderChange<ComplexFormComponent>>()
+            .Add<Changes.SetOrderChange<WritingSystem>>()
             // When adding anything other than a Delete or JsonPatch change,
             // you must add an instance of it to UseChangesTests.GetAllChanges()
             ;

--- a/backend/FwLite/LcmCrdt/OrderPicker.cs
+++ b/backend/FwLite/LcmCrdt/OrderPicker.cs
@@ -5,7 +5,8 @@ namespace LcmCrdt;
 
 public static class OrderPicker
 {
-    public static async Task<double> PickOrder<T>(IQueryable<T> siblings, BetweenPosition? between = null) where T : class, IOrderable
+    public static async Task<double> PickOrder<T>(IQueryable<T> siblings, BetweenPosition? between = null)
+        where T : class, IOrderableNoId, IObjectWithId//this is weird, but WritingSystems should not be IOrderable, because that won't work with FW data, but they have Ids when working with CRDTs
     {
         // a common case that we can optimize by not querying whole objects
         if (between is null or { Previous: null, Next: null })

--- a/backend/FwLite/MiniLcm.Tests/WritingSystemTestsBase.cs
+++ b/backend/FwLite/MiniLcm.Tests/WritingSystemTestsBase.cs
@@ -1,5 +1,5 @@
 ﻿using MiniLcm.Exceptions;
-using MiniLcm.Models;
+using MiniLcm.SyncHelpers;
 
 namespace MiniLcm.Tests;
 
@@ -99,10 +99,50 @@ public abstract class WritingSystemTestsBase : MiniLcmTestBase
         //act
         await Api.MoveWritingSystem(ws2.WsId, WritingSystemType.Vernacular, new(null, ws1.WsId));
 
+        //assert
         ws1 = await Api.GetWritingSystem(ws1.WsId, WritingSystemType.Vernacular);
         ws1.Should().NotBeNull();
         ws2 = await Api.GetWritingSystem(ws2.WsId, WritingSystemType.Vernacular);
         ws2.Should().NotBeNull();
         ws2.Order.Should().BeLessThan(ws1.Order);
+
+        var writingSystems = await Api.GetWritingSystems();
+        var en = writingSystems.Vernacular.Single(ws => ws.WsId.Code == "en");
+        writingSystems.Vernacular.Should().BeEquivalentTo([en, ws2, ws1],
+        // we care about the order of return, not the internal Order property
+        options => options.WithStrictOrdering().Excluding(ws => ws.Order));
+    }
+
+    [Fact]
+    public async Task InsertWritingSystem_Works()
+    {
+        var writingSystems = await Api.GetWritingSystems();
+        var en = writingSystems.Vernacular.Single(ws => ws.WsId.Code == "en");
+
+        //act
+        var ws1 = await Api.CreateWritingSystem(new()
+        {
+            Id = Guid.NewGuid(),
+            WsId = "es",
+            Type = WritingSystemType.Vernacular,
+            Name = "Spanish",
+            Abbreviation = "Es",
+            Font = "Arial"
+        }, new BetweenPosition<WritingSystemId?>(null, en.WsId));
+        var ws2 = await Api.CreateWritingSystem(new()
+        {
+            Id = Guid.NewGuid(),
+            WsId = "fr",
+            Type = WritingSystemType.Vernacular,
+            Name = "French",
+            Abbreviation = "Fr",
+            Font = "Arial"
+        }, new BetweenPosition<WritingSystemId?>(ws1.WsId, en.WsId));
+
+        // assert
+        writingSystems = await Api.GetWritingSystems();
+        writingSystems.Vernacular.Should().BeEquivalentTo([ws1, ws2, en],
+        // we care about the order of return, not the internal Order property
+        options => options.WithStrictOrdering().Excluding(ws => ws.Order));
     }
 }

--- a/backend/FwLite/MiniLcm.Tests/WritingSystemTestsBase.cs
+++ b/backend/FwLite/MiniLcm.Tests/WritingSystemTestsBase.cs
@@ -72,4 +72,37 @@ public abstract class WritingSystemTestsBase : MiniLcmTestBase
         var updatedWritingSystem = await Api.UpdateWritingSystem(original, writingSystem);
         updatedWritingSystem.Abbreviation.Should().Be("New Abbreviation");
     }
+
+    [Fact]
+    public async Task MoveWritingSystem_Works()
+    {
+        var ws1 = await Api.CreateWritingSystem(new()
+        {
+            Id = Guid.NewGuid(),
+            WsId = "es",
+            Type = WritingSystemType.Vernacular,
+            Name = "Spanish",
+            Abbreviation = "Es",
+            Font = "Arial"
+        });
+        var ws2 = await Api.CreateWritingSystem(new()
+        {
+            Id = Guid.NewGuid(),
+            WsId = "fr",
+            Type = WritingSystemType.Vernacular,
+            Name = "French",
+            Abbreviation = "Fr",
+            Font = "Arial"
+        });
+        ws2.Order.Should().BeGreaterThan(ws1.Order);
+
+        //act
+        await Api.MoveWritingSystem(ws2.WsId, WritingSystemType.Vernacular, new(null, ws1.WsId));
+
+        ws1 = await Api.GetWritingSystem(ws1.WsId, WritingSystemType.Vernacular);
+        ws1.Should().NotBeNull();
+        ws2 = await Api.GetWritingSystem(ws2.WsId, WritingSystemType.Vernacular);
+        ws2.Should().NotBeNull();
+        ws2.Order.Should().BeLessThan(ws1.Order);
+    }
 }

--- a/backend/FwLite/MiniLcm/IMiniLcmReadApi.cs
+++ b/backend/FwLite/MiniLcm/IMiniLcmReadApi.cs
@@ -9,6 +9,7 @@ namespace MiniLcm;
 public interface IMiniLcmReadApi
 {
     Task<WritingSystems> GetWritingSystems();
+    Task<WritingSystem?> GetWritingSystem(WritingSystemId id, WritingSystemType type);
     IAsyncEnumerable<PartOfSpeech> GetPartsOfSpeech();
     IAsyncEnumerable<Publication> GetPublications();
     IAsyncEnumerable<SemanticDomain> GetSemanticDomains();

--- a/backend/FwLite/MiniLcm/IMiniLcmWriteApi.cs
+++ b/backend/FwLite/MiniLcm/IMiniLcmWriteApi.cs
@@ -8,7 +8,7 @@ namespace MiniLcm;
 
 public interface IMiniLcmWriteApi
 {
-    Task<WritingSystem> CreateWritingSystem(WritingSystem writingSystem);
+    Task<WritingSystem> CreateWritingSystem(WritingSystem writingSystem, BetweenPosition<WritingSystemId?>? between = null);
 
     Task<WritingSystem> UpdateWritingSystem(WritingSystemId id,
         WritingSystemType type,

--- a/backend/FwLite/MiniLcm/IMiniLcmWriteApi.cs
+++ b/backend/FwLite/MiniLcm/IMiniLcmWriteApi.cs
@@ -15,6 +15,7 @@ public interface IMiniLcmWriteApi
         UpdateObjectInput<WritingSystem> update);
     Task<WritingSystem> UpdateWritingSystem(WritingSystem before, WritingSystem after, IMiniLcmApi? api = null);
     // Note there's no Task DeleteWritingSystem(Guid id) because deleting writing systems needs careful consideration, as it can cause a massive cascade of data deletion
+    Task MoveWritingSystem(WritingSystemId id, WritingSystemType type, BetweenPosition<WritingSystemId?> between);
 
     #region PartOfSpeech
     Task<PartOfSpeech> CreatePartOfSpeech(PartOfSpeech partOfSpeech);

--- a/backend/FwLite/MiniLcm/Models/IOrderable.cs
+++ b/backend/FwLite/MiniLcm/Models/IOrderable.cs
@@ -1,7 +1,11 @@
 ﻿namespace MiniLcm.Models;
 
-public interface IOrderable
+public interface IOrderableNoId
+{
+    double Order { get; set; }
+}
+
+public interface IOrderable: IOrderableNoId
 {
     Guid Id { get; }
-    double Order { get; set; }
 }

--- a/backend/FwLite/MiniLcm/Models/WritingSystem.cs
+++ b/backend/FwLite/MiniLcm/Models/WritingSystem.cs
@@ -1,4 +1,5 @@
 ﻿using System.Text.Json.Serialization;
+using MiniLcm.Attributes;
 
 namespace MiniLcm.Models;
 
@@ -21,6 +22,7 @@ public record WritingSystem: IObjectWithId<WritingSystem>, IOrderableNoId
 
     public static string[] LatinExemplars => Enumerable.Range('A', 'Z' - 'A' + 1).Select(c => ((char)c).ToString()).ToArray();
 
+    [MiniLcmInternal]
     public double Order { get; set; }
 
     public Guid[] GetReferences()

--- a/backend/FwLite/MiniLcm/Models/WritingSystem.cs
+++ b/backend/FwLite/MiniLcm/Models/WritingSystem.cs
@@ -2,8 +2,11 @@
 
 namespace MiniLcm.Models;
 
-public record WritingSystem: IObjectWithId<WritingSystem>, IOrderable
+public record WritingSystem: IObjectWithId<WritingSystem>, IOrderableNoId
 {
+    /// <summary>
+    /// this ID is always empty when working with FW data, it is only used when working with CRDTs
+    /// </summary>
     public required Guid Id { get; set; }
     public virtual required WritingSystemId WsId { get; set; }
     public bool IsAudio => WsId.IsAudio;

--- a/backend/FwLite/MiniLcm/Models/WritingSystem.cs
+++ b/backend/FwLite/MiniLcm/Models/WritingSystem.cs
@@ -2,7 +2,7 @@
 
 namespace MiniLcm.Models;
 
-public record WritingSystem: IObjectWithId<WritingSystem>
+public record WritingSystem: IObjectWithId<WritingSystem>, IOrderable
 {
     public required Guid Id { get; set; }
     public virtual required WritingSystemId WsId { get; set; }

--- a/backend/FwLite/MiniLcm/Models/WritingSystemId.cs
+++ b/backend/FwLite/MiniLcm/Models/WritingSystemId.cs
@@ -47,6 +47,7 @@ public readonly record struct WritingSystemId: ISpanFormattable, ISpanParsable<W
 
     public WritingSystemId(string code)
     {
+        ArgumentException.ThrowIfNullOrEmpty(code);
         //__key is used by the LfClassicMiniLcmApi to smuggle non guid ids with possibilitie lists
         if (code == "default" || code == "__key")
         {

--- a/backend/FwLite/MiniLcm/SyncHelpers/DiffCollection.cs
+++ b/backend/FwLite/MiniLcm/SyncHelpers/DiffCollection.cs
@@ -245,5 +245,13 @@ public record PositionDiff(int Index, PositionDiffKind Kind)
     public int SortIndex => Kind == PositionDiffKind.Remove ? -Index - 1 : Index;
 }
 
-public record BetweenPosition<T>(T? Previous, T? Next);
+public record BetweenPosition<T>(T? Previous, T? Next)
+{
+    public async Task<BetweenPosition> MapAsync(Func<T, Task<Guid?>> map)
+    {
+        return new BetweenPosition(
+            Previous is null ? null : await map(Previous),
+            Next is null ? null : await map(Next));
+    }
+}
 public record BetweenPosition(Guid? Previous, Guid? Next) : BetweenPosition<Guid?>(Previous, Next);

--- a/backend/FwLite/MiniLcm/SyncHelpers/WritingSystemSync.cs
+++ b/backend/FwLite/MiniLcm/SyncHelpers/WritingSystemSync.cs
@@ -99,8 +99,12 @@ public static class WritingSystemSync
 
         async Task<int> IOrderableCollectionDiffApi<OrderableWs>.Add(OrderableWs value, BetweenPosition between)
         {
-            //todo set order?
-            await api.CreateWritingSystem(value.Ws);
+            var betweenWsId = new BetweenPosition<WritingSystemId?>(
+                //we can't use `null` and must use new WritingSystemId?() to set a nullable value to null
+                between.Previous is null ? new WritingSystemId?() : Mapping[between.Previous.Value],
+                between.Next is null ? new WritingSystemId?() : Mapping[between.Next.Value]
+                );
+            await api.CreateWritingSystem(value.Ws, betweenWsId);
             return 1;
         }
 

--- a/backend/FwLite/MiniLcm/Validators/MiniLcmApiValidationWrapper.cs
+++ b/backend/FwLite/MiniLcm/Validators/MiniLcmApiValidationWrapper.cs
@@ -21,10 +21,10 @@ public partial class MiniLcmApiValidationWrapper(
 
     // ********** Overrides go here **********
 
-    public async Task<WritingSystem> CreateWritingSystem(WritingSystem writingSystem)
+    public async Task<WritingSystem> CreateWritingSystem(WritingSystem writingSystem, BetweenPosition<WritingSystemId?>? between = null)
     {
         await validators.ValidateAndThrow(writingSystem);
-        return await _api.CreateWritingSystem(writingSystem);
+        return await _api.CreateWritingSystem(writingSystem, between);
     }
 
     public async Task<WritingSystem> UpdateWritingSystem(WritingSystemId id, WritingSystemType type, UpdateObjectInput<WritingSystem> update)

--- a/backend/LfClassicData/LfClassicMiniLcmApi.cs
+++ b/backend/LfClassicData/LfClassicMiniLcmApi.cs
@@ -64,6 +64,17 @@ public class LfClassicMiniLcmApi(string projectCode, ProjectDbContext dbContext,
         };
     }
 
+    public async Task<WritingSystem?> GetWritingSystem(WritingSystemId id, WritingSystemType type)
+    {
+        var ws = await GetWritingSystems();
+        return type switch
+        {
+            WritingSystemType.Vernacular => ws.Vernacular.FirstOrDefault(w => w.WsId == id),
+            WritingSystemType.Analysis => ws.Analysis.FirstOrDefault(w => w.WsId == id),
+            _ => throw new ArgumentOutOfRangeException(nameof(type), type, null)
+        };
+    }
+
     public async Task<string?> PickDefaultVernacularWritingSystem()
     {
         var cacheKey = $"LfClassic|DefaultVernacular|{projectCode}";

--- a/frontend/viewer/src/lib/demo-entry-data.ts
+++ b/frontend/viewer/src/lib/demo-entry-data.ts
@@ -40,7 +40,6 @@ export const writingSystems: IWritingSystems = {
       'font': '???',
       'exemplars': ['A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J', 'K', 'L', 'M', 'N', 'O', 'P', 'Q', 'R', 'S', 'T', 'U', 'V', 'W', 'X', 'Y', 'Z'],
       'type': WritingSystemType.Analysis,
-      'order': 0,
       isAudio: false,
     },
     {
@@ -51,7 +50,6 @@ export const writingSystems: IWritingSystems = {
       'font': '???',
       'exemplars': ['A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J', 'K', 'L', 'M', 'N', 'O', 'P', 'Q', 'R', 'S', 'T', 'U', 'V', 'W', 'X', 'Y', 'Z'],
       'type': WritingSystemType.Analysis,
-      'order': 1,
       isAudio: false,
     }
   ],
@@ -64,7 +62,6 @@ export const writingSystems: IWritingSystems = {
       'font': '???',
       'exemplars': ['A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J', 'K', 'L', 'M', 'N', 'O', 'P', 'Q', 'R', 'S', 'T', 'U', 'V', 'W', 'X', 'Y', 'Z'],
       'type': WritingSystemType.Vernacular,
-      'order': 0,
       isAudio: false,
     },
     {
@@ -75,7 +72,6 @@ export const writingSystems: IWritingSystems = {
       'font': '???',
       'exemplars': ['A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J', 'K', 'L', 'M', 'N', 'O', 'P', 'Q', 'R', 'S', 'T', 'U', 'V', 'W', 'X', 'Y', 'Z'],
       'type': WritingSystemType.Vernacular,
-      'order': 1,
       isAudio: false,
     }
   ]

--- a/frontend/viewer/src/lib/dotnet-types/generated-types/MiniLcm/Models/IWritingSystem.ts
+++ b/frontend/viewer/src/lib/dotnet-types/generated-types/MiniLcm/Models/IWritingSystem.ts
@@ -17,6 +17,5 @@ export interface IWritingSystem extends IObjectWithId
 	deletedAt?: string;
 	type: WritingSystemType;
 	exemplars: string[];
-	order: number;
 }
 /* eslint-enable */

--- a/frontend/viewer/src/lib/utils.ts
+++ b/frontend/viewer/src/lib/utils.ts
@@ -73,7 +73,6 @@ export function defaultWritingSystem(type: WritingSystemType): IWritingSystem {
     abbreviation: 'en',
     font: 'Arial',
     exemplars: [],
-    order: 0,
     deletedAt: undefined,
     type
   };


### PR DESCRIPTION
closes #1887 
Updated the implementation to support moving writing systems. Key changes include:

- Handled diff for orderable writing systems.
- Added functionality to move writing systems in `LcmCrdt`.
- Integrated move writing system support in `FwData`.
- Created a new API for moving writing systems with accompanying tests.