### PR TITLE
Touch up app-bar

### DIFF
--- a/frontend/viewer/src/home/AppBar.svelte
+++ b/frontend/viewer/src/home/AppBar.svelte
@@ -15,7 +15,7 @@
   });
 </script>
 <header
-  class="flex items-center z-50 space-x-2 justify-between px-4 min-h-14 shadow-lg m-3 rounded-full sticky top-3">
+  class="flex items-center z-50 space-x-2 justify-between pr-2 px-4 min-h-14 shadow-lg m-3 rounded sticky top-3">
   {@render title()}
   <div class="grow-0"></div>
   {@render actions()}

--- a/frontend/viewer/src/home/AppBar.svelte
+++ b/frontend/viewer/src/home/AppBar.svelte
@@ -15,7 +15,7 @@
   });
 </script>
 <header
-  class="flex items-center z-50 space-x-2 justify-between pr-1 md:pr-3 pl-3 min-h-12 shadow-lg m-3 mb-0 rounded sticky top-3">
+  class="flex items-center z-50 space-x-2 justify-between px-4 min-h-14 shadow-lg m-3 rounded-full sticky top-3">
   {@render title()}
   <div class="grow-0"></div>
   {@render actions()}

--- a/frontend/viewer/src/home/HomeView.svelte
+++ b/frontend/viewer/src/home/HomeView.svelte
@@ -131,7 +131,7 @@
 <AppBar tabTitle={$t`Dictionaries`}>
   {#snippet title()}
     <div class="text-lg flex gap-2 items-center">
-      <Icon onclick={clickIcon} src={mode.current === 'dark' ? logoLight : logoDark} alt={$t`Lexbox logo`}/>
+      <Icon onclick={clickIcon} src={mode.current === 'dark' ? logoLight : logoDark} class="size-8" alt={$t`Lexbox logo`}/>
       <h3>{$t`Dictionaries`}</h3>
     </div>
   {/snippet}


### PR DESCRIPTION
The scrunchiness of the mobile app-bar was bugging me.

Before:
<img width="1911" height="269" alt="image" src="https://github.com/user-attachments/assets/943ba54c-6722-4861-9139-f4b39632a286" />

<img width="618" height="210" alt="image" src="https://github.com/user-attachments/assets/3ecfb258-b0b4-4c50-9b1a-fa9ef5b63413" />


After:
<img width="1914" height="344" alt="image" src="https://github.com/user-attachments/assets/555d7f55-b36a-4ab7-b284-c781e1a92c39" />
<img width="625" height="253" alt="image" src="https://github.com/user-attachments/assets/7ef96a66-ea28-4383-8fb6-33cb79509961" />


After - new (without rounding and larger app-icon):
<img width="1436" height="312" alt="image" src="https://github.com/user-attachments/assets/0a2e535f-f7fa-4e43-ae6c-068994942664" />
<img width="529" height="323" alt="image" src="https://github.com/user-attachments/assets/ea92f0b8-2dab-46bc-afb2-5d219c591416" />
<img width="412" height="103" alt="image" src="https://github.com/user-attachments/assets/6ace83d0-34f3-4f6a-9125-7adb1e895537" />
