### PR TITLE
Commit (i.e. save and reinitialize editor) when switching entry

### DIFF
--- a/frontend/viewer/src/lib/components/editor/editor-root.svelte
+++ b/frontend/viewer/src/lib/components/editor/editor-root.svelte
@@ -1,11 +1,24 @@
 <script lang="ts">
   import {cn} from '$lib/utils';
   import type {WithElementRef} from 'bits-ui';
+  import {tick} from 'svelte';
   import type {HTMLAttributes} from 'svelte/elements';
 
   type EditorRootProps = WithElementRef<HTMLAttributes<HTMLDivElement>>;
 
   let {class: className, children, ref = $bindable(null), ...restProps}: EditorRootProps = $props();
+
+  export async function commit() {
+    if (ref && document.activeElement instanceof HTMLElement && ref.contains(document.activeElement)) {
+      // We have change handlers that only trigger on blur and
+      // (1) add WS's to spans (i.e. finalize rich-strings. It's maybe a bad idea that we currently do that lazily) and
+      // (2) commit stomp-guards
+      // (3) run into errors if triggered too late (e.g. via onDestroy)
+      // this is a simple way to trigger all of that
+      document.activeElement.blur();
+      await tick();
+    }
+  }
 </script>
 
 <div class={cn('@container/editor', className)} {...restProps} bind:this={ref}>

--- a/frontend/viewer/src/lib/entry-editor/EditEntryDialog.svelte
+++ b/frontend/viewer/src/lib/entry-editor/EditEntryDialog.svelte
@@ -33,9 +33,12 @@
   const entryPersistence = new EntryPersistence(() => entry);
   let updating = $state(false);
 
+  let editor = $state<EntryEditor>();
+
   async function updateEntry() {
     if (!entry) return;
     updating = true;
+    await editor?.commit();
     await entryPersistence.updateEntry(entry).finally(() => updating = false);
     open = false;
   }
@@ -48,7 +51,7 @@
     {#if entryResource.loading}
       Loading...
     {:else if entry}
-      <EntryEditor autofocus modalMode bind:entry canAddSense={false} canAddExample={false}/>
+      <EntryEditor bind:this={editor} autofocus modalMode bind:entry canAddSense={false} canAddExample={false}/>
     {/if}
     <Dialog.DialogFooter>
       <Button onclick={() => open = false} variant="secondary">{$t`Cancel`}</Button>

--- a/frontend/viewer/src/lib/entry-editor/NewEntryDialog.svelte
+++ b/frontend/viewer/src/lib/entry-editor/NewEntryDialog.svelte
@@ -51,11 +51,14 @@
     }
   });
 
+  let editor = $state<Editor.Root>();
+
   async function createEntry(e: Event) {
     e.preventDefault();
     e.stopPropagation();
     if (!requester) throw new Error('No requester');
 
+    await editor?.commit();
     entry.senses = sense ? [sense] : [];
     if (!validateEntry()) return;
 
@@ -164,7 +167,7 @@
         ...(entryTemplate?.publishIn?.length ? ['publishIn'] as const : []),
         ...(senseTemplate?.semanticDomains?.length ? ['semanticDomains'] as const : [])
         ]}>
-        <Editor.Root>
+        <Editor.Root bind:this={editor}>
           <Editor.Grid>
             <EntryEditorPrimitive bind:entry autofocus modalMode
               publishInDescription={publishInIsFromTemplate ? fromActiveFilter : undefined} />

--- a/frontend/viewer/src/lib/entry-editor/entry-persistence.svelte.ts
+++ b/frontend/viewer/src/lib/entry-editor/entry-persistence.svelte.ts
@@ -45,8 +45,10 @@ export class EntryPersistence {
     if (this.initialEntry.id != entry.id) throw new Error('Entry id mismatch');
     const updatedEntry = await this.saveHandler.handleSave(() => this.lexboxApi.updateEntry(this.initialEntry as IEntry, $state.snapshot(entry)));
     this.onUpdated();
-    // use the version from the server or else we might get unsaved changes in initialEntry
-    this.updateInitialEntry(updatedEntry);
+
+    // update with the version from the server or else we might get unsaved changes in initialEntry
+    this.updateInitialEntryIfIdMatches(updatedEntry);
+
     return updatedEntry;
   }
 
@@ -62,7 +64,7 @@ export class EntryPersistence {
       updatedSense = await this.saveHandler.handleSave(() => this.lexboxApi.createSense(sense.entryId, $state.snapshot(sense)));
       entry.senses.push(updatedSense);
     }
