### PR TITLE
Fix race condition opening entry in FW

### DIFF
--- a/backend/FwHeadless/Services/SyncHostedService.cs
+++ b/backend/FwHeadless/Services/SyncHostedService.cs
@@ -184,7 +184,7 @@ public class SyncWorker(
         //always do this as existing projects need to run this even if they didn't S&R due to no pending changes
         await mediaFileService.SyncMediaFiles(fwdataApi.Cache);
 
-        using var deferCloseFwData = fwDataFactory.DeferClose(fwDataProject);
+        await using var deferCloseFwData = fwDataFactory.DeferCloseAsync(fwDataProject);
         var crdtProject = await SetupCrdtProject(crdtFile,
             projectLookupService,
             projectId,

--- a/backend/FwLite/FwDataMiniLcmBridge/FwDataFactory.cs
+++ b/backend/FwLite/FwDataMiniLcmBridge/FwDataFactory.cs
@@ -112,7 +112,7 @@ public class FwDataFactory(
         }
     }
 
-    public void CloseProject(FwDataProject project)
+    public async Task CloseProjectAsync(FwDataProject project)
     {
         // if we are shutting down, don't do anything because we want project dispose to be called as part of the shutdown process.
         if (_shuttingDown) return;
@@ -120,12 +120,15 @@ public class FwDataFactory(
         var cacheKey = CacheKey(project);
         var lcmCache = cache.Get<LcmCache>(cacheKey);
         if (lcmCache is null) return;
+        // Dispose cache immediately so file locks are released before we return.
+        // The caller assumes the project is ready to be opened somewhere else (e.g. in FieldWorks)
+        if (!lcmCache.IsDisposed) await Task.Run(lcmCache.Dispose);
         cache.Remove(cacheKey);
     }
 
-    public IDisposable DeferClose(FwDataProject project)
+    public IAsyncDisposable DeferCloseAsync(FwDataProject project)
     {
-        return Defer.Action(() => CloseProject(project));
+        return Defer.Async(() => CloseProjectAsync(project));
     }
 
     public Task StartAsync(CancellationToken cancellationToken)

--- a/backend/FwLite/FwLiteMaui/Services/AppLauncher.cs
+++ b/backend/FwLite/FwLiteMaui/Services/AppLauncher.cs
@@ -26,11 +26,11 @@ public class AppLauncher(IFwLinker? fwLinker = null) : IAppLauncher
     }
 
     [JSInvokable]
-    public Task<bool> OpenInFieldWorks(Guid entryId, string projectName)
+    public async Task<bool> OpenInFieldWorks(Guid entryId, string projectName)
     {
         if (fwLinker is null) throw new InvalidOperationException("FwLinker is not available.");
-        var link = fwLinker.GetLinkToEntry(entryId, projectName);
-        if (link is null) return Task.FromResult(false);
-        return _launcher.TryOpenAsync(link);
+        var link = await fwLinker.GetLinkToEntryAsync(entryId, projectName);
+        if (link is null) return false;
+        return await _launcher.TryOpenAsync(link);
     }
 }

--- a/backend/FwLite/FwLiteMaui/Services/FwLinker.cs
+++ b/backend/FwLite/FwLiteMaui/Services/FwLinker.cs
@@ -8,11 +8,11 @@ namespace FwLiteMaui.Services;
 
 public class FwLinker(FwDataFactory fwDataFactory, FieldWorksProjectList projectList) : IFwLinker
 {
-    public string? GetLinkToEntry(Guid entryId, string projectName)
+    public async Task<string?> GetLinkToEntryAsync(Guid entryId, string projectName)
     {
         var project = projectList.GetProject(projectName);
         if (project is null) return null;
-        fwDataFactory.CloseProject(project);
+        await fwDataFactory.CloseProjectAsync(project);
         return FwLink.ToEntry(entryId, projectName);
     }
 }

--- a/backend/FwLite/FwLiteShared/Services/IFwLinker.cs
+++ b/backend/FwLite/FwLiteShared/Services/IFwLinker.cs
@@ -2,5 +2,5 @@ namespace FwLiteShared.Services;
 
 public interface IFwLinker
 {
-    string? GetLinkToEntry(Guid entryId, string projectName);
+    Task<string?> GetLinkToEntryAsync(Guid entryId, string projectName);
 }

--- a/backend/FwLite/FwLiteWeb/Hubs/FwDataMiniLcmHub.cs
+++ b/backend/FwLite/FwLiteWeb/Hubs/FwDataMiniLcmHub.cs
@@ -35,7 +35,7 @@ public class FwDataMiniLcmHub(
             throw new InvalidOperationException("No project is set in the context.");
         }
         //todo if multiple clients are connected, this will close the project for all of them.
