### PR TITLE
Add tooltip for current project name on dropdown

### DIFF
--- a/frontend/viewer/src/project/ProjectDropdown.svelte
+++ b/frontend/viewer/src/project/ProjectDropdown.svelte
@@ -71,7 +71,7 @@
 {/snippet}
 
 <Popover.Root bind:open onOpenChange={handleOpen}>
-  <Popover.Trigger bind:ref={triggerRef}>
+  <Popover.Trigger bind:ref={triggerRef} title={projectName}>
     {#snippet child({ props })}
       <Button
         variant="ghost"


### PR DESCRIPTION
Resolves: https://community.software.sil.org/t/hover-over-project-selector-and-see-entire-project-name/10801/1

<img width="277" height="148" alt="image" src="https://github.com/user-attachments/assets/497351da-177b-4379-9770-3fb26fcb4cfe" />