-    this.updateInitialEntry(entry);
+    this.updateInitialEntryIfIdMatches(entry);
     return updatedSense;
   }
 
@@ -80,8 +82,16 @@ export class EntryPersistence {
       updatedExample = await this.saveHandler.handleSave(() => this.lexboxApi.createExampleSentence(sense.entryId, example.senseId, $state.snapshot(example)));
       sense.exampleSentences.push(updatedExample);
     }
-    this.updateInitialEntry(entry);
+    this.updateInitialEntryIfIdMatches(entry);
     return updatedExample;
+  }
+
+  // The user/view may have switched to a different "initial entry" while we were saving
+  // in which case we should NOT update the initial entry with the result of this save
+  private updateInitialEntryIfIdMatches(entry: IEntry): void {
+    if (this.initialEntry?.id === entry.id) {
+      this.updateInitialEntry(entry);
+    }
   }
 
   private updateInitialEntry(entry: ReadonlyDeep<IEntry> | undefined | null): void {

--- a/frontend/viewer/src/lib/entry-editor/object-editors/EntryEditor.svelte
+++ b/frontend/viewer/src/lib/entry-editor/object-editors/EntryEditor.svelte
@@ -49,6 +49,12 @@
   const dialogService = useDialogsService();
   const writingSystemService = useWritingSystemService();
 
+  let editor = $state<Editor.Root>();
+
+  export function commit() {
+    return editor?.commit();
+  }
+
   //used to not try to delete an object which has not been created yet
   let newSenses: ISense[] = [];
   let newExamples: IExampleSentence[] = [];
@@ -161,7 +167,7 @@
   const showSenses = $derived(showExamples || hasVisibleFields(viewService.currentView.senseFields));
 </script>
 
-<Editor.Root bind:ref>
+<Editor.Root bind:ref bind:this={editor}>
   <Editor.Grid bind:ref={editorElem}>
     <EntryEditorPrimitive class={ENTITY_FIELD_CONTAINER_CLASS} bind:entry {readonly} {autofocus} {modalMode} onchange={(entry) => onchange?.({entry})} />
 

--- a/frontend/viewer/src/project/browse/EntryView.svelte
+++ b/frontend/viewer/src/project/browse/EntryView.svelte
@@ -45,9 +45,12 @@
   // We want to keep the deleted entry in the view, so the user can optionally restore it.
   const dedupedEntryId = $derived(entryId);
 
+  let editor = $state<EntryEditor>();
+
   const entryResource = resource(
     () => dedupedEntryId,
     async (id) => {
+      await editor?.commit();
       const entry = await miniLcmApi.getEntry(id);
       return setEntry(entry);
     },
@@ -157,7 +160,14 @@
         </div>
       {/if}
       <div class="max-md:p-2 md:pb-2 md:px-2">
-        <EntryEditor bind:ref={editorRef} bind:entry readonly={readonly || !features.write || deleted} {...entryPersistence.entryEditorProps} />
+        {#key entry.id}
+          <EntryEditor
+            bind:this={editor}
+            bind:ref={editorRef}
+            bind:entry
+            readonly={readonly || !features.write || deleted}
+            {...entryPersistence.entryEditorProps} />
+        {/key}
       </div>
     </ScrollArea>
   {/if}

--- a/frontend/viewer/src/project/tasks/SubjectPopup.svelte
+++ b/frontend/viewer/src/project/tasks/SubjectPopup.svelte
@@ -14,7 +14,6 @@
   import {t} from 'svelte-i18n-lingui';
   import type {TaskSubject} from './subject.svelte';
   import type {Overrides} from '$lib/views/view-data';
-  import {tick} from 'svelte';
   import DictionaryEntry from '$lib/components/dictionary/DictionaryEntry.svelte';
 
   let {
@@ -60,19 +59,13 @@
     subjectIndex = 0;
   });
 
+  let editor = $state<Editor.Root>();
 
   async function onNext(skip: boolean = false) {
     if (!skip) {
       if (!subject || !isSubjectComplete()) return;
 
-      if (document.activeElement instanceof HTMLElement) {
-        // We have change rich-text change handlers that
-        // (1) add WS's to spans (i.e. finalize rich-strings. It's maybe a bad idea that we currently do that lazily) and
-        // (2) run into errors if triggered too late (e.g. via onDestroy)
-        // this is a simple way to ensure they run cleanly before we move on
-        document.activeElement.blur();
-        await tick();
-      }
+      await editor?.commit();
 
       switch (task.subjectType) {
         case 'example-sentence':
@@ -147,7 +140,7 @@
           <form bind:this={form} onsubmit={(e) => {e.preventDefault(); void onNext()}}>
             <!--        lets us submit by pressing enter on any field-->
             <input type="submit" style="display: none;"/>
-            <Editor.Root>
+            <Editor.Root bind:this={editor}>
               <Editor.Grid>
                 <OverrideFields shownFields={task.subjectFields} {overrides}>
                   {#if task.subjectType === 'entry' && subject.entry}

--- a/frontend/viewer/tests/back-navigation-persistence.test.ts
+++ b/frontend/viewer/tests/back-navigation-persistence.test.ts
@@ -1,0 +1,62 @@
+import {expect, test} from '@playwright/test';
+import {BrowsePage} from './browse-page';
+
+test.describe('Back navigation persistence', () => {
+
+  test('edit is applied to correct entry when navigating back without blurring', async ({page}) => {
+    const browsePage = new BrowsePage(page);
+    await browsePage.goto();
+
+    // Get three entries from demo data to ensure a solid history stack
+    const entryAId = await browsePage.api.getEntryIdAtIndex(0);
+    const entryBId = await browsePage.api.getEntryIdAtIndex(1);
+    const entryCId = await browsePage.api.getEntryIdAtIndex(2);
+
+    const originalLexemeA = await browsePage.api.getEntryLexeme(entryAId);
+    const originalLexemeB = await browsePage.api.getEntryLexeme(entryBId);
+
+    // 1) Open entry A
+    await browsePage.entriesList.selectEntryByIndex(0);
+    await browsePage.entryView.waitForEntryLoaded();
+
+    // 2) Open entry B
+    await browsePage.entriesList.selectEntryByIndex(1);
+    await browsePage.entryView.waitForEntryLoaded();
+
+    // 3) Open entry C
+    await browsePage.entriesList.selectEntryByIndex(2);
+    await browsePage.entryView.waitForEntryLoaded();
+
+    // 4) Edit a field on entry C (lexeme form)
+    const lexemeInput = await browsePage.entryView.getLexemeInput();
+    const timestamp = Date.now().toString().slice(-6);
+    const newValueC = `edited-C-${timestamp}`;
+
+    await lexemeInput.click();
+    await lexemeInput.press('ControlOrMeta+a');
+    await lexemeInput.fill(newValueC);
+    // DO NOT press Tab or Blur!
+
+    // 5) Trigger a back navigation WITHOUT blurring first
+    await page.goBack();
+
+    // Wait for entry B to be loaded again in the UI
+    await expect(page.locator('.i-mdi-loading')).toHaveCount(0, {timeout: 10000});
+    await browsePage.entryView.waitForEntryLoaded();
+
+    // Ensure the input value for Entry B is NOT newValueC
+    const lexemeInputAfterNav = await browsePage.entryView.getLexemeInput();
+    await expect(lexemeInputAfterNav).not.toHaveValue(newValueC);
+    await expect(lexemeInputAfterNav).toHaveValue(originalLexemeB);
+
+    // 6) Verify via API that entry B and A were NOT changed
+    const savedLexemeB = await browsePage.api.getEntryLexeme(entryBId);
+    expect(savedLexemeB, 'Entry B should not have the edit meant for Entry C').toBe(originalLexemeB);
+    const savedLexemeA = await browsePage.api.getEntryLexeme(entryAId);
+    expect(savedLexemeA, 'Entry A should not have the edit meant for Entry C').toBe(originalLexemeA);
+
+    // 7) Verify via API that entry C WAS changed
+    const savedLexemeC = await browsePage.api.getEntryLexeme(entryCId);
+    expect(savedLexemeC).toBe(newValueC);
+  });
+});


### PR DESCRIPTION
There are various editor events that only happen on blur.
If blur is triggered by e.g. going to the next task or navigating to a different entry (e.g. with Alt+Left), then blur can happen too late.

As a result (I could not perfectly reproduce it. I think it was partially device-dependent. The user was using a tablet) dirty values in stomp-guarded fields we're being applied to the wrong (and multiple) entries. I.e. changes were leaking into other entries.

We already had a fix in place for the task view. This PR generalizes that to a reusable method which is now used in the main entry editor, the new entry dialog and the update/edit entry dialog as well.

An additional `#key` around `EntryEditor` prevents stomp-guarded components from "guarding" against legitimate changes values  being applied due to changing entries. This was presumably already fixed without adding the `#key`, but both changes make good logical sense and it adds an additional safe guard against any kind of "leakage".

The added UI test also successfully reproduced the bug.