### PR TITLE
Add Swagger button for devs

### DIFF
--- a/frontend/viewer/src/home/HomeView.svelte
+++ b/frontend/viewer/src/home/HomeView.svelte
@@ -155,7 +155,8 @@
                 variant="ghost" size="icon" iconProps={{src: storybookIcon, alt: 'Storybook icon'}}/>
       {/if}
       <DevContent>
-        <Button href="/sandbox" variant="ghost" size="icon" icon="i-mdi-test-tube"/>
+        <Button href="/sandbox" variant="ghost" size="icon" icon="i-mdi-test-tube" title="Sandbox"/>
+        <Button href="/swagger" variant="ghost" size="icon" icon="i-mdi-api" target="_blank" title="Swagger"/>
       </DevContent>
       <LocalizationPicker/>
       <ThemePicker buttonProps={{variant: 'outline'}}/>


### PR DESCRIPTION
Adds link to the Swagger UI in the AppBar, visible only when developer mode is enabled. Fits standard icon-only button patterns by using the IconButton component.