### PR TITLE
Fix Send/Receive URL domain and copy button styling

### DIFF
--- a/frontend/src/lib/components/CopyToClipboardButton.svelte
+++ b/frontend/src/lib/components/CopyToClipboardButton.svelte
@@ -11,9 +11,10 @@
     delayMs?: Duration | number;
     size?: 'btn-sm';
     outline?: boolean;
+    join?: boolean;
   }
 
-  const { textToCopy, delayMs = Duration.Default, size, outline = true }: Props = $props();
+  const { textToCopy, delayMs = Duration.Default, size, outline = true, join = false }: Props = $props();
 
   async function copyToClipboard(): Promise<void> {
     copyingToClipboard = true;
@@ -31,6 +32,7 @@
       fake
       icon="i-mdi-check"
       {size}
+      {join}
       variant={outline ? undefined : 'btn-ghost'}
       class={outline ? 'btn-success' : 'text-success'}
     />
@@ -40,6 +42,7 @@
     loading={copyingToClipboard}
     icon="i-mdi-content-copy"
     {size}
+    {join}
     variant={outline ? undefined : 'btn-ghost'}
     onclick={copyToClipboard}
   />

--- a/frontend/src/routes/(authenticated)/project/[project_code]/SendReceiveUrlField.svelte
+++ b/frontend/src/routes/(authenticated)/project/[project_code]/SendReceiveUrlField.svelte
@@ -13,15 +13,15 @@
 
   let projectHgUrl = $derived(import.meta.env.DEV ? `http://hg.${page.url.hostname}/${projectCode}`
     : page.url.host.includes('develop') || page.url.host.includes('.dev') ? `https://hg-develop.lexbox.org/${projectCode}`
-    : page.url.host.includes('staging') ? `https://hg-${page.url.host.replace('depot', 'forge')}/${projectCode}`
-    : `https://hg-public.${page.url.host.replace('depot', 'forge')}/${projectCode}`);
+    : page.url.host.includes('staging') ? `https://hg-staging.languageforge.org/${projectCode}`
+    : `https://hg-public.languageforge.org/${projectCode}`);
 </script>
 
 <AdminContent>
   <FormField label={$t('project_page.get_project.send_receive_url')}>
     <div class="join">
       <input value={projectHgUrl} class="input input-bordered join-item w-full focus:input-success" readonly />
-      <CopyToClipboardButton textToCopy={projectHgUrl} />
+      <CopyToClipboardButton textToCopy={projectHgUrl} join />
     </div>
   </FormField>
 </AdminContent>


### PR DESCRIPTION
Use canonical hg-public.languageforge.org (and hg-staging.languageforge.org) instead of deriving from page host, which produced broken hg-public.lexbox.org. Forward a join prop through CopyToClipboardButton so the button renders as a proper join-item next to the input.

Before:
<img width="1026" height="267" alt="image" src="https://github.com/user-attachments/assets/e55227ec-533c-4b88-9d0c-3f11e9d9bf50" />

After:
<img width="915" height="137" alt="image" src="https://github.com/user-attachments/assets/f7e6d612-3dd8-44db-9e73-a3b692276bf3" />

<img width="677" height="187" alt="image" src="https://github.com/user-attachments/assets/22a4e94a-ee97-4c45-a02d-f3b4a90bb2a6" />


(I can't demonstrate the prod URL, but it's now just hardcoded).