### PR TITLE
Fix missing i18n placeholders in OpenInFlexModal

### DIFF
--- a/frontend/src/lib/i18n/locales/en.json
+++ b/frontend/src/lib/i18n/locales/en.json
@@ -531,7 +531,7 @@ so we can get this fixed!",
       "notify_success": "You have successfully added a project purpose."
     },
     "get_project": {
-      "instructions_header": "To {isEmpty, select, true {set up} other {get}} this project with {appName} {mode, select, manual {manually} other {}}",
+      "instructions_header": "To {isEmpty, select, true { set up } other { get } } this project with {type, select, FL_EX { FieldWorks } WE_SAY { WeSay } other { (e.g.) FieldWorks } } {mode, select, manual { manually} other { }}",
       "instructions_flex": "1. In the \"Send/Receive\" menu click \"Get Project from colleague…\"\n\
 1. In the \"Receive project\" dialog box, click \"Internet\"\n\
 1. In the \"Get Project From Internet\" dialog box, enter your \"Login\" ({login}) and \"Password\" for Lexbox and click \"Log in\"\n\

--- a/frontend/src/lib/i18n/locales/en.json
+++ b/frontend/src/lib/i18n/locales/en.json
@@ -531,7 +531,7 @@ so we can get this fixed!",
       "notify_success": "You have successfully added a project purpose."
     },
     "get_project": {
-      "instructions_header": "To {isEmpty, select, true { set up } other { get } } this project with {type, select, FL_EX { FieldWorks } WE_SAY { WeSay } other { (e.g.) FieldWorks } } {mode, select, manual { manually} other { }}",
+      "instructions_header": "To {isEmpty, select, true {set up} other {get}} this project with {appName} {mode, select, manual {manually} other {}}",
       "instructions_flex": "1. In the \"Send/Receive\" menu click \"Get Project from colleague…\"\n\
 1. In the \"Receive project\" dialog box, click \"Internet\"\n\
 1. In the \"Get Project From Internet\" dialog box, enter your \"Login\" ({login}) and \"Password\" for Lexbox and click \"Log in\"\n\

--- a/frontend/src/routes/(authenticated)/project/[project_code]/+page.svelte
+++ b/frontend/src/routes/(authenticated)/project/[project_code]/+page.svelte
@@ -361,7 +361,7 @@
         </Button>
       {:else if canSyncProject}
         {#if project && project.type === ProjectType.FlEx && !isEmpty}
-          <OpenInFlexModal bind:this={openInFlexModal} {project}/>
+          <OpenInFlexModal bind:this={openInFlexModal} {project} login={user.emailOrUsername}/>
           <OpenInFlexButton projectId={project.id} onclick={openInFlexModal?.open}/>
         {:else}
           <Dropdown>

--- a/frontend/src/routes/(authenticated)/project/[project_code]/+page.svelte
+++ b/frontend/src/routes/(authenticated)/project/[project_code]/+page.svelte
@@ -375,7 +375,7 @@
                   <div class="prose">
                     <h3>
                       {$t('project_page.get_project.instructions_header', {
-                        type: project.type,
+                        appName: project.type === ProjectType.FlEx ? 'FieldWorks' : project.type === ProjectType.WeSay ? 'WeSay' : '(e.g.) FieldWorks',
                         mode: 'normal',
                         isEmpty: isEmpty.toString(),
                       })}

--- a/frontend/src/routes/(authenticated)/project/[project_code]/+page.svelte
+++ b/frontend/src/routes/(authenticated)/project/[project_code]/+page.svelte
@@ -375,7 +375,7 @@
                   <div class="prose">
                     <h3>
                       {$t('project_page.get_project.instructions_header', {
-                        appName: project.type === ProjectType.FlEx ? 'FieldWorks' : project.type === ProjectType.WeSay ? 'WeSay' : '(e.g.) FieldWorks',
+                        type: project.type,
                         mode: 'normal',
                         isEmpty: isEmpty.toString(),
                       })}

--- a/frontend/src/routes/(authenticated)/project/[project_code]/OpenInFlexModal.svelte
+++ b/frontend/src/routes/(authenticated)/project/[project_code]/OpenInFlexModal.svelte
@@ -36,7 +36,7 @@
     <div class="collapse collapse-arrow">
       <input type="checkbox" />
       <h3 class="collapse-title my-0 px-0 pb-0">
-        {$t('project_page.get_project.instructions_header', { type: project.type, mode: 'manual', isEmpty: 'false' })}...
+        {$t('project_page.get_project.instructions_header', { appName: 'FieldWorks', mode: 'manual', isEmpty: 'false' })}...
       </h3>
       <div class="collapse-content p-0">
         <div class="divider mt-0"></div>

--- a/frontend/src/routes/(authenticated)/project/[project_code]/OpenInFlexModal.svelte
+++ b/frontend/src/routes/(authenticated)/project/[project_code]/OpenInFlexModal.svelte
@@ -36,7 +36,7 @@
     <div class="collapse collapse-arrow">
       <input type="checkbox" />
       <h3 class="collapse-title my-0 px-0 pb-0">
-        {$t('project_page.get_project.instructions_header', { appName: 'FieldWorks', mode: 'manual', isEmpty: 'false' })}...
+        {$t('project_page.get_project.instructions_header', { type: project.type, mode: 'manual', isEmpty: 'false' })}...
       </h3>
       <div class="collapse-content p-0">
         <div class="divider mt-0"></div>

--- a/frontend/src/routes/(authenticated)/project/[project_code]/OpenInFlexModal.svelte
+++ b/frontend/src/routes/(authenticated)/project/[project_code]/OpenInFlexModal.svelte
@@ -9,9 +9,10 @@
 
   interface Props {
     project: Project;
+    login: string;
   }
 
-  const { project }: Props = $props();
+  const { project, login }: Props = $props();
   let modal: Modal | undefined = $state();
 
   export async function open(): Promise<void> {
@@ -35,11 +36,11 @@
     <div class="collapse collapse-arrow">
       <input type="checkbox" />
       <h3 class="collapse-title my-0 px-0 pb-0">
-        {$t('project_page.get_project.instructions_header', { type: project.type, mode: 'manual' })}...
+        {$t('project_page.get_project.instructions_header', { type: project.type, mode: 'manual', isEmpty: 'false' })}...
       </h3>
       <div class="collapse-content p-0">
         <div class="divider mt-0"></div>
-        <Markdown md={$t('project_page.get_project.instructions_flex', { code: project.code, name: project.name })} />
+        <Markdown md={$t('project_page.get_project.instructions_flex', { code: project.code, login, name: project.name })} />
         <SendReceiveUrlField projectCode={project.code} />
       </div>
     </div>


### PR DESCRIPTION
The instructions_flex translation expects {login}, {code}, {name} but the modal only passed code and name, leaving login blank.
Also pass isEmpty to instructions_header so the select branches resolve correctly.

Before: (wrong login. Blank folder-name suggestion)
<img width="930" height="527" alt="image" src="https://github.com/user-attachments/assets/41954e3b-a805-43c7-b551-242be73ca7d6" />


After:
<img width="936" height="516" alt="image" src="https://github.com/user-attachments/assets/c7f85ebf-150c-4384-bb14-87752a46f8e2" />
