### PR TITLE
Don't read ComplexFormComponent.Id in dry-run-api

### DIFF
--- a/backend/FwLite/FwLiteProjectSync/DryRunMiniLcmApi.cs
+++ b/backend/FwLite/FwLiteProjectSync/DryRunMiniLcmApi.cs
@@ -301,23 +301,27 @@ public partial class DryRunMiniLcmApi(IMiniLcmApi api) : IMiniLcmApi
 
     public Task<ComplexFormComponent> CreateComplexFormComponent(ComplexFormComponent complexFormComponent, BetweenPosition<ComplexFormComponent>? between = null)
     {
-        var previousId = between?.Previous?.ComponentSenseId ?? between?.Previous?.ComponentEntryId;
-        var nextId = between?.Next?.ComponentSenseId ?? between?.Next?.ComponentEntryId;
-        DryRunRecords.Add(new DryRunRecord(nameof(CreateComplexFormComponent), $"Create complex form component complex entry: {complexFormComponent.ComplexFormHeadword}, component entry: {complexFormComponent.ComponentHeadword} between {previousId} and {nextId}"));
+        var complexFormName = ComplexFormName(complexFormComponent);
+        var componentName = ComplexFormComponentName(complexFormComponent);
+        var previous = ComplexFormComponentName(between?.Previous);
+        var next = ComplexFormComponentName(between?.Next);
+        DryRunRecords.Add(new DryRunRecord(nameof(CreateComplexFormComponent), $"Create complex form component complex entry: {complexFormName}, component entry: {componentName}, between {previous} and {next}"));
         return Task.FromResult(complexFormComponent);
     }
 
     public Task MoveComplexFormComponent(ComplexFormComponent complexFormComponent, BetweenPosition<ComplexFormComponent> between)
     {
-        var previousId = between.Previous?.ComponentSenseId ?? between.Previous?.ComponentEntryId;
-        var nextId = between.Next?.ComponentSenseId ?? between.Next?.ComponentEntryId;
-        DryRunRecords.Add(new DryRunRecord(nameof(MoveComplexFormComponent), $"Move complex form component {complexFormComponent.Id} between {previousId} and {nextId}"));
+        var componentName = ComplexFormComponentName(complexFormComponent);
+        var previous = ComplexFormComponentName(between.Previous);
+        var next = ComplexFormComponentName(between.Next);
+        DryRunRecords.Add(new DryRunRecord(nameof(MoveComplexFormComponent), $"Move complex form component {componentName} between {previous} and {next}"));
         return Task.CompletedTask;
     }
 
     public Task DeleteComplexFormComponent(ComplexFormComponent complexFormComponent)
     {
-        DryRunRecords.Add(new DryRunRecord(nameof(DeleteComplexFormComponent), $"Delete complex form component: {complexFormComponent}"));
+        var componentName = ComplexFormComponentName(complexFormComponent);
+        DryRunRecords.Add(new DryRunRecord(nameof(DeleteComplexFormComponent), $"Delete complex form component: {componentName}"));
         return Task.CompletedTask;
     }
 
@@ -361,6 +365,18 @@ public partial class DryRunMiniLcmApi(IMiniLcmApi api) : IMiniLcmApi
     {
         DryRunRecords.Add(new DryRunRecord(nameof(RemovePublication), $"Remove publication {publicationId} from entry {entryId}"));
         return Task.CompletedTask;
+    }
+
+    private string ComplexFormComponentName(ComplexFormComponent? component)
+    {
+        if (component == null) return "null";
+        return $"{component.ComponentHeadword} ({component.ComponentEntryId}:{component.ComponentSenseId})";
+    }
+
+    private string ComplexFormName(ComplexFormComponent? component)
+    {
+        if (component == null) return "null";
+        return $"{component.ComplexFormHeadword} ({component.ComplexFormEntryId})";
     }
 
     //this is now called to this method from the ResumableImportApi, but calling GetEntries will fail because there's no writing systems


### PR DESCRIPTION
`ComplexFormComponent.Id` cannot be safely used, because it's null for LibLCM components.
Callers are expected to check `MaybeId` first.

But, we can have better logs entirely, so I went with that.