### PR TITLE
Deleting test projects now deletes FwHeadless repo

### DIFF
--- a/backend/LexBoxApi/Controllers/ProjectController.cs
+++ b/backend/LexBoxApi/Controllers/ProjectController.cs
@@ -170,15 +170,12 @@ public class ProjectController(
     [AdminRequired]
     public async Task<ActionResult<Project>> DeleteProject(Guid id)
     {
-        //this project is only for testing purposes. It will delete projects permanently from the database.
+        //this endpoint is only for testing purposes. It will delete projects permanently from the database.
         var project = await lexBoxDbContext.Projects.FindAsync(id);
         if (project is null) return NotFound();
         if (project.RetentionPolicy != RetentionPolicy.Dev) return Forbid();
-        lexBoxDbContext.Projects.Remove(project);
-        var hgService = HttpContext.RequestServices.GetRequiredService<IHgService>();
-        await hgService.DeleteRepo(project.Code);
-        project.UpdateUpdatedDate();
-        await lexBoxDbContext.SaveChangesAsync();
+        project = await projectService.DeleteProjectPermanently(id);
+        if (project is null) return NotFound();
         return project;
     }
 

--- a/backend/LexBoxApi/Services/ProjectService.cs
+++ b/backend/LexBoxApi/Services/ProjectService.cs
@@ -211,6 +211,10 @@ public class ProjectService(
         await hgService.DeleteRepo(project.Code);
         await fwHeadless.DeleteRepo(projectId);
         project.UpdateUpdatedDate();
+        // Don't forget to add more Invalidate calls here if we add new caches
+        InvalidateProjectCodeCache(project.Code);
+        InvalidateProjectConfidentialityCache(projectId);
+        InvalidateProjectOrgIdsCache(projectId);
         await dbContext.SaveChangesAsync();
         return project;
     }


### PR DESCRIPTION
Fixes #1933.

The new DeleteProjectPermanently method in ProjectService is exactly the same code as the ProjectController's DELETE handler, with the addition of `fwHeadless.DeleteRepo` as well. By moving it into the ProjectService, we avoid the controller taking a FwHeadlessClient dependency.