### PR TITLE
Tidy up tasks' usage of label field

### DIFF
--- a/backend/FwLite/Taskfile.yml
+++ b/backend/FwLite/Taskfile.yml
@@ -10,7 +10,7 @@ tasks:
   web:
     aliases:
       - web-for-develop
-    label: Run FwLiteWeb with Local LexBox, requires vite dev server to be running, use task fw-lite-web in root
+    desc: Run FwLiteWeb with Local LexBox, requires vite dev server to be running, use task fw-lite-web in root
     dir: ./FwLiteWeb
     cmd: dotnet watch --no-hot-reload
   web-prod:
@@ -18,7 +18,7 @@ tasks:
     dir: ./FwLiteWeb
     cmd: dotnet run -- --FwLite:UseDevAssets=false
   web-chaos:
-    label: Run FwLiteWeb with some Chaos injected to http requests to lexbox, requests will have chaos 30% of the time, this includes some latency of 5 seconds
+    desc: Run FwLiteWeb with some Chaos injected to http requests to lexbox, requests will have chaos 30% of the time, this includes some latency of 5 seconds
     dir: ./FwLiteWeb
     env:
       FW_LITE_CHAOS: true
@@ -28,7 +28,6 @@ tasks:
     cmd: dotnet tool restore
   add-migration:
     deps: [ tool-restore ]
-    label: Add Migration
     desc: 'Usage: task add-migration -- "MigrationName"'
     dir: ./LcmCrdt
     cmd: dotnet ef migrations add {{.CLI_ARGS}}
@@ -47,12 +46,11 @@ tasks:
       - dotnet ef migrations remove
 
   maui-windows:
-    label: Run Maui Windows, requires vite dev server to be running, use task fw-lite-win in root
+    desc: Run Maui Windows, requires vite dev server to be running, use task fw-lite-win in root
     dir: ./FwLiteMaui
     cmd: dotnet run -f net9.0-windows10.0.19041.0
 
   publish-maui-windows:
-    label: Publish Maui Windows
     dir: ./FwLiteMaui
     cmds:
       - dotnet publish -f net9.0-windows10.0.19041.0 --artifacts-path ../artifacts -p:WindowsPackageType=None
@@ -60,12 +58,10 @@ tasks:
 
   build-maui-android:
     deps: [ ui:build-viewer ]
-    label: Build Maui Android
     dir: ./FwLiteMaui
     cmd: dotnet build -f net9.0-android -t:InstallAndroidDependencies -p:AcceptAndroidSdkLicenses=True # "-p:AndroidSdkDirectory=D:\tools\android"
 
   build-mini-lcm-sdk:
-    label: Build MiniLcm SDK
     desc: Builds the sdk, a zip with the FwLiteWeb server with a project and config to run locally
     dir: ./FwLiteWeb
     deps: [ ui:build-viewer ]

--- a/frontend/Taskfile.yml
+++ b/frontend/Taskfile.yml
@@ -72,13 +72,13 @@ tasks:
 
   build-viewer:
     deps: [viewer:build]
-    label: vite
+    label: ui:vite viewer build
   watch-viewer:
     deps: [viewer:watch]
-    label: vite
+    label: ui:vite viewer watch
   viewer-dev:
     deps: [viewer:app]
-    label: vite
+    label: ui:vite viewer app
 
   install-https-proxy:
     dir: ./https-proxy


### PR DESCRIPTION
This PR is largely to make my VSCode Task extension work better.

Tasks with a `label: thing` get hoisted to/are shown at the top level of the task hierarchy with their label, which I find confusing especially when three of them were all simply "vite".

By prefixing the labels with "ui:" they land in the correct place.

<img width="507" height="1109" alt="image" src="https://github.com/user-attachments/assets/6b92ddbd-78fd-4810-be0a-d81b9d7ea722" />
