### PR TITLE
Standardize not-found exceptions and always include id

### DIFF
--- a/backend/FwLite/LcmCrdt/Data/MiniLcmRepository.cs
+++ b/backend/FwLite/LcmCrdt/Data/MiniLcmRepository.cs
@@ -86,7 +86,7 @@ public class MiniLcmRepository(
                 WritingSystemType.Vernacular => _defaultVernacularWs ??=
                     await AsyncExtensions.FirstOrDefaultAsync(WritingSystemsOrdered, ws => ws.Type == type),
                 _ => throw new ArgumentOutOfRangeException(nameof(type), type, null)
-            } ?? throw NotFoundException.ForType<WritingSystem>($"{id.Code}: {type}");
+            } ?? throw NotFoundException.ForWs(id, type);
         }
 
         return await AsyncExtensions.FirstOrDefaultAsync(WritingSystemsOrdered, ws => ws.WsId == id && ws.Type == type);
@@ -160,10 +160,9 @@ public class MiniLcmRepository(
     {
         if (options.Exemplar is not null)
         {
-            var ws = (await GetWritingSystem(options.Exemplar.WritingSystem, WritingSystemType.Vernacular))?.WsId;
-            if (ws is null)
-                throw NotFoundException.ForType<WritingSystem>($"{options.Exemplar.WritingSystem.Code}: {WritingSystemType.Vernacular}");
-            queryable = queryable.WhereExemplar(ws.Value, options.Exemplar.Value);
+            var ws = (await GetWritingSystem(options.Exemplar.WritingSystem, WritingSystemType.Vernacular))?.WsId
+                ?? throw NotFoundException.ForWs(options.Exemplar.WritingSystem, WritingSystemType.Vernacular);
+            queryable = queryable.WhereExemplar(ws, options.Exemplar.Value);
         }
 
         if (options.Filter?.GridifyFilter != null)
@@ -196,9 +195,8 @@ public class MiniLcmRepository(
 
     private async ValueTask<IQueryable<Entry>> ApplySorting(IQueryable<Entry> queryable, QueryOptions options, string? query = null)
     {
-        var sortWs = await GetWritingSystem(options.Order.WritingSystem, WritingSystemType.Vernacular);
-        if (sortWs is null)
-            throw NotFoundException.ForType<WritingSystem>($"{options.Order.WritingSystem.Code}: {WritingSystemType.Vernacular}");
+        var sortWs = await GetWritingSystem(options.Order.WritingSystem, WritingSystemType.Vernacular)
+            ?? throw NotFoundException.ForWs(options.Order.WritingSystem, WritingSystemType.Vernacular);
 
         switch (options.Order.Field)
         {

--- a/backend/FwLite/MiniLcm/Exceptions/NotFoundException.cs
+++ b/backend/FwLite/MiniLcm/Exceptions/NotFoundException.cs
@@ -1,4 +1,5 @@
 using System.Diagnostics.CodeAnalysis;
+using MiniLcm.Models;
 
 namespace MiniLcm.Exceptions;
 
@@ -27,6 +28,16 @@ public class NotFoundException(string identifier, string type) : Exception($"Not
     public static NotFoundException ForType<T>(Guid identifier)
     {
         return ForType<T>(identifier.ToString());
+    }
+
+    public static NotFoundException ForWs(WritingSystemId id, WritingSystemType type)
+    {
+        return new($"{id.Code}: {type}", nameof(WritingSystem));
+    }
+
+    public static NotFoundException ForWs(WritingSystem ws)
+    {
+        return ForWs(ws.WsId.Code, ws.Type);
     }
 
     public string Type { get; set; } = type;


### PR DESCRIPTION
I initially started this work, because there were NullReferenceExceptions that didn't include any info about what was null.
Now things are standardized as well.