### PR TITLE
Try fix ObjectDisposedException test race condition

### DIFF
--- a/backend/FwLite/LcmCrdt.Tests/Data/RegressionTestHelper.cs
+++ b/backend/FwLite/LcmCrdt.Tests/Data/RegressionTestHelper.cs
@@ -1,4 +1,5 @@
 using System.Runtime.CompilerServices;
+using Microsoft.Data.Sqlite;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
@@ -16,7 +17,12 @@ public class RegressionTestHelper(string dbName): IAsyncLifetime
         var initialSqlFile = GetFilePath($"Scripts/{version}.sql");
         var projectsService = _asyncScope.ServiceProvider.GetRequiredService<CurrentProjectService>();
         var crdtProject = new CrdtProject(dbName, $"{dbName}.sqlite");
-        if (File.Exists(crdtProject.DbPath)) File.Delete(crdtProject.DbPath);
+        if (File.Exists(crdtProject.DbPath))
+        {
+            using var clearConn = new SqliteConnection($"Data Source={crdtProject.DbPath}");
+            SqliteConnection.ClearPool(clearConn);
+            File.Delete(crdtProject.DbPath);
+        }
         projectsService.SetupProjectContextForNewDb(crdtProject);
         await using var lcmCrdtDbContext = await _asyncScope.ServiceProvider.GetRequiredService<IDbContextFactory<LcmCrdtDbContext>>().CreateDbContextAsync();
         var sql = await File.ReadAllTextAsync(initialSqlFile);

--- a/backend/FwLite/LcmCrdt.Tests/Project/CurrentProjectServiceTests.cs
+++ b/backend/FwLite/LcmCrdt.Tests/Project/CurrentProjectServiceTests.cs
@@ -39,8 +39,7 @@ public class CurrentProjectServiceTests : IAsyncLifetime
 
     public Task InitializeAsync()
     {
-        if (Directory.Exists(_testRoot)) Directory.Delete(_testRoot, true);
-        if (!Directory.Exists(TestProjectPath)) Directory.CreateDirectory(TestProjectPath);
+        Directory.CreateDirectory(TestProjectPath);
         return Task.CompletedTask;
     }
 

--- a/backend/FwLite/LcmCrdt/LcmCrdtKernel.cs
+++ b/backend/FwLite/LcmCrdt/LcmCrdtKernel.cs
@@ -91,10 +91,11 @@ public static class LcmCrdtKernel
         return services;
     }
 
+    // DynamicDependency prevents the trimmer from removing ClearAllPools (used by LinqToDB via reflection)
+    // without actually calling it — ClearAllPools() clears ALL pools globally and breaks parallel tests.
+    [System.Diagnostics.CodeAnalysis.DynamicDependency(nameof(SqliteConnection.ClearAllPools), typeof(SqliteConnection))]
     private static void AvoidTrimming()
     {
-        //this is only here so that the compiler doesn't trim this method as Linq2Db uses it via reflection
-        SqliteConnection.ClearAllPools();
     }
 
     public static void ConfigureDbOptions(IServiceProvider provider, DbContextOptionsBuilder builder)


### PR DESCRIPTION
Just ran into this race condition in CI.
I thought I'd fixed this by factoring away some calls to `ClearAllPools`.
I'm hopeful that that did help (It certainly hasn't happened often recently) and that this last one will truly prevent this from happening.

