### PR TITLE
Prevent dialog dismissal in custom view dialogs

### DIFF
--- a/frontend/viewer/src/lib/views/custom/CreateCustomViewDialog.svelte
+++ b/frontend/viewer/src/lib/views/custom/CreateCustomViewDialog.svelte
@@ -24,7 +24,7 @@
 </script>
 
 <Dialog.Root bind:open>
-  <Dialog.Content class="max-w-5xl">
+  <Dialog.Content class="max-w-5xl" interactOutsideBehavior="ignore" escapeKeydownBehavior="ignore">
     <Dialog.Header>
       <Dialog.Title>{$t`Create Custom View`}</Dialog.Title>
     </Dialog.Header>

--- a/frontend/viewer/src/lib/views/custom/EditCustomViewDialog.svelte
+++ b/frontend/viewer/src/lib/views/custom/EditCustomViewDialog.svelte
@@ -25,7 +25,7 @@
 </script>
 
 <Dialog.Root bind:open>
-  <Dialog.Content class="max-w-5xl">
+  <Dialog.Content class="max-w-5xl" interactOutsideBehavior="ignore" escapeKeydownBehavior="ignore">
     <Dialog.Header>
       <Dialog.Title>{$t`Edit Custom View`}</Dialog.Title>
     </Dialog.Header>


### PR DESCRIPTION
## Summary
Updated the Create and Edit Custom View dialogs to prevent unintended dismissal by ignoring outside interactions and escape key presses.

## Changes
- Added `interactOutsideBehavior="ignore"` to prevent closing dialogs when clicking outside
- Added `escapeKeydownBehavior="ignore"` to prevent closing dialogs when pressing the Escape key
- Applied to both `CreateCustomViewDialog.svelte` and `EditCustomViewDialog.svelte`

## Details
These changes ensure that users cannot accidentally dismiss the custom view dialogs through common dismissal patterns (clicking outside or pressing Escape). This provides a better user experience by preventing accidental loss of form data or work in progress.

https://claude.ai/code/session_01WSjn7JbdCQqdQj9pc6YsDz