### PR TITLE
Add tasks for running and resetting verification tests

### DIFF
--- a/backend/FwLite/FwLiteProjectSync.Tests/ProjectSnapshotSerializationTests.cs
+++ b/backend/FwLite/FwLiteProjectSync.Tests/ProjectSnapshotSerializationTests.cs
@@ -54,6 +54,7 @@ public class ProjectSnapshotSerializationTests
     }
 
     [Fact]
+    [Trait("Category", "Verified")]
     public async Task LatestSena3SnapshotRoundTrips()
     {
         // arrange

--- a/backend/FwLite/FwLiteProjectSync.Tests/Sena3SyncTests.cs
+++ b/backend/FwLite/FwLiteProjectSync.Tests/Sena3SyncTests.cs
@@ -207,6 +207,7 @@ public class Sena3SyncTests : IClassFixture<Sena3Fixture>, IAsyncLifetime
     /// </summary>
     [Fact]
     [Trait("Category", "Integration")]
+    [Trait("Category", "Verified")]
     public async Task LiveSena3Sync()
     {
         // arrange - put "live" crdt db and fw-headless snapshot in place

--- a/backend/FwLite/LcmCrdt.Tests/Changes/ChangeSerializationTests.cs
+++ b/backend/FwLite/LcmCrdt.Tests/Changes/ChangeSerializationTests.cs
@@ -124,6 +124,7 @@ public class ChangeSerializationTests : BaseSerializationTest
     }
 
     [Fact]
+    [Trait("Category", "Verified")]
     public async Task RegressionDataUpToDate()
     {
         var legacyJsonArray = ReadJsonArrayFromFile(GetJsonFilePath("ChangeDeserializationRegressionData.legacy.verified.txt"));

--- a/backend/FwLite/LcmCrdt.Tests/Data/MigrationTests.cs
+++ b/backend/FwLite/LcmCrdt.Tests/Data/MigrationTests.cs
@@ -54,6 +54,7 @@ public class MigrationTests : IAsyncLifetime
     [Theory]
     [InlineData(RegressionTestHelper.RegressionVersion.v1)]
     [InlineData(RegressionTestHelper.RegressionVersion.v2)]
+    [Trait("Category", "Verified")]
     public async Task VerifyAfterMigrationFromScriptedDb(RegressionTestHelper.RegressionVersion regressionVersion)
     {
         await _helper.InitializeAsync(regressionVersion);
@@ -105,6 +106,7 @@ public class MigrationTests : IAsyncLifetime
     [Theory]
     [InlineData(RegressionTestHelper.RegressionVersion.v1)]
     [InlineData(RegressionTestHelper.RegressionVersion.v2)]
+    [Trait("Category", "Verified")]
     public async Task VerifyRegeneratedSnapshotsAfterMigrationFromScriptedDb(RegressionTestHelper.RegressionVersion regressionVersion)
     {
         await _helper.InitializeAsync(regressionVersion);

--- a/backend/FwLite/LcmCrdt.Tests/Data/SnapshotDeserializationTests.cs
+++ b/backend/FwLite/LcmCrdt.Tests/Data/SnapshotDeserializationTests.cs
@@ -91,6 +91,7 @@ public class SnapshotDeserializationTests : BaseSerializationTest
     }
 
     [Fact]
+    [Trait("Category", "Verified")]
     public async Task RegressionDataUpToDate()
     {
         var legacyJsonArray = ReadJsonArrayFromFile(GetJsonFilePath("SnapshotDeserializationRegressionData.legacy.verified.txt"));

--- a/backend/FwLite/LcmCrdt.Tests/DataModelSnapshotTests.cs
+++ b/backend/FwLite/LcmCrdt.Tests/DataModelSnapshotTests.cs
@@ -54,24 +54,28 @@ public class DataModelSnapshotTests : IAsyncLifetime
     }
 
     [Fact]
+    [Trait("Category", "Verified")]
     public async Task VerifyDbModel()
     {
         await Verify(_crdtDbContext.Model.ToDebugString(MetadataDebugStringOptions.LongDefault));
     }
 
     [Fact]
+    [Trait("Category", "Verified")]
     public async Task VerifyChangeModels()
     {
         await Verify(_jsonSerializerOptions.GetTypeInfo(typeof(IChange)).PolymorphismOptions);
     }
 
     [Fact]
+    [Trait("Category", "Verified")]
     public async Task VerifyIObjectBaseModels()
     {
         await Verify(_jsonSerializerOptions.GetTypeInfo(typeof(IObjectBase)).PolymorphismOptions);
     }
 
     [Fact]
+    [Trait("Category", "Verified")]
     public async Task VerifyIObjectWithIdModels()
     {
         await Verify(_jsonSerializerOptions.GetTypeInfo(typeof(IObjectWithId)).PolymorphismOptions);

--- a/backend/FwLite/LcmCrdt.Tests/FullTextSearch/EntrySearchServiceTests.cs
+++ b/backend/FwLite/LcmCrdt.Tests/FullTextSearch/EntrySearchServiceTests.cs
@@ -81,6 +81,7 @@ public class EntrySearchServiceTests : IAsyncLifetime
     }
 
     [Fact]
+    [Trait("Category", "Verified")]
     public async Task SearchTableIsUpdatedAutomaticallyOnInsert()
     {
         var id = Guid.NewGuid();
@@ -117,6 +118,7 @@ public class EntrySearchServiceTests : IAsyncLifetime
     }
 
     [Fact]
+    [Trait("Category", "Verified")]
     public async Task SearchTableIsUpdatedAutomaticallyOnUpdate()
     {
         var id = Guid.NewGuid();

--- a/backend/FwLite/Taskfile.yml
+++ b/backend/FwLite/Taskfile.yml
@@ -119,3 +119,17 @@ tasks:
     cmd: dotnet test ../../FwLiteOnly.slnf --filter Category!=Slow
   test-full:
     cmd: dotnet test ../../FwLiteOnly.slnf
+  test-verified:
+    desc: Run only tests that generate verified snapshot files
+    # always produces exit status 1, because the framework isn't valid for all test projects
+    cmd: dotnet test ../../FwLiteOnly.slnf --filter "Category=Verified" --framework net9.0 --logger "console;verbosity=minimal"
+  reset-verified:
+    desc: Reset all verified snapshot files to their state on origin/develop
+    cmds:
+      - git fetch origin develop
+      - git checkout origin/develop -- ":(glob)**/*.verified.*"
+  reverify:
+    desc: Reset verified snapshots to origin/develop, then re-run verified tests to regenerate them
+    cmds:
+      - task: reset-verified
+      - task: test-verified


### PR DESCRIPTION
Adds 3 tasks for C# tests using `Verify()`
- `test-verified` runs precisely those tests
- `reset-verified` resets all verified files in the working tree to what's currently on origin/develop
- `reverify` runs `reset-verified` and then `reset-verified`. This is useful if you've committed changes to `verified` files on your feature branch that are no longer correct.