### PR TITLE
Put SetFirstTranslationId changes in one commit

### DIFF
--- a/backend/FwLite/FwLiteProjectSync/CrdtFwdataProjectSyncService.cs
+++ b/backend/FwLite/FwLiteProjectSync/CrdtFwdataProjectSyncService.cs
@@ -43,7 +43,6 @@ public class CrdtFwdataProjectSyncService(MiniLcmImport miniLcmImport, ILogger<C
         {
             // Repair any missing translation IDs before doing the full sync, so the sync doesn't have to deal with them
             var syncedIdCount = await CrdtRepairs.SyncMissingTranslationIds(projectSnapshot.Entries, fwdataApi, crdt, dryRun);
-            activity?.AddTag("Sync.CrdtRepairs.SyncedTranslationIds", syncedIdCount);
         }
 
         SyncResult result = await Sync(crdtApi, fwdataApi, dryRun, fwdataApi.EntryCount, projectSnapshot);

--- a/backend/FwLite/LcmCrdt/CrdtMiniLcmApi.cs
+++ b/backend/FwLite/LcmCrdt/CrdtMiniLcmApi.cs
@@ -763,17 +763,22 @@ public class CrdtMiniLcmApi(
     }
 
     [Obsolete($"Use {nameof(AddTranslation)} instead")]
-    public async Task SetFirstTranslationId(
-        Guid exampleSentenceId,
-        Guid translationId)
+    public async Task SetFirstTranslationIds(IDictionary<Guid, Guid> exampleSentenceIdToTranslationId)
     {
-        // When calling this, the first translation of the relevant example-sentence should almost definitely
-        // be Translation.MissingTranslationId, which the API maps to the example sentence's DefaultFirstTranslationId.
-        // However, there are edge cases, which are probably valid. See the comment above the caling code in CrdtRepairs.
-        if (translationId == Translation.MissingTranslationId) throw new InvalidOperationException("Cannot set the first translation id to the missing id placeholder");
-        // We could also validate that translationId is not the default first translation ID,
-        // but it doesn't really matter if it is. It would just be unexpected.
-        await AddChange(new SetFirstTranslationIdChange(exampleSentenceId, translationId));
+        var changes = exampleSentenceIdToTranslationId
+            .Select(kv => GetSetFirstTranslationIdChange(kv.Key, kv.Value));
+        await AddChanges(changes);
+
+        static SetFirstTranslationIdChange GetSetFirstTranslationIdChange(Guid exampleSentenceId, Guid translationId)
+        {
+            // When calling this, the first translation of the relevant example-sentence should almost definitely
+            // be Translation.MissingTranslationId, which the API maps to the example sentence's DefaultFirstTranslationId.
+            // However, there are edge cases, which are probably valid. See the comment above the caling code in CrdtRepairs.
+            if (translationId == Translation.MissingTranslationId) throw new InvalidOperationException("Cannot set the first translation id to the missing id placeholder");
+            // We could also validate that translationId is not the default first translation ID,
+            // but it doesn't really matter if it is. It would just be unexpected.
+            return new SetFirstTranslationIdChange(exampleSentenceId, translationId);
+        }
     }
 
     public async Task<ReadFileResponse> GetFileStream(MediaUri mediaUri)


### PR DESCRIPTION
This will hopefully prevent unnecessary noise in projects that haven't already gone through this migration