### PR TITLE
Show all root fields in Update-entry-dialog

### DIFF
--- a/frontend/viewer/src/lib/entry-editor/EditEntryDialog.svelte
+++ b/frontend/viewer/src/lib/entry-editor/EditEntryDialog.svelte
@@ -6,6 +6,7 @@
   import * as Dialog from '$lib/components/ui/dialog';
   import {Button} from '$lib/components/ui/button';
   import {useViewService} from '$lib/views/view-service.svelte';
+  import RootFields from '$lib/views/RootFields.svelte';
   import {pt} from '$lib/views/view-text';
   import {t} from 'svelte-i18n-lingui';
   import {AppNotification} from '$lib/notifications/notifications';
@@ -51,7 +52,13 @@
     {#if entryResource.loading}
       Loading...
     {:else if entry}
-      <EntryEditor bind:this={editor} autofocus modalMode bind:entry canAddSense={false} canAddExample={false}/>
+      <!--
+      RootFields, so that the user is not limited to the fields of a potentially selected custom-view.
+      Custom-views should perhaps be scoped to the browse-view. I'm not sure.
+      -->
+      <RootFields>
+        <EntryEditor bind:this={editor} autofocus modalMode bind:entry canAddSense={false} canAddExample={false}/>
+      </RootFields>
     {/if}
     <Dialog.DialogFooter>
       <Button onclick={() => open = false} variant="secondary">{$t`Cancel`}</Button>

--- a/frontend/viewer/src/lib/entry-editor/NewEntryDialog.svelte
+++ b/frontend/viewer/src/lib/entry-editor/NewEntryDialog.svelte
@@ -13,7 +13,7 @@
   import {useSaveHandler} from '../services/save-event-service.svelte';
   import {useLexboxApi} from '../services/service-provider';
   import {defaultEntry, defaultSense} from '../utils';
-  import OverrideFields from '$lib/views/OverrideFields.svelte';
+  import RootFields from '$lib/views/RootFields.svelte';
   import {useWritingSystemService} from '$project/data';
   import {useDialogsService} from '$lib/services/dialogs-service.js';
   import {useBackHandler} from '$lib/utils/back-handler.svelte';
@@ -160,13 +160,7 @@
       <Dialog.DialogTitle>{pt($t`New Entry`, $t`New Word`, viewService.currentView)}</Dialog.DialogTitle>
     </Dialog.DialogHeader>
     <div>
-      <OverrideFields shownFields={[
-        'lexemeForm', 'citationForm',
-        'gloss', 'definition', 'partOfSpeechId',
-        /* only show semantic domains and publications if the "template" set it */
-        ...(entryTemplate?.publishIn?.length ? ['publishIn'] as const : []),
-        ...(senseTemplate?.semanticDomains?.length ? ['semanticDomains'] as const : [])
-        ]}>
+      <RootFields>
         <Editor.Root bind:this={editor}>
           <Editor.Grid>
             <EntryEditorPrimitive bind:entry autofocus modalMode
@@ -187,7 +181,7 @@
             {/if}
           </Editor.Grid>
         </Editor.Root>
-      </OverrideFields>
+      </RootFields>
     </div>
     {#if errors.length}
       <div class="text-end space-y-2">

--- a/frontend/viewer/src/lib/entry-editor/NewEntryDialog.svelte
+++ b/frontend/viewer/src/lib/entry-editor/NewEntryDialog.svelte
@@ -13,7 +13,7 @@
   import {useSaveHandler} from '../services/save-event-service.svelte';
   import {useLexboxApi} from '../services/service-provider';
   import {defaultEntry, defaultSense} from '../utils';
-  import RootFields from '$lib/views/RootFields.svelte';
+  import OverrideFields from '$lib/views/OverrideFields.svelte';
   import {useWritingSystemService} from '$project/data';
   import {useDialogsService} from '$lib/services/dialogs-service.js';
   import {useBackHandler} from '$lib/utils/back-handler.svelte';
@@ -160,7 +160,13 @@
       <Dialog.DialogTitle>{pt($t`New Entry`, $t`New Word`, viewService.currentView)}</Dialog.DialogTitle>
     </Dialog.DialogHeader>
     <div>
-      <RootFields>
+      <OverrideFields shownFields={[
+        'lexemeForm', 'citationForm',
+        'gloss', 'definition', 'partOfSpeechId',
+        /* only show semantic domains and publications if the "template" set it */
+        ...(entryTemplate?.publishIn?.length ? ['publishIn'] as const : []),
+        ...(senseTemplate?.semanticDomains?.length ? ['semanticDomains'] as const : [])
+        ]}>
         <Editor.Root bind:this={editor}>
           <Editor.Grid>
             <EntryEditorPrimitive bind:entry autofocus modalMode
@@ -181,7 +187,7 @@
             {/if}
           </Editor.Grid>
         </Editor.Root>
-      </RootFields>
+      </OverrideFields>
     </div>
     {#if errors.length}
       <div class="text-end space-y-2">

--- a/frontend/viewer/src/lib/views/RootFields.svelte
+++ b/frontend/viewer/src/lib/views/RootFields.svelte
@@ -1,0 +1,16 @@
+<script lang="ts">
+  import {initViewService, useViewService} from '$lib/views/view-service.svelte';
+  import type {Snippet} from 'svelte';
+
+  let {children}: {children?: Snippet} = $props();
+
+  const viewService = useViewService();
+  const overrideService = initViewService({persist: false});
+
+  $effect.pre(() => {
+    // use the root view of what is potentially a custom-view
+    overrideService.overrideView(viewService.rootView);
+  });
+</script>
+
+{@render children?.()}

--- a/frontend/viewer/src/lib/views/RootFields.svelte
+++ b/frontend/viewer/src/lib/views/RootFields.svelte
@@ -8,8 +8,15 @@
   const overrideService = initViewService({persist: false});
 
   $effect.pre(() => {
-    // use the root view of what is potentially a custom-view
-    overrideService.overrideView(viewService.rootView);
+    const rootView = viewService.rootView;
+    const currentView = viewService.currentView;
+    // show all root fields, but keep the current view's writing-system selection
+    overrideService.overrideView({
+      ...currentView,
+      entryFields: rootView.entryFields,
+      senseFields: rootView.senseFields,
+      exampleFields: rootView.exampleFields,
+    });
   });
 </script>
 


### PR DESCRIPTION
Without this, the update-entry-dialog that is accessible when reviewing entries touched during a task, might not include the fields and/or writing-systems that were used by the task. (i.e. if the currently selected custom-view doesn't include them).