### PR TITLE
Set project-type early

### DIFF
--- a/frontend/viewer/src/DotnetProjectView.svelte
+++ b/frontend/viewer/src/DotnetProjectView.svelte
@@ -32,6 +32,7 @@
   onMount(async () => {
     console.debug('ProjectView mounted');
     projectContext.projectCode = code;
+    projectContext.projectType = projectType;
     if (projectType === 'crdt') {
       const maybeProjectName = await projectServicesProvider.tryGetCrdtProjectName(code);
       projectName = maybeProjectName ? maybeProjectName : code;

--- a/frontend/viewer/src/lib/project-context.svelte.ts
+++ b/frontend/viewer/src/lib/project-context.svelte.ts
@@ -78,6 +78,9 @@ export class ProjectContext {
   public get projectType(): ProjectType {
     return this.#projectType;
   }
+  public set projectType(value: ProjectType) {
+    this.#projectType = value;
+  }
   public get server(): ILexboxServer | undefined {
     return this.#server;
   }


### PR DESCRIPTION
This prevents the FLEx logo from being shown for crdt projects while they're loading