### PR TITLE
Load less entries - esp. on mobile

### DIFF
--- a/frontend/viewer/src/project/browse/EntriesList.svelte
+++ b/frontend/viewer/src/project/browse/EntriesList.svelte
@@ -19,6 +19,7 @@
   import {Icon} from '$lib/components/ui/icon';
   import {useProjectContext} from '$lib/project-context.svelte';
   import {DEFAULT_DEBOUNCE_TIME} from '$lib/utils/time';
+  import {IsMobile} from '$lib/hooks/is-mobile.svelte';
 
   let {
     search = '',
@@ -74,7 +75,7 @@
     if (!silent) loadingUndebounced = true;
     try {
       const queryOptions: IQueryOptions = {
-        count: 10_000,
+        count: IsMobile.value ? 1_000 : 5_000,
         offset: 0,
         filter: {
           gridifyFilter: gridifyFilter ? gridifyFilter : undefined,


### PR DESCRIPTION
Part of #2032
I'd love to have bullet-proof lazy-loading/infinite-scrolling, but not today.

This feels like a safe improvement.
The biggest problem with loading less entries, is that we can only scroll to entries that were loaded.
I think for now that's less important than performance. Especially on mobile.