### PR TITLE
Move CRDT sync off of UI thread

### DIFF
--- a/backend/FwLite/FwLiteShared/Services/SyncServiceJsInvokable.cs
+++ b/backend/FwLite/FwLiteShared/Services/SyncServiceJsInvokable.cs
@@ -80,7 +80,7 @@ public class SyncServiceJsInvokable(SyncService syncService, SyncRepository sync
     [JSInvokable]
     public Task<SyncResults> ExecuteSync(bool skipNotifications)
     {
-        return syncService.ExecuteSync(skipNotifications);
+        return Task.Run(async () => await syncService.ExecuteSync(skipNotifications));
     }
 
     [JSInvokable]


### PR DESCRIPTION
A couple times I've noticed that if you do a log in on from in the sync dialog, it results in a CRDT sync, which can freeze up the app.
This should fix that. We've applied this same fix to quite a few C# methods.