### PR TITLE
Make clearer (and shorter) debug logging

### DIFF
--- a/frontend/viewer/src/lib/services/service-provider-dotnet.ts
+++ b/frontend/viewer/src/lib/services/service-provider-dotnet.ts
@@ -64,7 +64,10 @@ export function wrapInProxy<K extends ServiceKey>(dotnetObject: DotNet.DotNetObj
         console.debug(`[Dotnet Proxy] Calling ${serviceName} method ${dotnetMethodName}`, args);
         args = transformArgs(args);
         const result = await target.invokeMethodAsync(dotnetMethodName, ...args);
-        console.debug(`[Dotnet Proxy] ${serviceName} method ${dotnetMethodName} returned`, result);
+        const resultDebug = Array.isArray(result) && result.length
+          ? `a length-${result.length} array with first item ${result[0]}`
+          : result;
+        console.debug(`[Dotnet Proxy] ${serviceName} method ${dotnetMethodName} returned`, resultDebug);
         return result;
       };
     },


### PR DESCRIPTION
Instead of log entries like
```
[Dotnet Proxy] JsEventListener method LastEvent returned [object Object]

[Dotnet Proxy] CombinedProjectsService method LocalProjects returned [object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object]

[Dotnet Proxy] CombinedProjectsService method RemoteProjects returned [object Object]

[Dotnet Proxy] AuthService method Servers returned [object Object]

[Dotnet Proxy] AuthService method UseSystemWebView returned false

[Dotnet Proxy] CombinedProjectsService method LocalProjects returned [object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object]

[Dotnet Proxy] ProjectServicesProvider method OpenFwDataProject returned [object Object]

[Dotnet Proxy] MiniLcmApi method GetWritingSystems returned [object Object]

[Dotnet Proxy] MiniLcmApi method SupportedFeatures returned [object Object]

[Dotnet Proxy] MiniLcmApi method CountEntries returned 11974

[Dotnet Proxy] MiniLcmApi method GetPartsOfSpeech returned [object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object]

[Dotnet Proxy] ProjectServicesProvider method DisposeService returned [object Object]

[Dotnet Proxy] MiniLcmApi method GetEntries returned [object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[... had to shorten this for the GitHub pr body limits...],[object Object],[object Object]
```
this pr makes log entries like
```
[Dotnet Proxy] JsEventListener method LastEvent returned [object Object]

[Dotnet Proxy] CombinedProjectsService method LocalProjects returned a length-26 array with first item [object Object]

[Dotnet Proxy] CombinedProjectsService method RemoteProjects returned a length-1 array with first item [object Object]

[Dotnet Proxy] AuthService method Servers returned a length-1 array with first item [object Object]

[Dotnet Proxy] AuthService method UseSystemWebView returned false

[Dotnet Proxy] ProjectServicesProvider method OpenFwDataProject returned [object Object]

[Dotnet Proxy] MiniLcmApi method CountEntries returned 11974

[Dotnet Proxy] MiniLcmApi method SupportedFeatures returned [object Object]

[Dotnet Proxy] MiniLcmApi method GetWritingSystems returned [object Object]

[Dotnet Proxy] MiniLcmApi method GetPartsOfSpeech returned a length-62 array with first item [object Object]

[Dotnet Proxy] MiniLcmApi method GetEntries returned a length-10000 array with first item [object Object]
```