### PR TITLE
Make project identifying more robust

### DIFF
--- a/frontend/viewer/src/home/HomeView.svelte
+++ b/frontend/viewer/src/home/HomeView.svelte
@@ -181,7 +181,7 @@
                     onclick={() => refreshProjects()}/>
           </div>
           <div>
-            {#each projects.filter((p) => p.crdt) as project (project.id ?? project)}
+            {#each projects.filter((p) => p.crdt) as project (project)}
               {@const server = project.server}
               {@const loading = deletingProject === project.id}
               <div out:send={{key: 'project-' + project.code}} in:receive={{key: 'project-' + project.code}}>
@@ -249,7 +249,9 @@
           <div>
             <p class="sub-title">{$t`Classic FieldWorks Projects`}</p>
             <div>
-              {#each projects.filter((p) => p.fwdata) as project (project.name)}
+              <!-- project.name (and maybe code as well) can have duplicates
+              if there are 2 fwdata projects whose names are the name and code of a crdt project -->
+              {#each projects.filter((p) => p.fwdata) as project (project)}
                 <Anchor href={`/fwdata/${project.code}`}>
                   <ProjectListItem {project}>
                     {#snippet icon()}

--- a/frontend/viewer/src/project/ProjectDropdown.svelte
+++ b/frontend/viewer/src/project/ProjectDropdown.svelte
@@ -108,10 +108,12 @@
         {:else}
           <Command.Empty>{$t`No Dictionaries found`}</Command.Empty>
           {#each projectsResource.current ?? [] as project (project)}
+            {@const isCurrentProject = project.crdt === isCrdt &&
+              (isCrdt ? project.name === projectName : project.code === projectName)}
             <Command.Item
-              value={project.name + project.crdt}
+              value={`${project.name}-${project.code}-${project.crdt}`}
               onSelect={() => handleSelect(project)}
-              class={cn('cursor-pointer', (project.name === projectName || project.code === projectName) && project.crdt === isCrdt && 'bg-secondary')}
+              class={cn('cursor-pointer', isCurrentProject && 'bg-secondary')}
             >
               {@render projectIcon(project.crdt)}
               <ProjectTitle {project} />

--- a/frontend/viewer/src/url-tracker.ts
+++ b/frontend/viewer/src/url-tracker.ts
@@ -14,6 +14,8 @@ export function trackUrl(appStorage: AppStorage) {
     const currentUrl = pathname + search + hash;
 
     if (currentUrl === lastSavedUrl) return;
+    if (pathname.startsWith('/api/')) return;
+
     await appStorage.lastUrl.set(pathname + search + hash);
     lastSavedUrl = currentUrl;
   }) as () => void;


### PR DESCRIPTION
It turns out that (because we merge fwdata and crdt projects on the backend in some ways) it's trickier than we anticipated to uniquely identify projects.

E.g. given these 3 projects:
CRDT project: name(My project), code (my-proj)
FwData project: name(My project)
FwData project: name(my-proj)

The frontend ends up with 2 FwData projects:
Project 1: name(My project), code(My project)
Project 2: name(My project), code(my-proj)

So, there's a duplicate `name` and only `code` is unique.
Code is probably always unique, but my brain hurts and simply using the project object itself as the each key seems perfectly acceptable.