### PR TITLE
Delete draft projects as part of the project-create transaction

### DIFF
--- a/backend/LexBoxApi/Services/ProjectService.cs
+++ b/backend/LexBoxApi/Services/ProjectService.cs
@@ -52,7 +52,10 @@ public class ProjectService(
                 FlexProjectMetadata = input.Type == ProjectType.FLEx ? new() : null
             });
         // Also delete draft project, if any
-        await dbContext.DraftProjects.Where(dp => dp.Id == projectId).ExecuteDeleteAsync();
+        if (draftProject is not null)
+        {
+            dbContext.DraftProjects.Remove(draftProject);
+        }
 
         var manager = input.ProjectManagerId.HasValue ? await dbContext.Users.FindAsync(input.ProjectManagerId.Value) : null;
         manager?.UpdateCreateProjectsPermission(ProjectRole.Manager);


### PR DESCRIPTION
- Changes draft deletion to **not** use `ExecuteDeleteAsync`, because it should be part of the db-transaction.
- Delete-repo if any part of the project-creation fails
- Only send email to requesting user after everything has succeeded.