### PR TITLE
Explicitly declare minimum release age for pnpm

### DIFF
--- a/frontend/pnpm-workspace.yaml
+++ b/frontend/pnpm-workspace.yaml
@@ -2,6 +2,10 @@ packages:
   - https-proxy
   - viewer
 
+# explicitly prevent using packages that are too new
+minimumReleaseAge: 1440
+
+
 catalog:
   '@playwright/test': ^1.58.2
   '@stylistic/eslint-plugin': ^5.9.0


### PR DESCRIPTION
With recent issues with dependencies getting hacked I'd like to just make this explicit. 