### PR TITLE
Test adding context to a translated string

### DIFF
--- a/frontend/viewer/src/lib/components/field-editors/multi-select.svelte
+++ b/frontend/viewer/src/lib/components/field-editors/multi-select.svelte
@@ -15,6 +15,7 @@
   import {slide} from 'svelte/transition';
   import {watch} from 'runed';
   import {computeCommandScore} from 'bits-ui';
+  import {s} from '$lib/i18n';
 
   type Value = ReadonlyDeep<MutableValue>;
 
@@ -199,7 +200,7 @@
       <div class="flex items-center gap-2 flex-nowrap">
         {#if IsMobile.value}
           {#if filterValue}
-            <XButton onclick={() => (filterValue = '')} aria-label={$t`clear`} />
+            <XButton onclick={() => (filterValue = '')} aria-label={$t(s.clear)} />
           {/if}
         {:else}
           {#if dirty}

--- a/frontend/viewer/src/lib/components/field-editors/select.svelte
+++ b/frontend/viewer/src/lib/components/field-editors/select.svelte
@@ -10,6 +10,7 @@
   import {cn} from '$lib/utils';
   import {watch} from 'runed';
   import {computeCommandScore} from 'bits-ui';
+  import {s} from '$lib/i18n';
 
   type Value = ReadonlyDeep<MutableValue>;
 
@@ -113,7 +114,7 @@
       <div class="flex items-center gap-2 flex-nowrap">
         {#if IsMobile.value}
           {#if filterValue}
-            <XButton onclick={() => (filterValue = '')} aria-label={$t`clear`} />
+            <XButton onclick={() => (filterValue = '')} aria-label={$t(s.clear)} />
           {/if}
         {:else}
           <XButton onclick={dismiss} />

--- a/frontend/viewer/src/lib/i18n/index.ts
+++ b/frontend/viewer/src/lib/i18n/index.ts
@@ -1,5 +1,7 @@
-import {locale} from 'svelte-i18n-lingui';
 import {createSubscriber} from 'svelte/reactivity';
+import {locale} from 'svelte-i18n-lingui';
+
+export * from './strings.svelte'
 
 const hasSetLang = {value: false};
 const subscriber = createSubscriber(update => {

--- a/frontend/viewer/src/lib/i18n/strings.svelte.ts
+++ b/frontend/viewer/src/lib/i18n/strings.svelte.ts
@@ -1,0 +1,10 @@
+import {gt} from 'svelte-i18n-lingui';
+
+export const s = {
+  get clear() {
+    return gt({
+      message: 'clear',
+      comment: 'Button to clear/empty a text field e.g. when filtering for semantic domains',
+    });
+  },
+};

--- a/frontend/viewer/src/locales/en.po
+++ b/frontend/viewer/src/locales/en.po
@@ -205,8 +205,8 @@ msgstr "Citation Form"
 msgid "Classic FieldWorks Projects"
 msgstr "Classic FieldWorks Projects"
 
-#: src/lib/components/field-editors/select.svelte
-#: src/lib/components/field-editors/multi-select.svelte
+#. Button to clear/empty a text field e.g. when filtering for semantic domains
+#: src/lib/i18n/strings.svelte.ts
 msgid "clear"
 msgstr "clear"
 

--- a/frontend/viewer/src/locales/es.po
+++ b/frontend/viewer/src/locales/es.po
@@ -210,8 +210,8 @@ msgstr "Formulario de citación"
 msgid "Classic FieldWorks Projects"
 msgstr "Proyectos clásicos de FieldWorks"
 
-#: src/lib/components/field-editors/select.svelte
-#: src/lib/components/field-editors/multi-select.svelte
+#. Button to clear/empty a text field e.g. when filtering for semantic domains
+#: src/lib/i18n/strings.svelte.ts
 msgid "clear"
 msgstr "borrar"
 

--- a/frontend/viewer/src/locales/fr.po
+++ b/frontend/viewer/src/locales/fr.po
@@ -210,10 +210,10 @@ msgstr "Formulaire de citation"
 msgid "Classic FieldWorks Projects"
 msgstr "Projets FieldWorks classiques"
 
-#: src/lib/components/field-editors/select.svelte
-#: src/lib/components/field-editors/multi-select.svelte
+#. Button to clear/empty a text field e.g. when filtering for semantic domains
+#: src/lib/i18n/strings.svelte.ts
 msgid "clear"
-msgstr "clair"
+msgstr ""
 
 #: src/project/tasks/SubjectPopup.svelte
 #: src/lib/components/ui/button/x-button.svelte

--- a/frontend/viewer/src/locales/id.po
+++ b/frontend/viewer/src/locales/id.po
@@ -210,10 +210,10 @@ msgstr "Formulir Kutipan"
 msgid "Classic FieldWorks Projects"
 msgstr "Proyek FieldWorks Klasik"
 
-#: src/lib/components/field-editors/select.svelte
-#: src/lib/components/field-editors/multi-select.svelte
+#. Button to clear/empty a text field e.g. when filtering for semantic domains
+#: src/lib/i18n/strings.svelte.ts
 msgid "clear"
-msgstr "jelas"
+msgstr ""
 
 #: src/project/tasks/SubjectPopup.svelte
 #: src/lib/components/ui/button/x-button.svelte

--- a/frontend/viewer/src/locales/ko.po
+++ b/frontend/viewer/src/locales/ko.po
@@ -210,10 +210,10 @@ msgstr "인용 양식"
 msgid "Classic FieldWorks Projects"
 msgstr "클래식 FieldWorks 프로젝트"
 
-#: src/lib/components/field-editors/select.svelte
-#: src/lib/components/field-editors/multi-select.svelte
+#. Button to clear/empty a text field e.g. when filtering for semantic domains
+#: src/lib/i18n/strings.svelte.ts
 msgid "clear"
-msgstr "clear"
+msgstr ""
 
 #: src/project/tasks/SubjectPopup.svelte
 #: src/lib/components/ui/button/x-button.svelte

--- a/frontend/viewer/src/locales/ms.po
+++ b/frontend/viewer/src/locales/ms.po
@@ -210,10 +210,10 @@ msgstr "Bentuk Petikan"
 msgid "Classic FieldWorks Projects"
 msgstr "Projek FieldWorks Klasik"
 
-#: src/lib/components/field-editors/select.svelte
-#: src/lib/components/field-editors/multi-select.svelte
+#. Button to clear/empty a text field e.g. when filtering for semantic domains
+#: src/lib/i18n/strings.svelte.ts
 msgid "clear"
-msgstr "padam"
+msgstr ""
 
 #: src/project/tasks/SubjectPopup.svelte
 #: src/lib/components/ui/button/x-button.svelte

--- a/frontend/viewer/src/locales/sw.po
+++ b/frontend/viewer/src/locales/sw.po
@@ -210,10 +210,10 @@ msgstr "Fomu ya Manukuu"
 msgid "Classic FieldWorks Projects"
 msgstr ""
 
-#: src/lib/components/field-editors/select.svelte
-#: src/lib/components/field-editors/multi-select.svelte
+#. Button to clear/empty a text field e.g. when filtering for semantic domains
+#: src/lib/i18n/strings.svelte.ts
 msgid "clear"
-msgstr "futa"
+msgstr ""
 
 #: src/project/tasks/SubjectPopup.svelte
 #: src/lib/components/ui/button/x-button.svelte


### PR DESCRIPTION
A translator recently had a lot of questions as he translated our strings to French.
I think we should probably add some comments for translators for at least some of them.

This approach seems the cleanest, but it has the downside that the source reference comment now just points to strings.svelte.ts, which isn't helpful. On the other hand that reference probably isn't all that useful, so it probably doesn't matter.

Perhaps it's sort of a bug. I would expect either `msg` or `gt` (especially the former) to result in the reference to point to where the calls to `$t()` are actually located. But neither does.