### PR TITLE
Treat invalid uri's as null

### DIFF
--- a/backend/FwLite/FwLiteShared/Auth/AuthConfig.cs
+++ b/backend/FwLite/FwLiteShared/Auth/AuthConfig.cs
@@ -39,12 +39,14 @@ public class AuthConfig
     public bool TryGetServer(ProjectData projectData, [NotNullWhen(true)] out LexboxServer? server)
     {
         var originDomain = projectData.OriginDomain;
-        if (string.IsNullOrEmpty(originDomain))
+
+        if (Uri.TryCreate(originDomain, UriKind.Absolute, out var originUri))
         {
-            server = null;
-            return false;
+            return TryGetServerByAuthority(originUri.Authority, out server);
         }
-        return TryGetServerByAuthority(new Uri(originDomain).Authority, out server);
+
+        server = null;
+        return false;
     }
     public LexboxServer GetServer(string serverName)
     {

--- a/backend/FwLite/LcmCrdt/CrdtProject.cs
+++ b/backend/FwLite/LcmCrdt/CrdtProject.cs
@@ -37,7 +37,7 @@ public record ProjectData(string Name, string Code, Guid Id, string? OriginDomai
         return uri?.GetComponents(UriComponents.SchemeAndServer, UriFormat.Unescaped);
     }
 
-    public string? ServerId => OriginDomain is not null ? new Uri(OriginDomain).Authority : null;
+    public string? ServerId => Uri.TryCreate(OriginDomain, UriKind.Absolute, out var uri) ? uri.Authority : null;
     public bool IsReadonly => Role is not UserProjectRole.Editor and not UserProjectRole.Manager;
 }
 


### PR DESCRIPTION
I put an invalid uri in my database.
That's obviously not a real-world scenario, but there's not reason to have these methods blow up as a result.