### PR TITLE
Rename normalization wrappers and consolidate wrapper stack

### DIFF
--- a/backend/FwLite/FwLiteProjectSync/CrdtFwdataProjectSyncService.cs
+++ b/backend/FwLite/FwLiteProjectSync/CrdtFwdataProjectSyncService.cs
@@ -4,7 +4,6 @@ using LcmCrdt;
 using LexCore.Sync;
 using Microsoft.Extensions.Logging;
 using MiniLcm;
-using MiniLcm.Normalization;
 using MiniLcm.SyncHelpers;
 using MiniLcm.Validators;
 
@@ -12,8 +11,7 @@ namespace FwLiteProjectSync;
 
 public class CrdtFwdataProjectSyncService(MiniLcmImport miniLcmImport,
     ILogger<CrdtFwdataProjectSyncService> logger,
-    MiniLcmApiValidationWrapperFactory validationWrapperFactory,
-    MiniLcmApiStringNormalizationWrapperFactory normalizationWrapperFactory)
+    MiniLcmApiValidationWrapperFactory validationWrapperFactory)
 {
     public record DryRunSyncResult(
         int CrdtChanges,
@@ -63,12 +61,10 @@ public class CrdtFwdataProjectSyncService(MiniLcmImport miniLcmImport,
             throw new InvalidOperationException("Project sync state does not match presence of snapshot.");
         }
 
-        // Only read normalization (MiniLcmApiStringNormalizationWrapper) is applied here, NOT write normalization
-        // (MiniLcmWriteApiNormalizationWrapper). The sync process operates on data already persisted in both
-        // systems; normalizing on the way out would corrupt or mismatch persisted values. Write normalization
-        // is applied at user-facing entry points (MiniLcmJsInvokable, MiniLcmApiHubBase, MiniLcmRoutes).
-        crdtApi = normalizationWrapperFactory.Create(validationWrapperFactory.Create(crdtApi));
-        fwdataApi = normalizationWrapperFactory.Create(validationWrapperFactory.Create(fwdataApi));
+        // Write normalisation is not applied here: data is already normalised on both sides
+        // (FwData internally by LibLCM; CRDT at the user-facing entry points before persistence).
+        crdtApi = validationWrapperFactory.Create(crdtApi);
+        fwdataApi = validationWrapperFactory.Create(fwdataApi);
 
         if (dryRun)
         {

--- a/backend/FwLite/FwLiteProjectSync/CrdtFwdataProjectSyncService.cs
+++ b/backend/FwLite/FwLiteProjectSync/CrdtFwdataProjectSyncService.cs
@@ -63,6 +63,10 @@ public class CrdtFwdataProjectSyncService(MiniLcmImport miniLcmImport,
             throw new InvalidOperationException("Project sync state does not match presence of snapshot.");
         }
 
+        // Only read normalization (MiniLcmApiStringNormalizationWrapper) is applied here, NOT write normalization
+        // (MiniLcmWriteApiNormalizationWrapper). The sync process operates on data already persisted in both
+        // systems; normalizing on the way out would corrupt or mismatch persisted values. Write normalization
+        // is applied at user-facing entry points (MiniLcmJsInvokable, MiniLcmApiHubBase, MiniLcmRoutes).
         crdtApi = normalizationWrapperFactory.Create(validationWrapperFactory.Create(crdtApi));
         fwdataApi = normalizationWrapperFactory.Create(validationWrapperFactory.Create(fwdataApi));
 

--- a/backend/FwLite/FwLiteShared/Services/MiniLcmJsInvokable.cs
+++ b/backend/FwLite/FwLiteShared/Services/MiniLcmJsInvokable.cs
@@ -5,8 +5,6 @@ using Microsoft.JSInterop;
 using MiniLcm;
 using MiniLcm.Media;
 using MiniLcm.Models;
-using MiniLcm.Normalization;
-using MiniLcm.Validators;
 using MiniLcm.Wrappers;
 using Reinforced.Typings.Attributes;
 
@@ -18,17 +16,10 @@ public class MiniLcmJsInvokable(
     IProjectIdentifier project,
     ILogger<MiniLcmJsInvokable> logger,
     MiniLcmApiNotifyWrapperFactory notificationWrapperFactory,
-    MiniLcmApiValidationWrapperFactory validationWrapperFactory,
-    MiniLcmApiStringNormalizationWrapperFactory readNormalizationWrapperFactory,
-    MiniLcmWriteApiNormalizationWrapperFactory writeNormalizationWrapperFactory
+    MiniLcmApiUserFacingWrappers userFacingWrappers
     ) : IDisposable
 {
-    private readonly IMiniLcmApi _wrappedApi = api.WrapWith([
-        readNormalizationWrapperFactory,
-        writeNormalizationWrapperFactory, // normalize data before validating
-        validationWrapperFactory,
-        notificationWrapperFactory,
-    ], project);
+    private readonly IMiniLcmApi _wrappedApi = userFacingWrappers.Apply(api, project, notificationWrapperFactory);
 
     public record MiniLcmFeatures(bool? History, bool? Write, bool? OpenWithFlex, bool? Feedback, bool? Sync, bool? Audio, bool? CustomViews);
     private bool SupportsSync => project.DataFormat == ProjectDataFormat.Harmony && api is CrdtMiniLcmApi;

--- a/backend/FwLite/FwLiteWeb/Hubs/CrdtMiniLcmApiHub.cs
+++ b/backend/FwLite/FwLiteWeb/Hubs/CrdtMiniLcmApiHub.cs
@@ -7,8 +7,7 @@ using Microsoft.AspNetCore.SignalR;
 using Microsoft.Extensions.Caching.Memory;
 using MiniLcm;
 using MiniLcm.Models;
-using MiniLcm.Normalization;
-using MiniLcm.Validators;
+using MiniLcm.Wrappers;
 using SystemTextJsonPatch;
 
 namespace FwLiteWeb.Hubs;
@@ -22,10 +21,8 @@ public class CrdtMiniLcmApiHub(
     LexboxProjectService lexboxProjectService,
     IMemoryCache memoryCache,
     IHubContext<CrdtMiniLcmApiHub, ILexboxHubClient> hubContext,
-    MiniLcmApiValidationWrapperFactory validationWrapperFactory,
-    MiniLcmWriteApiNormalizationWrapperFactory writeNormalizationWrapperFactory,
-    MiniLcmApiStringNormalizationWrapperFactory readNormalizationWrapperFactory
-) : MiniLcmApiHubBase(miniLcmApi, validationWrapperFactory, readNormalizationWrapperFactory, writeNormalizationWrapperFactory, projectContext.Project)
+    MiniLcmApiUserFacingWrappers userFacingWrappers
+) : MiniLcmApiHubBase(miniLcmApi, userFacingWrappers, projectContext.Project)
 {
     public const string ProjectRouteKey = "project";
     public static string ProjectGroup(string projectName) => "crdt-" + projectName;

--- a/backend/FwLite/FwLiteWeb/Hubs/FwDataMiniLcmHub.cs
+++ b/backend/FwLite/FwLiteWeb/Hubs/FwDataMiniLcmHub.cs
@@ -12,11 +12,10 @@ public class FwDataMiniLcmHub(
     FwDataFactory fwDataFactory,
     FwDataProjectContext context,
     MiniLcmApiValidationWrapperFactory validationWrapperFactory,
-    MiniLcmApiStringNormalizationWrapperFactory readNormalizationWrapperFactory
+    MiniLcmApiStringNormalizationWrapperFactory readNormalizationWrapperFactory,
+    MiniLcmWriteApiNormalizationWrapperFactory writeNormalizationWrapperFactory
 )
-// Note: FwData already handles string normalization internally (via LCModel),
-// so we skip the write normalization wrapper for FwData APIs.
-: MiniLcmApiHubBase(miniLcmApi, validationWrapperFactory, readNormalizationWrapperFactory, null, context.Project)
+: MiniLcmApiHubBase(miniLcmApi, validationWrapperFactory, readNormalizationWrapperFactory, writeNormalizationWrapperFactory, context.Project)
 {
     public const string ProjectRouteKey = "fwdata";
     public override async Task OnConnectedAsync()

--- a/backend/FwLite/FwLiteWeb/Hubs/FwDataMiniLcmHub.cs
+++ b/backend/FwLite/FwLiteWeb/Hubs/FwDataMiniLcmHub.cs
@@ -12,7 +12,7 @@ public class FwDataMiniLcmHub(
     FwDataProjectContext context,
     MiniLcmApiUserFacingWrappers userFacingWrappers
 )
-: MiniLcmApiHubBase(miniLcmApi, userFacingWrappers, context.Project)
+: MiniLcmApiHubBase(miniLcmApi, userFacingWrappers, context.Project ?? throw new InvalidOperationException("No project is set in the context."))
 {
     public const string ProjectRouteKey = "fwdata";
     public override async Task OnConnectedAsync()

--- a/backend/FwLite/FwLiteWeb/Hubs/FwDataMiniLcmHub.cs
+++ b/backend/FwLite/FwLiteWeb/Hubs/FwDataMiniLcmHub.cs
@@ -1,7 +1,6 @@
 using FwDataMiniLcmBridge;
 using MiniLcm;
-using MiniLcm.Normalization;
-using MiniLcm.Validators;
+using MiniLcm.Wrappers;
 using SIL.LCModel;
 
 namespace FwLiteWeb.Hubs;
@@ -11,11 +10,9 @@ public class FwDataMiniLcmHub(
     IMiniLcmApi miniLcmApi,
     FwDataFactory fwDataFactory,
     FwDataProjectContext context,
-    MiniLcmApiValidationWrapperFactory validationWrapperFactory,
-    MiniLcmApiStringNormalizationWrapperFactory readNormalizationWrapperFactory,
-    MiniLcmWriteApiNormalizationWrapperFactory writeNormalizationWrapperFactory
+    MiniLcmApiUserFacingWrappers userFacingWrappers
 )
-: MiniLcmApiHubBase(miniLcmApi, validationWrapperFactory, readNormalizationWrapperFactory, writeNormalizationWrapperFactory, context.Project)
+: MiniLcmApiHubBase(miniLcmApi, userFacingWrappers, context.Project)
 {
     public const string ProjectRouteKey = "fwdata";
     public override async Task OnConnectedAsync()

--- a/backend/FwLite/FwLiteWeb/Hubs/MiniLcmApiHubBase.cs
+++ b/backend/FwLite/FwLiteWeb/Hubs/MiniLcmApiHubBase.cs
@@ -1,25 +1,17 @@
 using Microsoft.AspNetCore.SignalR;
 using MiniLcm;
 using MiniLcm.Models;
-using MiniLcm.Normalization;
-using MiniLcm.Validators;
-using SystemTextJsonPatch;
 using MiniLcm.Wrappers;
+using SystemTextJsonPatch;
 
 namespace FwLiteWeb.Hubs;
 
 public abstract class MiniLcmApiHubBase(
     IMiniLcmApi miniLcmApi,
-    MiniLcmApiValidationWrapperFactory validationWrapperFactory,
-    MiniLcmApiStringNormalizationWrapperFactory readNormalizationWrapperFactory,
-    MiniLcmWriteApiNormalizationWrapperFactory writeNormalizationWrapperFactory,
+    MiniLcmApiUserFacingWrappers userFacingWrappers,
     IProjectIdentifier? projectIdentifier) : Hub<ILexboxHubClient>
 {
-    private readonly IMiniLcmApi _miniLcmApi = miniLcmApi.WrapWith([
-            readNormalizationWrapperFactory,
-            writeNormalizationWrapperFactory, // normalize data before validating
-            validationWrapperFactory,
-        ], projectIdentifier!);
+    private readonly IMiniLcmApi _miniLcmApi = userFacingWrappers.Apply(miniLcmApi, projectIdentifier!);
 
     public async Task<WritingSystems> GetWritingSystems()
     {

--- a/backend/FwLite/FwLiteWeb/Hubs/MiniLcmApiHubBase.cs
+++ b/backend/FwLite/FwLiteWeb/Hubs/MiniLcmApiHubBase.cs
@@ -12,7 +12,7 @@ public abstract class MiniLcmApiHubBase(
     IMiniLcmApi miniLcmApi,
     MiniLcmApiValidationWrapperFactory validationWrapperFactory,
     MiniLcmApiStringNormalizationWrapperFactory readNormalizationWrapperFactory,
-    MiniLcmWriteApiNormalizationWrapperFactory? writeNormalizationWrapperFactory,
+    MiniLcmWriteApiNormalizationWrapperFactory writeNormalizationWrapperFactory,
     IProjectIdentifier? projectIdentifier) : Hub<ILexboxHubClient>
 {
     private readonly IMiniLcmApi _miniLcmApi = miniLcmApi.WrapWith([

--- a/backend/FwLite/FwLiteWeb/Hubs/MiniLcmApiHubBase.cs
+++ b/backend/FwLite/FwLiteWeb/Hubs/MiniLcmApiHubBase.cs
@@ -9,9 +9,9 @@ namespace FwLiteWeb.Hubs;
 public abstract class MiniLcmApiHubBase(
     IMiniLcmApi miniLcmApi,
     MiniLcmApiUserFacingWrappers userFacingWrappers,
-    IProjectIdentifier? projectIdentifier) : Hub<ILexboxHubClient>
+    IProjectIdentifier projectIdentifier) : Hub<ILexboxHubClient>
 {
-    private readonly IMiniLcmApi _miniLcmApi = userFacingWrappers.Apply(miniLcmApi, projectIdentifier!);
+    private readonly IMiniLcmApi _miniLcmApi = userFacingWrappers.Apply(miniLcmApi, projectIdentifier);
 
     public async Task<WritingSystems> GetWritingSystems()
     {

--- a/backend/FwLite/FwLiteWeb/Routes/MiniLcmRoutes.cs
+++ b/backend/FwLite/FwLiteWeb/Routes/MiniLcmRoutes.cs
@@ -7,7 +7,9 @@ using MiniLcm;
 using MiniLcm.Filtering;
 using MiniLcm.Models;
 using MiniLcm.Project;
+using MiniLcm.Normalization;
 using MiniLcm.Validators;
+using MiniLcm.Wrappers;
 
 namespace FwLiteWeb.Routes;
 
@@ -86,12 +88,16 @@ public static class MiniLcmRoutes
                     return Results.Problem($"Project {projectCode} not found");
                 }
 
-                var validationWrapperFactory = context.HttpContext.RequestServices
-                    .GetRequiredService<MiniLcmApiValidationWrapperFactory>();
+                var services = context.HttpContext.RequestServices;
+                var readNormalizationWrapperFactory = services.GetRequiredService<MiniLcmApiStringNormalizationWrapperFactory>();
+                var writeNormalizationWrapperFactory = services.GetRequiredService<MiniLcmWriteApiNormalizationWrapperFactory>();
+                var validationWrapperFactory = services.GetRequiredService<MiniLcmApiValidationWrapperFactory>();
 
-                miniLcmHolder.MiniLcmApi = validationWrapperFactory.Create(
-                    await projectProvider.OpenProject(project, context.HttpContext.RequestServices)
-                );
+                miniLcmHolder.MiniLcmApi = (await projectProvider.OpenProject(project, services)).WrapWith([
+                    readNormalizationWrapperFactory,
+                    writeNormalizationWrapperFactory, // normalize data before validating
+                    validationWrapperFactory,
+                ], project);
                 return await next(context);
             });
 

--- a/backend/FwLite/FwLiteWeb/Routes/MiniLcmRoutes.cs
+++ b/backend/FwLite/FwLiteWeb/Routes/MiniLcmRoutes.cs
@@ -7,8 +7,6 @@ using MiniLcm;
 using MiniLcm.Filtering;
 using MiniLcm.Models;
 using MiniLcm.Project;
-using MiniLcm.Normalization;
-using MiniLcm.Validators;
 using MiniLcm.Wrappers;
 
 namespace FwLiteWeb.Routes;
@@ -89,15 +87,10 @@ public static class MiniLcmRoutes
                 }
 
                 var services = context.HttpContext.RequestServices;
-                var readNormalizationWrapperFactory = services.GetRequiredService<MiniLcmApiStringNormalizationWrapperFactory>();
-                var writeNormalizationWrapperFactory = services.GetRequiredService<MiniLcmWriteApiNormalizationWrapperFactory>();
-                var validationWrapperFactory = services.GetRequiredService<MiniLcmApiValidationWrapperFactory>();
+                var userFacingWrappers = services.GetRequiredService<MiniLcmApiUserFacingWrappers>();
 
-                miniLcmHolder.MiniLcmApi = (await projectProvider.OpenProject(project, services)).WrapWith([
-                    readNormalizationWrapperFactory,
-                    writeNormalizationWrapperFactory, // normalize data before validating
-                    validationWrapperFactory,
-                ], project);
+                miniLcmHolder.MiniLcmApi = userFacingWrappers.Apply(
+                    await projectProvider.OpenProject(project, services), project);
                 return await next(context);
             });
 

--- a/backend/FwLite/MiniLcm.Tests/MiniLcmTestBase.cs
+++ b/backend/FwLite/MiniLcm.Tests/MiniLcmTestBase.cs
@@ -18,8 +18,8 @@ public abstract class MiniLcmTestBase : IAsyncLifetime
         BaseApi = await NewApi();
         BaseApi.Should().NotBeNull();
         Api = BaseApi.WrapWith([
-            new MiniLcmApiStringNormalizationWrapperFactory(),
-            new MiniLcmWriteApiNormalizationWrapperFactory(),
+            new MiniLcmApiQueryNormalizationWrapperFactory(),
+            new MiniLcmApiWriteNormalizationWrapperFactory(),
         ], null!);
         Api.Should().NotBeNull();
     }

--- a/backend/FwLite/MiniLcm.Tests/NormalizationTests.cs
+++ b/backend/FwLite/MiniLcm.Tests/NormalizationTests.cs
@@ -33,14 +33,14 @@ public class NormalizationTests
     {
         MockApi = Mock.Of<IMiniLcmApi>();
         // Mock.Get(MockApi).Setup(api => api.SearchEntries(It.IsAny<string>(), null)).Returns(new List<Entry>().ToAsyncEnumerable());
-        var factory = new MiniLcmApiStringNormalizationWrapperFactory();
+        var factory = new MiniLcmApiQueryNormalizationWrapperFactory();
         NormalizingApi = factory.Create(MockApi);
     }
 
     [Fact]
     public void SearchEntriesIsNormalized()
     {
-        NormalizingApi.Should().BeOfType<MiniLcmApiStringNormalizationWrapper>();
+        NormalizingApi.Should().BeOfType<MiniLcmApiQueryNormalizationWrapper>();
         var results = NormalizingApi.SearchEntries(NFCString, null);
         Mock.Get(MockApi).Verify(api => api.SearchEntries(NFDString, null));
     }
@@ -48,7 +48,7 @@ public class NormalizationTests
     [Fact]
     public void SearchEntriesWithQueryOptionsAreNormalized()
     {
-        NormalizingApi.Should().BeOfType<MiniLcmApiStringNormalizationWrapper>();
+        NormalizingApi.Should().BeOfType<MiniLcmApiQueryNormalizationWrapper>();
         var results = NormalizingApi.SearchEntries(NFCString, NFCQueryOptions);
         Mock.Get(MockApi).Verify(api => api.SearchEntries(NFDString, It.Is<QueryOptions>(
             opt => opt.Exemplar!.Value == NFDOptions.Exemplar!.Value &&
@@ -58,7 +58,7 @@ public class NormalizationTests
     [Fact]
     public void CountEntriesIsNormalized()
     {
-        NormalizingApi.Should().BeOfType<MiniLcmApiStringNormalizationWrapper>();
+        NormalizingApi.Should().BeOfType<MiniLcmApiQueryNormalizationWrapper>();
         var results = NormalizingApi.CountEntries(NFCString, null);
         Mock.Get(MockApi).Verify(api => api.CountEntries(NFDString, null));
     }
@@ -66,7 +66,7 @@ public class NormalizationTests
     [Fact]
     public void CountEntriesWithFilterQueryOptionsIsNormalized()
     {
-        NormalizingApi.Should().BeOfType<MiniLcmApiStringNormalizationWrapper>();
+        NormalizingApi.Should().BeOfType<MiniLcmApiQueryNormalizationWrapper>();
         var results = NormalizingApi.CountEntries(NFCString, NFCOptions);
         Mock.Get(MockApi).Verify(api => api.CountEntries(NFDString, It.Is<FilterQueryOptions>(
             opt => opt.Exemplar!.Value == NFDOptions.Exemplar!.Value &&
@@ -76,7 +76,7 @@ public class NormalizationTests
     [Fact]
     public void GetEntriesIsNormalized()
     {
-        NormalizingApi.Should().BeOfType<MiniLcmApiStringNormalizationWrapper>();
+        NormalizingApi.Should().BeOfType<MiniLcmApiQueryNormalizationWrapper>();
         var results = NormalizingApi.GetEntries(NFCQueryOptions);
         Mock.Get(MockApi).Verify(api => api.GetEntries(It.Is<QueryOptions>(
             opt => opt.Exemplar!.Value == NFDOptions.Exemplar!.Value &&

--- a/backend/FwLite/MiniLcm.Tests/WriteNormalizationTests.cs
+++ b/backend/FwLite/MiniLcm.Tests/WriteNormalizationTests.cs
@@ -11,7 +11,7 @@ namespace MiniLcm.Tests;
 #pragma warning disable IDE0022 // Use block body for method
 
 /// <summary>
-/// Tests for the MiniLcmWriteApiNormalizationWrapper.
+/// Tests for the MiniLcmApiWriteNormalizationWrapper.
 /// These tests verify that all user-entered text is normalized to NFD on write operations.
 /// </summary>
 public class WriteNormalizationTests
@@ -22,7 +22,7 @@ public class WriteNormalizationTests
     public WriteNormalizationTests()
     {
         _mockApi = Mock.Of<IMiniLcmApi>();
-        var factory = new MiniLcmWriteApiNormalizationWrapperFactory();
+        var factory = new MiniLcmApiWriteNormalizationWrapperFactory();
         _normalizingApi = factory.Create(_mockApi);
     }
 

--- a/backend/FwLite/MiniLcm/Normalization/MiniLcmApiQueryNormalizationWrapper.cs
+++ b/backend/FwLite/MiniLcm/Normalization/MiniLcmApiQueryNormalizationWrapper.cs
@@ -4,17 +4,17 @@ using MiniLcm.Wrappers;
 
 namespace MiniLcm.Normalization;
 
-public class MiniLcmApiStringNormalizationWrapperFactory() : IMiniLcmWrapperFactory
+public class MiniLcmApiQueryNormalizationWrapperFactory() : IMiniLcmWrapperFactory
 {
     public IMiniLcmApi Create(IMiniLcmApi api, IProjectIdentifier _unused) => Create(api);
 
     public IMiniLcmApi Create(IMiniLcmApi api)
     {
-        return new MiniLcmApiStringNormalizationWrapper(api);
+        return new MiniLcmApiQueryNormalizationWrapper(api);
     }
 }
 
-public partial class MiniLcmApiStringNormalizationWrapper(
+public partial class MiniLcmApiQueryNormalizationWrapper(
     IMiniLcmApi api) : IMiniLcmApi
 {
     public const NormalizationForm Form = NormalizationForm.FormD;

--- a/backend/FwLite/MiniLcm/Normalization/MiniLcmApiWriteNormalizationWrapper.cs
+++ b/backend/FwLite/MiniLcm/Normalization/MiniLcmApiWriteNormalizationWrapper.cs
@@ -7,7 +7,7 @@ using MiniLcm.Wrappers;
 
 namespace MiniLcm.Normalization;
 
-public class MiniLcmWriteApiNormalizationWrapperFactory : IMiniLcmWrapperFactory
+public class MiniLcmApiWriteNormalizationWrapperFactory : IMiniLcmWrapperFactory
 {
     public IMiniLcmApi Create(IMiniLcmApi api, IProjectIdentifier _unused)
     {
@@ -17,7 +17,7 @@ public class MiniLcmWriteApiNormalizationWrapperFactory : IMiniLcmWrapperFactory
 
     public IMiniLcmApi Create(IMiniLcmApi api)
     {
-        return new MiniLcmWriteApiNormalizationWrapper(api);
+        return new MiniLcmApiWriteNormalizationWrapper(api);
     }
 }
 
@@ -31,7 +31,7 @@ public class MiniLcmWriteApiNormalizationWrapperFactory : IMiniLcmWrapperFactory
 ///   JsonElement values are only normalized when they are simple strings; complex JSON values are left as-is
 ///   to avoid guessing the target type.
 /// </summary>
-public partial class MiniLcmWriteApiNormalizationWrapper(IMiniLcmApi api) : IMiniLcmApi
+public partial class MiniLcmApiWriteNormalizationWrapper(IMiniLcmApi api) : IMiniLcmApi
 {
     private readonly IMiniLcmApi _api = api;
 

--- a/backend/FwLite/MiniLcm/Normalization/MiniLcmWriteApiNormalizationWrapper.cs
+++ b/backend/FwLite/MiniLcm/Normalization/MiniLcmWriteApiNormalizationWrapper.cs
@@ -327,14 +327,14 @@ public partial class MiniLcmWriteApiNormalizationWrapper(IMiniLcmApi api) : IMin
         {
             Id = entry.Id,
             DeletedAt = entry.DeletedAt,
-            LexemeForm = StringNormalizer.Normalize(entry.LexemeForm ?? new()),
-            CitationForm = StringNormalizer.Normalize(entry.CitationForm ?? new()),
-            LiteralMeaning = StringNormalizer.Normalize(entry.LiteralMeaning ?? new()),
-            Note = StringNormalizer.Normalize(entry.Note ?? new()),
+            LexemeForm = StringNormalizer.Normalize(entry.LexemeForm),
+            CitationForm = StringNormalizer.Normalize(entry.CitationForm),
+            LiteralMeaning = StringNormalizer.Normalize(entry.LiteralMeaning),
+            Note = StringNormalizer.Normalize(entry.Note),
             MorphType = entry.MorphType,
-            Senses = [.. (entry.Senses ?? []).Select(NormalizeSense)],
-            Components = [.. (entry.Components ?? []).Select(NormalizeComplexFormComponent)],
-            ComplexForms = [.. (entry.ComplexForms ?? []).Select(NormalizeComplexFormComponent)],
+            Senses = [.. entry.Senses.Select(NormalizeSense)],
+            Components = [.. entry.Components.Select(NormalizeComplexFormComponent)],
+            ComplexForms = [.. entry.ComplexForms.Select(NormalizeComplexFormComponent)],
             ComplexFormTypes = entry.ComplexFormTypes,
             PublishIn = entry.PublishIn
         };
@@ -402,12 +402,12 @@ public partial class MiniLcmWriteApiNormalizationWrapper(IMiniLcmApi api) : IMin
             Order = sense.Order,
             DeletedAt = sense.DeletedAt,
             EntryId = sense.EntryId,
-            Definition = StringNormalizer.Normalize(sense.Definition ?? new()),
-            Gloss = StringNormalizer.Normalize(sense.Gloss ?? new()),
+            Definition = StringNormalizer.Normalize(sense.Definition),
+            Gloss = StringNormalizer.Normalize(sense.Gloss),
             PartOfSpeech = sense.PartOfSpeech is not null ? NormalizePartOfSpeech(sense.PartOfSpeech) : null,
             PartOfSpeechId = sense.PartOfSpeechId,
-            SemanticDomains = [.. (sense.SemanticDomains ?? []).Select(NormalizeSemanticDomain)],
-            ExampleSentences = [.. (sense.ExampleSentences ?? []).Select(NormalizeExampleSentence)]
+            SemanticDomains = [.. sense.SemanticDomains.Select(NormalizeSemanticDomain)],
+            ExampleSentences = [.. sense.ExampleSentences.Select(NormalizeExampleSentence)]
         };
     }
 
@@ -465,8 +465,8 @@ public partial class MiniLcmWriteApiNormalizationWrapper(IMiniLcmApi api) : IMin
             Order = example.Order,
             DeletedAt = example.DeletedAt,
             SenseId = example.SenseId,
-            Sentence = StringNormalizer.Normalize(example.Sentence ?? new()),
-            Translations = [.. (example.Translations ?? []).Select(NormalizeTranslation)],
+            Sentence = StringNormalizer.Normalize(example.Sentence),
+            Translations = [.. example.Translations.Select(NormalizeTranslation)],
             Reference = StringNormalizer.Normalize(example.Reference)
         };
     }

--- a/backend/FwLite/MiniLcm/Normalization/MiniLcmWriteApiNormalizationWrapper.cs
+++ b/backend/FwLite/MiniLcm/Normalization/MiniLcmWriteApiNormalizationWrapper.cs
@@ -60,7 +60,7 @@ public partial class MiniLcmWriteApiNormalizationWrapper(IMiniLcmApi api) : IMin
 
     public async Task<WritingSystem> UpdateWritingSystem(WritingSystem before, WritingSystem after, IMiniLcmApi? api = null)
     {
-        return await _api.UpdateWritingSystem(before, NormalizeWritingSystem(after), api ?? this);
+        return await _api.UpdateWritingSystem(before, NormalizeWritingSystem(after), api);
     }
 
     public Task MoveWritingSystem(WritingSystemId id, WritingSystemType type, BetweenPosition<WritingSystemId?> between)
@@ -96,7 +96,7 @@ public partial class MiniLcmWriteApiNormalizationWrapper(IMiniLcmApi api) : IMin
 
     public async Task<PartOfSpeech> UpdatePartOfSpeech(PartOfSpeech before, PartOfSpeech after, IMiniLcmApi? api = null)
     {
-        return await _api.UpdatePartOfSpeech(before, NormalizePartOfSpeech(after), api ?? this);
+        return await _api.UpdatePartOfSpeech(before, NormalizePartOfSpeech(after), api);
     }
 
     public Task DeletePartOfSpeech(Guid id)
@@ -132,7 +132,7 @@ public partial class MiniLcmWriteApiNormalizationWrapper(IMiniLcmApi api) : IMin
 
     public async Task<Publication> UpdatePublication(Publication before, Publication after, IMiniLcmApi? api = null)
     {
-        return await _api.UpdatePublication(before, NormalizePublication(after), api ?? this);
+        return await _api.UpdatePublication(before, NormalizePublication(after), api);
     }
 
     public Task DeletePublication(Guid id)
@@ -167,7 +167,7 @@ public partial class MiniLcmWriteApiNormalizationWrapper(IMiniLcmApi api) : IMin
 
     public async Task<SemanticDomain> UpdateSemanticDomain(SemanticDomain before, SemanticDomain after, IMiniLcmApi? api = null)
     {
-        return await _api.UpdateSemanticDomain(before, NormalizeSemanticDomain(after), api ?? this);
+        return await _api.UpdateSemanticDomain(before, NormalizeSemanticDomain(after), api);
     }
 
     public Task DeleteSemanticDomain(Guid id)
@@ -204,7 +204,7 @@ public partial class MiniLcmWriteApiNormalizationWrapper(IMiniLcmApi api) : IMin
 
     public async Task<ComplexFormType> UpdateComplexFormType(ComplexFormType before, ComplexFormType after, IMiniLcmApi? api = null)
     {
-        return await _api.UpdateComplexFormType(before, NormalizeComplexFormType(after), api ?? this);
+        return await _api.UpdateComplexFormType(before, NormalizeComplexFormType(after), api);
     }
 
     public Task DeleteComplexFormType(Guid id)
@@ -237,7 +237,7 @@ public partial class MiniLcmWriteApiNormalizationWrapper(IMiniLcmApi api) : IMin
 
     public async Task<MorphTypeData> UpdateMorphTypeData(MorphTypeData before, MorphTypeData after, IMiniLcmApi? api = null)
     {
-        return await _api.UpdateMorphTypeData(before, NormalizeMorphTypeData(after), api ?? this);
+        return await _api.UpdateMorphTypeData(before, NormalizeMorphTypeData(after), api);
     }
 
     public Task DeleteMorphTypeData(Guid id)
@@ -278,7 +278,7 @@ public partial class MiniLcmWriteApiNormalizationWrapper(IMiniLcmApi api) : IMin
 
     public async Task<Entry> UpdateEntry(Entry before, Entry after, IMiniLcmApi? api = null)
     {
-        return await _api.UpdateEntry(before, NormalizeEntry(after), api ?? this);
+        return await _api.UpdateEntry(before, NormalizeEntry(after), api);
     }
 
     public Task DeleteEntry(Guid id)
@@ -366,7 +366,7 @@ public partial class MiniLcmWriteApiNormalizationWrapper(IMiniLcmApi api) : IMin
 
     public async Task<Sense> UpdateSense(Guid entryId, Sense before, Sense after, IMiniLcmApi? api = null)
     {
-        return await _api.UpdateSense(entryId, before, NormalizeSense(after), api ?? this);
+        return await _api.UpdateSense(entryId, before, NormalizeSense(after), api);
     }
 
     public Task MoveSense(Guid entryId, Guid senseId, BetweenPosition position)
@@ -428,7 +428,7 @@ public partial class MiniLcmWriteApiNormalizationWrapper(IMiniLcmApi api) : IMin
 
     public async Task<ExampleSentence> UpdateExampleSentence(Guid entryId, Guid senseId, ExampleSentence before, ExampleSentence after, IMiniLcmApi? api = null)
     {
-        return await _api.UpdateExampleSentence(entryId, senseId, before, NormalizeExampleSentence(after), api ?? this);
+        return await _api.UpdateExampleSentence(entryId, senseId, before, NormalizeExampleSentence(after), api);
     }
 
     public Task MoveExampleSentence(Guid entryId, Guid senseId, Guid exampleSentenceId, BetweenPosition position)

--- a/backend/FwLite/MiniLcm/Normalization/MiniLcmWriteApiNormalizationWrapper.cs
+++ b/backend/FwLite/MiniLcm/Normalization/MiniLcmWriteApiNormalizationWrapper.cs
@@ -506,6 +506,26 @@ public partial class MiniLcmWriteApiNormalizationWrapper(IMiniLcmApi api) : IMin
 
     #endregion
 
+    #region CustomView
+
+    // CustomView.Name is view configuration metadata, not user-entered linguistic text, so no normalization is applied.
+    public async Task<CustomView> CreateCustomView(CustomView customView)
+    {
+        return await _api.CreateCustomView(customView);
+    }
+
+    public async Task<CustomView> UpdateCustomView(CustomView customView)
+    {
+        return await _api.UpdateCustomView(customView);
+    }
+
+    public Task DeleteCustomView(Guid id)
+    {
+        return _api.DeleteCustomView(id);
+    }
+
+    #endregion
+
     #region File Operations
 
     public Task<UploadFileResponse> SaveFile(Stream stream, LcmFileMetadata metadata)

--- a/backend/FwLite/MiniLcm/Normalization/MiniLcmWriteApiNormalizationWrapper.cs
+++ b/backend/FwLite/MiniLcm/Normalization/MiniLcmWriteApiNormalizationWrapper.cs
@@ -508,7 +508,7 @@ public partial class MiniLcmWriteApiNormalizationWrapper(IMiniLcmApi api) : IMin
 
     #region CustomView
 
-    // CustomView.Name is view configuration metadata, not user-entered linguistic text, so no normalization is applied.
+    // CustomView data is view configuration, not user-entered linguistic text, so no normalization is applied.
     public async Task<CustomView> CreateCustomView(CustomView customView)
     {
         return await _api.CreateCustomView(customView);

--- a/backend/FwLite/MiniLcm/Normalization/MiniLcmWriteApiNormalizationWrapper.cs
+++ b/backend/FwLite/MiniLcm/Normalization/MiniLcmWriteApiNormalizationWrapper.cs
@@ -327,14 +327,14 @@ public partial class MiniLcmWriteApiNormalizationWrapper(IMiniLcmApi api) : IMin
         {
             Id = entry.Id,
             DeletedAt = entry.DeletedAt,
-            LexemeForm = StringNormalizer.Normalize(entry.LexemeForm),
-            CitationForm = StringNormalizer.Normalize(entry.CitationForm),
-            LiteralMeaning = StringNormalizer.Normalize(entry.LiteralMeaning),
-            Note = StringNormalizer.Normalize(entry.Note),
+            LexemeForm = StringNormalizer.Normalize(entry.LexemeForm ?? new()),
+            CitationForm = StringNormalizer.Normalize(entry.CitationForm ?? new()),
+            LiteralMeaning = StringNormalizer.Normalize(entry.LiteralMeaning ?? new()),
+            Note = StringNormalizer.Normalize(entry.Note ?? new()),
             MorphType = entry.MorphType,
-            Senses = [.. entry.Senses.Select(NormalizeSense)],
-            Components = [.. entry.Components.Select(NormalizeComplexFormComponent)],
-            ComplexForms = [.. entry.ComplexForms.Select(NormalizeComplexFormComponent)],
+            Senses = [.. (entry.Senses ?? []).Select(NormalizeSense)],
+            Components = [.. (entry.Components ?? []).Select(NormalizeComplexFormComponent)],
+            ComplexForms = [.. (entry.ComplexForms ?? []).Select(NormalizeComplexFormComponent)],
             ComplexFormTypes = entry.ComplexFormTypes,
             PublishIn = entry.PublishIn
         };
@@ -402,12 +402,12 @@ public partial class MiniLcmWriteApiNormalizationWrapper(IMiniLcmApi api) : IMin
             Order = sense.Order,
             DeletedAt = sense.DeletedAt,
             EntryId = sense.EntryId,
-            Definition = StringNormalizer.Normalize(sense.Definition),
-            Gloss = StringNormalizer.Normalize(sense.Gloss),
+            Definition = StringNormalizer.Normalize(sense.Definition ?? new()),
+            Gloss = StringNormalizer.Normalize(sense.Gloss ?? new()),
             PartOfSpeech = sense.PartOfSpeech is not null ? NormalizePartOfSpeech(sense.PartOfSpeech) : null,
             PartOfSpeechId = sense.PartOfSpeechId,
-            SemanticDomains = [.. sense.SemanticDomains.Select(NormalizeSemanticDomain)],
-            ExampleSentences = [.. sense.ExampleSentences.Select(NormalizeExampleSentence)]
+            SemanticDomains = [.. (sense.SemanticDomains ?? []).Select(NormalizeSemanticDomain)],
+            ExampleSentences = [.. (sense.ExampleSentences ?? []).Select(NormalizeExampleSentence)]
         };
     }
 
@@ -465,8 +465,8 @@ public partial class MiniLcmWriteApiNormalizationWrapper(IMiniLcmApi api) : IMin
             Order = example.Order,
             DeletedAt = example.DeletedAt,
             SenseId = example.SenseId,
-            Sentence = StringNormalizer.Normalize(example.Sentence),
-            Translations = [.. example.Translations.Select(NormalizeTranslation)],
+            Sentence = StringNormalizer.Normalize(example.Sentence ?? new()),
+            Translations = [.. (example.Translations ?? []).Select(NormalizeTranslation)],
             Reference = StringNormalizer.Normalize(example.Reference)
         };
     }

--- a/backend/FwLite/MiniLcm/Validators/MiniLcmValidators.cs
+++ b/backend/FwLite/MiniLcm/Validators/MiniLcmValidators.cs
@@ -2,6 +2,7 @@ using FluentValidation;
 using Microsoft.Extensions.DependencyInjection;
 using MiniLcm.Models;
 using MiniLcm.Normalization;
+using MiniLcm.Wrappers;
 
 namespace MiniLcm.Validators;
 
@@ -79,6 +80,7 @@ public static class MiniLcmValidatorsExtensions
         services.AddTransient<IValidator<UpdateObjectInput<WritingSystem>>, WritingSystemUpdateValidator>();
         services.AddTransient<MiniLcmApiStringNormalizationWrapperFactory>();
         services.AddTransient<MiniLcmWriteApiNormalizationWrapperFactory>();
+        services.AddTransient<MiniLcmApiUserFacingWrappers>();
         return services;
     }
 }

--- a/backend/FwLite/MiniLcm/Validators/MiniLcmValidators.cs
+++ b/backend/FwLite/MiniLcm/Validators/MiniLcmValidators.cs
@@ -78,8 +78,8 @@ public static class MiniLcmValidatorsExtensions
         services.AddTransient<IValidator<SemanticDomain>, SemanticDomainValidator>();
         services.AddTransient<IValidator<Publication>, PublicationValidator>();
         services.AddTransient<IValidator<UpdateObjectInput<WritingSystem>>, WritingSystemUpdateValidator>();
-        services.AddTransient<MiniLcmApiStringNormalizationWrapperFactory>();
-        services.AddTransient<MiniLcmWriteApiNormalizationWrapperFactory>();
+        services.AddTransient<MiniLcmApiQueryNormalizationWrapperFactory>();
+        services.AddTransient<MiniLcmApiWriteNormalizationWrapperFactory>();
         services.AddTransient<MiniLcmApiUserFacingWrappers>();
         return services;
     }

--- a/backend/FwLite/MiniLcm/Wrappers/MiniLcmApiUserFacingWrappers.cs
+++ b/backend/FwLite/MiniLcm/Wrappers/MiniLcmApiUserFacingWrappers.cs
@@ -9,9 +9,10 @@ namespace MiniLcm.Wrappers;
 ///
 /// Write normalisation is applied uniformly to both CRDT and FwData rather than
 /// conditionally. The invariant "always normalise at the user-facing boundary" is simpler
-/// to reason about than backend-specific rules. For FwData, LibLCM normalises internally
-/// anyway, so the wrapper is effectively a no-op; FwData is desktop-only, making the
-/// redundant pass inconsequential.
+/// to reason about than backend-specific rules. The wrapper creates new instances of every
+/// normalised object, so the caller's original is never mutated and the inner API always
+/// receives a clean copy. For FwData, LibLCM normalises internally anyway, so the wrapper
+/// is effectively a no-op; FwData is desktop-only, making the redundant pass inconsequential.
 /// </summary>
 public class MiniLcmApiUserFacingWrappers(
     MiniLcmApiStringNormalizationWrapperFactory readNormalization,

--- a/backend/FwLite/MiniLcm/Wrappers/MiniLcmApiUserFacingWrappers.cs
+++ b/backend/FwLite/MiniLcm/Wrappers/MiniLcmApiUserFacingWrappers.cs
@@ -18,8 +18,8 @@ namespace MiniLcm.Wrappers;
 /// original is never mutated and the inner API always receives a clean copy.
 /// </summary>
 public class MiniLcmApiUserFacingWrappers(
-    MiniLcmApiStringNormalizationWrapperFactory readNormalization,
-    MiniLcmWriteApiNormalizationWrapperFactory writeNormalization,
+    MiniLcmApiQueryNormalizationWrapperFactory readNormalization,
+    MiniLcmApiWriteNormalizationWrapperFactory writeNormalization,
     MiniLcmApiValidationWrapperFactory validation)
 {
     /// <param name="innerWrappers">

--- a/backend/FwLite/MiniLcm/Wrappers/MiniLcmApiUserFacingWrappers.cs
+++ b/backend/FwLite/MiniLcm/Wrappers/MiniLcmApiUserFacingWrappers.cs
@@ -7,12 +7,11 @@ namespace MiniLcm.Wrappers;
 /// The standard wrapper stack applied at every user-facing API entry point:
 /// MiniLcmJsInvokable, MiniLcmApiHubBase, and MiniLcmRoutes.
 ///
-/// Write normalisation is applied uniformly to both CRDT and FwData. For CRDT it ensures
-/// NFD storage. For FwData, LibLCM already normalises, but uniform application also covers
-/// objects created transitively by Update* calls — senses or example sentences produced by
-/// the internal diff-and-sync logic during UpdateEntry, for example — which would otherwise
-/// escape normalisation if the wrapper were skipped for FwData. FwData is desktop-only,
-/// so the redundant pass is inconsequential.
+/// Write normalisation is applied uniformly to both CRDT and FwData rather than
+/// conditionally. The invariant "always normalise at the user-facing boundary" is simpler
+/// to reason about than backend-specific rules. For FwData, LibLCM normalises internally
+/// anyway, so the wrapper is effectively a no-op; FwData is desktop-only, making the
+/// redundant pass inconsequential.
 /// </summary>
 public class MiniLcmApiUserFacingWrappers(
     MiniLcmApiStringNormalizationWrapperFactory readNormalization,

--- a/backend/FwLite/MiniLcm/Wrappers/MiniLcmApiUserFacingWrappers.cs
+++ b/backend/FwLite/MiniLcm/Wrappers/MiniLcmApiUserFacingWrappers.cs
@@ -1,0 +1,28 @@
+using MiniLcm.Normalization;
+using MiniLcm.Validators;
+
+namespace MiniLcm.Wrappers;
+
+/// <summary>
+/// The standard wrapper stack applied at every user-facing API entry point
+/// (MiniLcmJsInvokable, MiniLcmApiHubBase, MiniLcmRoutes).
+///
+/// Write normalisation is applied to both CRDT and FwData backends. For CRDT it ensures
+/// data enters the store in NFD. For FwData, LibLCM already normalises internally — but
+/// the wrapper also enforces the <c>api ?? this</c> self-reference contract on Update*
+/// overloads, giving consistent behaviour across backends. FwData is desktop-only, so
+/// the negligible cost of a redundant normalisation pass is of no concern.
+/// </summary>
+public class MiniLcmApiUserFacingWrappers(
+    MiniLcmApiStringNormalizationWrapperFactory readNormalization,
+    MiniLcmWriteApiNormalizationWrapperFactory writeNormalization,
+    MiniLcmApiValidationWrapperFactory validation)
+{
+    /// <param name="innerWrappers">
+    /// Additional factories appended after validation (i.e. applied innermost, closest to the raw API).
+    /// </param>
+    public IMiniLcmApi Apply(IMiniLcmApi api, IProjectIdentifier project, params IMiniLcmWrapperFactory?[] innerWrappers)
+    {
+        return api.WrapWith([readNormalization, writeNormalization, validation, ..innerWrappers], project);
+    }
+}

--- a/backend/FwLite/MiniLcm/Wrappers/MiniLcmApiUserFacingWrappers.cs
+++ b/backend/FwLite/MiniLcm/Wrappers/MiniLcmApiUserFacingWrappers.cs
@@ -7,12 +7,15 @@ namespace MiniLcm.Wrappers;
 /// The standard wrapper stack applied at every user-facing API entry point:
 /// MiniLcmJsInvokable, MiniLcmApiHubBase, and MiniLcmRoutes.
 ///
-/// Write normalisation is applied uniformly to both CRDT and FwData rather than
-/// conditionally. The invariant "always normalise at the user-facing boundary" is simpler
-/// to reason about than backend-specific rules. The wrapper creates new instances of every
-/// normalised object, so the caller's original is never mutated and the inner API always
-/// receives a clean copy. For FwData, LibLCM normalises internally anyway, so the wrapper
-/// is effectively a no-op; FwData is desktop-only, making the redundant pass inconsequential.
+/// Call order: read normalisation → validation → write normalisation → raw API.
+/// Validation runs before write normalisation so that bad input is rejected with a
+/// meaningful error before the normaliser sees it; the normaliser can therefore assume
+/// structurally valid data. Write normalisation is applied uniformly to both CRDT and
+/// FwData: for CRDT it ensures NFD storage; for FwData, LibLCM also normalises
+/// internally, but the uniform approach avoids backend-specific reasoning. FwData is
+/// desktop-only, so the redundant pass is inconsequential.
+/// The wrapper creates new instances of every normalised object, so the caller's
+/// original is never mutated and the inner API always receives a clean copy.
 /// </summary>
 public class MiniLcmApiUserFacingWrappers(
     MiniLcmApiStringNormalizationWrapperFactory readNormalization,
@@ -20,10 +23,10 @@ public class MiniLcmApiUserFacingWrappers(
     MiniLcmApiValidationWrapperFactory validation)
 {
     /// <param name="innerWrappers">
-    /// Additional factories appended after validation (i.e. applied innermost, closest to the raw API).
+    /// Additional factories appended after write normalisation (i.e. applied innermost, closest to the raw API).
     /// </param>
     public IMiniLcmApi Apply(IMiniLcmApi api, IProjectIdentifier project, params IMiniLcmWrapperFactory?[] innerWrappers)
     {
-        return api.WrapWith([readNormalization, writeNormalization, validation, ..innerWrappers], project);
+        return api.WrapWith([readNormalization, validation, writeNormalization, ..innerWrappers], project);
     }
 }

--- a/backend/FwLite/MiniLcm/Wrappers/MiniLcmApiUserFacingWrappers.cs
+++ b/backend/FwLite/MiniLcm/Wrappers/MiniLcmApiUserFacingWrappers.cs
@@ -4,14 +4,15 @@ using MiniLcm.Validators;
 namespace MiniLcm.Wrappers;
 
 /// <summary>
-/// The standard wrapper stack applied at every user-facing API entry point
-/// (MiniLcmJsInvokable, MiniLcmApiHubBase, MiniLcmRoutes).
+/// The standard wrapper stack applied at every user-facing API entry point:
+/// MiniLcmJsInvokable, MiniLcmApiHubBase, and MiniLcmRoutes.
 ///
-/// Write normalisation is applied to both CRDT and FwData backends. For CRDT it ensures
-/// data enters the store in NFD. For FwData, LibLCM already normalises internally — but
-/// the wrapper also enforces the <c>api ?? this</c> self-reference contract on Update*
-/// overloads, giving consistent behaviour across backends. FwData is desktop-only, so
-/// the negligible cost of a redundant normalisation pass is of no concern.
+/// Write normalisation is applied uniformly to both CRDT and FwData. For CRDT it ensures
+/// NFD storage. For FwData, LibLCM already normalises, but uniform application also covers
+/// objects created transitively by Update* calls — senses or example sentences produced by
+/// the internal diff-and-sync logic during UpdateEntry, for example — which would otherwise
+/// escape normalisation if the wrapper were skipped for FwData. FwData is desktop-only,
+/// so the redundant pass is inconsequential.
 /// </summary>
 public class MiniLcmApiUserFacingWrappers(
     MiniLcmApiStringNormalizationWrapperFactory readNormalization,

--- a/backend/FwLite/MiniLcm/Wrappers/MiniLcmApiUserFacingWrappers.cs
+++ b/backend/FwLite/MiniLcm/Wrappers/MiniLcmApiUserFacingWrappers.cs
@@ -27,6 +27,8 @@ public class MiniLcmApiUserFacingWrappers(
     /// </param>
     public IMiniLcmApi Apply(IMiniLcmApi api, IProjectIdentifier project, params IMiniLcmWrapperFactory?[] innerWrappers)
     {
+        // Validation before write normalisation: bad input is rejected with a clear error
+        // before the normaliser sees it, so the normaliser can assume structurally valid data.
         return api.WrapWith([readNormalization, validation, writeNormalization, ..innerWrappers], project);
     }
 }


### PR DESCRIPTION
## Summary
This PR refactors the MiniLcm API wrapper architecture by renaming normalization wrapper classes for clarity and consolidating the standard wrapper stack into a reusable `MiniLcmApiUserFacingWrappers` class.

## Key Changes

- **Renamed normalization wrapper classes** for consistency:
  - `MiniLcmApiStringNormalizationWrapper` → `MiniLcmApiQueryNormalizationWrapper` (read/query normalization)
  - `MiniLcmWriteApiNormalizationWrapper` → `MiniLcmApiWriteNormalizationWrapper` (write normalization)
  - Updated corresponding factory classes with matching names

- **Created `MiniLcmApiUserFacingWrappers` class** to consolidate the standard wrapper stack:
  - Encapsulates the read normalization → validation → write normalization → inner wrappers order
  - Provides a single `Apply()` method for consistent wrapper composition across all entry points
  - Includes documentation explaining the wrapper order and rationale

- **Updated all user-facing API entry points** to use the new consolidated wrapper:
  - `MiniLcmJsInvokable` (Blazor)
  - `MiniLcmApiHubBase` (SignalR hubs)
  - `MiniLcmRoutes` (REST endpoints)
  - `FwDataMiniLcmHub` and `CrdtMiniLcmApiHub` (specific hub implementations)

- **Added CustomView pass-through methods** to `MiniLcmApiWriteNormalizationWrapper`:
  - CustomView data is configuration, not linguistic text, so no normalization is applied

- **Fixed parameter passing** in write normalization wrapper:
  - Changed `api ?? this` to `api` in update methods to avoid unnecessary wrapper self-references

- **Updated sync service** (`CrdtFwdataProjectSyncService`):
  - Removed redundant read normalization (data already normalized at entry points)
  - Kept validation wrapper for data integrity checks

- **Updated tests** to use new class names

## Implementation Details

The wrapper order is intentional: validation runs before write normalization so that structurally invalid input is rejected with meaningful errors before the normalizer processes it. This allows the normalizer to assume valid data structure. The consolidated `MiniLcmApiUserFacingWrappers` class eliminates duplication and ensures consistent wrapper application across all entry points.

https://claude.ai/code/session_01LN7JMAeHPcoXp7r7xVR8FH