### PR TITLE
Remove unused props from component interfaces

### DIFF
--- a/frontend/viewer/src/lib/entry-editor/ItemList.svelte
+++ b/frontend/viewer/src/lib/entry-editor/ItemList.svelte
@@ -1,7 +1,7 @@
 <script lang="ts" module>
   import type {Snippet} from 'svelte';
 
-  export interface ItemListProps<T> extends Omit<ItemListItemProps<T>, 'item' | 'index'> {
+  export interface ItemListProps<T> extends Omit<ItemListItemProps<T>, 'item'> {
     actions?: Snippet;
   }
 </script>
@@ -20,10 +20,9 @@
 </script>
 
 <div class="flex gap-2 flex-wrap items-center">
-  {#each items as item, index (item)}
+  {#each items as item (item)}
     <ItemListItem
       {item}
-      {index}
       bind:items
       {readonly}
       {...rest} />

--- a/frontend/viewer/src/lib/entry-editor/ItemListItem.svelte
+++ b/frontend/viewer/src/lib/entry-editor/ItemListItem.svelte
@@ -3,14 +3,12 @@
 
   export type ItemListItemProps<T> = {
     item: T;
-    index: number;
     items: T[];
     readonly: boolean;
     orderable?: boolean;
     getDisplayName: (item: T) => string | undefined;
     onchange?: (value: T[]) => void;
     menuItems?: Snippet<[T]>;
-    actions?: Snippet;
   };
 </script>
 
@@ -23,18 +21,12 @@
 
   let {
     item,
-    // TODO: Either use `index` or remove it as a prop
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    index,
     items = $bindable(),
     readonly,
     orderable = false,
     getDisplayName,
     onchange,
     menuItems,
-    // TODO: Either use `actions` or remove it as a prop
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    actions,
   } : ItemListItemProps<T> = $props();
 
   const displayName = $derived(getDisplayName(item) || '–');

--- a/frontend/viewer/src/project/browse/SortMenu.svelte
+++ b/frontend/viewer/src/project/browse/SortMenu.svelte
@@ -36,15 +36,11 @@
   type Props = {
     value?: SortConfig;
     autoSelector: Getter<SortField>;
-    autoDirection?: SortDirection;
   };
 
   let {
     value = $bindable(),
     autoSelector,
-    // TODO: Either use `autoDirection` or remove it as a prop
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    autoDirection,
   }: Props = $props();
 
   let selectedSortField = $state<SortField>();


### PR DESCRIPTION
## Summary
This PR removes unused props from three Svelte components that were previously marked with TODO comments and eslint-disable directives. The changes clean up the component APIs by eliminating props that were never actually used in the component logic.

## Key Changes
- **ItemList.svelte**: Removed `index` from the `ItemListProps` interface omit list and stopped passing it to `ItemListItem` component
- **ItemListItem.svelte**: Removed unused `index` and `actions` props from `ItemListItemProps` type definition and component destructuring
- **SortMenu.svelte**: Removed unused `autoDirection` prop from the `Props` type definition and component destructuring

## Implementation Details
- All three components had TODO comments indicating uncertainty about whether these props should be used or removed
- The removal of these props simplifies the component contracts and reduces unnecessary prop drilling
- No functional changes to component behavior - these props were not being utilized in any logic
- Removes associated eslint-disable directives that were suppressing "no-unused-vars" warnings

https://claude.ai/code/session_01PUhjcafyCWi8Jb537ATia6