### PR TITLE
Add confirmation for project deletion

### DIFF
--- a/frontend/viewer/src/home/HomeView.svelte
+++ b/frontend/viewer/src/home/HomeView.svelte
@@ -28,6 +28,7 @@
   import {cubicOut} from 'svelte/easing';
   import {transitionContext} from './transitions';
   import Anchor from '$lib/components/ui/anchor/anchor.svelte';
+  import DeleteDialog from '$lib/entry-editor/DeleteDialog.svelte';
 
   const projectsService = useProjectsService();
   const importFwdataService = useImportFwdataService();
@@ -71,6 +72,7 @@
 
   async function deleteProject(project: IProjectModel) {
     try {
+      if (!await deleteDialog.prompt($t`Project`, $t`${project.name}, you may have changes not synced to Lexbox`, true)) return;
       deletingProject = project.id;
       await projectsService.deleteProject(project.code);
       await refreshProjects();
@@ -125,8 +127,10 @@
       clickTimeout = setTimeout(resetClickCounter, 500);
     }
   }
-
+  let deleteDialog = $state<DeleteDialog>();
 </script>
+
+<DeleteDialog bind:this={deleteDialog}/>
 
 <AppBar tabTitle={$t`Dictionaries`}>
   {#snippet title()}
@@ -216,11 +220,9 @@
                         {$t`Troubleshoot`}
                       </ResponsiveMenu.Item>
                     {/if}
-                    {#if $isDev}
-                      <ResponsiveMenu.Item icon="i-mdi-delete" onSelect={() => void deleteProject(project)}>
-                        {$t`Delete`}
-                      </ResponsiveMenu.Item>
-                    {/if}
+                    <ResponsiveMenu.Item icon="i-mdi-delete" onSelect={() => void deleteProject(project)}>
+                      {$t`Delete`}
+                    </ResponsiveMenu.Item>
                   </ResponsiveMenu.Content>
                 </ResponsiveMenu.Root>
               </div>

--- a/frontend/viewer/src/lib/DialogsProvider.svelte
+++ b/frontend/viewer/src/lib/DialogsProvider.svelte
@@ -2,8 +2,14 @@
   import NewEntryDialog from '$lib/entry-editor/NewEntryDialog.svelte';
   import DeleteDialog from '$lib/entry-editor/DeleteDialog.svelte';
   import AudioDialog from './components/audio/AudioDialog.svelte';
+  import {useDialogsService} from '$lib/services/dialogs-service';
+  const dialogsService = useDialogsService();
+  let deleteDialog = $state<DeleteDialog>();
+  $effect(() => {
+    dialogsService.invokeDeleteDialog = deleteDialog?.prompt;
+  })
 </script>
 
 <NewEntryDialog/>
-<DeleteDialog/>
+<DeleteDialog bind:this={deleteDialog}/>
 <AudioDialog/>

--- a/frontend/viewer/src/lib/entry-editor/DeleteDialog.svelte
+++ b/frontend/viewer/src/lib/entry-editor/DeleteDialog.svelte
@@ -4,11 +4,14 @@
   import {t} from 'svelte-i18n-lingui';
   import {useDialogsService} from '$lib/services/dialogs-service';
   import {useBackHandler} from '$lib/utils/back-handler.svelte';
+  import {Switch} from '$lib/components/ui/switch';
 
   const dialogsService = useDialogsService();
   dialogsService.invokeDeleteDialog = prompt;
   let subject = $state('');
   let description = $state<string>();
+  let dangerous = $state(false);
+  let confirmed = $state(false);
   const subjectWithDescription = $derived(description ? `${subject}: ${description}` : subject);
 
   let open = $state(false);
@@ -34,12 +37,14 @@
     open = false;
   }
 
-  export function prompt(promptSubject: string, subjectDescription?: string): Promise<boolean> {
+  export function prompt(promptSubject: string, subjectDescription?: string, isDangerous: boolean = false): Promise<boolean> {
     if (requester) throw new Error('already prompting for a delete');
     return new Promise((resolve) => {
       requester = { resolve };
       subject = promptSubject;
       description = subjectDescription;
+      dangerous = isDangerous;
+      confirmed = false;
       open = true;
     });
   }
@@ -54,9 +59,14 @@
     <AlertDialog.Description>
       {$t`Are you sure you want to delete ${subjectWithDescription}?`}
     </AlertDialog.Description>
+    {#if dangerous}
+      <div class="mt-4">
+        <Switch label={$t`I confirm that I understand I can't undo this delete`} bind:checked={confirmed} />
+      </div>
+    {/if}
     <AlertDialog.Footer>
       <Button onclick={() => cancel()} variant="secondary">{$t`Don't delete`}</Button>
-      <Button icon="i-mdi-trash-can-outline" variant="destructive" onclick={_ => confirm()}>{$t`Delete ${subject}`}</Button>
+      <Button icon="i-mdi-trash-can-outline" variant="destructive" onclick={_ => confirm()} disabled={dangerous && !confirmed}>{$t`Delete ${subject}`}</Button>
     </AlertDialog.Footer>
   </AlertDialog.Content>
 </AlertDialog.Root>

--- a/frontend/viewer/src/lib/entry-editor/DeleteDialog.svelte
+++ b/frontend/viewer/src/lib/entry-editor/DeleteDialog.svelte
@@ -2,12 +2,9 @@
   import {Button} from '$lib/components/ui/button';
   import * as AlertDialog from '$lib/components/ui/alert-dialog';
   import {t} from 'svelte-i18n-lingui';
-  import {useDialogsService} from '$lib/services/dialogs-service';
   import {useBackHandler} from '$lib/utils/back-handler.svelte';
   import {Switch} from '$lib/components/ui/switch';
 
-  const dialogsService = useDialogsService();
-  dialogsService.invokeDeleteDialog = prompt;
   let subject = $state('');
   let description = $state<string>();
   let dangerous = $state(false);
@@ -61,7 +58,7 @@
     </AlertDialog.Description>
     {#if dangerous}
       <div class="mt-4">
-        <Switch label={$t`I confirm that I understand I can't undo this delete`} bind:checked={confirmed} />
+        <Switch label={$t`I understand that this can't be undone`} bind:checked={confirmed} />
       </div>
     {/if}
     <AlertDialog.Footer>

--- a/frontend/viewer/src/lib/sandbox/Sandbox.svelte
+++ b/frontend/viewer/src/lib/sandbox/Sandbox.svelte
@@ -34,6 +34,7 @@
   import {SvelteDate} from 'svelte/reactivity';
   import {RichTextToggle} from '$lib/dotnet-types/generated-types/MiniLcm/Models/RichTextToggle';
   import {FFmpegApi} from '$lib/components/audio/ffmpeg';
+  import {useDialogsService} from '$lib/services/dialogs-service';
 
   const testingService = tryUseService(DotnetService.TestingService);
 
@@ -109,6 +110,18 @@
   useBackHandler({addToStack: () => isBetter, onBack: () => isBetter = false, key: 'sandbox-better'});
   let dialogOpen = $state(false);
   useBackHandler({addToStack: () => dialogOpen, onBack: () => dialogOpen = false, key: 'sandbox-dialog'});
+
+  // Dialogs service demo
+  const dialogsService = useDialogsService();
+  let deleteResult: string | undefined = $state(undefined);
+  async function showDelete() {
+    const res = await dialogsService.promptDelete('Example item', 'Normal example');
+    deleteResult = res ? 'Confirmed delete' : 'Cancelled delete';
+  }
+  async function showDangerous() {
+    const res = await dialogsService.promptDelete('Dangerous item', 'This is irreversible', true);
+    deleteResult = res ? 'Confirmed dangerous delete' : 'Cancelled dangerous delete';
+  }
 
   const variants = Object.keys(buttonVariants.variants.variant) as unknown as (keyof typeof buttonVariants.variants.variant)[];
   const sizes = Object.keys(buttonVariants.variants.size) as unknown as (keyof typeof buttonVariants.variants.size)[];
@@ -249,6 +262,16 @@
         </div>
       </Dialog.Content>
     </Dialog.Root>
+  </div>
+  <div class="flex flex-col gap-2 border p-4 justify-between">
+    <h3 class="font-medium">Delete dialog example</h3>
+    <div class="flex gap-2 flex-wrap">
+      <Button onclick={showDelete}>Show Delete Dialog</Button>
+      <Button variant="destructive" onclick={showDangerous}>Show Dangerous Delete Dialog</Button>
+    </div>
+    {#if deleteResult}
+      <div>Result: {deleteResult}</div>
+    {/if}
   </div>
 </div>
 

--- a/frontend/viewer/src/lib/services/dialogs-service.ts
+++ b/frontend/viewer/src/lib/services/dialogs-service.ts
@@ -15,7 +15,7 @@ export class DialogsService {
   }
 
   #invokeDeleteDialog: undefined | ((subject: string, subjectDescription?: string, dangerous?: boolean) => Promise<boolean>);
-  set invokeDeleteDialog(dialog: ((subject: string, subjectDescription?: string, dangerous?: boolean) => Promise<boolean>)) {
+  set invokeDeleteDialog(dialog: ((subject: string, subjectDescription?: string, dangerous?: boolean) => Promise<boolean>) | undefined) {
     this.#invokeDeleteDialog = dialog;
   }
   #invokeNewEntryDialog: undefined | ((newEntry: Partial<IEntry>) => Promise<IEntry | undefined>);

--- a/frontend/viewer/src/lib/services/dialogs-service.ts
+++ b/frontend/viewer/src/lib/services/dialogs-service.ts
@@ -14,8 +14,8 @@ export class DialogsService {
   constructor(private writingSystemService: WritingSystemService) {
   }
 
-  #invokeDeleteDialog: undefined | ((subject: string, subjectDescription?: string) => Promise<boolean>);
-  set invokeDeleteDialog(dialog: ((subject: string, subjectDescription?: string) => Promise<boolean>)) {
+  #invokeDeleteDialog: undefined | ((subject: string, subjectDescription?: string, dangerous?: boolean) => Promise<boolean>);
+  set invokeDeleteDialog(dialog: ((subject: string, subjectDescription?: string, dangerous?: boolean) => Promise<boolean>)) {
     this.#invokeDeleteDialog = dialog;
   }
   #invokeNewEntryDialog: undefined | ((newEntry: Partial<IEntry>) => Promise<IEntry | undefined>);
@@ -38,9 +38,9 @@ export class DialogsService {
     const entry = await this.#invokeNewEntryDialog(partialEntry);
     return entry;
   }
-  async promptDelete(subject: string, subjectDescription?: string): Promise<boolean> {
+  async promptDelete(subject: string, subjectDescription?: string, dangerous?: boolean): Promise<boolean> {
     if (!this.#invokeDeleteDialog) throw new Error('No delete dialog');
-    return this.#invokeDeleteDialog(subject, subjectDescription);
+    return this.#invokeDeleteDialog(subject, subjectDescription, dangerous);
   }
   async getAudio(): Promise<string | undefined> {
     if (!this.#invokeAudioDialog) throw new Error('No audio dialog');


### PR DESCRIPTION
This pull request introduces changes to enhance the user experience when deleting projects. Specifically:

- Added a confirmation dialog to prevent accidental deletions of projects.
- Introduced a `dangerous` flag in `DialogsService` for handling critical actions.
- Updated the delete dialog to require explicit confirmation for dangerous actions.
- Enhanced the Sandbox component with examples demonstrating the updated delete dialog.
