### PR TITLE
fix: suppress ResizeObserver and other harmless errors from logging

### DIFF
--- a/frontend/viewer/src/lib/errors/global-errors.ts
+++ b/frontend/viewer/src/lib/errors/global-errors.ts
@@ -22,7 +22,7 @@ function unifyErrorEvent(event: ErrorEvent | PromiseRejectionEvent): UnifiedErro
   }
 }
 
-function suppressErrorNotification(message: string): boolean {
+function shouldIgnoreError(message: string): boolean {
   if (message.includes('Perhaps the DotNetObjectReference instance was already disposed')) return true;
   // Code (i.e. {expression}) inside a <MenuItem> slot, inside a portal causes this error if the portal is open while the screen is resized 🙃
   // It's worth noting that in Lexbox we've also seen browser extensions trigger this error
@@ -57,8 +57,8 @@ export function setupGlobalErrorHandlers() {
 
 function onErrorEvent(event: ErrorEvent | PromiseRejectionEvent) {
   const errorEvent = unifyErrorEvent(event);
+  if (shouldIgnoreError(errorEvent.message)) return;
   void tryLogErrorToDotNet(errorEvent);
-  if (suppressErrorNotification(errorEvent.message)) return;
   const {message: simpleMessage, detail} = processErrorIntoDetails(errorEvent);
   AppNotification.error(simpleMessage, detail);
 }


### PR DESCRIPTION
Refactored global error handler to skip both logging and notifications for harmless errors, specifically targeting 'ResizeObserver loop completed with undelivered notifications' and others that are expected behavior.