### PR TITLE
Add debounce to entry/sense picker

### DIFF
--- a/frontend/viewer/src/lib/entry-editor/EntryOrSensePicker.svelte
+++ b/frontend/viewer/src/lib/entry-editor/EntryOrSensePicker.svelte
@@ -68,7 +68,7 @@
       count: fetchCount,
       order: {field: SortField.Headword, writingSystem: 'default', ascending: true},
     });
-  }, {initialValue: []});
+  }, {initialValue: [], debounce: 300});
   const displayedEntries = $derived(searchResource.current?.slice(0, displayCount) ?? []);
   $effect(() => {
     // eslint-disable-next-line @typescript-eslint/no-unused-expressions


### PR DESCRIPTION
Search is currently happening on every keystroke.
We use 300ms on the main entry-list too.