### PR TITLE
Prevent editors from requesting beta access

### DIFF
--- a/frontend/src/lib/i18n/locales/en.json
+++ b/frontend/src/lib/i18n/locales/en.json
@@ -680,7 +680,9 @@ it's done, you should see your project in FieldWorks Lite and be able to use it.
     "user_not_in_beta": "FieldWorks Lite is currently in a beta testing phase. \n\
 Only selected early access users can download Lexbox projects in FieldWorks Lite. \n\
 Click the button below to request to join the early access program. It may take a few days for us to respond.",
-    "only_managers_can_request_beta": "Only project managers can request early access to FieldWorks Lite.",
+    "non_manager_not_in_beta": "FieldWorks Lite is currently in a beta testing phase. \n\
+Only selected early access users can download Lexbox projects in FieldWorks Lite. \n\
+You are not currently a project manager. Only project managers can request early access.",
     "request_beta_access": "Request early access to FieldWorks Lite",
     "access_request_sent": "Your request to join the early access program has been submitted",
     "already_in_beta": "You're already in the early access program",

--- a/frontend/src/routes/(authenticated)/wheresMyProject/+page.svelte
+++ b/frontend/src/routes/(authenticated)/wheresMyProject/+page.svelte
@@ -53,13 +53,14 @@
         <Markdown md={$t('where_is_my_project.body')} />
       {/snippet}
       {#snippet missingFlagContent()}
-        <Markdown md={$t('where_is_my_project.user_not_in_beta')} />
-        <div class="text-center">
-          <Button disabled={!managesProjects} loading={requesting} variant="btn-primary" onclick={requestBetaAccess}>{$t('where_is_my_project.request_beta_access')}</Button>
-          {#if !managesProjects}
-            <p class="mt-2 text-error">{$t('where_is_my_project.only_managers_can_request_beta')}</p>
-          {/if}
-        </div>
+        {#if managesProjects}
+          <Markdown md={$t('where_is_my_project.user_not_in_beta')} />
+          <div class="text-center">
+            <Button loading={requesting} variant="btn-primary" onclick={requestBetaAccess}>{$t('where_is_my_project.request_beta_access')}</Button>
+          </div>
+        {:else}
+          <Markdown md={$t('where_is_my_project.non_manager_not_in_beta')} />
+        {/if}
       {/snippet}
     </FeatureFlagAlternateContent>
   </div>


### PR DESCRIPTION
I've got a surprising number of beta requests from editors who don't need it and probably requested it more or less out of curiosity.
So, this disables the "Request beta access" button for them.
Now only site admins and users who manage at least 1 project can request access.

Potentially org admins should also be able to request beta access, but nah. There's been no need for that so far and open beta will come soon enough.

<img width="1170" height="712" alt="image" src="https://github.com/user-attachments/assets/d771ef30-3be3-4c46-8d59-d049fd42d540" />

UPDATE: changed text and hid button for non-managers:
<img width="744" height="248" alt="image" src="https://github.com/user-attachments/assets/cbde7547-0270-4a39-bead-a18ba814d005" />
