### PR TITLE
Improve beta request emails

### DIFF
--- a/backend/LexBoxApi/Services/EmailService.cs
+++ b/backend/LexBoxApi/Services/EmailService.cs
@@ -225,7 +225,7 @@ public class EmailService(
     public async Task SendJoinFwLiteBetaEmail(User user)
     {
         var email = StartUserEmail("Lexbox Support", "lexbox_support@groups.sil.org"); // TODO: Get from environment
-        await RenderEmail(email, new JoinFwLiteBetaEmail(user.Name, user.Email ?? ""), user.LocalizationCode);
+        await RenderEmail(email, new JoinFwLiteBetaEmail(user.Name, user.Email ?? user.Username ?? ""), user.LocalizationCode);
         await SendEmailWithRetriesAsync(email);
     }
 

--- a/frontend/src/lib/email/JoinFwLiteBetaRequest.svelte
+++ b/frontend/src/lib/email/JoinFwLiteBetaRequest.svelte
@@ -5,7 +5,8 @@
   export let name: string;
   export let email: string;
   export let baseUrl: string;
-  let approveUrl = new URL(`/admin/?userSearch=${encodeURIComponent(email)}`, baseUrl);
+  const encodedEmail = encodeURIComponent(email);
+  let approveUrl = new URL(`/admin?userSearch=${encodedEmail}&memberSearch=${encodedEmail}`, baseUrl);
 </script>
 
 <Email subject={$t('emails.join_fw_lite_beta_request_email.subject', { name })}>


### PR DESCRIPTION
Adding `memberSearch=${encodedEmail}` will be quite convenient. I basically always do that manually atm.
I think there's only been one request from a user with no email address, so that's not as critical, but it's still an improvement.