### PR TITLE
Validate existence of project-codes before doing anything

### DIFF
--- a/backend/LexBoxApi/Controllers/TestingController.cs
+++ b/backend/LexBoxApi/Controllers/TestingController.cs
@@ -1,4 +1,3 @@
-using System.Collections.Immutable;
 using LexBoxApi.Auth;
 using LexBoxApi.Auth.Attributes;
 using LexBoxApi.Services;
@@ -81,9 +80,16 @@ public class TestingController(
 
     [HttpPost("copyToNewProject")]
     [AdminRequired]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(string), StatusCodes.Status404NotFound)]
+    [ProducesResponseType(typeof(string), StatusCodes.Status400BadRequest)]
+    [ProducesDefaultResponseType]
     public async Task<ActionResult<Guid>> CopyToNewProject(string newProjectCode, string existingProjectCode)
     {
         var id = Guid.NewGuid();
+        if (!await projectService.ProjectExists(existingProjectCode)) return NotFound("Existing project code not found");
+        if (await projectService.ProjectExists(newProjectCode)) return BadRequest("New project code already in use");
+
         await projectService.CreateProject(new(id,
             newProjectCode,
             "Copy of " + existingProjectCode,


### PR DESCRIPTION
I called this endpoint with the intended codes swapped.
Luckily the create already fails in that case, because the DB throws a duplicate exception.
But it makes a lot of sense to also validate that the original code is actually valid before creating a project for the new copy.