### PR TITLE
Close sidebar when navigating on mobile

### DIFF
--- a/frontend/viewer/src/lib/components/ui/sidebar/sidebar.svelte
+++ b/frontend/viewer/src/lib/components/ui/sidebar/sidebar.svelte
@@ -25,6 +25,9 @@
   export function isOpen() {
     return sidebar.open;
   }
+  export function closeMobile() {
+    sidebar.openMobile = false;
+  }
 </script>
 
 {#if collapsible === 'none'}

--- a/frontend/viewer/src/project/ProjectSidebar.svelte
+++ b/frontend/viewer/src/project/ProjectSidebar.svelte
@@ -58,7 +58,7 @@
 
 {#snippet ViewButton(view: View, icon: IconClass, label: string, stat?: string)}
   <Sidebar.MenuItem>
-    <Sidebar.MenuButton onclick={() => goto(view)} isActive={$activeRoute?.uri.endsWith(view)}>
+    <Sidebar.MenuButton onclick={() => {goto(view); sidebar?.closeMobile()}} isActive={$activeRoute?.uri.endsWith(view)}>
       <Icon {icon} />
       <span>{label}</span>
       {#if stat}


### PR DESCRIPTION
closes #1974
This pull request ensures that the sidebar is automatically closed when navigating between views on mobile devices.