### PR TITLE
Add troubleshooting dialog copy version button

### DIFF
--- a/frontend/viewer/src/home/HomeView.svelte
+++ b/frontend/viewer/src/home/HomeView.svelte
@@ -102,7 +102,6 @@
     projectsPromise = promise;
   }
 
-  const supportsTroubleshooting = useTroubleshootingService();
   let troubleshootDialog: TroubleshootDialog | undefined;
 
   let clickCount = 0;
@@ -153,18 +152,14 @@
           <ResponsiveMenu.Item href={fwLiteConfig.feedbackUrl} target="_blank" icon="i-mdi-chat-question">
             {$t`Feedback`}
           </ResponsiveMenu.Item>
-          {#if supportsTroubleshooting}
-            <ResponsiveMenu.Item
-              icon="i-mdi-face-agent"
-              onSelect={() => troubleshootDialog?.open()}>
-              {$t`Troubleshoot`}
-            </ResponsiveMenu.Item>
-          {/if}
+          <ResponsiveMenu.Item
+            icon="i-mdi-face-agent"
+            onSelect={() => troubleshootDialog?.open()}>
+            {$t`Troubleshoot`}
+          </ResponsiveMenu.Item>
         </ResponsiveMenu.Content>
       </ResponsiveMenu.Root>
-      {#if supportsTroubleshooting}
-        <TroubleshootDialog bind:this={troubleshootDialog}/>
-      {/if}
+      <TroubleshootDialog bind:this={troubleshootDialog}/>
     </div>
     {/snippet}
 </AppBar>
@@ -211,11 +206,9 @@
                     {/snippet}
                   </ResponsiveMenu.Trigger>
                   <ResponsiveMenu.Content>
-                    {#if supportsTroubleshooting}
-                      <ResponsiveMenu.Item icon="i-mdi-bug" onSelect={() => troubleshootDialog?.open(project.code)}>
-                        {$t`Troubleshoot`}
-                      </ResponsiveMenu.Item>
-                    {/if}
+                    <ResponsiveMenu.Item icon="i-mdi-bug" onSelect={() => troubleshootDialog?.open(project.code)}>
+                      {$t`Troubleshoot`}
+                    </ResponsiveMenu.Item>
                     {#if $isDev}
                       <ResponsiveMenu.Item icon="i-mdi-delete" onSelect={() => void deleteProject(project)}>
                         {$t`Delete`}

--- a/frontend/viewer/src/lib/components/ui/button/copy-button.svelte
+++ b/frontend/viewer/src/lib/components/ui/button/copy-button.svelte
@@ -1,0 +1,39 @@
+<script lang="ts">
+  import {Button, type ButtonProps} from '$lib/components/ui/button';
+  import { AppNotification } from '$lib/notifications/notifications';
+  import { t } from 'svelte-i18n-lingui';
+  import type {Snippet} from 'svelte';
+
+  type Props = {
+    text?: string;
+    notify?: boolean;
+    children?: Snippet;
+    // plus any other Button props via rest
+  };
+
+  // Svelte 5 props and children
+  const { text, notify = true, children = undefined, ...rest }: Props & ButtonProps = $props();
+
+  async function handleClick(_event: MouseEvent) {
+    try {
+      if (!text) {
+        if (notify) AppNotification.display($t`Nothing to copy`, 'warning');
+        return;
+      }
+      await navigator.clipboard.writeText(text);
+      if (notify) AppNotification.display($t`Copied to clipboard`, 'success');
+    } catch (error) {
+      if (notify) AppNotification.display($t`Failed to copy to clipboard`, 'error');
+      // In Svelte 5 we avoid createEventDispatcher; consumers can rely on notifications
+      // or we could later emit a CustomEvent from a DOM element if needed.
+    }
+  }
+</script>
+
+<!--
+  A wrapper around our shared Button that copies `text` to the clipboard when clicked.
+  All other props are passed through to the underlying Button via Svelte 5 $props rest.
+-->
+<Button onclick={handleClick} icon="i-mdi-content-copy" {...rest}>
+  {@render children?.()}
+</Button>

--- a/frontend/viewer/src/lib/components/ui/button/index.ts
+++ b/frontend/viewer/src/lib/components/ui/button/index.ts
@@ -6,10 +6,12 @@ import Root, {
 } from './button.svelte';
 
 import XButton from './x-button.svelte';
+import CopyButton from './copy-button.svelte';
 
 export {
   Root,
   XButton,
+  CopyButton,
   type ButtonProps,
   type ButtonSize,
   type ButtonVariant,

--- a/frontend/viewer/src/lib/troubleshoot/TroubleshootDialog.svelte
+++ b/frontend/viewer/src/lib/troubleshoot/TroubleshootDialog.svelte
@@ -7,6 +7,7 @@
   import {QueryParamStateBool} from '$lib/utils/url.svelte';
   import InputShell from '$lib/components/ui/input/input-shell.svelte';
   import Label from '$lib/components/ui/label/label.svelte';
+  import {CopyButton} from '$lib/components/ui/button';
 
   const openQueryParam = new QueryParamStateBool({
     key: 'troubleshootDialogOpen',
@@ -42,7 +43,13 @@
       <DialogTitle>{$t`Troubleshoot`}</DialogTitle>
     </DialogHeader>
     <div class="flex flex-col gap-4 items-start">
-      <p>{$t`Application version`}: <span class="font-mono text-muted-foreground border-b">{config.appVersion}</span>
+      <p class="flex items-center gap-2">{$t`Application version`}: <span class="font-mono text-muted-foreground border-b">{config.appVersion}</span>
+        <CopyButton
+          variant="ghost"
+          size="xs-icon"
+          title={$t`Copy version`}
+          text={`${config.appVersion} on ${config.os}`}
+        />
       </p>
       <div class="w-full">
         <Label>{$t`Data Directory`}</Label>

--- a/frontend/viewer/src/lib/troubleshoot/TroubleshootDialog.svelte
+++ b/frontend/viewer/src/lib/troubleshoot/TroubleshootDialog.svelte
@@ -51,16 +51,18 @@
           text={`${config.appVersion} on ${config.os}`}
         />
       </p>
-      <div class="w-full">
-        <Label>{$t`Data Directory`}</Label>
-        <InputShell class="ps-2 pe-1">
-          {#await service?.getDataDirectory() then value}
-            {value}
-          {/await}
-          <Button variant="ghost" icon="i-mdi-folder-search" size="xs-icon" title={$t`Open Data Directory`}
-                  onclick={() => tryOpenDataDirectory()}/>
-        </InputShell>
-      </div>
+      {#if service}
+        <div class="w-full">
+          <Label>{$t`Data Directory`}</Label>
+          <InputShell class="ps-2 pe-1">
+            {#await service?.getDataDirectory() then value}
+              {value}
+            {/await}
+            <Button variant="ghost" icon="i-mdi-folder-search" size="xs-icon" title={$t`Open Data Directory`}
+                    onclick={() => tryOpenDataDirectory()}/>
+          </InputShell>
+        </div>
+      {/if}
       {#if projectCode}
         <div class="flex gap-2">
           <Button variant="outline" onclick={() => shareProject()}>
@@ -69,16 +71,18 @@
           </Button>
         </div>
       {/if}
-      <div class="flex gap-2">
-        <Button variant="outline" onclick={() => service?.openLogFile()}>
-          <i class="i-mdi-file-eye"></i>
-          {$t`Open Log file`}
-        </Button>
-        <Button variant="outline" onclick={() => service?.shareLogFile()}>
-          <i class="i-mdi-file-export"></i>
-          {$t`Share Log file`}
-        </Button>
-      </div>
+      {#if service}
+        <div class="flex gap-2">
+          <Button variant="outline" onclick={() => service?.openLogFile()}>
+            <i class="i-mdi-file-eye"></i>
+            {$t`Open Log file`}
+          </Button>
+          <Button variant="outline" onclick={() => service?.shareLogFile()}>
+            <i class="i-mdi-file-export"></i>
+            {$t`Share Log file`}
+          </Button>
+        </div>
+      {/if}
     </div>
   </DialogContent>
 </Dialog>

--- a/frontend/viewer/src/locales/en.po
+++ b/frontend/viewer/src/locales/en.po
@@ -68,11 +68,11 @@ msgstr "a word"
 msgid "About"
 msgstr "About"
 
-#: src/project/ProjectSidebar.svelte:140
+#: src/project/ProjectSidebar.svelte:139
 msgid "Account"
 msgstr "Account"
 
-#: src/project/ProjectSidebar.svelte:96
+#: src/project/ProjectSidebar.svelte:95
 msgid "Activity"
 msgstr "Activity"
 
@@ -121,7 +121,7 @@ msgstr "an entry"
 msgid "Any Ws"
 msgstr "Any Ws"
 
-#: src/lib/troubleshoot/TroubleshootDialog.svelte:45
+#: src/lib/troubleshoot/TroubleshootDialog.svelte:46
 msgid "Application version"
 msgstr "Application version"
 
@@ -163,11 +163,11 @@ msgstr "before"
 msgid "Best match"
 msgstr "Best match"
 
-#: src/project/ProjectSidebar.svelte:91
+#: src/project/ProjectSidebar.svelte:90
 msgid "Browse"
 msgstr "Browse"
 
-#: src/lib/entry-editor/NewEntryDialog.svelte:110
+#: src/lib/entry-editor/NewEntryDialog.svelte:113
 #: src/lib/entry-editor/EntryOrSensePicker.svelte:245
 #: src/lib/components/field-editors/select.svelte:164
 #: src/lib/components/field-editors/multi-select.svelte:277
@@ -184,7 +184,7 @@ msgstr "Citation form"
 msgid "Citation Form"
 msgstr "Citation Form"
 
-#: src/home/HomeView.svelte:260
+#: src/home/HomeView.svelte:253
 msgid "Classic FieldWorks Projects"
 msgstr "Classic FieldWorks Projects"
 
@@ -199,7 +199,7 @@ msgstr "clear"
 msgid "Close"
 msgstr "Close"
 
-#: src/project/ProjectSidebar.svelte:159
+#: src/project/ProjectSidebar.svelte:158
 msgid "Close Dictionary"
 msgstr "Close Dictionary"
 
@@ -236,7 +236,15 @@ msgstr "Components"
 msgid "Contains"
 msgstr "Contains"
 
-#: src/lib/entry-editor/NewEntryDialog.svelte:112
+#: src/lib/components/ui/button/copy-button.svelte:24
+msgid "Copied to clipboard"
+msgstr "Copied to clipboard"
+
+#: src/lib/troubleshoot/TroubleshootDialog.svelte:50
+msgid "Copy version"
+msgstr "Copy version"
+
+#: src/lib/entry-editor/NewEntryDialog.svelte:115
 msgid "Create {0}"
 msgstr "Create {0}"
 
@@ -244,7 +252,7 @@ msgstr "Create {0}"
 msgid "Create entry"
 msgstr "Create entry"
 
-#: src/home/HomeView.svelte:239
+#: src/home/HomeView.svelte:232
 msgid "Create Example Project"
 msgstr "Create Example Project"
 
@@ -262,11 +270,11 @@ msgstr "Current Entry"
 msgid "Current Word"
 msgstr "Current Word"
 
-#: src/project/ProjectSidebar.svelte:89
+#: src/project/ProjectSidebar.svelte:88
 msgid "Dashboard"
 msgstr "Dashboard"
 
-#: src/lib/troubleshoot/TroubleshootDialog.svelte:48
+#: src/lib/troubleshoot/TroubleshootDialog.svelte:56
 msgid "Data Directory"
 msgstr "Data Directory"
 
@@ -274,7 +282,7 @@ msgstr "Data Directory"
 msgid "Definition"
 msgstr "Definition"
 
-#: src/home/HomeView.svelte:221
+#: src/home/HomeView.svelte:214
 msgid "Delete"
 msgstr "Delete"
 
@@ -291,12 +299,12 @@ msgstr "Delete Entry"
 msgid "Delete Word"
 msgstr "Delete Word"
 
-#: src/home/HomeView.svelte:131
-#: src/home/HomeView.svelte:135
+#: src/home/HomeView.svelte:130
+#: src/home/HomeView.svelte:134
 msgid "Dictionaries"
 msgstr "Dictionaries"
 
-#: src/project/ProjectSidebar.svelte:85
+#: src/project/ProjectSidebar.svelte:84
 msgid "Dictionary"
 msgstr "Dictionary"
 
@@ -359,7 +367,7 @@ msgid "Ends with"
 msgstr "Ends with"
 
 #: src/project/browse/EntryMenu.svelte:37
-#: src/lib/entry-editor/NewEntryDialog.svelte:84
+#: src/lib/entry-editor/NewEntryDialog.svelte:87
 #: src/lib/entry-editor/EntryOrSensePicker.svelte:250
 msgid "Entry"
 msgstr "Entry"
@@ -376,7 +384,7 @@ msgstr "Entry or sense:"
 msgid "Equals"
 msgstr "Equals"
 
-#: src/project/ProjectSidebar.svelte:121
+#: src/project/ProjectSidebar.svelte:120
 msgid "Error getting sync status"
 msgstr "Error getting sync status"
 
@@ -396,6 +404,10 @@ msgstr "Example"
 msgid "Example sentence"
 msgstr "Example sentence"
 
+#: src/lib/components/ui/button/copy-button.svelte:26
+msgid "Failed to copy to clipboard"
+msgstr "Failed to copy to clipboard"
+
 #: src/home/Server.svelte:53
 msgid "Failed to download {0}"
 msgstr "Failed to download {0}"
@@ -405,7 +417,7 @@ msgstr "Failed to download {0}"
 msgid "Failed to load entries"
 msgstr "Failed to load entries"
 
-#: src/lib/troubleshoot/TroubleshootDialog.svelte:28
+#: src/lib/troubleshoot/TroubleshootDialog.svelte:29
 msgid "Failed to open data directory, use the path in the text field instead"
 msgstr "Failed to open data directory, use the path in the text field instead"
 
@@ -421,8 +433,8 @@ msgstr "Failed to synchronize"
 msgid "Failed to synchronize."
 msgstr "Failed to synchronize."
 
-#: src/project/ProjectSidebar.svelte:181
-#: src/home/HomeView.svelte:154
+#: src/project/ProjectSidebar.svelte:178
+#: src/home/HomeView.svelte:153
 msgid "Feedback"
 msgstr "Feedback"
 
@@ -436,7 +448,7 @@ msgstr "Field Labels"
 
 #: src/project/ProjectDropdown.svelte:69
 #: src/lib/OpenInFieldWorksButton.svelte:55
-#: src/home/HomeView.svelte:266
+#: src/home/HomeView.svelte:259
 msgid "FieldWorks logo"
 msgstr "FieldWorks logo"
 
@@ -528,7 +540,7 @@ msgstr "Hold to record or\\npress and release to start recording."
 msgid "I don't see my project"
 msgstr "I don't see my project"
 
-#: src/home/HomeView.svelte:274
+#: src/home/HomeView.svelte:267
 msgid "Import"
 msgstr "Import"
 
@@ -541,7 +553,7 @@ msgstr "Last change: {0}"
 msgid "Length:"
 msgstr "Length:"
 
-#: src/home/HomeView.svelte:134
+#: src/home/HomeView.svelte:133
 msgid "Lexbox logo"
 msgstr "Lexbox logo"
 
@@ -565,15 +577,15 @@ msgstr "Literal meaning"
 msgid "Loading Dictionaries..."
 msgstr "Loading Dictionaries..."
 
-#: src/home/HomeView.svelte:175
+#: src/home/HomeView.svelte:170
 msgid "loading..."
 msgstr "loading..."
 
-#: src/home/HomeView.svelte:180
+#: src/home/HomeView.svelte:175
 msgid "Local"
 msgstr "Local"
 
-#: src/home/HomeView.svelte:202
+#: src/home/HomeView.svelte:197
 msgid "Local only"
 msgstr "Local only"
 
@@ -590,7 +602,7 @@ msgstr "Login to see projects"
 msgid "Logout"
 msgstr "Logout"
 
-#: src/project/ProjectSidebar.svelte:195
+#: src/project/ProjectSidebar.svelte:192
 msgid "Made with ❤️ from 🇦🇹 🇹🇭 🇺🇸"
 msgstr "Made with ❤️ from 🇦🇹 🇹🇭 🇺🇸"
 
@@ -633,7 +645,7 @@ msgstr "Never"
 msgid "New"
 msgstr "New"
 
-#: src/lib/entry-editor/NewEntryDialog.svelte:97
+#: src/lib/entry-editor/NewEntryDialog.svelte:100
 msgid "New {0}"
 msgstr "New {0}"
 
@@ -676,7 +688,7 @@ msgid "No items found"
 msgstr "No items found"
 
 #: src/project/SyncDialog.svelte:193
-#: src/project/ProjectSidebar.svelte:115
+#: src/project/ProjectSidebar.svelte:114
 msgid "No server configured"
 msgstr "No server configured"
 
@@ -694,7 +706,7 @@ msgid "Not equal"
 msgstr "Not equal"
 
 #: src/project/SyncDialog.svelte:257
-#: src/project/ProjectSidebar.svelte:113
+#: src/project/ProjectSidebar.svelte:112
 msgid "Not logged in"
 msgstr "Not logged in"
 
@@ -702,12 +714,16 @@ msgstr "Not logged in"
 msgid "Note"
 msgstr "Note"
 
+#: src/lib/components/ui/button/copy-button.svelte:20
+msgid "Nothing to copy"
+msgstr "Nothing to copy"
+
 #: src/lib/admin-dialogs/GetProjectByCodeDialog.svelte:42
 msgid "Observer"
 msgstr "Observer"
 
 #: src/project/SyncDialog.svelte:187
-#: src/project/ProjectSidebar.svelte:111
+#: src/project/ProjectSidebar.svelte:110
 msgid "Offline"
 msgstr "Offline"
 
@@ -715,7 +731,7 @@ msgstr "Offline"
 msgid "Offline, unable to download"
 msgstr "Offline, unable to download"
 
-#: src/lib/troubleshoot/TroubleshootDialog.svelte:53
+#: src/lib/troubleshoot/TroubleshootDialog.svelte:61
 msgid "Open Data Directory"
 msgstr "Open Data Directory"
 
@@ -727,7 +743,7 @@ msgstr "Open in FieldWorks"
 msgid "Open in new Window"
 msgstr "Open in new Window"
 
-#: src/lib/troubleshoot/TroubleshootDialog.svelte:68
+#: src/lib/troubleshoot/TroubleshootDialog.svelte:78
 msgid "Open Log file"
 msgstr "Open Log file"
 
@@ -764,7 +780,7 @@ msgstr "Project {0} not found on {1}"
 msgid "Project {0} on {1} is not yet set up for FieldWorks Lite"
 msgstr "Project {0} on {1} is not yet set up for FieldWorks Lite"
 
-#: src/home/HomeView.svelte:245
+#: src/home/HomeView.svelte:238
 msgid "Project name..."
 msgstr "Project name..."
 
@@ -778,7 +794,7 @@ msgid "Refine your filter to see more..."
 msgstr "Refine your filter to see more..."
 
 #: src/home/Server.svelte:119
-#: src/home/HomeView.svelte:184
+#: src/home/HomeView.svelte:179
 msgid "Refresh Projects"
 msgstr "Refresh Projects"
 
@@ -838,7 +854,7 @@ msgstr "Sense"
 msgid "Sentence"
 msgstr "Sentence"
 
-#: src/project/ProjectSidebar.svelte:146
+#: src/project/ProjectSidebar.svelte:145
 msgid "Settings"
 msgstr "Settings"
 
@@ -846,11 +862,11 @@ msgstr "Settings"
 msgid "Shadcn Sandbox # #"
 msgstr "Shadcn Sandbox # #"
 
-#: src/lib/troubleshoot/TroubleshootDialog.svelte:72
+#: src/lib/troubleshoot/TroubleshootDialog.svelte:82
 msgid "Share Log file"
 msgstr "Share Log file"
 
-#: src/lib/troubleshoot/TroubleshootDialog.svelte:61
+#: src/lib/troubleshoot/TroubleshootDialog.svelte:70
 msgid "Share project data file"
 msgstr "Share project data file"
 
@@ -880,18 +896,18 @@ msgstr "Starts with"
 msgid "Submit"
 msgstr "Submit"
 
-#: src/project/ProjectSidebar.svelte:119
+#: src/project/ProjectSidebar.svelte:118
 #: src/lib/activity/ActivityView.svelte:108
 msgid "Synced"
 msgstr "Synced"
 
-#: src/home/HomeView.svelte:202
+#: src/home/HomeView.svelte:197
 msgid "Synced with {0}"
 msgstr "Synced with {0}"
 
 #: src/project/SyncDialog.svelte:149
 #: src/project/SyncDialog.svelte:234
-#: src/project/ProjectSidebar.svelte:126
+#: src/project/ProjectSidebar.svelte:125
 msgid "Synchronize"
 msgstr "Synchronize"
 
@@ -904,7 +920,7 @@ msgstr "Synchronizing FieldWorks Lite with FieldWorks..."
 msgid "Synchronizing..."
 msgstr "Synchronizing..."
 
-#: src/project/ProjectSidebar.svelte:93
+#: src/project/ProjectSidebar.svelte:92
 msgid "Tasks"
 msgstr "Tasks"
 
@@ -932,10 +948,10 @@ msgstr "Toggle theme"
 msgid "Translation"
 msgstr "Translation"
 
-#: src/project/ProjectSidebar.svelte:172
-#: src/lib/troubleshoot/TroubleshootDialog.svelte:42
-#: src/home/HomeView.svelte:160
-#: src/home/HomeView.svelte:216
+#: src/project/ProjectSidebar.svelte:170
+#: src/lib/troubleshoot/TroubleshootDialog.svelte:43
+#: src/home/HomeView.svelte:158
+#: src/home/HomeView.svelte:210
 msgid "Troubleshoot"
 msgstr "Troubleshoot"
 
@@ -954,7 +970,7 @@ msgstr "Unable to open in FieldWorks"
 msgid "Unknown"
 msgstr "Unknown"
 
-#: src/project/ProjectSidebar.svelte:117
+#: src/project/ProjectSidebar.svelte:116
 #: src/lib/components/audio/AudioDialog.svelte:93
 msgid "Unknown error"
 msgstr "Unknown error"
@@ -981,7 +997,7 @@ msgstr "Untitled"
 msgid "Uses components as"
 msgstr "Uses components as"
 
-#: src/project/ProjectSidebar.svelte:194
+#: src/project/ProjectSidebar.svelte:191
 msgid "Version {0}"
 msgstr "Version {0}"
 
@@ -995,7 +1011,7 @@ msgstr "Where are my projects?"
 
 #: src/project/browse/SearchFilter.svelte:40
 #: src/project/browse/EntryMenu.svelte:37
-#: src/lib/entry-editor/NewEntryDialog.svelte:84
+#: src/lib/entry-editor/NewEntryDialog.svelte:87
 #: src/lib/entry-editor/EntryOrSensePicker.svelte:250
 #: src/lib/entry-editor/object-editors/EntryEditorPrimitive.svelte:43
 msgid "Word"

--- a/frontend/viewer/src/locales/es.po
+++ b/frontend/viewer/src/locales/es.po
@@ -73,11 +73,11 @@ msgstr "una palabra"
 msgid "About"
 msgstr "Acerca de"
 
-#: src/project/ProjectSidebar.svelte:140
+#: src/project/ProjectSidebar.svelte:139
 msgid "Account"
 msgstr "Cuenta"
 
-#: src/project/ProjectSidebar.svelte:96
+#: src/project/ProjectSidebar.svelte:95
 msgid "Activity"
 msgstr "Actividad"
 
@@ -126,7 +126,7 @@ msgstr "una entrada"
 msgid "Any Ws"
 msgstr "Cualquier W"
 
-#: src/lib/troubleshoot/TroubleshootDialog.svelte:45
+#: src/lib/troubleshoot/TroubleshootDialog.svelte:46
 msgid "Application version"
 msgstr "Versión de la aplicación"
 
@@ -168,11 +168,11 @@ msgstr "antes de"
 msgid "Best match"
 msgstr "Mejor partido"
 
-#: src/project/ProjectSidebar.svelte:91
+#: src/project/ProjectSidebar.svelte:90
 msgid "Browse"
 msgstr "Visite"
 
-#: src/lib/entry-editor/NewEntryDialog.svelte:110
+#: src/lib/entry-editor/NewEntryDialog.svelte:113
 #: src/lib/entry-editor/EntryOrSensePicker.svelte:245
 #: src/lib/components/field-editors/select.svelte:164
 #: src/lib/components/field-editors/multi-select.svelte:277
@@ -189,7 +189,7 @@ msgstr "Formulario de cita"
 msgid "Citation Form"
 msgstr "Formulario de citación"
 
-#: src/home/HomeView.svelte:260
+#: src/home/HomeView.svelte:253
 msgid "Classic FieldWorks Projects"
 msgstr "Proyectos clásicos de FieldWorks"
 
@@ -204,7 +204,7 @@ msgstr "borrar"
 msgid "Close"
 msgstr "Cerrar"
 
-#: src/project/ProjectSidebar.svelte:159
+#: src/project/ProjectSidebar.svelte:158
 msgid "Close Dictionary"
 msgstr "Cerrar Diccionario"
 
@@ -241,7 +241,15 @@ msgstr "Componentes"
 msgid "Contains"
 msgstr "Contiene"
 
-#: src/lib/entry-editor/NewEntryDialog.svelte:112
+#: src/lib/components/ui/button/copy-button.svelte:24
+msgid "Copied to clipboard"
+msgstr ""
+
+#: src/lib/troubleshoot/TroubleshootDialog.svelte:50
+msgid "Copy version"
+msgstr ""
+
+#: src/lib/entry-editor/NewEntryDialog.svelte:115
 msgid "Create {0}"
 msgstr "Cree {0}"
 
@@ -249,7 +257,7 @@ msgstr "Cree {0}"
 msgid "Create entry"
 msgstr "Crear entrada"
 
-#: src/home/HomeView.svelte:239
+#: src/home/HomeView.svelte:232
 msgid "Create Example Project"
 msgstr "Crear un proyecto de ejemplo"
 
@@ -267,11 +275,11 @@ msgstr "Entrada actual"
 msgid "Current Word"
 msgstr "Palabra actual"
 
-#: src/project/ProjectSidebar.svelte:89
+#: src/project/ProjectSidebar.svelte:88
 msgid "Dashboard"
 msgstr "Cuadro de mandos"
 
-#: src/lib/troubleshoot/TroubleshootDialog.svelte:48
+#: src/lib/troubleshoot/TroubleshootDialog.svelte:56
 msgid "Data Directory"
 msgstr "Directorio de datos"
 
@@ -279,7 +287,7 @@ msgstr "Directorio de datos"
 msgid "Definition"
 msgstr "Definición"
 
-#: src/home/HomeView.svelte:221
+#: src/home/HomeView.svelte:214
 msgid "Delete"
 msgstr "Borrar"
 
@@ -296,12 +304,12 @@ msgstr "Borrar entrada"
 msgid "Delete Word"
 msgstr "Borrar palabra"
 
-#: src/home/HomeView.svelte:131
-#: src/home/HomeView.svelte:135
+#: src/home/HomeView.svelte:130
+#: src/home/HomeView.svelte:134
 msgid "Dictionaries"
 msgstr "Diccionarios"
 
-#: src/project/ProjectSidebar.svelte:85
+#: src/project/ProjectSidebar.svelte:84
 msgid "Dictionary"
 msgstr "Diccionario"
 
@@ -364,7 +372,7 @@ msgid "Ends with"
 msgstr "Termina con"
 
 #: src/project/browse/EntryMenu.svelte:37
-#: src/lib/entry-editor/NewEntryDialog.svelte:84
+#: src/lib/entry-editor/NewEntryDialog.svelte:87
 #: src/lib/entry-editor/EntryOrSensePicker.svelte:250
 msgid "Entry"
 msgstr "Entrada"
@@ -381,7 +389,7 @@ msgstr "Entrada o sentido:"
 msgid "Equals"
 msgstr "Es igual a"
 
-#: src/project/ProjectSidebar.svelte:121
+#: src/project/ProjectSidebar.svelte:120
 msgid "Error getting sync status"
 msgstr "Error al obtener el estado de sincronización"
 
@@ -401,6 +409,10 @@ msgstr "Ejemplo"
 msgid "Example sentence"
 msgstr "Ejemplo de frase"
 
+#: src/lib/components/ui/button/copy-button.svelte:26
+msgid "Failed to copy to clipboard"
+msgstr ""
+
 #: src/home/Server.svelte:53
 msgid "Failed to download {0}"
 msgstr "Error al descargar {0}"
@@ -410,7 +422,7 @@ msgstr "Error al descargar {0}"
 msgid "Failed to load entries"
 msgstr "Error al cargar entradas"
 
-#: src/lib/troubleshoot/TroubleshootDialog.svelte:28
+#: src/lib/troubleshoot/TroubleshootDialog.svelte:29
 msgid "Failed to open data directory, use the path in the text field instead"
 msgstr "Error al abrir el directorio de datos, utilice la ruta en el campo de texto en su lugar"
 
@@ -426,8 +438,8 @@ msgstr "Error de sincronización"
 msgid "Failed to synchronize."
 msgstr "Error de sincronización."
 
-#: src/project/ProjectSidebar.svelte:181
-#: src/home/HomeView.svelte:154
+#: src/project/ProjectSidebar.svelte:178
+#: src/home/HomeView.svelte:153
 msgid "Feedback"
 msgstr "Comentarios"
 
@@ -441,7 +453,7 @@ msgstr "Etiquetas de campo"
 
 #: src/project/ProjectDropdown.svelte:69
 #: src/lib/OpenInFieldWorksButton.svelte:55
-#: src/home/HomeView.svelte:266
+#: src/home/HomeView.svelte:259
 msgid "FieldWorks logo"
 msgstr "Logotipo de FieldWorks"
 
@@ -533,7 +545,7 @@ msgstr "Mantenga pulsado para grabar o\\npulse y suelte para iniciar la grabaci�
 msgid "I don't see my project"
 msgstr "No veo mi proyecto"
 
-#: src/home/HomeView.svelte:274
+#: src/home/HomeView.svelte:267
 msgid "Import"
 msgstr "Importar"
 
@@ -546,7 +558,7 @@ msgstr "Última modificación: {0}"
 msgid "Length:"
 msgstr "Longitud:"
 
-#: src/home/HomeView.svelte:134
+#: src/home/HomeView.svelte:133
 msgid "Lexbox logo"
 msgstr "Logotipo de Lexbox"
 
@@ -570,15 +582,15 @@ msgstr "Significado literal"
 msgid "Loading Dictionaries..."
 msgstr "Cargando diccionarios..."
 
-#: src/home/HomeView.svelte:175
+#: src/home/HomeView.svelte:170
 msgid "loading..."
 msgstr "cargando..."
 
-#: src/home/HomeView.svelte:180
+#: src/home/HomeView.svelte:175
 msgid "Local"
 msgstr "Local"
 
-#: src/home/HomeView.svelte:202
+#: src/home/HomeView.svelte:197
 msgid "Local only"
 msgstr "Sólo local"
 
@@ -595,7 +607,7 @@ msgstr "Inicie sesión para ver los proyectos"
 msgid "Logout"
 msgstr "Cierre de sesión"
 
-#: src/project/ProjectSidebar.svelte:195
+#: src/project/ProjectSidebar.svelte:192
 msgid "Made with ❤️ from 🇦🇹 🇹🇭 🇺🇸"
 msgstr "Hecho con ❤️ de 🇦🇹 🇹🇭 🇺🇸"
 
@@ -638,7 +650,7 @@ msgstr "Nunca"
 msgid "New"
 msgstr "Nuevo"
 
-#: src/lib/entry-editor/NewEntryDialog.svelte:97
+#: src/lib/entry-editor/NewEntryDialog.svelte:100
 msgid "New {0}"
 msgstr "Nuevo {0}"
 
@@ -681,7 +693,7 @@ msgid "No items found"
 msgstr "No se han encontrado artículos"
 
 #: src/project/SyncDialog.svelte:193
-#: src/project/ProjectSidebar.svelte:115
+#: src/project/ProjectSidebar.svelte:114
 msgid "No server configured"
 msgstr "Ningún servidor configurado"
 
@@ -699,7 +711,7 @@ msgid "Not equal"
 msgstr "No es igual"
 
 #: src/project/SyncDialog.svelte:257
-#: src/project/ProjectSidebar.svelte:113
+#: src/project/ProjectSidebar.svelte:112
 msgid "Not logged in"
 msgstr "No conectado"
 
@@ -707,12 +719,16 @@ msgstr "No conectado"
 msgid "Note"
 msgstr "Nota"
 
+#: src/lib/components/ui/button/copy-button.svelte:20
+msgid "Nothing to copy"
+msgstr ""
+
 #: src/lib/admin-dialogs/GetProjectByCodeDialog.svelte:42
 msgid "Observer"
 msgstr "Observador"
 
 #: src/project/SyncDialog.svelte:187
-#: src/project/ProjectSidebar.svelte:111
+#: src/project/ProjectSidebar.svelte:110
 msgid "Offline"
 msgstr "Fuera de línea"
 
@@ -720,7 +736,7 @@ msgstr "Fuera de línea"
 msgid "Offline, unable to download"
 msgstr "Desconectado, no se puede descargar"
 
-#: src/lib/troubleshoot/TroubleshootDialog.svelte:53
+#: src/lib/troubleshoot/TroubleshootDialog.svelte:61
 msgid "Open Data Directory"
 msgstr "Directorio de datos abiertos"
 
@@ -732,7 +748,7 @@ msgstr "Abrir en FieldWorks"
 msgid "Open in new Window"
 msgstr "Abrir en una ventana nueva"
 
-#: src/lib/troubleshoot/TroubleshootDialog.svelte:68
+#: src/lib/troubleshoot/TroubleshootDialog.svelte:78
 msgid "Open Log file"
 msgstr "Abrir archivo Log"
 
@@ -769,7 +785,7 @@ msgstr "Proyecto {0} no encontrado en {1}"
 msgid "Project {0} on {1} is not yet set up for FieldWorks Lite"
 msgstr "El proyecto {0} en {1} aún no está configurado para FieldWorks Lite"
 
-#: src/home/HomeView.svelte:245
+#: src/home/HomeView.svelte:238
 msgid "Project name..."
 msgstr "Nombre del proyecto..."
 
@@ -783,7 +799,7 @@ msgid "Refine your filter to see more..."
 msgstr "Afine su filtro para ver más..."
 
 #: src/home/Server.svelte:119
-#: src/home/HomeView.svelte:184
+#: src/home/HomeView.svelte:179
 msgid "Refresh Projects"
 msgstr "Actualizar proyectos"
 
@@ -843,7 +859,7 @@ msgstr "Sentido"
 msgid "Sentence"
 msgstr "Sentencia"
 
-#: src/project/ProjectSidebar.svelte:146
+#: src/project/ProjectSidebar.svelte:145
 msgid "Settings"
 msgstr "Ajustes"
 
@@ -851,11 +867,11 @@ msgstr "Ajustes"
 msgid "Shadcn Sandbox # #"
 msgstr "Shadcn Sandbox"
 
-#: src/lib/troubleshoot/TroubleshootDialog.svelte:72
+#: src/lib/troubleshoot/TroubleshootDialog.svelte:82
 msgid "Share Log file"
 msgstr "Compartir archivo de registro"
 
-#: src/lib/troubleshoot/TroubleshootDialog.svelte:61
+#: src/lib/troubleshoot/TroubleshootDialog.svelte:70
 msgid "Share project data file"
 msgstr "Compartir archivo de datos del proyecto"
 
@@ -885,18 +901,18 @@ msgstr "Empieza por"
 msgid "Submit"
 msgstr "Enviar"
 
-#: src/project/ProjectSidebar.svelte:119
+#: src/project/ProjectSidebar.svelte:118
 #: src/lib/activity/ActivityView.svelte:108
 msgid "Synced"
 msgstr "Sincronizado"
 
-#: src/home/HomeView.svelte:202
+#: src/home/HomeView.svelte:197
 msgid "Synced with {0}"
 msgstr "Sincronizado con {0}"
 
 #: src/project/SyncDialog.svelte:149
 #: src/project/SyncDialog.svelte:234
-#: src/project/ProjectSidebar.svelte:126
+#: src/project/ProjectSidebar.svelte:125
 msgid "Synchronize"
 msgstr "Sincronice"
 
@@ -909,7 +925,7 @@ msgstr "Sincronización de FieldWorks Lite con FieldWorks..."
 msgid "Synchronizing..."
 msgstr "Sincronizar..."
 
-#: src/project/ProjectSidebar.svelte:93
+#: src/project/ProjectSidebar.svelte:92
 msgid "Tasks"
 msgstr "Tareas"
 
@@ -937,10 +953,10 @@ msgstr "Alternar tema"
 msgid "Translation"
 msgstr "Traducción"
 
-#: src/project/ProjectSidebar.svelte:172
-#: src/lib/troubleshoot/TroubleshootDialog.svelte:42
-#: src/home/HomeView.svelte:160
-#: src/home/HomeView.svelte:216
+#: src/project/ProjectSidebar.svelte:170
+#: src/lib/troubleshoot/TroubleshootDialog.svelte:43
+#: src/home/HomeView.svelte:158
+#: src/home/HomeView.svelte:210
 msgid "Troubleshoot"
 msgstr "Solución de problemas"
 
@@ -959,7 +975,7 @@ msgstr "No se puede abrir en FieldWorks"
 msgid "Unknown"
 msgstr "Desconocido"
 
-#: src/project/ProjectSidebar.svelte:117
+#: src/project/ProjectSidebar.svelte:116
 #: src/lib/components/audio/AudioDialog.svelte:93
 msgid "Unknown error"
 msgstr "Error desconocido"
@@ -986,7 +1002,7 @@ msgstr "Sin título"
 msgid "Uses components as"
 msgstr "Utiliza componentes como"
 
-#: src/project/ProjectSidebar.svelte:194
+#: src/project/ProjectSidebar.svelte:191
 msgid "Version {0}"
 msgstr "Versión {0}"
 
@@ -1000,7 +1016,7 @@ msgstr "¿Dónde están mis proyectos?"
 
 #: src/project/browse/SearchFilter.svelte:40
 #: src/project/browse/EntryMenu.svelte:37
-#: src/lib/entry-editor/NewEntryDialog.svelte:84
+#: src/lib/entry-editor/NewEntryDialog.svelte:87
 #: src/lib/entry-editor/EntryOrSensePicker.svelte:250
 #: src/lib/entry-editor/object-editors/EntryEditorPrimitive.svelte:43
 msgid "Word"
@@ -1034,4 +1050,3 @@ msgstr "No tiene permiso para descargar el proyecto {0} desde {1}"
 #: src/home/Server.svelte:85
 msgid "You have already downloaded the {0} project"
 msgstr "Ya has descargado el proyecto {0}"
-

--- a/frontend/viewer/src/locales/fr.po
+++ b/frontend/viewer/src/locales/fr.po
@@ -73,11 +73,11 @@ msgstr "un mot"
 msgid "About"
 msgstr "A propos de"
 
-#: src/project/ProjectSidebar.svelte:140
+#: src/project/ProjectSidebar.svelte:139
 msgid "Account"
 msgstr "Compte"
 
-#: src/project/ProjectSidebar.svelte:96
+#: src/project/ProjectSidebar.svelte:95
 msgid "Activity"
 msgstr "Activité"
 
@@ -126,7 +126,7 @@ msgstr "une entrée"
 msgid "Any Ws"
 msgstr "Tous les W"
 
-#: src/lib/troubleshoot/TroubleshootDialog.svelte:45
+#: src/lib/troubleshoot/TroubleshootDialog.svelte:46
 msgid "Application version"
 msgstr "Version de l'application"
 
@@ -168,11 +168,11 @@ msgstr "avant"
 msgid "Best match"
 msgstr "Meilleure correspondance"
 
-#: src/project/ProjectSidebar.svelte:91
+#: src/project/ProjectSidebar.svelte:90
 msgid "Browse"
 msgstr "Parcourir"
 
-#: src/lib/entry-editor/NewEntryDialog.svelte:110
+#: src/lib/entry-editor/NewEntryDialog.svelte:113
 #: src/lib/entry-editor/EntryOrSensePicker.svelte:245
 #: src/lib/components/field-editors/select.svelte:164
 #: src/lib/components/field-editors/multi-select.svelte:277
@@ -189,7 +189,7 @@ msgstr "Formulaire de citation"
 msgid "Citation Form"
 msgstr "Formulaire de citation"
 
-#: src/home/HomeView.svelte:260
+#: src/home/HomeView.svelte:253
 msgid "Classic FieldWorks Projects"
 msgstr "Projets FieldWorks classiques"
 
@@ -204,7 +204,7 @@ msgstr "clair"
 msgid "Close"
 msgstr "Fermer"
 
-#: src/project/ProjectSidebar.svelte:159
+#: src/project/ProjectSidebar.svelte:158
 msgid "Close Dictionary"
 msgstr "Fermer le dictionnaire"
 
@@ -241,7 +241,15 @@ msgstr "Composants"
 msgid "Contains"
 msgstr "Contient"
 
-#: src/lib/entry-editor/NewEntryDialog.svelte:112
+#: src/lib/components/ui/button/copy-button.svelte:24
+msgid "Copied to clipboard"
+msgstr ""
+
+#: src/lib/troubleshoot/TroubleshootDialog.svelte:50
+msgid "Copy version"
+msgstr ""
+
+#: src/lib/entry-editor/NewEntryDialog.svelte:115
 msgid "Create {0}"
 msgstr "Créer {0}"
 
@@ -249,7 +257,7 @@ msgstr "Créer {0}"
 msgid "Create entry"
 msgstr "Créer une entrée"
 
-#: src/home/HomeView.svelte:239
+#: src/home/HomeView.svelte:232
 msgid "Create Example Project"
 msgstr "Créer un projet d'exemple"
 
@@ -267,11 +275,11 @@ msgstr "Entrée actuelle"
 msgid "Current Word"
 msgstr "Mot actuel"
 
-#: src/project/ProjectSidebar.svelte:89
+#: src/project/ProjectSidebar.svelte:88
 msgid "Dashboard"
 msgstr "Tableau de bord"
 
-#: src/lib/troubleshoot/TroubleshootDialog.svelte:48
+#: src/lib/troubleshoot/TroubleshootDialog.svelte:56
 msgid "Data Directory"
 msgstr "Répertoire de données"
 
@@ -279,7 +287,7 @@ msgstr "Répertoire de données"
 msgid "Definition"
 msgstr "Définition"
 
-#: src/home/HomeView.svelte:221
+#: src/home/HomeView.svelte:214
 msgid "Delete"
 msgstr "Supprimer"
 
@@ -296,12 +304,12 @@ msgstr "Supprimer l'entrée"
 msgid "Delete Word"
 msgstr "Supprimer un mot"
 
-#: src/home/HomeView.svelte:131
-#: src/home/HomeView.svelte:135
+#: src/home/HomeView.svelte:130
+#: src/home/HomeView.svelte:134
 msgid "Dictionaries"
 msgstr "Dictionnaires"
 
-#: src/project/ProjectSidebar.svelte:85
+#: src/project/ProjectSidebar.svelte:84
 msgid "Dictionary"
 msgstr "Dictionnaire"
 
@@ -364,7 +372,7 @@ msgid "Ends with"
 msgstr "Se termine par"
 
 #: src/project/browse/EntryMenu.svelte:37
-#: src/lib/entry-editor/NewEntryDialog.svelte:84
+#: src/lib/entry-editor/NewEntryDialog.svelte:87
 #: src/lib/entry-editor/EntryOrSensePicker.svelte:250
 msgid "Entry"
 msgstr "Entrée"
@@ -381,7 +389,7 @@ msgstr "Entrée ou sens :"
 msgid "Equals"
 msgstr "Équivalents"
 
-#: src/project/ProjectSidebar.svelte:121
+#: src/project/ProjectSidebar.svelte:120
 msgid "Error getting sync status"
 msgstr "Erreur dans l'obtention de l'état de la synchronisation"
 
@@ -401,6 +409,10 @@ msgstr "Exemple"
 msgid "Example sentence"
 msgstr "Exemple de phrase"
 
+#: src/lib/components/ui/button/copy-button.svelte:26
+msgid "Failed to copy to clipboard"
+msgstr ""
+
 #: src/home/Server.svelte:53
 msgid "Failed to download {0}"
 msgstr "Échec du téléchargement de {0}"
@@ -410,7 +422,7 @@ msgstr "Échec du téléchargement de {0}"
 msgid "Failed to load entries"
 msgstr "Échec du chargement des entrées"
 
-#: src/lib/troubleshoot/TroubleshootDialog.svelte:28
+#: src/lib/troubleshoot/TroubleshootDialog.svelte:29
 msgid "Failed to open data directory, use the path in the text field instead"
 msgstr "Échec de l'ouverture du répertoire de données, utilisez plutôt le chemin d'accès dans le champ texte."
 
@@ -426,8 +438,8 @@ msgstr "Échec de la synchronisation"
 msgid "Failed to synchronize."
 msgstr "Échec de la synchronisation."
 
-#: src/project/ProjectSidebar.svelte:181
-#: src/home/HomeView.svelte:154
+#: src/project/ProjectSidebar.svelte:178
+#: src/home/HomeView.svelte:153
 msgid "Feedback"
 msgstr "Retour d'information"
 
@@ -441,7 +453,7 @@ msgstr "Étiquettes de champ"
 
 #: src/project/ProjectDropdown.svelte:69
 #: src/lib/OpenInFieldWorksButton.svelte:55
-#: src/home/HomeView.svelte:266
+#: src/home/HomeView.svelte:259
 msgid "FieldWorks logo"
 msgstr "Logo FieldWorks"
 
@@ -533,7 +545,7 @@ msgstr "Maintenez la touche enfoncée pour enregistrer ou\\nappuyez et relâchez
 msgid "I don't see my project"
 msgstr "Je ne vois pas mon projet"
 
-#: src/home/HomeView.svelte:274
+#: src/home/HomeView.svelte:267
 msgid "Import"
 msgstr "Importation"
 
@@ -546,7 +558,7 @@ msgstr "Dernière modification : {0}"
 msgid "Length:"
 msgstr "Longueur :"
 
-#: src/home/HomeView.svelte:134
+#: src/home/HomeView.svelte:133
 msgid "Lexbox logo"
 msgstr "Logo Lexbox"
 
@@ -570,15 +582,15 @@ msgstr "Sens littéral"
 msgid "Loading Dictionaries..."
 msgstr "Chargement des dictionnaires..."
 
-#: src/home/HomeView.svelte:175
+#: src/home/HomeView.svelte:170
 msgid "loading..."
 msgstr "chargement..."
 
-#: src/home/HomeView.svelte:180
+#: src/home/HomeView.svelte:175
 msgid "Local"
 msgstr "Locale"
 
-#: src/home/HomeView.svelte:202
+#: src/home/HomeView.svelte:197
 msgid "Local only"
 msgstr "Uniquement au niveau local"
 
@@ -595,7 +607,7 @@ msgstr "Se connecter pour voir les projets"
 msgid "Logout"
 msgstr "Déconnexion"
 
-#: src/project/ProjectSidebar.svelte:195
+#: src/project/ProjectSidebar.svelte:192
 msgid "Made with ❤️ from 🇦🇹 🇹🇭 🇺🇸"
 msgstr "Réalisé avec ❤️ à partir de 🇦🇹 🇹🇭 🇺🇸"
 
@@ -638,7 +650,7 @@ msgstr "Jamais"
 msgid "New"
 msgstr "Nouveau"
 
-#: src/lib/entry-editor/NewEntryDialog.svelte:97
+#: src/lib/entry-editor/NewEntryDialog.svelte:100
 msgid "New {0}"
 msgstr "Nouveau {0}"
 
@@ -681,7 +693,7 @@ msgid "No items found"
 msgstr "Aucun élément trouvé"
 
 #: src/project/SyncDialog.svelte:193
-#: src/project/ProjectSidebar.svelte:115
+#: src/project/ProjectSidebar.svelte:114
 msgid "No server configured"
 msgstr "Pas de serveur configuré"
 
@@ -699,7 +711,7 @@ msgid "Not equal"
 msgstr "Pas d'égalité"
 
 #: src/project/SyncDialog.svelte:257
-#: src/project/ProjectSidebar.svelte:113
+#: src/project/ProjectSidebar.svelte:112
 msgid "Not logged in"
 msgstr "Non connecté"
 
@@ -707,12 +719,16 @@ msgstr "Non connecté"
 msgid "Note"
 msgstr "Note"
 
+#: src/lib/components/ui/button/copy-button.svelte:20
+msgid "Nothing to copy"
+msgstr ""
+
 #: src/lib/admin-dialogs/GetProjectByCodeDialog.svelte:42
 msgid "Observer"
 msgstr "Observateur"
 
 #: src/project/SyncDialog.svelte:187
-#: src/project/ProjectSidebar.svelte:111
+#: src/project/ProjectSidebar.svelte:110
 msgid "Offline"
 msgstr "Hors ligne"
 
@@ -720,7 +736,7 @@ msgstr "Hors ligne"
 msgid "Offline, unable to download"
 msgstr "Hors ligne, impossible de télécharger"
 
-#: src/lib/troubleshoot/TroubleshootDialog.svelte:53
+#: src/lib/troubleshoot/TroubleshootDialog.svelte:61
 msgid "Open Data Directory"
 msgstr "Répertoire des données ouvertes"
 
@@ -732,7 +748,7 @@ msgstr "Ouvrir dans FieldWorks"
 msgid "Open in new Window"
 msgstr "Ouvrir dans une nouvelle fenêtre"
 
-#: src/lib/troubleshoot/TroubleshootDialog.svelte:68
+#: src/lib/troubleshoot/TroubleshootDialog.svelte:78
 msgid "Open Log file"
 msgstr "Ouvrir le fichier journal"
 
@@ -769,7 +785,7 @@ msgstr "Projet {0} introuvable sur {1}"
 msgid "Project {0} on {1} is not yet set up for FieldWorks Lite"
 msgstr "Le projet {0} sur {1} n'est pas encore configuré pour FieldWorks Lite"
 
-#: src/home/HomeView.svelte:245
+#: src/home/HomeView.svelte:238
 msgid "Project name..."
 msgstr "Nom du projet..."
 
@@ -783,7 +799,7 @@ msgid "Refine your filter to see more..."
 msgstr "Affinez votre filtre pour voir plus..."
 
 #: src/home/Server.svelte:119
-#: src/home/HomeView.svelte:184
+#: src/home/HomeView.svelte:179
 msgid "Refresh Projects"
 msgstr "Projets de rafraîchissement"
 
@@ -843,7 +859,7 @@ msgstr "Sens"
 msgid "Sentence"
 msgstr "Phrase"
 
-#: src/project/ProjectSidebar.svelte:146
+#: src/project/ProjectSidebar.svelte:145
 msgid "Settings"
 msgstr "Paramètres"
 
@@ -851,11 +867,11 @@ msgstr "Paramètres"
 msgid "Shadcn Sandbox # #"
 msgstr "Shadcn Sandbox # #"
 
-#: src/lib/troubleshoot/TroubleshootDialog.svelte:72
+#: src/lib/troubleshoot/TroubleshootDialog.svelte:82
 msgid "Share Log file"
 msgstr "Partager le fichier journal"
 
-#: src/lib/troubleshoot/TroubleshootDialog.svelte:61
+#: src/lib/troubleshoot/TroubleshootDialog.svelte:70
 msgid "Share project data file"
 msgstr "Partager le fichier de données du projet"
 
@@ -885,18 +901,18 @@ msgstr "Commence par"
 msgid "Submit"
 msgstr "Soumettre"
 
-#: src/project/ProjectSidebar.svelte:119
+#: src/project/ProjectSidebar.svelte:118
 #: src/lib/activity/ActivityView.svelte:108
 msgid "Synced"
 msgstr "Synchronisé"
 
-#: src/home/HomeView.svelte:202
+#: src/home/HomeView.svelte:197
 msgid "Synced with {0}"
 msgstr "Synchronisé avec {0}"
 
 #: src/project/SyncDialog.svelte:149
 #: src/project/SyncDialog.svelte:234
-#: src/project/ProjectSidebar.svelte:126
+#: src/project/ProjectSidebar.svelte:125
 msgid "Synchronize"
 msgstr "Synchroniser"
 
@@ -909,7 +925,7 @@ msgstr "Synchronisation de FieldWorks Lite avec FieldWorks..."
 msgid "Synchronizing..."
 msgstr "Synchronisation..."
 
-#: src/project/ProjectSidebar.svelte:93
+#: src/project/ProjectSidebar.svelte:92
 msgid "Tasks"
 msgstr "Tâches"
 
@@ -937,10 +953,10 @@ msgstr "Toggle theme"
 msgid "Translation"
 msgstr "Traduction"
 
-#: src/project/ProjectSidebar.svelte:172
-#: src/lib/troubleshoot/TroubleshootDialog.svelte:42
-#: src/home/HomeView.svelte:160
-#: src/home/HomeView.svelte:216
+#: src/project/ProjectSidebar.svelte:170
+#: src/lib/troubleshoot/TroubleshootDialog.svelte:43
+#: src/home/HomeView.svelte:158
+#: src/home/HomeView.svelte:210
 msgid "Troubleshoot"
 msgstr "Dépannage"
 
@@ -959,7 +975,7 @@ msgstr "Impossible d'ouvrir FieldWorks"
 msgid "Unknown"
 msgstr "Inconnu"
 
-#: src/project/ProjectSidebar.svelte:117
+#: src/project/ProjectSidebar.svelte:116
 #: src/lib/components/audio/AudioDialog.svelte:93
 msgid "Unknown error"
 msgstr "Erreur inconnue"
@@ -986,7 +1002,7 @@ msgstr "Sans titre"
 msgid "Uses components as"
 msgstr "Utilise des composants tels que"
 
-#: src/project/ProjectSidebar.svelte:194
+#: src/project/ProjectSidebar.svelte:191
 msgid "Version {0}"
 msgstr "Version {0}"
 
@@ -1000,7 +1016,7 @@ msgstr "Où sont mes projets ?"
 
 #: src/project/browse/SearchFilter.svelte:40
 #: src/project/browse/EntryMenu.svelte:37
-#: src/lib/entry-editor/NewEntryDialog.svelte:84
+#: src/lib/entry-editor/NewEntryDialog.svelte:87
 #: src/lib/entry-editor/EntryOrSensePicker.svelte:250
 #: src/lib/entry-editor/object-editors/EntryEditorPrimitive.svelte:43
 msgid "Word"
@@ -1034,4 +1050,3 @@ msgstr "Vous n'avez pas la permission de télécharger le projet {0} depuis {1}"
 #: src/home/Server.svelte:85
 msgid "You have already downloaded the {0} project"
 msgstr "Vous avez déjà téléchargé le projet {0}"
-

--- a/frontend/viewer/src/locales/id.po
+++ b/frontend/viewer/src/locales/id.po
@@ -73,11 +73,11 @@ msgstr "sebuah kata"
 msgid "About"
 msgstr "Tentang"
 
-#: src/project/ProjectSidebar.svelte:140
+#: src/project/ProjectSidebar.svelte:139
 msgid "Account"
 msgstr "Akun"
 
-#: src/project/ProjectSidebar.svelte:96
+#: src/project/ProjectSidebar.svelte:95
 msgid "Activity"
 msgstr "Aktivitas"
 
@@ -126,7 +126,7 @@ msgstr "sebuah entri"
 msgid "Any Ws"
 msgstr "Setiap Ws"
 
-#: src/lib/troubleshoot/TroubleshootDialog.svelte:45
+#: src/lib/troubleshoot/TroubleshootDialog.svelte:46
 msgid "Application version"
 msgstr "Versi aplikasi"
 
@@ -168,11 +168,11 @@ msgstr "sebelum"
 msgid "Best match"
 msgstr "Pertandingan terbaik"
 
-#: src/project/ProjectSidebar.svelte:91
+#: src/project/ProjectSidebar.svelte:90
 msgid "Browse"
 msgstr "Jelajahi"
 
-#: src/lib/entry-editor/NewEntryDialog.svelte:110
+#: src/lib/entry-editor/NewEntryDialog.svelte:113
 #: src/lib/entry-editor/EntryOrSensePicker.svelte:245
 #: src/lib/components/field-editors/select.svelte:164
 #: src/lib/components/field-editors/multi-select.svelte:277
@@ -189,7 +189,7 @@ msgstr "Formulir kutipan"
 msgid "Citation Form"
 msgstr "Formulir Kutipan"
 
-#: src/home/HomeView.svelte:260
+#: src/home/HomeView.svelte:253
 msgid "Classic FieldWorks Projects"
 msgstr "Proyek Pekerjaan Lapangan Klasik"
 
@@ -204,7 +204,7 @@ msgstr "jelas"
 msgid "Close"
 msgstr "Tutup"
 
-#: src/project/ProjectSidebar.svelte:159
+#: src/project/ProjectSidebar.svelte:158
 msgid "Close Dictionary"
 msgstr "Tutup Kamus"
 
@@ -241,7 +241,15 @@ msgstr "Komponen"
 msgid "Contains"
 msgstr "Berisi"
 
-#: src/lib/entry-editor/NewEntryDialog.svelte:112
+#: src/lib/components/ui/button/copy-button.svelte:24
+msgid "Copied to clipboard"
+msgstr ""
+
+#: src/lib/troubleshoot/TroubleshootDialog.svelte:50
+msgid "Copy version"
+msgstr ""
+
+#: src/lib/entry-editor/NewEntryDialog.svelte:115
 msgid "Create {0}"
 msgstr "Buat {0}"
 
@@ -249,7 +257,7 @@ msgstr "Buat {0}"
 msgid "Create entry"
 msgstr "Buat entri"
 
-#: src/home/HomeView.svelte:239
+#: src/home/HomeView.svelte:232
 msgid "Create Example Project"
 msgstr "Buat Proyek Contoh"
 
@@ -267,11 +275,11 @@ msgstr "Entri Saat Ini"
 msgid "Current Word"
 msgstr "Kata saat ini"
 
-#: src/project/ProjectSidebar.svelte:89
+#: src/project/ProjectSidebar.svelte:88
 msgid "Dashboard"
 msgstr "Dasbor"
 
-#: src/lib/troubleshoot/TroubleshootDialog.svelte:48
+#: src/lib/troubleshoot/TroubleshootDialog.svelte:56
 msgid "Data Directory"
 msgstr "Direktori Data"
 
@@ -279,7 +287,7 @@ msgstr "Direktori Data"
 msgid "Definition"
 msgstr "Definisi"
 
-#: src/home/HomeView.svelte:221
+#: src/home/HomeView.svelte:214
 msgid "Delete"
 msgstr "Menghapus"
 
@@ -296,12 +304,12 @@ msgstr "Hapus Entri"
 msgid "Delete Word"
 msgstr "Menghapus kata"
 
-#: src/home/HomeView.svelte:131
-#: src/home/HomeView.svelte:135
+#: src/home/HomeView.svelte:130
+#: src/home/HomeView.svelte:134
 msgid "Dictionaries"
 msgstr "Kamus"
 
-#: src/project/ProjectSidebar.svelte:85
+#: src/project/ProjectSidebar.svelte:84
 msgid "Dictionary"
 msgstr "Kamus"
 
@@ -364,7 +372,7 @@ msgid "Ends with"
 msgstr "Diakhiri dengan"
 
 #: src/project/browse/EntryMenu.svelte:37
-#: src/lib/entry-editor/NewEntryDialog.svelte:84
+#: src/lib/entry-editor/NewEntryDialog.svelte:87
 #: src/lib/entry-editor/EntryOrSensePicker.svelte:250
 msgid "Entry"
 msgstr "Masuk"
@@ -381,7 +389,7 @@ msgstr "Masuk atau masuk akal:"
 msgid "Equals"
 msgstr "Sama"
 
-#: src/project/ProjectSidebar.svelte:121
+#: src/project/ProjectSidebar.svelte:120
 msgid "Error getting sync status"
 msgstr "Kesalahan mendapatkan status sinkronisasi"
 
@@ -401,6 +409,10 @@ msgstr "Contoh"
 msgid "Example sentence"
 msgstr "Contoh kalimat"
 
+#: src/lib/components/ui/button/copy-button.svelte:26
+msgid "Failed to copy to clipboard"
+msgstr ""
+
 #: src/home/Server.svelte:53
 msgid "Failed to download {0}"
 msgstr "Gagal mengunduh {0}"
@@ -410,7 +422,7 @@ msgstr "Gagal mengunduh {0}"
 msgid "Failed to load entries"
 msgstr "Gagal memuat entri"
 
-#: src/lib/troubleshoot/TroubleshootDialog.svelte:28
+#: src/lib/troubleshoot/TroubleshootDialog.svelte:29
 msgid "Failed to open data directory, use the path in the text field instead"
 msgstr "Gagal membuka direktori data, gunakan jalur di bidang teks sebagai gantinya"
 
@@ -426,8 +438,8 @@ msgstr "Gagal menyinkronkan"
 msgid "Failed to synchronize."
 msgstr "Gagal melakukan sinkronisasi."
 
-#: src/project/ProjectSidebar.svelte:181
-#: src/home/HomeView.svelte:154
+#: src/project/ProjectSidebar.svelte:178
+#: src/home/HomeView.svelte:153
 msgid "Feedback"
 msgstr "Umpan balik"
 
@@ -441,7 +453,7 @@ msgstr "Label Bidang"
 
 #: src/project/ProjectDropdown.svelte:69
 #: src/lib/OpenInFieldWorksButton.svelte:55
-#: src/home/HomeView.svelte:266
+#: src/home/HomeView.svelte:259
 msgid "FieldWorks logo"
 msgstr "Logo FieldWorks"
 
@@ -533,7 +545,7 @@ msgstr "Tahan untuk merekam atau\\ntekan dan lepaskan untuk mulai merekam."
 msgid "I don't see my project"
 msgstr "Saya tidak melihat proyek saya"
 
-#: src/home/HomeView.svelte:274
+#: src/home/HomeView.svelte:267
 msgid "Import"
 msgstr "Impor"
 
@@ -546,7 +558,7 @@ msgstr "Perubahan terakhir: {0}"
 msgid "Length:"
 msgstr "Panjang:"
 
-#: src/home/HomeView.svelte:134
+#: src/home/HomeView.svelte:133
 msgid "Lexbox logo"
 msgstr "Logo Lexbox"
 
@@ -570,15 +582,15 @@ msgstr "Arti harfiah"
 msgid "Loading Dictionaries..."
 msgstr "Memuat Kamus..."
 
-#: src/home/HomeView.svelte:175
+#: src/home/HomeView.svelte:170
 msgid "loading..."
 msgstr "Loading..."
 
-#: src/home/HomeView.svelte:180
+#: src/home/HomeView.svelte:175
 msgid "Local"
 msgstr "Lokal"
 
-#: src/home/HomeView.svelte:202
+#: src/home/HomeView.svelte:197
 msgid "Local only"
 msgstr "Hanya lokal"
 
@@ -595,7 +607,7 @@ msgstr "Login untuk melihat proyek"
 msgid "Logout"
 msgstr "Keluar"
 
-#: src/project/ProjectSidebar.svelte:195
+#: src/project/ProjectSidebar.svelte:192
 msgid "Made with ❤️ from 🇦🇹 🇹🇭 🇺🇸"
 msgstr "Dibuat dengan ❤️ dari 🇦🇹 🇹🇭 🇺🇸"
 
@@ -638,7 +650,7 @@ msgstr "Tidak pernah."
 msgid "New"
 msgstr "Baru"
 
-#: src/lib/entry-editor/NewEntryDialog.svelte:97
+#: src/lib/entry-editor/NewEntryDialog.svelte:100
 msgid "New {0}"
 msgstr "Baru {0}"
 
@@ -681,7 +693,7 @@ msgid "No items found"
 msgstr "Tidak ada barang yang ditemukan"
 
 #: src/project/SyncDialog.svelte:193
-#: src/project/ProjectSidebar.svelte:115
+#: src/project/ProjectSidebar.svelte:114
 msgid "No server configured"
 msgstr "Tidak ada server yang dikonfigurasi"
 
@@ -699,7 +711,7 @@ msgid "Not equal"
 msgstr "Tidak sama"
 
 #: src/project/SyncDialog.svelte:257
-#: src/project/ProjectSidebar.svelte:113
+#: src/project/ProjectSidebar.svelte:112
 msgid "Not logged in"
 msgstr "Tidak masuk"
 
@@ -707,12 +719,16 @@ msgstr "Tidak masuk"
 msgid "Note"
 msgstr "Catatan"
 
+#: src/lib/components/ui/button/copy-button.svelte:20
+msgid "Nothing to copy"
+msgstr ""
+
 #: src/lib/admin-dialogs/GetProjectByCodeDialog.svelte:42
 msgid "Observer"
 msgstr "Pengamat"
 
 #: src/project/SyncDialog.svelte:187
-#: src/project/ProjectSidebar.svelte:111
+#: src/project/ProjectSidebar.svelte:110
 msgid "Offline"
 msgstr "Offline"
 
@@ -720,7 +736,7 @@ msgstr "Offline"
 msgid "Offline, unable to download"
 msgstr "Offline, tidak dapat mengunduh"
 
-#: src/lib/troubleshoot/TroubleshootDialog.svelte:53
+#: src/lib/troubleshoot/TroubleshootDialog.svelte:61
 msgid "Open Data Directory"
 msgstr "Direktori Data Terbuka"
 
@@ -732,7 +748,7 @@ msgstr "Buka di FieldWorks"
 msgid "Open in new Window"
 msgstr "Buka di jendela baru"
 
-#: src/lib/troubleshoot/TroubleshootDialog.svelte:68
+#: src/lib/troubleshoot/TroubleshootDialog.svelte:78
 msgid "Open Log file"
 msgstr "Buka file Log"
 
@@ -769,7 +785,7 @@ msgstr "Proyek {0} tidak ditemukan di {1}"
 msgid "Project {0} on {1} is not yet set up for FieldWorks Lite"
 msgstr "Proyek {0} di {1} belum disiapkan untuk FieldWorks Lite"
 
-#: src/home/HomeView.svelte:245
+#: src/home/HomeView.svelte:238
 msgid "Project name..."
 msgstr "Nama proyek..."
 
@@ -783,7 +799,7 @@ msgid "Refine your filter to see more..."
 msgstr "Sempurnakan filter Anda untuk melihat lebih banyak..."
 
 #: src/home/Server.svelte:119
-#: src/home/HomeView.svelte:184
+#: src/home/HomeView.svelte:179
 msgid "Refresh Projects"
 msgstr "Menyegarkan Proyek"
 
@@ -843,7 +859,7 @@ msgstr "Sense"
 msgid "Sentence"
 msgstr "Kalimat"
 
-#: src/project/ProjectSidebar.svelte:146
+#: src/project/ProjectSidebar.svelte:145
 msgid "Settings"
 msgstr "Pengaturan"
 
@@ -851,11 +867,11 @@ msgstr "Pengaturan"
 msgid "Shadcn Sandbox # #"
 msgstr "Kotak Pasir Shadcn # #"
 
-#: src/lib/troubleshoot/TroubleshootDialog.svelte:72
+#: src/lib/troubleshoot/TroubleshootDialog.svelte:82
 msgid "Share Log file"
 msgstr "Bagikan file Log"
 
-#: src/lib/troubleshoot/TroubleshootDialog.svelte:61
+#: src/lib/troubleshoot/TroubleshootDialog.svelte:70
 msgid "Share project data file"
 msgstr "Berbagi file data proyek"
 
@@ -885,18 +901,18 @@ msgstr "Dimulai dengan"
 msgid "Submit"
 msgstr "Kirim"
 
-#: src/project/ProjectSidebar.svelte:119
+#: src/project/ProjectSidebar.svelte:118
 #: src/lib/activity/ActivityView.svelte:108
 msgid "Synced"
 msgstr "Disinkronkan"
 
-#: src/home/HomeView.svelte:202
+#: src/home/HomeView.svelte:197
 msgid "Synced with {0}"
 msgstr "Disinkronkan dengan {0}"
 
 #: src/project/SyncDialog.svelte:149
 #: src/project/SyncDialog.svelte:234
-#: src/project/ProjectSidebar.svelte:126
+#: src/project/ProjectSidebar.svelte:125
 msgid "Synchronize"
 msgstr "Sinkronisasi"
 
@@ -909,7 +925,7 @@ msgstr "Menyinkronkan FieldWorks Lite dengan FieldWorks..."
 msgid "Synchronizing..."
 msgstr "Menyinkronkan..."
 
-#: src/project/ProjectSidebar.svelte:93
+#: src/project/ProjectSidebar.svelte:92
 msgid "Tasks"
 msgstr "Tugas"
 
@@ -937,10 +953,10 @@ msgstr "Beralih tema"
 msgid "Translation"
 msgstr "Terjemahan"
 
-#: src/project/ProjectSidebar.svelte:172
-#: src/lib/troubleshoot/TroubleshootDialog.svelte:42
-#: src/home/HomeView.svelte:160
-#: src/home/HomeView.svelte:216
+#: src/project/ProjectSidebar.svelte:170
+#: src/lib/troubleshoot/TroubleshootDialog.svelte:43
+#: src/home/HomeView.svelte:158
+#: src/home/HomeView.svelte:210
 msgid "Troubleshoot"
 msgstr "Memecahkan masalah"
 
@@ -959,7 +975,7 @@ msgstr "Tidak dapat dibuka di FieldWorks"
 msgid "Unknown"
 msgstr "Tidak diketahui"
 
-#: src/project/ProjectSidebar.svelte:117
+#: src/project/ProjectSidebar.svelte:116
 #: src/lib/components/audio/AudioDialog.svelte:93
 msgid "Unknown error"
 msgstr "Kesalahan yang tidak diketahui"
@@ -986,7 +1002,7 @@ msgstr "Tanpa judul"
 msgid "Uses components as"
 msgstr "Menggunakan komponen sebagai"
 
-#: src/project/ProjectSidebar.svelte:194
+#: src/project/ProjectSidebar.svelte:191
 msgid "Version {0}"
 msgstr "Versi {0}"
 
@@ -1000,7 +1016,7 @@ msgstr "Di mana proyek saya?"
 
 #: src/project/browse/SearchFilter.svelte:40
 #: src/project/browse/EntryMenu.svelte:37
-#: src/lib/entry-editor/NewEntryDialog.svelte:84
+#: src/lib/entry-editor/NewEntryDialog.svelte:87
 #: src/lib/entry-editor/EntryOrSensePicker.svelte:250
 #: src/lib/entry-editor/object-editors/EntryEditorPrimitive.svelte:43
 msgid "Word"
@@ -1034,4 +1050,3 @@ msgstr "Anda tidak memiliki izin untuk mengunduh proyek {0} dari {1}"
 #: src/home/Server.svelte:85
 msgid "You have already downloaded the {0} project"
 msgstr "Anda telah mengunduh proyek {0}"
-

--- a/frontend/viewer/src/locales/ko.po
+++ b/frontend/viewer/src/locales/ko.po
@@ -73,11 +73,11 @@ msgstr "한 마디"
 msgid "About"
 msgstr "정보"
 
-#: src/project/ProjectSidebar.svelte:140
+#: src/project/ProjectSidebar.svelte:139
 msgid "Account"
 msgstr "계정"
 
-#: src/project/ProjectSidebar.svelte:96
+#: src/project/ProjectSidebar.svelte:95
 msgid "Activity"
 msgstr "활동"
 
@@ -126,7 +126,7 @@ msgstr "항목"
 msgid "Any Ws"
 msgstr "모든 W"
 
-#: src/lib/troubleshoot/TroubleshootDialog.svelte:45
+#: src/lib/troubleshoot/TroubleshootDialog.svelte:46
 msgid "Application version"
 msgstr "애플리케이션 버전"
 
@@ -168,11 +168,11 @@ msgstr "전에"
 msgid "Best match"
 msgstr "베스트 매치"
 
-#: src/project/ProjectSidebar.svelte:91
+#: src/project/ProjectSidebar.svelte:90
 msgid "Browse"
 msgstr "찾아보기"
 
-#: src/lib/entry-editor/NewEntryDialog.svelte:110
+#: src/lib/entry-editor/NewEntryDialog.svelte:113
 #: src/lib/entry-editor/EntryOrSensePicker.svelte:245
 #: src/lib/components/field-editors/select.svelte:164
 #: src/lib/components/field-editors/multi-select.svelte:277
@@ -189,7 +189,7 @@ msgstr "인용 양식"
 msgid "Citation Form"
 msgstr "인용 양식"
 
-#: src/home/HomeView.svelte:260
+#: src/home/HomeView.svelte:253
 msgid "Classic FieldWorks Projects"
 msgstr "클래식 FieldWorks 프로젝트"
 
@@ -204,7 +204,7 @@ msgstr "clear"
 msgid "Close"
 msgstr "닫기"
 
-#: src/project/ProjectSidebar.svelte:159
+#: src/project/ProjectSidebar.svelte:158
 msgid "Close Dictionary"
 msgstr "사전 닫기"
 
@@ -241,7 +241,15 @@ msgstr "구성 요소"
 msgid "Contains"
 msgstr "포함 사항"
 
-#: src/lib/entry-editor/NewEntryDialog.svelte:112
+#: src/lib/components/ui/button/copy-button.svelte:24
+msgid "Copied to clipboard"
+msgstr ""
+
+#: src/lib/troubleshoot/TroubleshootDialog.svelte:50
+msgid "Copy version"
+msgstr ""
+
+#: src/lib/entry-editor/NewEntryDialog.svelte:115
 msgid "Create {0}"
 msgstr "{0}만들기"
 
@@ -249,7 +257,7 @@ msgstr "{0}만들기"
 msgid "Create entry"
 msgstr "항목 만들기"
 
-#: src/home/HomeView.svelte:239
+#: src/home/HomeView.svelte:232
 msgid "Create Example Project"
 msgstr "예제 프로젝트 만들기"
 
@@ -267,11 +275,11 @@ msgstr "현재 항목"
 msgid "Current Word"
 msgstr "현재 단어"
 
-#: src/project/ProjectSidebar.svelte:89
+#: src/project/ProjectSidebar.svelte:88
 msgid "Dashboard"
 msgstr "대시보드"
 
-#: src/lib/troubleshoot/TroubleshootDialog.svelte:48
+#: src/lib/troubleshoot/TroubleshootDialog.svelte:56
 msgid "Data Directory"
 msgstr "데이터 디렉토리"
 
@@ -279,7 +287,7 @@ msgstr "데이터 디렉토리"
 msgid "Definition"
 msgstr "정의"
 
-#: src/home/HomeView.svelte:221
+#: src/home/HomeView.svelte:214
 msgid "Delete"
 msgstr "삭제"
 
@@ -296,12 +304,12 @@ msgstr "항목 삭제"
 msgid "Delete Word"
 msgstr "단어 삭제"
 
-#: src/home/HomeView.svelte:131
-#: src/home/HomeView.svelte:135
+#: src/home/HomeView.svelte:130
+#: src/home/HomeView.svelte:134
 msgid "Dictionaries"
 msgstr "사전"
 
-#: src/project/ProjectSidebar.svelte:85
+#: src/project/ProjectSidebar.svelte:84
 msgid "Dictionary"
 msgstr "사전"
 
@@ -364,7 +372,7 @@ msgid "Ends with"
 msgstr "로 끝납니다."
 
 #: src/project/browse/EntryMenu.svelte:37
-#: src/lib/entry-editor/NewEntryDialog.svelte:84
+#: src/lib/entry-editor/NewEntryDialog.svelte:87
 #: src/lib/entry-editor/EntryOrSensePicker.svelte:250
 msgid "Entry"
 msgstr "항목"
@@ -381,7 +389,7 @@ msgstr "입력 또는 센스:"
 msgid "Equals"
 msgstr "같음"
 
-#: src/project/ProjectSidebar.svelte:121
+#: src/project/ProjectSidebar.svelte:120
 msgid "Error getting sync status"
 msgstr "동기화 상태 가져오기 오류"
 
@@ -401,6 +409,10 @@ msgstr "예"
 msgid "Example sentence"
 msgstr "문장 예시"
 
+#: src/lib/components/ui/button/copy-button.svelte:26
+msgid "Failed to copy to clipboard"
+msgstr ""
+
 #: src/home/Server.svelte:53
 msgid "Failed to download {0}"
 msgstr "다운로드에 실패했습니다 {0}"
@@ -410,7 +422,7 @@ msgstr "다운로드에 실패했습니다 {0}"
 msgid "Failed to load entries"
 msgstr "항목을 로드하지 못했습니다."
 
-#: src/lib/troubleshoot/TroubleshootDialog.svelte:28
+#: src/lib/troubleshoot/TroubleshootDialog.svelte:29
 msgid "Failed to open data directory, use the path in the text field instead"
 msgstr "데이터 디렉토리를 열지 못했습니다. 대신 텍스트 필드에 경로를 사용하세요."
 
@@ -426,8 +438,8 @@ msgstr "동기화 실패"
 msgid "Failed to synchronize."
 msgstr "동기화하지 못했습니다."
 
-#: src/project/ProjectSidebar.svelte:181
-#: src/home/HomeView.svelte:154
+#: src/project/ProjectSidebar.svelte:178
+#: src/home/HomeView.svelte:153
 msgid "Feedback"
 msgstr "피드백"
 
@@ -441,7 +453,7 @@ msgstr "필드 레이블"
 
 #: src/project/ProjectDropdown.svelte:69
 #: src/lib/OpenInFieldWorksButton.svelte:55
-#: src/home/HomeView.svelte:266
+#: src/home/HomeView.svelte:259
 msgid "FieldWorks logo"
 msgstr "FieldWorks 로고"
 
@@ -533,7 +545,7 @@ msgstr "길게 눌러 녹화하거나\\n을 눌렀다 놓으면 녹화가 시작
 msgid "I don't see my project"
 msgstr "내 프로젝트가 보이지 않습니다."
 
-#: src/home/HomeView.svelte:274
+#: src/home/HomeView.svelte:267
 msgid "Import"
 msgstr "가져오기"
 
@@ -546,7 +558,7 @@ msgstr "마지막 변경 사항: {0}"
 msgid "Length:"
 msgstr "길이:"
 
-#: src/home/HomeView.svelte:134
+#: src/home/HomeView.svelte:133
 msgid "Lexbox logo"
 msgstr "렉스박스 로고"
 
@@ -570,15 +582,15 @@ msgstr "문자 그대로의 의미"
 msgid "Loading Dictionaries..."
 msgstr "사전 로드 중..."
 
-#: src/home/HomeView.svelte:175
+#: src/home/HomeView.svelte:170
 msgid "loading..."
 msgstr "로딩 중..."
 
-#: src/home/HomeView.svelte:180
+#: src/home/HomeView.svelte:175
 msgid "Local"
 msgstr "로컬"
 
-#: src/home/HomeView.svelte:202
+#: src/home/HomeView.svelte:197
 msgid "Local only"
 msgstr "로컬 전용"
 
@@ -595,7 +607,7 @@ msgstr "로그인하여 프로젝트 보기"
 msgid "Logout"
 msgstr "로그아웃"
 
-#: src/project/ProjectSidebar.svelte:195
+#: src/project/ProjectSidebar.svelte:192
 msgid "Made with ❤️ from 🇦🇹 🇹🇭 🇺🇸"
 msgstr "제작: ❤️ 출처: 🇦🇹 🇹🇭 🇺🇸"
 
@@ -638,7 +650,7 @@ msgstr "절대로"
 msgid "New"
 msgstr "신규"
 
-#: src/lib/entry-editor/NewEntryDialog.svelte:97
+#: src/lib/entry-editor/NewEntryDialog.svelte:100
 msgid "New {0}"
 msgstr "신규 {0}"
 
@@ -681,7 +693,7 @@ msgid "No items found"
 msgstr "항목을 찾을 수 없습니다."
 
 #: src/project/SyncDialog.svelte:193
-#: src/project/ProjectSidebar.svelte:115
+#: src/project/ProjectSidebar.svelte:114
 msgid "No server configured"
 msgstr "구성된 서버 없음"
 
@@ -699,7 +711,7 @@ msgid "Not equal"
 msgstr "동일하지 않음"
 
 #: src/project/SyncDialog.svelte:257
-#: src/project/ProjectSidebar.svelte:113
+#: src/project/ProjectSidebar.svelte:112
 msgid "Not logged in"
 msgstr "로그인하지 않음"
 
@@ -707,12 +719,16 @@ msgstr "로그인하지 않음"
 msgid "Note"
 msgstr "참고"
 
+#: src/lib/components/ui/button/copy-button.svelte:20
+msgid "Nothing to copy"
+msgstr ""
+
 #: src/lib/admin-dialogs/GetProjectByCodeDialog.svelte:42
 msgid "Observer"
 msgstr "옵저버"
 
 #: src/project/SyncDialog.svelte:187
-#: src/project/ProjectSidebar.svelte:111
+#: src/project/ProjectSidebar.svelte:110
 msgid "Offline"
 msgstr "오프라인"
 
@@ -720,7 +736,7 @@ msgstr "오프라인"
 msgid "Offline, unable to download"
 msgstr "오프라인 상태, 다운로드할 수 없음"
 
-#: src/lib/troubleshoot/TroubleshootDialog.svelte:53
+#: src/lib/troubleshoot/TroubleshootDialog.svelte:61
 msgid "Open Data Directory"
 msgstr "오픈 데이터 디렉터리"
 
@@ -732,7 +748,7 @@ msgstr "FieldWorks에서 열기"
 msgid "Open in new Window"
 msgstr "새 창에서 열기"
 
-#: src/lib/troubleshoot/TroubleshootDialog.svelte:68
+#: src/lib/troubleshoot/TroubleshootDialog.svelte:78
 msgid "Open Log file"
 msgstr "로그 파일 열기"
 
@@ -769,7 +785,7 @@ msgstr "프로젝트 {0} {1}에서 찾을 수 없음"
 msgid "Project {0} on {1} is not yet set up for FieldWorks Lite"
 msgstr "{1} 의 프로젝트 {0} 는 아직 FieldWorks Lite용으로 설정되지 않았습니다."
 
-#: src/home/HomeView.svelte:245
+#: src/home/HomeView.svelte:238
 msgid "Project name..."
 msgstr "프로젝트 이름..."
 
@@ -783,7 +799,7 @@ msgid "Refine your filter to see more..."
 msgstr "필터를 세분화하여 자세히 보기..."
 
 #: src/home/Server.svelte:119
-#: src/home/HomeView.svelte:184
+#: src/home/HomeView.svelte:179
 msgid "Refresh Projects"
 msgstr "프로젝트 새로 고침"
 
@@ -843,7 +859,7 @@ msgstr "Sense"
 msgid "Sentence"
 msgstr "문장"
 
-#: src/project/ProjectSidebar.svelte:146
+#: src/project/ProjectSidebar.svelte:145
 msgid "Settings"
 msgstr "설정"
 
@@ -851,11 +867,11 @@ msgstr "설정"
 msgid "Shadcn Sandbox # #"
 msgstr "Shadcn 샌드박스 # #"
 
-#: src/lib/troubleshoot/TroubleshootDialog.svelte:72
+#: src/lib/troubleshoot/TroubleshootDialog.svelte:82
 msgid "Share Log file"
 msgstr "로그 파일 공유"
 
-#: src/lib/troubleshoot/TroubleshootDialog.svelte:61
+#: src/lib/troubleshoot/TroubleshootDialog.svelte:70
 msgid "Share project data file"
 msgstr "프로젝트 데이터 파일 공유"
 
@@ -885,18 +901,18 @@ msgstr "다음으로 시작"
 msgid "Submit"
 msgstr "제출하기"
 
-#: src/project/ProjectSidebar.svelte:119
+#: src/project/ProjectSidebar.svelte:118
 #: src/lib/activity/ActivityView.svelte:108
 msgid "Synced"
 msgstr "동기화"
 
-#: src/home/HomeView.svelte:202
+#: src/home/HomeView.svelte:197
 msgid "Synced with {0}"
 msgstr "{0}으로 동기화"
 
 #: src/project/SyncDialog.svelte:149
 #: src/project/SyncDialog.svelte:234
-#: src/project/ProjectSidebar.svelte:126
+#: src/project/ProjectSidebar.svelte:125
 msgid "Synchronize"
 msgstr "동기화"
 
@@ -909,7 +925,7 @@ msgstr "FieldWorks Lite와 FieldWorks 동기화..."
 msgid "Synchronizing..."
 msgstr "동기화 중..."
 
-#: src/project/ProjectSidebar.svelte:93
+#: src/project/ProjectSidebar.svelte:92
 msgid "Tasks"
 msgstr "작업"
 
@@ -937,10 +953,10 @@ msgstr "테마 토글"
 msgid "Translation"
 msgstr "번역"
 
-#: src/project/ProjectSidebar.svelte:172
-#: src/lib/troubleshoot/TroubleshootDialog.svelte:42
-#: src/home/HomeView.svelte:160
-#: src/home/HomeView.svelte:216
+#: src/project/ProjectSidebar.svelte:170
+#: src/lib/troubleshoot/TroubleshootDialog.svelte:43
+#: src/home/HomeView.svelte:158
+#: src/home/HomeView.svelte:210
 msgid "Troubleshoot"
 msgstr "문제 해결"
 
@@ -959,7 +975,7 @@ msgstr "FieldWorks에서 열 수 없음"
 msgid "Unknown"
 msgstr "알 수 없음"
 
-#: src/project/ProjectSidebar.svelte:117
+#: src/project/ProjectSidebar.svelte:116
 #: src/lib/components/audio/AudioDialog.svelte:93
 msgid "Unknown error"
 msgstr "알 수 없는 오류"
@@ -986,7 +1002,7 @@ msgstr "제목 없음"
 msgid "Uses components as"
 msgstr "구성 요소를 다음과 같이 사용합니다."
 
-#: src/project/ProjectSidebar.svelte:194
+#: src/project/ProjectSidebar.svelte:191
 msgid "Version {0}"
 msgstr "버전 {0}"
 
@@ -1000,7 +1016,7 @@ msgstr "내 프로젝트는 어디에 있나요?"
 
 #: src/project/browse/SearchFilter.svelte:40
 #: src/project/browse/EntryMenu.svelte:37
-#: src/lib/entry-editor/NewEntryDialog.svelte:84
+#: src/lib/entry-editor/NewEntryDialog.svelte:87
 #: src/lib/entry-editor/EntryOrSensePicker.svelte:250
 #: src/lib/entry-editor/object-editors/EntryEditorPrimitive.svelte:43
 msgid "Word"
@@ -1034,4 +1050,3 @@ msgstr "{1}에서 {0} 프로젝트를 다운로드할 수 있는 권한이 없�
 #: src/home/Server.svelte:85
 msgid "You have already downloaded the {0} project"
 msgstr "이미 {0} 프로젝트를 다운로드하셨습니다."
-

--- a/frontend/viewer/src/project/ProjectSidebar.svelte
+++ b/frontend/viewer/src/project/ProjectSidebar.svelte
@@ -49,7 +49,6 @@
     navigate(newLocation);
   }
 
-  const supportsTroubleshooting = useTroubleshootingService();
   let troubleshootDialog = $state<TroubleshootDialog>();
   let syncDialog = $state<SyncDialog>();
 </script>
@@ -164,15 +163,13 @@
 
     <Sidebar.Group>
       <Sidebar.Menu>
-        {#if supportsTroubleshooting}
-          <TroubleshootDialog bind:this={troubleshootDialog}/>
-          <Sidebar.MenuItem>
-            <Sidebar.MenuButton onclick={() => troubleshootDialog?.open(projectContext.projectData?.code)}>
-              <Icon icon="i-mdi-help-circle" />
-              <span>{$t`Troubleshoot`}</span>
-            </Sidebar.MenuButton>
-          </Sidebar.MenuItem>
-        {/if}
+        <TroubleshootDialog bind:this={troubleshootDialog}/>
+        <Sidebar.MenuItem>
+          <Sidebar.MenuButton onclick={() => troubleshootDialog?.open(projectContext.projectData?.code)}>
+            <Icon icon="i-mdi-help-circle" />
+            <span>{$t`Troubleshoot`}</span>
+          </Sidebar.MenuButton>
+        </Sidebar.MenuItem>
         <Sidebar.MenuItem>
           <Sidebar.MenuButton>
             {#snippet child({ props })}


### PR DESCRIPTION
### Description of Changes

- Updated troubleshooting dialog to always be available as an option.
- Modified UI to hide elements that are not applicable without the service.
- Added a `CopyButton` to the TroubleshootDialog for convenient copying of app version and OS details.