### PR TITLE
disable compression of static assets

### DIFF
--- a/backend/FwLite/FwLiteMaui/FwLiteMaui.csproj
+++ b/backend/FwLite/FwLiteMaui/FwLiteMaui.csproj
@@ -19,6 +19,7 @@
     <SingleProject>true</SingleProject>
     <ImplicitUsings>enable</ImplicitUsings>
     <EnableDefaultCssItems>false</EnableDefaultCssItems>
+    <CompressionEnabled>false</CompressionEnabled>
     <Nullable>enable</Nullable>
     <SelfContained>true</SelfContained>
     <EnableWindowsTargeting Condition="$([MSBuild]::IsOSPlatform('linux'))">true</EnableWindowsTargeting>

--- a/backend/FwLite/FwLiteShared/FwLiteShared.csproj
+++ b/backend/FwLite/FwLiteShared/FwLiteShared.csproj
@@ -1,4 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Razor">
+  <PropertyGroup>
+    <CompressionEnabled>false</CompressionEnabled>
+  </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="BeaKona.AutoInterfaceGenerator" />
     <PackageReference Include="Humanizer.Core" />

--- a/backend/FwLite/Taskfile.yml
+++ b/backend/FwLite/Taskfile.yml
@@ -51,10 +51,17 @@ tasks:
     cmd: dotnet run -f net9.0-windows10.0.19041.0
 
   publish-maui-windows:
+    deps: [ publish-maui-windows-msix, publish-maui-windows-portable]
+
+  publish-maui-windows-portable:
     dir: ./FwLiteMaui
     cmds:
-      - dotnet publish -f net9.0-windows10.0.19041.0 --artifacts-path ../artifacts -p:WindowsPackageType=None
-      - dotnet publish -f net9.0-windows10.0.19041.0 --artifacts-path ../artifacts
+      - dotnet publish -f net9.0-windows10.0.19041.0 --artifacts-path ../artifacts -p:WindowsPackageType=None -p:BuildAndroid=false
+
+  publish-maui-windows-msix:
+    dir: ./FwLiteMaui
+    cmds:
+      - dotnet publish -f net9.0-windows10.0.19041.0 --artifacts-path ../artifacts -p:BuildAndroid=false
 
   run-maui-android:
     dir: ./FwLiteMaui


### PR DESCRIPTION
Currently our apps include compressed versions of all static assets, there's little benefit to this because the assets are just loaded in memory and all it does is bloat the file size of the app.

Sizes:
| Type | Before | After | Saved|
|--------|--------|--------|---|
| android | 147mb | 125mb | -22mb |
| msix | 187mb | 165mb | -22mb |