### PR TITLE
Allow downloading projects that match fwdata project

### DIFF
--- a/backend/FwLite/FwLiteShared/Projects/CombinedProjectsService.cs
+++ b/backend/FwLite/FwLiteShared/Projects/CombinedProjectsService.cs
@@ -164,6 +164,8 @@ public class CombinedProjectsService(LexboxProjectService lexboxProjectService,
             {
                 var (status, projectId) = await lexboxProjectService.GetLexboxProjectId(server, code);
                 if (status != DownloadProjectByCodeResult.Success) return status;
+                // Note: the project might be from a different server, but that's current only relevant for devs
+                // and we still can't download two projects with the same code
                 if (crdtProjectsService.ProjectExists(code)) return DownloadProjectByCodeResult.ProjectAlreadyDownloaded;
                 var role = userRole.HasValue ? FromRole(userRole.Value) : ProjectRole.Editor;
                 project = new ProjectModel(

--- a/frontend/viewer/src/home/Server.svelte
+++ b/frontend/viewer/src/home/Server.svelte
@@ -81,7 +81,7 @@
   }
 
   function validateCodeForDownload(projectCode: string): string | undefined {
-    if (localProjects.some(p => p.code === projectCode)) {
+    if (localProjects.some(p => p.code === projectCode && p.server?.id === server?.id)) {
       return $t`You have already downloaded the ${projectCode} project`;
     }
   }


### PR DESCRIPTION
I coudn't download a project using the fancy admin download-by-code feature, because I had a fwdata project with that name (because fwdata projects are in `localProjects`).