### PR TITLE
Double postgres memory

### DIFF
--- a/deployment/base/db-deployment.yaml
+++ b/deployment/base/db-deployment.yaml
@@ -55,9 +55,9 @@ spec:
         # https://kubernetes.io/docs/concepts/configuration/manage-resources-containers
         resources:
           requests:
-            memory: 200Mi
+            memory: 400Mi
           limits:
-            memory: 200Mi
+            memory: 400Mi
 
         env:
           - name: PGDATA


### PR DESCRIPTION
Resolves #2058 (presumably/hopefully)

Because it looks like the db container memory is essentially always pretty much maxed out:
`cat /sys/fs/cgroup/memory.max` = `209715200`
`cat /sys/fs/cgroup/memory.current` = `207126528`