### PR TITLE
Fix LFClassic api 500 error when querying for all entries

### DIFF
--- a/backend/LfClassicData/LfClassicMiniLcmApi.cs
+++ b/backend/LfClassicData/LfClassicMiniLcmApi.cs
@@ -211,7 +211,7 @@ public class LfClassicMiniLcmApi(string projectCode, ProjectDbContext dbContext,
                 .Ascending(entry => entry.MorphologyType)
                 .Ascending(entry => entry.Guid))
             .Skip(options.Offset)
-            .Limit(options.Count)
+            .Limit(options.Count == QueryOptions.QueryAll ? 0 : options.Count)
             .Project(entry => entry as Entities.Entry);
 
         await foreach (var entry in Entries.Aggregate(pipeline).ToAsyncEnumerable())


### PR DESCRIPTION
`count=-1` is how to indicate to the API to get all entries, but that is accomplished with MongoDB via `.Limit(0)`, not `.Limit(-1)`.