### PR TITLE
Move fw-lite log out of folders watched by Platform.Bible

### DIFF
--- a/backend/FwLite/FwLiteWeb/FwLiteWebConfig.cs
+++ b/backend/FwLite/FwLiteWeb/FwLiteWebConfig.cs
@@ -5,4 +5,5 @@ public class FwLiteWebConfig
     public bool CorsAllowAny { get; init; } = false;
     public bool OpenBrowser { get; init; } = true;
     public string? LogFileName { get; init; } = null;
+    public bool EnableFileLogging { get; init; } = true;
 }

--- a/backend/FwLite/FwLiteWeb/FwLiteWebServer.cs
+++ b/backend/FwLite/FwLiteWeb/FwLiteWebServer.cs
@@ -50,7 +50,8 @@ public static class FwLiteWebServer
         });
         builder.Logging.AddDebug();
         builder.Services.AddRazorComponents().AddInteractiveServerComponents(circuitOptions => circuitOptions.DetailedErrors = true);
-        if (builder.Configuration.GetValue<string>("FwLiteWeb:LogFileName") is { Length: > 0 } logFileName)
+        if (builder.Configuration.GetValue("FwLiteWeb:EnableFileLogging", true) &&
+            builder.Configuration.GetValue<string>("FwLiteWeb:LogFileName") is { Length: > 0 } logFileName)
         {
             builder.Logging.AddFile(logFileName,
                 fileLoggerOptions =>

--- a/platform.bible-extension/src/main.ts
+++ b/platform.bible-extension/src/main.ts
@@ -261,6 +261,7 @@ function launchFwLiteWeb(context: ExecutionActivationContext): string {
       baseUrl,
       '--FwLite:UpdateCheckCondition=Never',
       '--FwLiteWeb:CorsAllowAny=true',
+      '--FwLiteWeb:EnableFileLogging=false', // already piped to P.B (and triggers npm watch)
       '--FwLiteWeb:OpenBrowser=false',
     ],
     { stdio: ['pipe', 'pipe', 'pipe'] },


### PR DESCRIPTION
~Writing to the default `fw-lite/fw-lite-web.log` log file causes Platform.Bible to get stuck in a refresh loop because the containing directories are being watched. This pr sets `LogFileName` to `../../../fw-lite-extension.log`.~ With this pr:

- running `npm start` from `languageforge-lexbox/platform.bible-extension/`
  - ~generates `languageforge-lexbox/fw-lite-extension.log`~ generates no log file
  - instead of `languageforge-lexbox/platform.bible-extension/dist/fw-lite/fw-lite-web.log`;
- running `npm start` from `paranext-core/` (with a production build of fw-lite-extension copied in)
  - ~generates `paranext-core/dev-appdata/fw-lite-extension.log`~ generates no log file
  - instead of `paranext-core/dev-appdata/installed-extensions/fw-lite-extension/fw-lite/fw-lite-web.log`~

🌱 If it were possible to simply disable the log, ~that might be preferable. (I tried setting it to an empty string, but it just uses the default.)~ ...Tim did so.