### PR TITLE
Respect current view's writing-systems in OverrideFields

### DIFF
--- a/frontend/viewer/src/lib/views/OverrideFields.svelte
+++ b/frontend/viewer/src/lib/views/OverrideFields.svelte
@@ -18,13 +18,14 @@
     overrides = {}
   }: Props = $props();
 
-  const parentService = useViewService();
+  const viewService = useViewService();
   const overrideService = initViewService({persist: false});
 
   $effect.pre(() => {
-    const rootView = parentService.rootView;
+    const rootView = viewService.rootView;
+    const currentView = viewService.currentView;
     overrideService.overrideView({
-      ...rootView,
+      ...currentView, // use current view's WS's by default
       entryFields: overrideEntityFields(rootView.entryFields, shownFields, respectOrder),
       senseFields: overrideEntityFields(rootView.senseFields, shownFields, respectOrder),
       exampleFields: overrideEntityFields(rootView.exampleFields, shownFields, respectOrder),


### PR DESCRIPTION
This results in e.g. only showing a custom-view's writing-systems in the audio-dialog (which shows fields for recording context).
If a user is recording in a custom-view, then surely they've selected the writing-systems that they need to reference.