### PR TITLE
Standardize NotFoundException usage

### DIFF
--- a/backend/FwLite/FwDataMiniLcmBridge/Api/FwDataMiniLcmApi.cs
+++ b/backend/FwLite/FwDataMiniLcmBridge/Api/FwDataMiniLcmApi.cs
@@ -1,6 +1,5 @@
 using System.Collections.Frozen;
 using System.Globalization;
-using System.Reflection;
 using System.Text;
 using FwDataMiniLcmBridge.Api.UpdateProxy;
 using FwDataMiniLcmBridge.LcmUtils;
@@ -853,7 +852,7 @@ public class FwDataMiniLcmApi(
         //path includes `AudioVisual` currently
         var mediaUri = new MediaUri(mediaUriString);
         var path = mediaAdapter.PathFromMediaUri(mediaUri, Cache);
-        if (path is null) throw new NotFoundException($"Unable to find file {mediaUri.FileId}.", nameof(MediaFile));
+        if (path is null) throw new NotFoundException($"File ID: {mediaUri.FileId}.", nameof(MediaFile));
         return Path.GetRelativePath(Path.Join(Cache.LangProject.LinkedFilesRootDir, AudioVisualFolder), path);
     }
 
@@ -1229,7 +1228,7 @@ public class FwDataMiniLcmApi(
     internal void AddPublication(ILexEntry entry, Guid publicationId)
     {
         var lcmPublication = GetLcmPublication(publicationId);
-        if (lcmPublication is null) throw new NotFoundException("unable to find publication with id " + publicationId, nameof(Publication));
+        NotFoundException.ThrowIfNull<Publication>(lcmPublication, publicationId);
         entry.DoNotPublishInRC.Remove(lcmPublication);
     }
 
@@ -1248,8 +1247,7 @@ public class FwDataMiniLcmApi(
     internal void RemovePublication(ILexEntry entry, Guid publicationId)
     {
         var lcmPublication = GetLcmPublication(publicationId);
-        if (lcmPublication is null)
-            throw new NotFoundException("unable to find publication with id " + publicationId, nameof(Publication));
+        NotFoundException.ThrowIfNull<Publication>(lcmPublication, publicationId);
         entry.DoNotPublishInRC.Add(lcmPublication);
     }
 

--- a/backend/FwLite/FwLiteProjectSync/DryRunMiniLcmApi.cs
+++ b/backend/FwLite/FwLiteProjectSync/DryRunMiniLcmApi.cs
@@ -336,13 +336,13 @@ public partial class DryRunMiniLcmApi(IMiniLcmApi api) : IMiniLcmApi
     public async Task<Publication> UpdatePublication(Guid id, UpdateObjectInput<Publication> update)
     {
         DryRunRecords.Add(new DryRunRecord(nameof(UpdatePublication), $"Update publication {id}"));
-        return await _api.GetPublication(id) ?? throw new NotFoundException("Publication not found", nameof(Publication));
+        return await _api.GetPublication(id) ?? throw NotFoundException.ForType<Publication>(id);
     }
 
     public async Task<Publication> UpdatePublication(Publication before, Publication after, IMiniLcmApi? api = null)
     {
         DryRunRecords.Add(new DryRunRecord(nameof(UpdatePublication), $"Update publication {before.Id}"));
-        return await _api.GetPublication(before.Id) ?? throw new NotFoundException("Publication not found", nameof(Publication));
+        return await _api.GetPublication(before.Id) ?? throw NotFoundException.ForType<Publication>(before.Id);
     }
 
     public Task DeletePublication(Guid id)

--- a/backend/FwLite/LcmCrdt/CrdtMiniLcmApi.cs
+++ b/backend/FwLite/LcmCrdt/CrdtMiniLcmApi.cs
@@ -85,7 +85,7 @@ public class CrdtMiniLcmApi(
         var betweenIds = between is null ? null : await between.MapAsync(async wsId => wsId is null ? null : (await repo.GetWritingSystem(wsId.Value, wsType))?.Id);
         var order = await OrderPicker.PickOrder(repo.WritingSystems.Where(ws => ws.Type == wsType), betweenIds);
         await AddChange(new CreateWritingSystemChange(writingSystem, entityId, order));
-        return await repo.GetWritingSystem(writingSystem.WsId, wsType) ?? throw new NotFoundException($"Writing system {writingSystem.WsId.Code} not found", nameof(WritingSystem));
+        return await repo.GetWritingSystem(writingSystem.WsId, wsType) ?? throw NotFoundException.ForType<WritingSystem>($"{writingSystem.WsId.Code}: {wsType}");
     }
 
     public async Task<WritingSystem> UpdateWritingSystem(WritingSystemId id, WritingSystemType type, UpdateObjectInput<WritingSystem> update)
@@ -95,7 +95,7 @@ public class CrdtMiniLcmApi(
         if (ws is null) throw new NullReferenceException($"unable to find writing system with id {id}");
         var patchChange = new JsonPatchChange<WritingSystem>(ws.Id, update.Patch);
         await AddChange(patchChange);
-        return await repo.GetWritingSystem(id, type) ?? throw new NotFoundException($"Writing system {id.Code} not found", nameof(WritingSystem));
+        return await repo.GetWritingSystem(id, type) ?? throw NotFoundException.ForType<WritingSystem>($"{id.Code}: {type}");
     }
 
     public async Task<WritingSystem> UpdateWritingSystem(WritingSystem before, WritingSystem after, IMiniLcmApi? api = null)
@@ -330,7 +330,7 @@ public class CrdtMiniLcmApi(
         var order = await OrderPicker.PickOrder(repo.ComplexFormComponents.Where(s => s.ComplexFormEntryId == component.ComplexFormEntryId), betweenIds);
         var id = component.MaybeId ??
                  (await repo.FindComplexFormComponent(component))?.Id
-                 ?? throw new NotFoundException($"Component {component}", nameof(ComplexFormComponent));
+                 ?? throw NotFoundException.ForType<ComplexFormComponent>("missing ID");
         await AddChange(new Changes.SetOrderChange<ComplexFormComponent>(id, order));
     }
 

--- a/backend/FwLite/LcmCrdt/Data/MiniLcmRepository.cs
+++ b/backend/FwLite/LcmCrdt/Data/MiniLcmRepository.cs
@@ -114,7 +114,7 @@ public class MiniLcmRepository(
     public async Task<ComplexFormComponent> FindComplexFormComponent(Guid objectId)
     {
         return (await AsyncExtensions.SingleOrDefaultAsync(ComplexFormComponents, c => c.Id == objectId)) ??
-               throw NotFoundException.ForType<ComplexFormComponent>();
+               throw NotFoundException.ForType<ComplexFormComponent>(objectId);
     }
 
     public async Task<int> CountEntries(string? query = null, FilterQueryOptions? options = null)

--- a/backend/FwLite/MiniLcm/Exceptions/NotFoundException.cs
+++ b/backend/FwLite/MiniLcm/Exceptions/NotFoundException.cs
@@ -2,15 +2,32 @@ using System.Diagnostics.CodeAnalysis;
 
 namespace MiniLcm.Exceptions;
 
-public class NotFoundException(string message, string type) : Exception(message)
+public class NotFoundException(string identifier, string type) : Exception($"Not found: {identifier} ({type})")
 {
-    public static void ThrowIfNull<T>([AllowNull, NotNull] T arg)
+    public NotFoundException(Guid id, Type type) : this(id.ToString(), type.Name)
     {
-        if (arg is null)
-            throw ForType<T>();
     }
 
-    public static NotFoundException ForType<T>() => new($"{typeof(T).Name} not found", typeof(T).Name);
+    public static void ThrowIfNull<T>([AllowNull, NotNull] object arg, string identifier)
+    {
+        if (arg is null)
+            throw ForType<T>(identifier);
+    }
+
+    public static void ThrowIfNull<T>([AllowNull, NotNull] object arg, Guid identifier)
+    {
+        ThrowIfNull<T>(arg, identifier.ToString());
+    }
+
+    public static NotFoundException ForType<T>(string identifier)
+    {
+        return new(identifier, typeof(T).Name);
+    }
+
+    public static NotFoundException ForType<T>(Guid identifier)
+    {
+        return ForType<T>(identifier.ToString());
+    }
 
     public string Type { get; set; } = type;
 }


### PR DESCRIPTION
The last time I wanted to use this exception I realized I'd like it to explicitly take not an identifier, rather than only a type.