### PR TITLE
Add dev button for jumping to entry from entry activity

### DIFF
--- a/frontend/viewer/src/lib/activity/ActivityView.svelte
+++ b/frontend/viewer/src/lib/activity/ActivityView.svelte
@@ -8,6 +8,8 @@
   import ListItem from '$lib/components/ListItem.svelte';
   import {VList} from 'virtua/svelte';
   import {FormatDuration, formatDuration} from '$lib/components/ui/format';
+  import DevContent from '$lib/layout/DevContent.svelte';
+  import {Button} from '$lib/components/ui/button';
 
   const historyService = useHistoryService();
   const projectContext = useProjectContext();
@@ -117,6 +119,12 @@
             {#snippet children(change)}
               <div class="change whitespace-pre-wrap font-mono text-sm">
                 {formatJsonForUi(change)}
+                <DevContent>
+                  {#if 'entityId' in change}
+                    <Button href={`./browse?entryId=${change.entityId}`} icon="i-mdi-tag-search" size="icon"
+                      title="Go to entry (only works for entry changes)" />
+                  {/if}
+                </DevContent>
               </div>
             {/snippet}
           </VList>


### PR DESCRIPTION
In was debugging a change and wanted to jump to the relevant entry, so I just added a (dev-only) button.
Dev-only, because it only works for some change types and it's non-trivial determining when it will work.

https://github.com/user-attachments/assets/ed89832f-368a-4b40-a0a5-7847cffbd4d8