-        fwDataFactory.CloseProject(project);
+        await fwDataFactory.CloseProjectAsync(project);
 
         if (exception is LcmFileLockedException)
         {

--- a/backend/FwLite/FwLiteWeb/Routes/FwIntegrationRoutes.cs
+++ b/backend/FwLite/FwLiteWeb/Routes/FwIntegrationRoutes.cs
@@ -28,7 +28,7 @@ public static class FwIntegrationRoutes
             {
                 if (context.Project is null) return Results.BadRequest("No project is set in the context");
                 await hubContext.Clients.Group(context.Project.Name).OnProjectClosed(CloseReason.Locked);
-                factory.CloseProject(context.Project);
+                await factory.CloseProjectAsync(context.Project);
                 var link = FwLink.ToEntry(id, context.Project.Name);
                 return Results.Text(link, "text/plain");
             });

--- a/frontend/viewer/src/lib/components/OpenInFieldWorksButton.svelte
+++ b/frontend/viewer/src/lib/components/OpenInFieldWorksButton.svelte
@@ -19,30 +19,31 @@
   const appLauncher = useAppLauncherService();
   const projectContext = useProjectContext();
 
-  async function openInFlex() {
-    let opened = false;
-    if (appLauncher) {
-      opened = await appLauncher.openInFieldWorks(entry.id, projectContext.projectName);
-    } else {
-      // a 302 redirect to the protocol handler works, but sends the user to the home page 🤷
-      const fieldWorksUrlResponse = await fetch(`/api/fw/${projectContext.projectName}/link/entry/${entry.id}`);
-      if (fieldWorksUrlResponse.ok) {
-        opened = true;
-        window.location.href = await fieldWorksUrlResponse.text();
+  function openInFlex() {
+    async function triggerOpenInFlex() {
+      let opened = false;
+      if (appLauncher) {
+        opened = await appLauncher.openInFieldWorks(entry.id, projectContext.projectName);
+      } else {
+        // a 302 redirect to the protocol handler works, but sends the user to the home page 🤷
+        const fieldWorksUrlResponse = await fetch(`/api/fw/${projectContext.projectName}/link/entry/${entry.id}`);
+        if (fieldWorksUrlResponse.ok) {
+          opened = true;
+          window.location.href = await fieldWorksUrlResponse.text();
+        }
       }
+      if (!opened) throw new Error('Unable to open in FieldWorks');
     }
-    if (opened) {
-      AppNotification.displayAction(
-        $t`This project is now open in FieldWorks. To continue working in FieldWorks Lite, close the project in FieldWorks and click Reopen.`,
-        {
-          label: $t`Reopen`,
-          callback: () => window.location.reload(),
-        },
-        'warning',
-      );
-    } else {
-      AppNotification.display($t`Unable to open in FieldWorks`, 'error');
-    }
+
+    AppNotification.promise(triggerOpenInFlex(), {
+      loading: $t`Opening in FieldWorks…`,
+      success: $t`This project is now open in FieldWorks. To continue working in FieldWorks Lite, close the project in FieldWorks and click Reopen.`,
+      error: $t`Unable to open in FieldWorks`,
+      action: {
+        label: $t`Reopen`,
+        onClick: () => window.location.reload(),
+      },
+    });
   }
 
   const mergedProps = $derived(

--- a/frontend/viewer/src/locales/en.po
+++ b/frontend/viewer/src/locales/en.po
@@ -1366,6 +1366,10 @@ msgstr "Open in new Window"
 msgid "Open Log file"
 msgstr "Open Log file"
 
+#: src/lib/components/OpenInFieldWorksButton.svelte
+msgid "Opening in FieldWorks…"
+msgstr "Opening in FieldWorks…"
+
 #. Color theme option
 #: src/lib/components/ThemePicker.svelte
 msgid "orange"

--- a/frontend/viewer/src/locales/es.po
+++ b/frontend/viewer/src/locales/es.po
@@ -1371,6 +1371,10 @@ msgstr "Abrir en una ventana nueva"
 msgid "Open Log file"
 msgstr "Abrir archivo Log"
 
+#: src/lib/components/OpenInFieldWorksButton.svelte
+msgid "Opening in FieldWorks…"
+msgstr ""
+
 #. Color theme option
 #: src/lib/components/ThemePicker.svelte
 msgid "orange"
@@ -1871,7 +1875,6 @@ msgstr "Alternar fijado"
 msgid "Translation"
 msgstr "Traducción"
 
-#. Language-specific translation field
 #: src/lib/entry-editor/object-editors/ExampleEditorPrimitive.svelte
 msgid "Translation {0}"
 msgstr "Traducción {0}"

--- a/frontend/viewer/src/locales/fr.po
+++ b/frontend/viewer/src/locales/fr.po
@@ -1371,6 +1371,10 @@ msgstr "Ouvrir dans une nouvelle fenêtre"
 msgid "Open Log file"
 msgstr "Ouvrir le fichier journal"
 
+#: src/lib/components/OpenInFieldWorksButton.svelte
+msgid "Opening in FieldWorks…"
+msgstr ""
+
 #. Color theme option
 #: src/lib/components/ThemePicker.svelte
 msgid "orange"
@@ -1871,7 +1875,6 @@ msgstr "Activer/désactiver épinglé"
 msgid "Translation"
 msgstr "Traduction"
 
-#. Language-specific translation field
 #: src/lib/entry-editor/object-editors/ExampleEditorPrimitive.svelte
 msgid "Translation {0}"
 msgstr "Traduction {0}"

--- a/frontend/viewer/src/locales/id.po
+++ b/frontend/viewer/src/locales/id.po
@@ -1371,6 +1371,10 @@ msgstr "Buka di jendela baru"
 msgid "Open Log file"
 msgstr "Buka file Log"
 
+#: src/lib/components/OpenInFieldWorksButton.svelte
+msgid "Opening in FieldWorks…"
+msgstr ""
+
 #. Color theme option
 #: src/lib/components/ThemePicker.svelte
 msgid "orange"
@@ -1871,7 +1875,6 @@ msgstr "Beralih disematkan"
 msgid "Translation"
 msgstr "Terjemahan"
 
-#. Language-specific translation field
 #: src/lib/entry-editor/object-editors/ExampleEditorPrimitive.svelte
 msgid "Translation {0}"
 msgstr "Terjemahan {0}"

--- a/frontend/viewer/src/locales/ko.po
+++ b/frontend/viewer/src/locales/ko.po
@@ -1371,6 +1371,10 @@ msgstr "새 창에서 열기"
 msgid "Open Log file"
 msgstr "로그 파일 열기"
 
+#: src/lib/components/OpenInFieldWorksButton.svelte
+msgid "Opening in FieldWorks…"
+msgstr ""
+
 #. Color theme option
 #: src/lib/components/ThemePicker.svelte
 msgid "orange"
@@ -1871,7 +1875,6 @@ msgstr "고정 토글"
 msgid "Translation"
 msgstr "번역"
 
-#. Language-specific translation field
 #: src/lib/entry-editor/object-editors/ExampleEditorPrimitive.svelte
 msgid "Translation {0}"
 msgstr "번역 {0}"

--- a/frontend/viewer/src/locales/ms.po
+++ b/frontend/viewer/src/locales/ms.po
@@ -1371,6 +1371,10 @@ msgstr "Buka dalam Tetingkap baharu"
 msgid "Open Log file"
 msgstr "Buka fail Log"
 
+#: src/lib/components/OpenInFieldWorksButton.svelte
+msgid "Opening in FieldWorks…"
+msgstr ""
+
 #. Color theme option
 #: src/lib/components/ThemePicker.svelte
 msgid "orange"
@@ -1871,7 +1875,6 @@ msgstr "Togol disemat"
 msgid "Translation"
 msgstr "Terjemahan"
 
-#. Language-specific translation field
 #: src/lib/entry-editor/object-editors/ExampleEditorPrimitive.svelte
 msgid "Translation {0}"
 msgstr "Terjemahan {0}"

--- a/frontend/viewer/src/locales/sw.po
+++ b/frontend/viewer/src/locales/sw.po
@@ -1371,6 +1371,10 @@ msgstr "Fungua kwenye Dirisha Jipya"
 msgid "Open Log file"
 msgstr "Fungua faili la logi"
 
+#: src/lib/components/OpenInFieldWorksButton.svelte
+msgid "Opening in FieldWorks…"
+msgstr ""
+
 #. Color theme option
 #: src/lib/components/ThemePicker.svelte
 msgid "orange"
@@ -1871,7 +1875,6 @@ msgstr "Geuza iliyobandikwa"
 msgid "Translation"
 msgstr "Tafsiri"
 
-#. Language-specific translation field
 #: src/lib/entry-editor/object-editors/ExampleEditorPrimitive.svelte
 msgid "Translation {0}"
 msgstr "Tafsiri {0}"

--- a/frontend/viewer/src/locales/vi.po
+++ b/frontend/viewer/src/locales/vi.po
@@ -1371,6 +1371,10 @@ msgstr "Mở trong cửa sổ mới"
 msgid "Open Log file"
 msgstr "Mở tệp nhật ký"
 
+#: src/lib/components/OpenInFieldWorksButton.svelte
+msgid "Opening in FieldWorks…"
+msgstr ""
+
 #. Color theme option
 #: src/lib/components/ThemePicker.svelte
 msgid "orange"
@@ -1871,7 +1875,6 @@ msgstr "Chuyển trạng thái ghim"
 msgid "Translation"
 msgstr "Bản dịch"
 
-#. Language-specific translation field
 #: src/lib/entry-editor/object-editors/ExampleEditorPrimitive.svelte
 msgid "Translation {0}"
 msgstr "Bản dịch {0}"


### PR DESCRIPTION
Today more than once I ran into the problem that when using the "Open in FieldWorks" feature, FieldWorks failed to open the project, because it was still in use in FieldWorks Lite. The reason was that we were depending on a IMemoryCache post-eviction handler to **actually** close the cache.

This PR refactors that so that we dispose the cache explicitly.

I also observed that that can take 3-5s on my machine, so I refactored the toast to a promise toast, so that the user gets immediate feedback/a loading indicator while the FieldWorks project is being closed.

I tested this in both the web and windows versions.