### PR TITLE
Double pg-dump size: 2Gi

### DIFF
--- a/deployment/production/backup.yaml
+++ b/deployment/production/backup.yaml
@@ -98,7 +98,7 @@ spec:
                 claimName: kopia-cache
             - name: pg-dump
               emptyDir:
-                sizeLimit: 1Gi
+                sizeLimit: 2Gi
             - name: hg-repos
               persistentVolumeClaim:
                 claimName: hg-repos

--- a/deployment/restore-scripts/kopia-maint.yaml
+++ b/deployment/restore-scripts/kopia-maint.yaml
@@ -60,9 +60,9 @@ spec:
       - key: kopia.config
         path: repository.config
       secretName: backups
-  - emptyDir:
-      sizeLimit: 1Gi
-    name: pg-dump
+  - name: pg-dump
+    emptyDir:
+      sizeLimit: 2Gi
   - name: hg-repos
     persistentVolumeClaim:
       claimName: hg-repos


### PR DESCRIPTION
Kopia backups are apparently failing with: (according to @g3mackay)

> Usage of EmptyDir volume "pg-dump" exceeds the limit "1Gi".

And failure emails mention:

> **Annotations**
> description = PVC hg-repos is only 9.96% free.}
> message = PVC hg-repos has less than 9.96% free

~**Regarding hg-repos**~ Moved to https://github.com/sillsdev/languageforge-lexbox/pull/2235

**Regarding pg-dump**

We're definitely putting way more stuff in the DB these days: the entire data/change history of every project that starts using FW-Lite.

While I'm sure there's some cleanup that could happen, it will definitely continue to grow and grow.

**Regarding debugging the backup failures**

I have not been able to view/find any logs on any of the failed jobs. That puzzles me and makes it guess work on my side.
It seems that every time the job is triggered it first fails and then succeeds. Which also puzzles me.