### PR TITLE
Make Lexbox notifications scroll if too tall

### DIFF
--- a/frontend/src/lib/notify/Notify.svelte
+++ b/frontend/src/lib/notify/Notify.svelte
@@ -8,16 +8,16 @@
 </script>
 
 {#if $notifications.length > 0}
-  <div class="toast toast-center prose z-20">
+  <div class="toast toast-center prose z-20 max-h-full">
     {#if $notifications.length > 1}
       <div class="flex justify-end" in:slide out:blur>
         <BadgeButton onclick={removeAllNotifications}>{$t('notify.close_all')}<span class="ml-2">✕</span></BadgeButton>
       </div>
     {/if}
     {#each $notifications as note (note)}
-      <div class="alert {note.category ?? ''}" in:slide out:blur>
+      <div class="alert {note.category ?? ''} overflow-y-auto" in:slide out:blur>
         {note.message}
-        <button onclick={() => removeNotification(note)} class="btn btn-circle btn-sm btn-ghost">✕</button>
+        <button onclick={() => removeNotification(note)} class="btn btn-circle btn-sm btn-ghost sticky top-0 bottom-0">✕</button>
       </div>
     {/each}
   </div>


### PR DESCRIPTION
And keep the close button in view. Using sticky is a bit weird, but fixed and absolute make things messy and this is only for edge cases.

Big notifications now look like this:
<img width="975" height="924" alt="image" src="https://github.com/user-attachments/assets/6af05ece-618c-43be-b580-cc5d39f4dbb3" />
And the close button doesn't scroll out of view:
<img width="999" height="227" alt="image" src="https://github.com/user-attachments/assets/409a1525-f8a9-4f35-83af-c56415a84251" />

If we use position: fixed or absolute then the button is removed from the dom flow and things go underneath it. This is a much easier fix for this edge case.