### PR TITLE
Add CLAUDE.md files referencing AGENTS.md across project

### DIFF
--- a/.github/CLAUDE.md
+++ b/.github/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/backend/CLAUDE.md
+++ b/backend/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/backend/FwHeadless/CLAUDE.md
+++ b/backend/FwHeadless/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/backend/FwLite/CLAUDE.md
+++ b/backend/FwLite/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/backend/LexBoxApi/CLAUDE.md
+++ b/backend/LexBoxApi/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/frontend/CLAUDE.md
+++ b/frontend/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/frontend/viewer/CLAUDE.md
+++ b/frontend/viewer/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md


### PR DESCRIPTION
## Summary
Claude Code does [not yet support](https://github.com/anthropics/claude-code/issues/6235) AGENTS.md.
So, this PR uses the simplest workaround: import AGENTS.md into CLAUDE.md.

## Changes
- Added `CLAUDE.md` files in 8 locations across the project:
  - Root directory
  - `.github/` directory
  - `backend/` directory
  - `backend/FwHeadless/` directory
  - `backend/FwLite/` directory
  - `backend/LexBoxApi/` directory
  - `frontend/` directory
  - `frontend/viewer/` directory

https://claude.ai/code/session_01JPDQvQvubHMKGNBE15UQKx