> Error: System.ObjectDisposedException : Cannot access a disposed object.
> Object name: 'SQLitePCL.sqlite3'.
> 
>   Failed LcmCrdt.Tests.MiniLcmTests.PublicationsTests.UpdatePublication_WithUpdateObject_Works [1 ms]
>   Error Message:
>    System.ObjectDisposedException : Cannot access a disposed object.
> Object name: 'SQLitePCL.sqlite3'.
>   Stack Trace:
>      at System.Runtime.InteropServices.SafeHandle.DangerousAddRef(Boolean& success)
>    at SQLitePCL.SQLite3Provider_e_sqlite3.SQLitePCL.ISQLite3Provider.sqlite3_create_function(sqlite3 db, Byte[] name, Int32 nargs, Int32 flags, Object v, delegate_function_scalar func)
>    at SQLitePCL.raw.sqlite3_create_function(sqlite3 db, String name, Int32 nArg, Int32 flags, Object v, delegate_function_scalar func)
>    at SQLitePCL.raw.sqlite3_create_function(sqlite3 db, String name, Int32 nArg, Object v, delegate_function_scalar func)
>    at Microsoft.Data.Sqlite.SqliteConnection.Open()
>    at System.Data.Common.DbConnection.OpenAsync(CancellationToken cancellationToken)
> --- End of stack trace from previous location ---
>    at Microsoft.EntityFrameworkCore.Storage.RelationalConnection.OpenInternalAsync(Boolean errorsExpected, CancellationToken cancellationToken)
>    at Microsoft.EntityFrameworkCore.Storage.RelationalConnection.OpenInternalAsync(Boolean errorsExpected, CancellationToken cancellationToken)
>    at Microsoft.EntityFrameworkCore.Storage.RelationalConnection.OpenAsync(CancellationToken cancellationToken, Boolean errorsExpected)
>    at Microsoft.EntityFrameworkCore.Storage.RelationalCommand.ExecuteReaderAsync(RelationalCommandParameterObject parameterObject, CancellationToken cancellationToken)
>    at Microsoft.EntityFrameworkCore.Query.Internal.SingleQueryingEnumerable`1.AsyncEnumerator.InitializeReaderAsync(AsyncEnumerator enumerator, CancellationToken cancellationToken)
>    at Microsoft.EntityFrameworkCore.Query.Internal.SingleQueryingEnumerable`1.AsyncEnumerator.MoveNextAsync()
>    at Microsoft.EntityFrameworkCore.Query.ShapedQueryCompilingExpressionVisitor.SingleAsync[TSource](IAsyncEnumerable`1 asyncEnumerable, CancellationToken cancellationToken)
>    at Microsoft.EntityFrameworkCore.Query.ShapedQueryCompilingExpressionVisitor.SingleAsync[TSource](IAsyncEnumerable`1 asyncEnumerable, CancellationToken cancellationToken)
>    at SIL.Harmony.Db.CrdtRepository.HasCommit(Guid commitId) in D:\a\languageforge-lexbox\languageforge-lexbox\backend\harmony\src\SIL.Harmony\Db\CrdtRepository.cs:line 109
>    at SIL.Harmony.DataModel.Add(Commit commit) in D:\a\languageforge-lexbox\languageforge-lexbox\backend\harmony\src\SIL.Harmony\DataModel.cs:line 117
>    at SIL.Harmony.DataModel.Add(Commit commit) in D:\a\languageforge-lexbox\languageforge-lexbox\backend\harmony\src\SIL.Harmony\DataModel.cs:line 128
>    at SIL.Harmony.DataModel.AddChanges(Guid clientId, IEnumerable`1 changes, Guid commitId, CommitMetadata commitMetadata) in D:\a\languageforge-lexbox\languageforge-lexbox\backend\harmony\src\SIL.Harmony\DataModel.cs:line 98
>    at SIL.Harmony.DataModel.AddChange(Guid clientId, IChange change, Guid commitId, CommitMetadata commitMetadata) in D:\a\languageforge-lexbox\languageforge-lexbox\backend\harmony\src\SIL.Harmony\DataModel.cs:line 66
>    at LcmCrdt.CrdtMiniLcmApi.AddChange(IChange change) in D:\a\languageforge-lexbox\languageforge-lexbox\backend\FwLite\LcmCrdt\CrdtMiniLcmApi.cs:line 51
>    at LcmCrdt.CrdtMiniLcmApi.CreatePublication(Publication pub) in D:\a\languageforge-lexbox\languageforge-lexbox\backend\FwLite\LcmCrdt\CrdtMiniLcmApi.cs:line 179
>    at MiniLcm.Tests.PublicationsTestsBase.InitializeAsync() in D:\a\languageforge-lexbox\languageforge-lexbox\backend\FwLite\MiniLcm.Tests\PublicationsTestsBase.cs:line 10

<!-- Additional changes were necessary, because it turned out that other tests were depending on the fact that connections pools were regularly, globally closed. -->