### PR TITLE
Fix AppBar is above dialog backdrops

### DIFF
--- a/frontend/viewer/src/home/AppBar.svelte
+++ b/frontend/viewer/src/home/AppBar.svelte
@@ -15,7 +15,7 @@
   });
 </script>
 <header
-  class="flex items-center z-50 space-x-2 justify-between pr-2 px-4 min-h-14 shadow-lg m-3 rounded sticky top-3">
+  class="flex items-center z-10 space-x-2 justify-between pr-2 px-4 min-h-14 shadow-lg m-3 rounded sticky top-3">
   {@render title()}
   <div class="grow-0"></div>
   {@render actions()}


### PR DESCRIPTION
Before:
<img width="905" height="551" alt="image" src="https://github.com/user-attachments/assets/eccbddbe-f82c-42d9-befd-10510bd6282a" />

After:
<img width="1018" height="562" alt="image" src="https://github.com/user-attachments/assets/8ec52705-b8ba-4331-a6c8-8fa899e4081c" />
