### PR TITLE
Map empty RichStrings to null in crdt api

### DIFF
--- a/backend/FwLite/FwDataMiniLcmBridge/Api/FwDataMiniLcmApi.cs
+++ b/backend/FwLite/FwDataMiniLcmBridge/Api/FwDataMiniLcmApi.cs
@@ -859,6 +859,7 @@ public class FwDataMiniLcmApi(
 
     internal RichString? ToRichString(ITsString? tsString)
     {
+        /// Same null mapping logic as <see cref="RichStringConverter"/>
         if (tsString is null or { Length: 0 }) return null;
         return RichTextMapping.FromTsString(tsString,
             h =>

--- a/backend/FwLite/MiniLcm/Models/RichString.cs
+++ b/backend/FwLite/MiniLcm/Models/RichString.cs
@@ -72,7 +72,10 @@ public class RichString(ICollection<RichSpan> spans) : IEquatable<RichString>
                 return new RichString(text);//ws is actually set when the string is assigned to a RichMultiString
             }
             var model = JsonSerializer.Deserialize<RichStringPrimitive>(ref reader, options);
-            return model?.Spans is null ? null : new RichString([..model.Spans]);
+
+            /// Same null mapping logic as <see cref="FwDataMiniLcmApi.ToRichString"/>
+            if (model?.Spans is null or { Count: 0 }) return null;
+            return new RichString([..model.Spans]);
         }
 
         public override void Write(Utf8JsonWriter writer, RichString value, JsonSerializerOptions options)


### PR DESCRIPTION
Currently, if an example sentence is added in crdt with no Reference (or an existing Reference is cleared) then the Reference field is set to an empty rich-string. The fwdata api maps empty rich-strings to null. So, on the second sync, the crdt Reference will get updated to null. I.e. syncing is not idempotent.

This PR changes the crdt api to also map empty rich-strings to null.

See: https://github.com/sillsdev/languageforge-lexbox/issues/2036