### PR TITLE
Fix delete commits count

### DIFF
--- a/backend/FwLite/LcmCrdt/SnapshotAtCommitService.cs
+++ b/backend/FwLite/LcmCrdt/SnapshotAtCommitService.cs
@@ -98,8 +98,9 @@ public class SnapshotAtCommitService(
             // JSON Sqlite gotcha: null != "FieldWorks" == false (apparently)
             (Json.Value(c.Metadata, m => m.AuthorName) ?? "") != "FieldWorks");
         }
+        var count = await commitsToDelete.CountAsyncLinqToDB();
         context.Set<Commit>().RemoveRange(commitsToDelete);
         await context.SaveChangesAsync();
-        return commitsToDelete.Count();
+        return count;
     }
 }


### PR DESCRIPTION
A random bug that AI happened to notice:
We were/are counting commits **in** the DB **after** we delete them from the DB 😆.