### PR TITLE
Standardize lcm-cache disposal logging

### DIFF
--- a/backend/FwLite/FwDataMiniLcmBridge/FwDataProject.cs
+++ b/backend/FwLite/FwDataMiniLcmBridge/FwDataProject.cs
@@ -12,6 +12,10 @@ namespace FwDataMiniLcmBridge;
 /// </param>
 public class FwDataProject(string name, string projectsPath) : IProjectIdentifier
 {
+    /// <summary>
+    /// Note: in fw-headless this is always "fw", which is not very useful for debugging.
+    /// So, the FilePath (which includes code and id) should be used for logging.
+    /// </summary>
     public string Name => name;
     public string FileName => name + ".fwdata";
     public string FilePath => Path.Combine(ProjectFolder, FileName);


### PR DESCRIPTION
This refactor was primarily inspired by the fact that fw-headless was creating logs like this:
> Explicitly Closing project fw

Which doesn't tell me which project it actually is.
So, I standardized all log messages surrounding lcm-cache disposal to use the whole fwdata-file path in logs.