### PR TITLE
Find fwlite.desktop.template in correct directory

### DIFF
--- a/backend/FwLite/FwLiteWeb/install-launcher.sh
+++ b/backend/FwLite/FwLiteWeb/install-launcher.sh
@@ -4,7 +4,15 @@
 APPDIR="$(dirname "$(realpath "${BASH_SOURCE[0]}")")"
 
 # Make it the current directory so rest of script will work
-cd "$APPDIR"
+cd "$APPDIR" || {
+        echo "Automatic install failed: couldn't load launcher template from $APPDIR"
+        echo "You can create the FwLite launcher yourself by doing the following:"
+        echo "  1. Copy $APPDIR/fwlite.desktop.template to your home folder"
+        echo "  2. Edit it to replace the word APPDIR with ${APPDIR}"
+        echo "  3. Rename it to fwlite.desktop and run chmod +x fwlite.desktop"
+        echo "  4. Copy it into ${HOME}/.local/share/applications"
+        exit 1
+}
 
 # Replace APPDIR in the template and create the actual .desktop file
 sed "s|APPDIR|$APPDIR|g" fwlite.desktop.template > fwlite.desktop


### PR DESCRIPTION
If install-lancher.sh script is run from a different working directory, then it can fail to find the fwlite.desktop.template file. We can fix that by finding the script's directory and cd'ing into it at the outset. This will only affect the working directory of the subshell running the script, and will not affect the user's working directory, so it's safe.

Fixes #2132.