### PR TITLE
Don't clear used connection pools

### DIFF
--- a/backend/FwLite/LcmCrdt.Tests/SnapshotAtCommitServiceTests.cs
+++ b/backend/FwLite/LcmCrdt.Tests/SnapshotAtCommitServiceTests.cs
@@ -333,6 +333,7 @@ public class SnapshotAtCommitServiceFileBasedTests : IAsyncLifetime
         using var clearConn = new SqliteConnection($"Data Source={_dbPath}");
         SqliteConnection.ClearPool(clearConn);
         await _dbContext.Database.EnsureDeletedAsync();
+        await _dbContext.DisposeAsync();
         await _services.DisposeAsync();
         if (File.Exists(_dbPath))
         {

--- a/backend/FwLite/LcmCrdt/SnapshotAtCommitService.cs
+++ b/backend/FwLite/LcmCrdt/SnapshotAtCommitService.cs
@@ -68,9 +68,6 @@ public class SnapshotAtCommitService(
             {
                 try
                 {
-                    // Clear only the fork connection pool, not all pools.
-                    // ClearAllPools() would destroy connections to other databases
-                    // (including in-memory test databases).
                     using var clearConn = new SqliteConnection($"Data Source={forkDbPath}");
                     SqliteConnection.ClearPool(clearConn);
                     File.Delete(forkDbPath);


### PR DESCRIPTION
I'm hoping one of these changes will prevent the race-condition that has resulted in this exception in CI over the past weeks:

```
[xUnit.net 00:01:33.36]     LcmCrdt.Tests.SnapshotAtCommitServiceTests.ModifiedEntry_ShowsOriginalState [FAIL]
[xUnit.net 00:01:33.48]     LcmCrdt.Tests.SnapshotAtCommitServiceTests.DeletedEntry_StillAppearsInSnapshot [FAIL]
[xUnit.net 00:01:33.59]     LcmCrdt.Tests.SnapshotAtCommitServiceTests.NonExistentCommit_ReturnsNull [FAIL]
[xUnit.net 00:01:33.74]     LcmCrdt.Tests.SnapshotAtCommitServiceTests.CanRegenerateSnapshotAtPreviousCommit [FAIL]
[xUnit.net 00:01:33.85]     LcmCrdt.Tests.SnapshotAtCommitServiceTests.LatestCommit_ReturnsCurrentState [FAIL]
[xUnit.net 00:01:33.95]     LcmCrdt.Tests.SnapshotAtCommitServiceTests.PreserveAllFieldWorksCommits_IncludesFieldWorksChangesInSnapshot [FAIL]
Error: System.ObjectDisposedException : Cannot access a disposed object.
Object name: 'SQLitePCL.sqlite3'.
  Failed LcmCrdt.Tests.SnapshotAtCommitServiceTests.ModifiedEntry_ShowsOriginalState [14 s]
  Error Message:
   System.ObjectDisposedException : Cannot access a disposed object.
Object name: 'SQLitePCL.sqlite3'.
  Stack Trace:
     at System.Runtime.InteropServices.SafeHandle.DangerousAddRef(Boolean& success)
   at SQLitePCL.SQLite3Provider_e_sqlite3.SQLitePCL.ISQLite3Provider.sqlite3_create_collation(sqlite3 db, Byte[] name, Object v, delegate_collation func)
   at SQLitePCL.raw.sqlite3_create_collation(sqlite3 db, String name, Object v, strdelegate_collation f)
   at Microsoft.Data.Sqlite.SqliteConnection.Open()
   at System.Data.Common.DbConnection.OpenAsync(CancellationToken cancellationToken)
--- End of stack trace from previous location ---
   at Microsoft.EntityFrameworkCore.Storage.RelationalConnection.OpenInternalAsync(Boolean errorsExpected, CancellationToken cancellationToken)
   at Microsoft.EntityFrameworkCore.Storage.RelationalConnection.OpenInternalAsync(Boolean errorsExpected, CancellationToken cancellationToken)
   at Microsoft.EntityFrameworkCore.Storage.RelationalConnection.OpenAsync(CancellationToken cancellationToken, Boolean errorsExpected)
   at Microsoft.EntityFrameworkCore.Storage.RelationalCommand.ExecuteReaderAsync(RelationalCommandParameterObject parameterObject, CancellationToken cancellationToken)
   at Microsoft.EntityFrameworkCore.Query.Internal.SingleQueryingEnumerable`1.AsyncEnumerator.InitializeReaderAsync(AsyncEnumerator enumerator, CancellationToken cancellationToken)
   at Microsoft.EntityFrameworkCore.Query.Internal.SingleQueryingEnumerable`1.AsyncEnumerator.MoveNextAsync()
   at Microsoft.EntityFrameworkCore.Query.ShapedQueryCompilingExpressionVisitor.SingleOrDefaultAsync[TSource](IAsyncEnumerable`1 asyncEnumerable, CancellationToken cancellationToken)
   at Microsoft.EntityFrameworkCore.Query.ShapedQueryCompilingExpressionVisitor.SingleOrDefaultAsync[TSource](IAsyncEnumerable`1 asyncEnumerable, CancellationToken cancellationToken)
   at SIL.Harmony.Db.CrdtRepository.GetEntityEntry(Type entityType, Guid entityId) in D:\a\languageforge-lexbox\languageforge-lexbox\backend\harmony\src\SIL.Harmony\Db\CrdtRepository.cs:line 372
   at SIL.Harmony.Db.CrdtRepository.ProjectSnapshot(ObjectSnapshot objectSnapshot) in D:\a\languageforge-lexbox\languageforge-lexbox\backend\harmony\src\SIL.Harmony\Db\CrdtRepository.cs:line 341
   at SIL.Harmony.Db.CrdtRepository.AddSnapshots(IEnumerable`1 snapshots) in D:\a\languageforge-lexbox\languageforge-lexbox\backend\harmony\src\SIL.Harmony\Db\CrdtRepository.cs:line 319
   at SIL.Harmony.SnapshotWorker.UpdateSnapshots(SortedSet`1 commits) in D:\a\languageforge-lexbox\languageforge-lexbox\backend\harmony\src\SIL.Harmony\SnapshotWorker.cs:line 55
   at SIL.Harmony.DataModel.UpdateSnapshots(CrdtRepository repo, SortedSet`1 commitsToApply) in D:\a\languageforge-lexbox\languageforge-lexbox\backend\harmony\src\SIL.Harmony\DataModel.cs:line 217
   at SIL.Harmony.DataModel.RegenerateSnapshots() in D:\a\languageforge-lexbox\languageforge-lexbox\backend\harmony\src\SIL.Harmony\DataModel.cs:line 248
   at SIL.Harmony.DataModel.RegenerateSnapshots() in D:\a\languageforge-lexbox\languageforge-lexbox\backend\harmony\src\SIL.Harmony\DataModel.cs:line 248
   at LcmCrdt.Tests.SnapshotAtCommitServiceTests.ModifiedEntry_ShowsOriginalState() in D:\a\languageforge-lexbox\languageforge-lexbox\backend\FwLite\LcmCrdt.Tests\SnapshotAtCommitServiceTests.cs:line 98
--- End of stack trace from previous location ---
Error: System.InvalidOperationException : Sequence contains no matching element
```