### PR TITLE
Include chorusmerge script in FwHeadless

### DIFF
--- a/backend/Directory.Packages.props
+++ b/backend/Directory.Packages.props
@@ -97,6 +97,7 @@
     <PackageVersion Include="Refit.HttpClientFactory" Version="8.0.0" />
     <PackageVersion Include="Reinforced.Typings" Version="1.6.5" />
     <PackageVersion Include="Scalar.AspNetCore" Version="1.2.22" />
+    <PackageVersion Include="SIL.Chorus.ChorusMerge" Version="6.0.0-beta0055" />
     <PackageVersion Include="SIL.Chorus.LibChorus" Version="6.0.0-beta0055" />
     <PackageVersion Include="SIL.Chorus.Mercurial" Version="6.5.1.43" />
     <PackageVersion Include="SIL.ChorusPlugin.LfMergeBridge" Version="4.2.0-beta0028" />

--- a/backend/FwHeadless/Dockerfile
+++ b/backend/FwHeadless/Dockerfile
@@ -24,8 +24,8 @@ RUN apt-get update \
 	&& rm -rf /var/lib/apt/lists/*
 WORKDIR /app
 COPY --from=publish /app/publish .
-# Ensure Mercurial exec bit was not stripped by dotnet CLI tools
-RUN chmod +x Mercurial/hg && chmod +x Mercurial/chg 2>/dev/null || true
+# Ensure Chorus and Mercurial exec bits were not stripped by dotnet CLI tools
+RUN chmod +x chorusmerge && chmod +x Mercurial/hg && chmod +x Mercurial/chg 2>/dev/null || true
 # Fix up mercurial.ini path to fixutf8
 RUN sed -i -e 's/fixutf8 = \/FwHeadless/fixutf8 = \/app/' Mercurial/mercurial.ini
 USER www-data:www-data

--- a/backend/FwHeadless/FwHeadless.csproj
+++ b/backend/FwHeadless/FwHeadless.csproj
@@ -10,6 +10,7 @@
     <PackageReference Include="Scalar.AspNetCore" />
     <PackageReference Include="SIL.ChorusPlugin.LfMergeBridge" />
     <PackageReference Include="SIL.Chorus.Mercurial" />
+    <PackageReference Include="SIL.Chorus.ChorusMerge" GeneratePathProperty="true" />
     <PackageReference Include="System.Security.Cryptography.Xml" />
   </ItemGroup>
   <ItemGroup>
@@ -24,7 +25,19 @@
   <ItemGroup>
     <!-- json files get imported by default because this is a web project, so exclude those here so they aren't imported again below -->
     <Content Remove="Mercurial\contrib\asv.conf.json" />
+    <!-- Mercurial 6.5.2 and up has a new vs2022-settings.json file in its contrib folder that also needs excluding -->
+    <Content Remove="Mercurial\contrib\vs2022-settings.json" />
     <Content Include="Mercurial\**" CopyToOutputDirectory="Always" Watch="false" />
     <Content Include="MercurialExtensions\**" CopyToOutputDirectory="Always" Watch="false" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="chorusmerge">
+      <Link>chorusmerge</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Include="$(PkgSIL_Chorus_ChorusMerge)\lib\net8.0\ChorusMerge.runtimeconfig.json">
+      <Link>ChorusMerge.runtimeconfig.json</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
   </ItemGroup>
 </Project>

--- a/backend/FwHeadless/FwHeadless.csproj
+++ b/backend/FwHeadless/FwHeadless.csproj
@@ -35,6 +35,7 @@
       <Link>chorusmerge</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+    <!-- Do not update this net8.0 path when we change frameworks; instead, this should be updated if/when Chorus acquires a net10.0 build -->
     <None Include="$(PkgSIL_Chorus_ChorusMerge)\lib\net8.0\ChorusMerge.runtimeconfig.json">
       <Link>ChorusMerge.runtimeconfig.json</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>

--- a/backend/FwHeadless/chorusmerge
+++ b/backend/FwHeadless/chorusmerge
@@ -1,3 +1,6 @@
 #!/bin/bash
 
-exec dotnet ChorusMerge.dll "$@"
+# cwd while running script is inside hg repo, so ensure we look for ChorusMerge.dll in right place
+SCRIPT_DIR=$(dirname $(readlink -f "$0"))
+
+exec dotnet "${SCRIPT_DIR}/ChorusMerge.dll" "$@"

--- a/backend/FwHeadless/chorusmerge
+++ b/backend/FwHeadless/chorusmerge
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+exec dotnet ChorusMerge.dll "$@"


### PR DESCRIPTION
We never caught this omission because our tests weren't triggering a merge conflict in Chorus, so Chorus wasn't trying to run the chorusmerge script.

Fixes #2244.