### PR TITLE
Remove MorphType creation and deletion operations

### DIFF
--- a/backend/FwLite/FwDataMiniLcmBridge.Tests/MiniLcmTests/MorphTypeTests.cs
+++ b/backend/FwLite/FwDataMiniLcmBridge.Tests/MiniLcmTests/MorphTypeTests.cs
@@ -1,0 +1,12 @@
+using FwDataMiniLcmBridge.Tests.Fixtures;
+
+namespace FwDataMiniLcmBridge.Tests.MiniLcmTests;
+
+[Collection(ProjectLoaderFixture.Name)]
+public class MorphTypeTests(ProjectLoaderFixture fixture) : MorphTypeTestsBase
+{
+    protected override Task<IMiniLcmApi> NewApi()
+    {
+        return Task.FromResult<IMiniLcmApi>(fixture.NewProjectApi("morph-type-test", "en", "en"));
+    }
+}

--- a/backend/FwLite/FwDataMiniLcmBridge/Api/FwDataMiniLcmApi.cs
+++ b/backend/FwLite/FwDataMiniLcmBridge/Api/FwDataMiniLcmApi.cs
@@ -581,12 +581,6 @@ public class FwDataMiniLcmApi(
         };
     }
 
-    public Task<MorphType> CreateMorphType(MorphType morphType)
-    {
-        // Creating new morph types not allowed in FwData projects, so silently ignore operation
-        return Task.FromResult(morphType);
-    }
-
     public Task<MorphType> UpdateMorphType(Guid id, UpdateObjectInput<MorphType> update)
     {
         var lcmMorphType = MorphTypeRepository.GetObject(id);
@@ -606,12 +600,6 @@ public class FwDataMiniLcmApi(
     {
         await MorphTypeSync.Sync(before, after, api ?? this);
         return await GetMorphType(after.Id) ?? throw new NullReferenceException("unable to find morph type with id " + after.Id);
-    }
-
-    public Task DeleteMorphType(Guid id)
-    {
-        // Deleting morph types not allowed in FwData projects, so silently ignore operation
-        return Task.CompletedTask;
     }
 
     public IAsyncEnumerable<VariantType> GetVariantTypes()

--- a/backend/FwLite/FwLiteProjectSync.Tests/Import/ResumableTests.cs
+++ b/backend/FwLite/FwLiteProjectSync.Tests/Import/ResumableTests.cs
@@ -189,11 +189,6 @@ internal partial class UnreliableApi(IMiniLcmApi api, Random random) : IMiniLcmA
         ResumableTests.MaybeThrowRandom(random, 0.2);
         return _api.CreateComplexFormType(complexFormType);
     }
-    Task<MorphType> IMiniLcmWriteApi.CreateMorphType(MorphType morphType)
-    {
-        ResumableTests.MaybeThrowRandom(random, 0.02);
-        return _api.CreateMorphType(morphType);
-    }
     Task<SemanticDomain> IMiniLcmWriteApi.CreateSemanticDomain(SemanticDomain semanticDomain)
     {
         ResumableTests.MaybeThrowRandom(random, 0.2);

--- a/backend/FwLite/FwLiteProjectSync.Tests/SyncTestHelpers.cs
+++ b/backend/FwLite/FwLiteProjectSync.Tests/SyncTestHelpers.cs
@@ -1,29 +1,9 @@
-using FwDataMiniLcmBridge.Api;
 using MiniLcm.Models;
 
 namespace FwLiteProjectSync.Tests;
 
 public static class SyncTestHelpers
 {
-    public static MorphType CreateMorphType(MorphTypeKind kind, string? prefix = null, string? postfix = null, int secondaryOrder = 0)
-    {
-        var guid = LcmHelpers.ToLcmMorphTypeId(kind) ?? Guid.NewGuid();
-        var name = $"Test {kind}";
-        var abbr = $"Tst {kind}";
-        var desc = $"Test morph type {kind}";
-        return new MorphType
-        {
-            Id = guid,
-            Kind = kind,
-            Name = new MultiString() { { "en", name } },
-            Abbreviation = new MultiString() { { "en", abbr } },
-            Description = new RichMultiString() { { "en", new RichString(desc) } },
-            Prefix = prefix,
-            Postfix = postfix,
-            SecondaryOrder = secondaryOrder,
-        };
-    }
-
     public static MorphType UpdateMorphType(MorphType orig, string? newName = null, string? newAbbreviation = null)
     {
         var newby = orig.Copy();

--- a/backend/FwLite/FwLiteProjectSync.Tests/SyncTests.cs
+++ b/backend/FwLite/FwLiteProjectSync.Tests/SyncTests.cs
@@ -507,51 +507,6 @@ public class SyncTests : IClassFixture<SyncFixture>, IAsyncLifetime
 
     [Fact]
     [Trait("Category", "Integration")]
-    public async Task MorphTypeCreationDoesNotSyncCrdtToFw()
-    {
-        // FwDataMiniLcmApi.CreateMorphType is a no-op because FLEx forbids morph type creation or deletion
-        var crdtApi = _fixture.CrdtApi;
-        var fwdataApi = _fixture.FwDataApi;
-        await _syncService.Import(crdtApi, fwdataApi);
-        var projectSnapshot = await _fixture.RegenerateAndGetSnapshot();
-
-        var newMorphType = SyncTestHelpers.CreateMorphType(MorphTypeKind.Unknown, prefix: "!", postfix: "!");
-        await crdtApi.CreateMorphType(newMorphType);
-        var syncResult = await _syncService.Sync(crdtApi, fwdataApi, projectSnapshot);
-
-        var fwdataMorphTypes = await fwdataApi.GetMorphTypes().ToArrayAsync();
-        var crdtMorphTypes = await crdtApi.GetMorphTypes().ToArrayAsync();
-        crdtMorphTypes.Should().ContainEquivalentOf(newMorphType);
-        fwdataMorphTypes.Should().NotContainEquivalentOf(newMorphType);
-        crdtMorphTypes.Length.Should().Be(fwdataMorphTypes.Length + 1);
-        crdtMorphTypes.Where(m => m.Kind != MorphTypeKind.Unknown).Should().BeEquivalentTo(fwdataMorphTypes);
-    }
-
-    [Fact]
-    [Trait("Category", "Integration")]
-    public async Task MorphTypeDeletionDoesNotSyncCrdtToFw()
-    {
-        // FwDataMiniLcmApi.DeleteMorphType is a no-op because FLEx forbids morph type creation or deletion
-        var crdtApi = _fixture.CrdtApi;
-        var fwdataApi = _fixture.FwDataApi;
-        await _syncService.Import(crdtApi, fwdataApi);
-        var projectSnapshot = await _fixture.RegenerateAndGetSnapshot();
-
-        var prefixingInterfix = await crdtApi.GetMorphType(MorphTypeKind.PrefixingInterfix);
-        prefixingInterfix.Should().NotBeNull();
-        await crdtApi.DeleteMorphType(prefixingInterfix.Id);
-        var syncResult = await _syncService.Sync(crdtApi, fwdataApi, projectSnapshot);
-
-        var fwdataMorphTypes = await fwdataApi.GetMorphTypes().ToArrayAsync();
-        var crdtMorphTypes = await crdtApi.GetMorphTypes().ToArrayAsync();
-        fwdataMorphTypes.Should().ContainEquivalentOf(prefixingInterfix);
-        crdtMorphTypes.Should().NotContainEquivalentOf(prefixingInterfix);
-        crdtMorphTypes.Length.Should().Be(fwdataMorphTypes.Length - 1);
-        crdtMorphTypes.Should().BeEquivalentTo(fwdataMorphTypes.Where(m => m.Kind != MorphTypeKind.PrefixingInterfix));
-    }
-
-    [Fact]
-    [Trait("Category", "Integration")]
     public async Task UpdatingAnEntryInEachProjectSyncsAcrossBoth()
     {
         var crdtApi = _fixture.CrdtApi;

--- a/backend/FwLite/FwLiteProjectSync.Tests/UpdateDiffTests.cs
+++ b/backend/FwLite/FwLiteProjectSync.Tests/UpdateDiffTests.cs
@@ -73,4 +73,18 @@ public class UpdateDiffTests
         before.Should().BeEquivalentTo(after, options => options
             .Excluding(x => x.Id));
     }
+
+    [Fact]
+    public void MorphTypeDiffShouldUpdateAllFields()
+    {
+        var before = new MorphType { Kind = MorphTypeKind.Stem };
+        var after = AutoFaker.Generate<MorphType>();
+        after.Kind = before.Kind; // Kind is immutable per MorphTypeUpdateValidator
+        var morphTypeDiffToUpdate = MorphTypeSync.MorphTypeDiffToUpdate(before, after);
+        ArgumentNullException.ThrowIfNull(morphTypeDiffToUpdate);
+        morphTypeDiffToUpdate.Apply(before);
+        before.Should().BeEquivalentTo(after, options => options
+            .Excluding(x => x.Id)
+            .Excluding(x => x.DeletedAt));
+    }
 }

--- a/backend/FwLite/FwLiteProjectSync/DryRunMiniLcmApi.cs
+++ b/backend/FwLite/FwLiteProjectSync/DryRunMiniLcmApi.cs
@@ -126,13 +126,6 @@ public partial class DryRunMiniLcmApi(IMiniLcmApi api) : IMiniLcmApi
         return Task.CompletedTask;
     }
 
-    public Task<MorphType> CreateMorphType(MorphType morphType)
-    {
-        DryRunRecords.Add(new DryRunRecord(nameof(CreateMorphType),
-            $"Create morph type {morphType.Name}"));
-        return Task.FromResult(morphType);
-    }
-
     public async Task<MorphType> UpdateMorphType(Guid id, UpdateObjectInput<MorphType> update)
     {
         DryRunRecords.Add(new DryRunRecord(nameof(UpdateMorphType), $"Update morph type {id}"));
@@ -143,12 +136,6 @@ public partial class DryRunMiniLcmApi(IMiniLcmApi api) : IMiniLcmApi
     {
         DryRunRecords.Add(new DryRunRecord(nameof(UpdateMorphType), $"Update morph type {after.Id}"));
         return Task.FromResult(after);
-    }
-
-    public Task DeleteMorphType(Guid id)
-    {
-        DryRunRecords.Add(new DryRunRecord(nameof(DeleteMorphType), $"Delete morph type {id}"));
-        return Task.CompletedTask;
     }
 
     public Task<Entry> CreateEntry(Entry entry, CreateEntryOptions? options)

--- a/backend/FwLite/FwLiteProjectSync/Import/ResumableImportApi.cs
+++ b/backend/FwLite/FwLiteProjectSync/Import/ResumableImportApi.cs
@@ -58,10 +58,6 @@ public partial class ResumableImportApi(IMiniLcmApi api) : IMiniLcmApi
     {
         return await HasCreated(complexFormType, _api.GetComplexFormTypes(), () => _api.CreateComplexFormType(complexFormType));
     }
-    async Task<MorphType> IMiniLcmWriteApi.CreateMorphType(MorphType morphType)
-    {
-        return await HasCreated(morphType, _api.GetMorphTypes(), () => _api.CreateMorphType(morphType), m => m.Kind.ToString());
-    }
     async Task<SemanticDomain> IMiniLcmWriteApi.CreateSemanticDomain(SemanticDomain semanticDomain)
     {
         return await HasCreated(semanticDomain, _api.GetSemanticDomains(), () => _api.CreateSemanticDomain(semanticDomain));

--- a/backend/FwLite/FwLiteWeb/Hubs/CrdtMiniLcmApiHub.cs
+++ b/backend/FwLite/FwLiteWeb/Hubs/CrdtMiniLcmApiHub.cs
@@ -99,13 +99,6 @@ public class CrdtMiniLcmApiHub(
         return base.SearchEntries(query, options);
     }
 
-    public override async Task<MorphType> CreateMorphType(MorphType morphType)
-    {
-        var newMorphType = await base.CreateMorphType(morphType);
-        TriggerSync();
-        return newMorphType;
-    }
-
     public override async Task<MorphType> UpdateMorphType(Guid id, JsonPatchDocument<MorphType> update)
     {
         var updatedMorphType = await base.UpdateMorphType(id, update);

--- a/backend/FwLite/FwLiteWeb/Hubs/MiniLcmApiHubBase.cs
+++ b/backend/FwLite/FwLiteWeb/Hubs/MiniLcmApiHubBase.cs
@@ -47,12 +47,6 @@ public abstract class MiniLcmApiHubBase(IMiniLcmApi miniLcmApi,
         return _miniLcmApi.GetComplexFormTypes();
     }
 
-    public virtual async Task<MorphType> CreateMorphType(MorphType morphType)
-    {
-        var newMorphType = await _miniLcmApi.CreateMorphType(morphType);
-        return newMorphType;
-    }
-
     public virtual async Task<MorphType> UpdateMorphType(Guid id, JsonPatchDocument<MorphType> update)
     {
         var updatedMorphType = await _miniLcmApi.UpdateMorphType(id, new UpdateObjectInput<MorphType>(update));

--- a/backend/FwLite/LcmCrdt.Tests/MiniLcmTests/MorphTypeTests.cs
+++ b/backend/FwLite/LcmCrdt.Tests/MiniLcmTests/MorphTypeTests.cs
@@ -1,0 +1,19 @@
+namespace LcmCrdt.Tests.MiniLcmTests;
+
+public class MorphTypeTests : MorphTypeTestsBase
+{
+    private readonly MiniLcmApiFixture _fixture = new();
+
+    protected override async Task<IMiniLcmApi> NewApi()
+    {
+        await _fixture.InitializeAsync();
+        var api = _fixture.Api;
+        return api;
+    }
+
+    public override async Task DisposeAsync()
+    {
+        await base.DisposeAsync();
+        await _fixture.DisposeAsync();
+    }
+}

--- a/backend/FwLite/LcmCrdt/CrdtMiniLcmApi.cs
+++ b/backend/FwLite/LcmCrdt/CrdtMiniLcmApi.cs
@@ -370,23 +370,6 @@ public class CrdtMiniLcmApi(
         return await repo.MorphTypes.SingleOrDefaultAsync(m => m.Kind == kind);
     }
 
-    public async Task<MorphType> CreateMorphType(MorphType morphType)
-    {
-        await using var repo = await repoFactory.CreateRepoAsync();
-
-        // Duplicate MorphTypes (by kind) are not allowed
-        // Note: can't put this in validation wrapper since we need a repo
-        var exists = await repo.MorphTypes.AnyAsync(m => m.Kind == morphType.Kind);
-        if (exists) throw new DuplicateObjectException($"Morph type {morphType.Kind} already exists");
-
-        await AddChange(new CreateMorphTypeChange(morphType));
-        // MorphTypeKind value must be unique in DB, so return by MorphType rather than Id in case a race condition
-        // ended up causing two CreateMorphType calls to happen at the same time. It's possible that the other
-        // call went through, creating a MorphType entry with a different GUID but the same Kind (which would
-        // violate the constraint). So we fetch by Kind rather than by Id here to mitigate that rare case.
-        return await repo.MorphTypes.SingleAsync(c => c.Kind == morphType.Kind);
-    }
-
     public async Task<MorphType> UpdateMorphType(Guid id, UpdateObjectInput<MorphType> update)
     {
         await AddChange(new JsonPatchChange<MorphType>(id, update.Patch));
@@ -397,11 +380,6 @@ public class CrdtMiniLcmApi(
     {
         await MorphTypeSync.Sync(before, after, api ?? this);
         return await GetMorphType(after.Id) ?? throw NotFoundException.ForType<MorphType>(after.Id);
-    }
-
-    public async Task DeleteMorphType(Guid id)
-    {
-        await AddChange(new DeleteChange<MorphType>(id));
     }
 
     public async Task<int> CountEntries(string? query = null, FilterQueryOptions? options = null)

--- a/backend/FwLite/MiniLcm.Tests/MorphTypeSyncTests.cs
+++ b/backend/FwLite/MiniLcm.Tests/MorphTypeSyncTests.cs
@@ -1,0 +1,36 @@
+using MiniLcm.SyncHelpers;
+
+namespace MiniLcm.Tests;
+
+public class MorphTypeSyncTests
+{
+    [Fact]
+    public async Task Sync_ThrowsOnAdd_WhenAfterContainsExtraMorphType()
+    {
+        var before = CanonicalMorphTypes.All.Values.ToArray();
+        var extraMorphType = new MorphType
+        {
+            Id = Guid.NewGuid(),
+            Kind = MorphTypeKind.Unknown,
+            Name = new MultiString { { "en", "bogus" } },
+        };
+        var after = before.Append(extraMorphType).ToArray();
+
+        var act = () => MorphTypeSync.Sync(before, after, null!);
+
+        await act.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("*cannot be created*");
+    }
+
+    [Fact]
+    public async Task Sync_ThrowsOnRemove_WhenAfterIsMissingMorphType()
+    {
+        var before = CanonicalMorphTypes.All.Values.ToArray();
+        var after = before.Skip(1).ToArray(); // drop one
+
+        var act = () => MorphTypeSync.Sync(before, after, null!);
+
+        await act.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("*cannot be deleted*");
+    }
+}

--- a/backend/FwLite/MiniLcm.Tests/MorphTypeTestsBase.cs
+++ b/backend/FwLite/MiniLcm.Tests/MorphTypeTestsBase.cs
@@ -1,0 +1,89 @@
+namespace MiniLcm.Tests;
+
+public abstract class MorphTypeTestsBase : MiniLcmTestBase
+{
+    [Fact]
+    public async Task GetMorphTypes_ReturnsAllCanonicalMorphTypes()
+    {
+        var morphTypes = await Api.GetMorphTypes().ToArrayAsync();
+        morphTypes.Should().NotBeEmpty();
+        morphTypes.Should().AllSatisfy(mt => mt.Id.Should().NotBe(Guid.Empty));
+        // All canonical kinds (except Unknown) should be present
+        var allKinds = Enum.GetValues<MorphTypeKind>().Where(k => k != MorphTypeKind.Unknown);
+        morphTypes.Select(mt => mt.Kind).Should().BeEquivalentTo(allKinds);
+    }
+
+    [Fact]
+    public async Task GetMorphType_ById_ReturnsExpected()
+    {
+        var morphTypes = await Api.GetMorphTypes().ToArrayAsync();
+        var stem = morphTypes.First(mt => mt.Kind == MorphTypeKind.Stem);
+
+        var result = await Api.GetMorphType(stem.Id);
+
+        result.Should().NotBeNull();
+        result!.Kind.Should().Be(MorphTypeKind.Stem);
+        result.Id.Should().Be(stem.Id);
+    }
+
+    [Fact]
+    public async Task GetMorphType_ByKind_ReturnsExpected()
+    {
+        var result = await Api.GetMorphType(MorphTypeKind.Prefix);
+
+        result.Should().NotBeNull();
+        result!.Kind.Should().Be(MorphTypeKind.Prefix);
+    }
+
+    [Fact]
+    public async Task GetMorphType_ByKind_Unknown_ReturnsNull()
+    {
+        var result = await Api.GetMorphType(MorphTypeKind.Unknown);
+        result.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task UpdateMorphType_UpdatesName()
+    {
+        var stem = await Api.GetMorphType(MorphTypeKind.Stem);
+        stem.Should().NotBeNull();
+
+        var updatedStem = stem!.Copy();
+        updatedStem.Name["en"] = "Updated Stem Name";
+        await Api.UpdateMorphType(stem, updatedStem);
+
+        var result = await Api.GetMorphType(MorphTypeKind.Stem);
+        result.Should().NotBeNull();
+        result!.Name["en"].Should().Be("Updated Stem Name");
+    }
+
+    [Fact]
+    public async Task UpdateMorphType_UpdatesAbbreviation()
+    {
+        var prefix = await Api.GetMorphType(MorphTypeKind.Prefix);
+        prefix.Should().NotBeNull();
+
+        var updated = prefix!.Copy();
+        updated.Abbreviation["en"] = "updated pfx";
+        await Api.UpdateMorphType(prefix, updated);
+
+        var result = await Api.GetMorphType(MorphTypeKind.Prefix);
+        result.Should().NotBeNull();
+        result!.Abbreviation["en"].Should().Be("updated pfx");
+    }
+
+    [Fact]
+    public async Task UpdateMorphType_NoChanges_DoesNotThrow()
+    {
+        var stem = await Api.GetMorphType(MorphTypeKind.Stem);
+        stem.Should().NotBeNull();
+
+        var copy = stem!.Copy();
+        // No changes made - should be a no-op
+        await Api.UpdateMorphType(stem, copy);
+
+        var result = await Api.GetMorphType(MorphTypeKind.Stem);
+        result.Should().NotBeNull();
+        result.Should().BeEquivalentTo(stem);
+    }
+}

--- a/backend/FwLite/MiniLcm/IMiniLcmWriteApi.cs
+++ b/backend/FwLite/MiniLcm/IMiniLcmWriteApi.cs
@@ -45,10 +45,8 @@ public interface IMiniLcmWriteApi
     #endregion
 
     #region MorphType
-    Task<MorphType> CreateMorphType(MorphType morphType);
     Task<MorphType> UpdateMorphType(Guid id, UpdateObjectInput<MorphType> update);
     Task<MorphType> UpdateMorphType(MorphType before, MorphType after, IMiniLcmApi? api = null);
-    Task DeleteMorphType(Guid id);
     #endregion
 
     #region Entry

--- a/backend/FwLite/MiniLcm/SyncHelpers/MorphTypeSync.cs
+++ b/backend/FwLite/MiniLcm/SyncHelpers/MorphTypeSync.cs
@@ -55,16 +55,16 @@ public static class MorphTypeSync
 
     private class MorphTypeDiffApi(IMiniLcmApi api) : ObjectWithIdCollectionDiffApi<MorphType>
     {
-        public override async Task<int> Add(MorphType currentMorphType)
+        public override Task<int> Add(MorphType currentMorphType)
         {
-            await api.CreateMorphType(currentMorphType);
-            return 1;
+            throw new InvalidOperationException(
+                $"MorphTypes are predefined and cannot be created. Unexpected morph type: {currentMorphType.Kind} ({currentMorphType.Id}). This indicates a data inconsistency.");
         }
 
-        public override async Task<int> Remove(MorphType beforeMorphType)
+        public override Task<int> Remove(MorphType beforeMorphType)
         {
-            await api.DeleteMorphType(beforeMorphType.Id);
-            return 1;
+            throw new InvalidOperationException(
+                $"MorphTypes are predefined and cannot be deleted. Unexpected morph type removal: {beforeMorphType.Kind} ({beforeMorphType.Id}). This indicates a data inconsistency.");
         }
 
         public override Task<int> Replace(MorphType beforeMorphType, MorphType afterMorphType)


### PR DESCRIPTION
## Summary
This PR removes the ability to create and delete MorphTypes across the codebase, reflecting the constraint that MorphTypes are predefined and immutable in FLEx. The operations are replaced with explicit error handling to catch any unexpected attempts to modify the MorphType collection.

Also resolves #1850 

## Key Changes

- **Removed MorphType CRUD methods** from all API implementations:
  - `CreateMorphType()` removed from `CrdtMiniLcmApi`, `FwDataMiniLcmApi`, `DryRunMiniLcmApi`, and hub classes
  - `DeleteMorphType()` removed from the same implementations
  - Methods removed from `IMiniLcmWriteApi` interface

- **Updated MorphTypeSync** to throw `InvalidOperationException` instead of attempting create/delete operations:
  - `Add()` now throws with message about predefined MorphTypes
  - `Remove()` now throws with message about immutable MorphTypes
  - Provides clear error messages for data inconsistency detection

- **Removed test cases** that validated the no-op behavior:
  - `MorphTypeCreationDoesNotSyncCrdtToFw` test removed
  - `MorphTypeDeletionDoesNotSyncCrdtToFw` test removed

- **Cleaned up helper code**:
  - Removed `CreateMorphType()` helper from `SyncTestHelpers`
  - Removed MorphType creation logic from `MiniLcmImport`
  - Removed resumable import wrappers for MorphType creation

## Implementation Details

The changes enforce that MorphTypes can only be updated, not created or deleted. Any attempt to add or remove a MorphType during sync operations will now fail with a clear error message indicating a data inconsistency, rather than silently ignoring the operation or creating/deleting entries that FLEx forbids.

https://claude.ai/code/session_01VsXD87DK8c9vMgujUAmfSu