### PR TITLE
Add shimmer to entry skeletons

### DIFF
--- a/frontend/viewer/src/project/browse/EntryRow.svelte
+++ b/frontend/viewer/src/project/browse/EntryRow.svelte
@@ -45,10 +45,10 @@
 
 <ListItem bind:ref {...rest}>
   {#if rest.skeleton || !entry}
-    <div class="animate-pulse" style="animation-delay: {animationDelay}">
-      <div class="h-5 bg-muted-foreground/20 rounded mb-2" style="width: {headwordWidth}"></div>
-      <div class="h-4 bg-muted-foreground/20 rounded mb-2" style="width: {definitionWidth}"></div>
-      <div class="h-6 bg-muted-foreground/20 rounded-full" style="width: {badgeWidth}"></div>
+    <div>
+      <div class="h-5 motion-safe:animate-shimmer bg-shimmer rounded mb-2" style="width: {headwordWidth}"></div>
+      <div class="h-4 motion-safe:animate-pulse bg-muted-foreground/20 rounded mb-2" style="width: {definitionWidth}; animation-delay: {animationDelay}"></div>
+      <div class="h-6 motion-safe:animate-pulse bg-muted-foreground/20 rounded-full" style="width: {badgeWidth}; animation-delay: {animationDelay}"></div>
     </div>
   {:else if previewDictionary}
     <DictionaryEntry {entry}/>

--- a/frontend/viewer/tailwind.config.ts
+++ b/frontend/viewer/tailwind.config.ts
@@ -129,11 +129,26 @@ export default {
           '0%,70%,100%': {opacity: '1'},
           '20%,50%': {opacity: '0'},
         },
+        'shimmer': {
+          from: {
+            'background-position': '100% 0;'
+          },
+          to: {
+            'background-position': '-100% 0;'
+          }
+        },
       },
       animation: {
         'accordion-down': 'accordion-down 0.2s ease-out',
         'accordion-up': 'accordion-up 0.2s ease-out',
         'caret-blink': 'caret-blink 1.25s ease-out infinite',
+        'shimmer': 'shimmer 2.0s linear infinite',
+      },
+      backgroundImage: {
+        'shimmer': 'linear-gradient(90deg, hsl(var(--muted-foreground)/0.2) 20%, hsl(var(--foreground)/0.3) 50%, hsl(var(--muted-foreground)/0.2) 65%)',
+      },
+      backgroundSize: {
+        'shimmer': '200% 100%',
       },
     },
   },


### PR DESCRIPTION
A [user thought](https://groups.google.com/a/groups.sil.org/g/lexbox_support/c/KQ1Ld_5go8E) that his dictionary didn't load on his phone, because it was taking too long (at least I think that was the problem).

See https://github.com/sillsdev/languageforge-lexbox/pull/2033 for the simple performance improvement I'm using for now.

I'm hoping this more noticeable loading effect will be advantageous in that regards.

https://github.com/user-attachments/assets/c9eca2d0-0d13-4745-9e3d-b91033e34605

