### PR TITLE
Add Swagger and GraphQL UI links for developers

### DIFF
--- a/frontend/src/lib/layout/AppBar.svelte
+++ b/frontend/src/lib/layout/AppBar.svelte
@@ -2,11 +2,12 @@
   import {resolve} from '$app/paths';
   import {env} from '$env/dynamic/public';
   import t from '$lib/i18n';
-  import {AuthenticatedUserIcon, UserAddOutline} from '$lib/icons';
+  import {AuthenticatedUserIcon, UserAddOutline, Icon} from '$lib/icons';
   import {onMount} from 'svelte';
   import type {LexAuthUser} from '$lib/user';
   import {page} from '$app/state';
   import AppLogo from '$lib/icons/AppLogo.svelte';
+  import DevContent from './DevContent.svelte';
 
   onMount(() => {
     isPlaywright = localStorage.getItem('isPlaywright') === 'true';
@@ -40,7 +41,18 @@
         </span>
       </div>
     </a>
-    <div>
+    <div class="flex gap-2">
+      <DevContent>
+        <a href={resolve('/sandbox')} class="btn btn-ghost btn-square" title="Sandbox">
+          <Icon icon="i-mdi-package-variant" size="text-2xl" />
+        </a>
+        <a href={resolve('/api/swagger')} target="_blank" class="btn btn-ghost btn-square" title="Swagger UI">
+          <Icon icon="i-mdi-api" size="text-2xl" />
+        </a>
+        <a href={resolve('/api/graphql/ui')} target="_blank" class="btn btn-ghost btn-square" title="GraphQL UI">
+          <Icon icon="i-mdi-graphql" size="text-2xl" />
+        </a>
+      </DevContent>
       {#if user}
         <!-- using a label means it works before hydration is complete -->
         <label for="drawer-toggle" class="btn btn-primary glass px-2">

--- a/frontend/src/lib/layout/Layout.svelte
+++ b/frontend/src/lib/layout/Layout.svelte
@@ -13,7 +13,6 @@
   import {resolve} from '$app/paths';
   import {page} from '$app/state';
   import type {LayoutData} from '../../routes/$types';
-  import DevContent from './DevContent.svelte';
   import {helpLinks} from '$lib/components/help';
 
   interface Props {
@@ -55,11 +54,6 @@
         <div class="bg-neutral text-neutral-content p-2 md:px-6 flex justify-between items-center gap-2">
           <Breadcrumbs />
           <div class="flex gap-2 items-center">
-            <DevContent>
-              <a href={resolve('/sandbox')} class="btn btn-sm btn-neutral glass">
-                <Icon size="text-2xl" icon="i-mdi-package-variant" />
-              </a>
-            </DevContent>
             <!-- eslint-disable-next-line svelte/no-navigation-without-resolve -->
             <a href={helpLinks.helpList}
               target="_blank"


### PR DESCRIPTION
Adds links to the Swagger and GraphQL UI in the AppBar, visible only when developer mode is enabled. Fits standard icon-only button patterns by using the IconButton component.