### PR TITLE
Add sync benchmarks

### DIFF
--- a/.github/workflows/fw-lite.yaml
+++ b/.github/workflows/fw-lite.yaml
@@ -69,16 +69,17 @@ jobs:
 
   benchmark:
     name: Run FW Lite sync benchmarks
-    # BenchmarkDotNet timings are only meaningful in Release; this job runs the FwLiteProjectSync.Tests
-    # project in Release with --filter "Category=Benchmark" so threshold assertions actually fire.
+    # Runs post-merge on develop only — benchmarks are too slow and too variance-prone on shared
+    # runners to gate every PR. Revisit once they're fast enough for the PR critical path.
+    if: github.event_name == 'push' && github.ref == 'refs/heads/develop'
     timeout-minutes: 40
     runs-on: windows-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
         with:
           submodules: true
-      - uses: actions/setup-dotnet@v4
+      - uses: actions/setup-dotnet@9a946fdbd5fb07b82b2f5a4466058b876ab72bb2 # v5.3.0
         with:
           dotnet-version: '10.x'
 
@@ -90,11 +91,11 @@ jobs:
 
       - name: Upload benchmark results
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5.0.0
         with:
           name: benchmark-results
           path: '**/BenchmarkDotNet.Artifacts/**'
-          if-no-files-found: warn
+          if-no-files-found: error
 
   frontend:
     runs-on: ubuntu-latest

--- a/.github/workflows/fw-lite.yaml
+++ b/.github/workflows/fw-lite.yaml
@@ -72,7 +72,9 @@ jobs:
     # Runs post-merge on develop only — benchmarks are too slow and too variance-prone on shared
     # runners to gate every PR. Revisit once they're fast enough for the PR critical path.
     if: github.event_name == 'push' && github.ref == 'refs/heads/develop'
-    timeout-minutes: 40
+    # The full suite re-imports Sena-3 before every iteration (1 warmup + 4 × 5 profiles), so the
+    # measured syncs plus setup imports plus the Release build run well past the 40 min used elsewhere.
+    timeout-minutes: 90
     runs-on: windows-latest
     steps:
       - name: Checkout
@@ -95,7 +97,9 @@ jobs:
         with:
           name: benchmark-results
           path: '**/BenchmarkDotNet.Artifacts/**'
-          if-no-files-found: error
+          # warn, not error: with if: always() a build/crash failure emits no artifacts, and the real
+          # failure is already red elsewhere — a threshold-assertion failure still writes artifacts first.
+          if-no-files-found: warn
 
   frontend:
     runs-on: ubuntu-latest

--- a/.github/workflows/fw-lite.yaml
+++ b/.github/workflows/fw-lite.yaml
@@ -72,9 +72,8 @@ jobs:
     # Runs post-merge on develop only — benchmarks are too slow and too variance-prone on shared
     # runners to gate every PR. Revisit once they're fast enough for the PR critical path.
     if: github.event_name == 'push' && github.ref == 'refs/heads/develop'
-    # The full suite re-imports Sena-3 before every iteration (1 warmup + 4 × 5 profiles), so the
-    # measured syncs plus setup imports plus the Release build run well past the 40 min used elsewhere.
-    timeout-minutes: 90
+    # ~30 min typical in CI (worst observed ~34) — 60 leaves headroom for hosted-runner variance.
+    timeout-minutes: 60
     runs-on: windows-latest
     steps:
       - name: Checkout

--- a/.github/workflows/fw-lite.yaml
+++ b/.github/workflows/fw-lite.yaml
@@ -80,7 +80,7 @@ jobs:
           submodules: true
       - uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: '9.x'
+          dotnet-version: '10.x'
 
       - name: Dotnet build (Release)
         run: dotnet build backend/FwLite/FwLiteProjectSync.Tests/FwLiteProjectSync.Tests.csproj -c Release

--- a/.github/workflows/fw-lite.yaml
+++ b/.github/workflows/fw-lite.yaml
@@ -69,9 +69,8 @@ jobs:
 
   benchmark:
     name: Run FW Lite sync benchmarks
-    # Runs post-merge on develop only — benchmarks are too slow and too variance-prone on shared
-    # runners to gate every PR. Revisit once they're fast enough for the PR critical path.
-    # TEMP: also allow manual workflow_dispatch to capture a Linux CI baseline on this branch; revert to develop-only before merge.
+    # Auto-runs post-merge on develop only — too slow and variance-prone to gate every PR (revisit
+    # if they get fast enough). Also runnable on demand via workflow_dispatch to baseline a branch.
     if: github.event_name == 'workflow_dispatch' || (github.event_name == 'push' && github.ref == 'refs/heads/develop')
     # Benchmarks take tens of minutes; 60 leaves headroom for hosted-runner variance.
     timeout-minutes: 60

--- a/.github/workflows/fw-lite.yaml
+++ b/.github/workflows/fw-lite.yaml
@@ -88,6 +88,14 @@ jobs:
       - name: Dotnet test (benchmarks)
         run: dotnet test backend/FwLite/FwLiteProjectSync.Tests/FwLiteProjectSync.Tests.csproj -c Release --logger GitHubActions --no-build --filter "Category=Benchmark"
 
+      - name: Upload benchmark results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: benchmark-results
+          path: '**/BenchmarkDotNet.Artifacts/**'
+          if-no-files-found: warn
+
   frontend:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/fw-lite.yaml
+++ b/.github/workflows/fw-lite.yaml
@@ -64,7 +64,29 @@ jobs:
         run: task fw-lite:has-pending-model-changes -- --no-build
 
       - name: Dotnet test
-        run: dotnet test FwLiteOnly.slnf --logger GitHubActions --no-build -p:BuildAndroid=false
+        # Benchmarks run in a separate Release-mode job — see `benchmark` below.
+        run: dotnet test FwLiteOnly.slnf --logger GitHubActions --no-build -p:BuildAndroid=false --filter "Category!=Benchmark"
+
+  benchmark:
+    name: Run FW Lite sync benchmarks
+    # BenchmarkDotNet timings are only meaningful in Release; this job runs the FwLiteProjectSync.Tests
+    # project in Release with --filter "Category=Benchmark" so threshold assertions actually fire.
+    timeout-minutes: 40
+    runs-on: windows-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          submodules: true
+      - uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '9.x'
+
+      - name: Dotnet build (Release)
+        run: dotnet build backend/FwLite/FwLiteProjectSync.Tests/FwLiteProjectSync.Tests.csproj -c Release
+
+      - name: Dotnet test (benchmarks)
+        run: dotnet test backend/FwLite/FwLiteProjectSync.Tests/FwLiteProjectSync.Tests.csproj -c Release --logger GitHubActions --no-build --filter "Category=Benchmark"
 
   frontend:
     runs-on: ubuntu-latest

--- a/.github/workflows/fw-lite.yaml
+++ b/.github/workflows/fw-lite.yaml
@@ -71,10 +71,11 @@ jobs:
     name: Run FW Lite sync benchmarks
     # Runs post-merge on develop only — benchmarks are too slow and too variance-prone on shared
     # runners to gate every PR. Revisit once they're fast enough for the PR critical path.
-    if: github.event_name == 'push' && github.ref == 'refs/heads/develop'
-    # ~30 min typical in CI (worst observed ~34) — 60 leaves headroom for hosted-runner variance.
+    # TEMP: also allow manual workflow_dispatch to capture a Linux CI baseline on this branch; revert to develop-only before merge.
+    if: github.event_name == 'workflow_dispatch' || (github.event_name == 'push' && github.ref == 'refs/heads/develop')
+    # Benchmarks take tens of minutes; 60 leaves headroom for hosted-runner variance.
     timeout-minutes: 60
-    runs-on: windows-latest
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1

--- a/backend/Directory.Packages.props
+++ b/backend/Directory.Packages.props
@@ -9,7 +9,7 @@
   <ItemGroup>
     <PackageVersion Include="AppAny.Quartz.EntityFrameworkCore.Migrations.PostgreSQL" Version="0.5.2" />
     <PackageVersion Include="BeaKona.AutoInterfaceGenerator" Version="1.0.46" />
-    <PackageVersion Include="BenchmarkDotNet" Version="0.14.0" />
+    <PackageVersion Include="BenchmarkDotNet" Version="0.15.8" />
     <PackageVersion Include="coverlet.collector" Version="10.0.0" />
     <PackageVersion Include="CrystalQuartz.AspNetCore" Version="7.3.0" />
     <PackageVersion Include="DataAnnotatedModelValidations" Version="10.0.0" />

--- a/backend/Directory.Packages.props
+++ b/backend/Directory.Packages.props
@@ -9,6 +9,7 @@
   <ItemGroup>
     <PackageVersion Include="AppAny.Quartz.EntityFrameworkCore.Migrations.PostgreSQL" Version="0.5.2" />
     <PackageVersion Include="BeaKona.AutoInterfaceGenerator" Version="1.0.46" />
+    <PackageVersion Include="BenchmarkDotNet" Version="0.14.0" />
     <PackageVersion Include="coverlet.collector" Version="10.0.0" />
     <PackageVersion Include="CrystalQuartz.AspNetCore" Version="7.3.0" />
     <PackageVersion Include="DataAnnotatedModelValidations" Version="10.0.0" />

--- a/backend/FwLite/FwLiteProjectSync.Tests/BenchmarkSupport.cs
+++ b/backend/FwLite/FwLiteProjectSync.Tests/BenchmarkSupport.cs
@@ -1,0 +1,56 @@
+using BenchmarkDotNet.Columns;
+using BenchmarkDotNet.Configs;
+using BenchmarkDotNet.Engines;
+using BenchmarkDotNet.Exporters.Json;
+using BenchmarkDotNet.Jobs;
+using BenchmarkDotNet.Reports;
+using BenchmarkDotNet.Toolchains.InProcess.NoEmit;
+using FluentAssertions.Execution;
+using Xunit.Abstractions;
+
+namespace FwLiteProjectSync.Tests;
+
+internal static class BenchmarkSupport
+{
+    /// <summary>
+    /// Standard config for sync benchmarks: in-process toolchain, cold iterations, and a logger
+    /// that pipes the BDN summary table into xUnit's test output.
+    /// </summary>
+    /// <remarks>
+    /// The in-process toolchain is what lets a benchmark class read a static field set by its
+    /// xUnit driver (see <c>FirstSyncBench.Fixture</c>) — a separate-process toolchain would
+    /// fork a clean AppDomain and lose that reference.
+    ///
+    /// The default <see cref="InProcessNoEmitToolchain"/> timeout is 5 min, which is too short
+    /// for multi-iteration sync benchmarks (e.g. delete-heavy alone is ~80s/iter and full-import
+    /// setup adds ~50s/iter, so 5 iterations need ~11 min). 30 min covers the worst case with
+    /// headroom.
+    /// </remarks>
+    public static IConfig ConfigFor(ITestOutputHelper output)
+    {
+        var toolchain = new InProcessNoEmitToolchain(TimeSpan.FromMinutes(30), logOutput: false);
+        return ManualConfig.CreateEmpty()
+            .AddJob(Job.Default
+                .WithStrategy(RunStrategy.ColdStart)
+                .WithIterationCount(5)
+                .WithToolchain(toolchain))
+            .AddExporter(JsonExporter.FullCompressed)
+            .AddColumnProvider(DefaultColumnProviders.Instance)
+            .AddLogger(new XUnitBenchmarkLogger(output));
+    }
+
+    /// <summary>
+    /// Asserts the benchmark run produced usable measurements. Call inside an
+    /// <see cref="AssertionScope"/> so per-report threshold failures still surface.
+    /// </summary>
+    public static void AssertRunWasSuccessful(Summary summary)
+    {
+        summary.HasCriticalValidationErrors.Should().BeFalse("BenchmarkDotNet reported critical validation errors");
+        summary.Reports.Should().NotBeEmpty("BenchmarkDotNet produced no reports");
+        foreach (var report in summary.Reports)
+        {
+            report.Success.Should().BeTrue($"benchmark {report.BenchmarkCase.DisplayInfo} should have completed without error");
+            report.ResultStatistics.Should().NotBeNull($"benchmark {report.BenchmarkCase.DisplayInfo} should have produced statistics");
+        }
+    }
+}

--- a/backend/FwLite/FwLiteProjectSync.Tests/BenchmarkSupport.cs
+++ b/backend/FwLite/FwLiteProjectSync.Tests/BenchmarkSupport.cs
@@ -13,8 +13,9 @@ namespace FwLiteProjectSync.Tests;
 internal static class BenchmarkSupport
 {
     /// <summary>
-    /// Standard config for sync benchmarks: in-process toolchain, cold iterations, and a logger
-    /// that pipes the BDN summary table into xUnit's test output.
+    /// Standard config for sync benchmarks: in-process toolchain, one warmup + four measurement
+    /// iterations (Monitoring strategy), and a logger that pipes the BDN summary table into
+    /// xUnit's test output.
     /// </summary>
     /// <remarks>
     /// The in-process toolchain is what lets a benchmark class read a static field set by its
@@ -25,14 +26,20 @@ internal static class BenchmarkSupport
     /// for multi-iteration sync benchmarks (e.g. delete-heavy alone is ~80s/iter and full-import
     /// setup adds ~50s/iter, so 5 iterations need ~11 min). 30 min covers the worst case with
     /// headroom.
+    ///
+    /// Monitoring + WarmupCount=1 means iteration 1 absorbs JIT + EF model build + first-touch
+    /// file cache and is discarded; iterations 2-5 are measured. ColdStart would skip warmup
+    /// entirely; for these slow ops the JIT/model-build noise in iteration 1 is large enough
+    /// that one discarded warmup tightens StdDev meaningfully without changing total CI time.
     /// </remarks>
     public static IConfig ConfigFor(ITestOutputHelper output)
     {
         var toolchain = new InProcessNoEmitToolchain(TimeSpan.FromMinutes(30), logOutput: false);
         return ManualConfig.CreateEmpty()
             .AddJob(Job.Default
-                .WithStrategy(RunStrategy.ColdStart)
-                .WithIterationCount(5)
+                .WithStrategy(RunStrategy.Monitoring)
+                .WithWarmupCount(1)
+                .WithIterationCount(4)
                 .WithToolchain(toolchain))
             .AddExporter(JsonExporter.FullCompressed)
             .AddColumnProvider(DefaultColumnProviders.Instance)

--- a/backend/FwLite/FwLiteProjectSync.Tests/BenchmarkSupport.cs
+++ b/backend/FwLite/FwLiteProjectSync.Tests/BenchmarkSupport.cs
@@ -13,24 +13,13 @@ namespace FwLiteProjectSync.Tests;
 internal static class BenchmarkSupport
 {
     /// <summary>
-    /// Standard config for sync benchmarks: in-process toolchain, one warmup + four measurement
-    /// iterations (Monitoring strategy), and a logger that pipes the BDN summary table into
-    /// xUnit's test output.
+    /// Standard config for sync benchmarks: in-process toolchain, Monitoring with one warmup +
+    /// four measurement iterations, BDN output piped to xUnit.
     /// </summary>
     /// <remarks>
-    /// The in-process toolchain is what lets a benchmark class read a static field set by its
-    /// xUnit driver (see <c>FirstSyncBench.Fixture</c>) — a separate-process toolchain would
-    /// fork a clean AppDomain and lose that reference.
-    ///
-    /// The default <see cref="InProcessNoEmitToolchain"/> timeout is 5 min, which is too short
-    /// for multi-iteration sync benchmarks (e.g. delete-heavy alone is ~80s/iter and full-import
-    /// setup adds ~50s/iter, so 5 iterations need ~11 min). 30 min covers the worst case with
-    /// headroom.
-    ///
-    /// Monitoring + WarmupCount=1 means iteration 1 absorbs JIT + EF model build + first-touch
-    /// file cache and is discarded; iterations 2-5 are measured. ColdStart would skip warmup
-    /// entirely; for these slow ops the JIT/model-build noise in iteration 1 is large enough
-    /// that one discarded warmup tightens StdDev meaningfully without changing total CI time.
+    /// In-process is required so benchmark classes can read static fields set by their xUnit driver
+    /// (e.g. <c>FirstSyncBench.Fixture</c>) — a separate-process toolchain would lose that reference.
+    /// The 30-min timeout overrides BDN's 5-min default, which is too short for our slowest profiles.
     /// </remarks>
     public static IConfig ConfigFor(ITestOutputHelper output)
     {

--- a/backend/FwLite/FwLiteProjectSync.Tests/Fixtures/Sena3Collection.cs
+++ b/backend/FwLite/FwLiteProjectSync.Tests/Fixtures/Sena3Collection.cs
@@ -1,0 +1,13 @@
+namespace FwLiteProjectSync.Tests.Fixtures;
+
+/// <summary>
+/// Groups every test class that uses <see cref="Sena3Fixture"/> into a single xUnit
+/// collection so they share one fixture instance and run serially. Without this, parallel
+/// classes each spin up their own fixture and race on the shared <c>./Sena3Fixture/</c>
+/// folder during <see cref="Sena3Fixture.InitializeAsync"/>.
+/// </summary>
+[CollectionDefinition(Name)]
+public class Sena3Collection : ICollectionFixture<Sena3Fixture>
+{
+    public const string Name = nameof(Sena3Collection);
+}

--- a/backend/FwLite/FwLiteProjectSync.Tests/FwLiteProjectSync.Tests.csproj
+++ b/backend/FwLite/FwLiteProjectSync.Tests/FwLiteProjectSync.Tests.csproj
@@ -5,6 +5,7 @@
     <Mercurial4ChorusDestDir>$(MSBuildProjectDirectory)</Mercurial4ChorusDestDir>
   </PropertyGroup>
   <ItemGroup>
+    <PackageReference Include="BenchmarkDotNet" />
     <PackageReference Include="coverlet.collector">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/backend/FwLite/FwLiteProjectSync.Tests/Sena3SyncTests.cs
+++ b/backend/FwLite/FwLiteProjectSync.Tests/Sena3SyncTests.cs
@@ -13,7 +13,8 @@ using MiniLcm.Models;
 namespace FwLiteProjectSync.Tests;
 
 [Trait("Category", "Integration")]
-public class Sena3SyncTests : IClassFixture<Sena3Fixture>, IAsyncLifetime
+[Collection(Sena3Collection.Name)]
+public class Sena3SyncTests : IAsyncLifetime
 {
     private readonly Sena3Fixture _fixture;
     private CrdtFwdataProjectSyncService _syncService = null!;

--- a/backend/FwLite/FwLiteProjectSync.Tests/SyncBenchmark.cs
+++ b/backend/FwLite/FwLiteProjectSync.Tests/SyncBenchmark.cs
@@ -53,7 +53,7 @@ public class SyncBenchmark(Sena3Fixture fixture, ITestOutputHelper output)
 public class FirstSyncBench
 {
     // CI 2026-05-06: mean 49.5s, StdDev 2.4s (medium variance) => 57s (~3σ above mean)
-    public const double ThresholdSeconds = 57.0;
+    public const double ThresholdSeconds = 1;//57.0;
 
     internal static Sena3Fixture Fixture = null!;
 

--- a/backend/FwLite/FwLiteProjectSync.Tests/SyncBenchmark.cs
+++ b/backend/FwLite/FwLiteProjectSync.Tests/SyncBenchmark.cs
@@ -1,0 +1,91 @@
+using BenchmarkDotNet.Attributes;
+#if !DEBUG
+using BenchmarkDotNet.Running;
+using FluentAssertions.Execution;
+#endif
+using FwLiteProjectSync.Tests.Fixtures;
+using LexCore.Sync;
+using Microsoft.Extensions.DependencyInjection;
+using MiniLcm;
+using Xunit.Abstractions;
+
+namespace FwLiteProjectSync.Tests;
+
+/// <summary>
+/// Times a first sync of Sena-3 from an empty CRDT (sync, not import — we save an empty
+/// snapshot first so the path runs as a real sync).
+/// </summary>
+[Trait("Category", "Integration")]
+[Trait("Category", "Benchmark")]
+[Collection(Sena3Collection.Name)]
+public class SyncBenchmark(Sena3Fixture fixture, ITestOutputHelper output)
+{
+    [Fact]
+    public void First_Sync_Sena3()
+    {
+        FirstSyncBench.Fixture = fixture;
+#if DEBUG
+        // Debug timings are unreliable (no JIT optimizations + BDN harness flags Debug builds).
+        // Run once for code-path coverage; thresholds enforced in Release only (CI benchmark job).
+        output.WriteLine("Debug build: running once for coverage; threshold enforced in Release only.");
+        var bench = new FirstSyncBench();
+        bench.IterationSetup();
+        try { _ = bench.SyncFromEmpty(); }
+        finally { bench.IterationCleanup(); }
+#else
+        using var scope = new AssertionScope();
+        var summary = BenchmarkRunner.Run<FirstSyncBench>(BenchmarkSupport.ConfigFor(output));
+        BenchmarkSupport.AssertRunWasSuccessful(summary);
+
+        var report = summary.Reports.Single();
+        var meanSeconds = report.ResultStatistics!.Mean / 1_000_000_000.0;
+        output.WriteLine($"first-sync mean = {meanSeconds:F2}s (bound={FirstSyncBench.ThresholdSeconds:F2}s)");
+
+        meanSeconds.Should().BeLessThan(FirstSyncBench.ThresholdSeconds,
+            $"first-sync should not regress past its threshold — see {nameof(FirstSyncBench)}.{nameof(FirstSyncBench.ThresholdSeconds)}");
+#endif
+    }
+}
+
+// BenchmarkDotNet has no async support. .Result is intentional and will not deadlock.
+#pragma warning disable VSTHRD002
+
+public class FirstSyncBench
+{
+    // CI 2026-05-06: mean 49.5s, StdDev 2.4s (medium variance) => 57s (~3σ above mean)
+    public const double ThresholdSeconds = 57.0;
+
+    internal static Sena3Fixture Fixture = null!;
+
+    private TestProject _project = null!;
+    private ProjectSnapshot _projectSnapshot = null!;
+    private CrdtFwdataProjectSyncService _syncService = null!;
+
+    [IterationSetup]
+    public void IterationSetup()
+    {
+        _project = Fixture.SetupProjects().GetAwaiter().GetResult();
+        _syncService = _project.Services.GetRequiredService<CrdtFwdataProjectSyncService>();
+
+        // Save an empty snapshot so the first sync runs as Sync, not Import.
+        ProjectSnapshotService.SaveProjectSnapshot(_project.FwDataProject, ProjectSnapshot.Empty)
+            .GetAwaiter().GetResult();
+        _projectSnapshot = _project.Services.GetRequiredService<ProjectSnapshotService>()
+            .GetProjectSnapshot(_project.FwDataProject).GetAwaiter().GetResult()
+            ?? throw new InvalidOperationException("Expected snapshot to exist after saving");
+    }
+
+    [Benchmark]
+    public SyncResult SyncFromEmpty()
+    {
+        return _syncService.Sync(_project.CrdtApi, _project.FwDataApi, _projectSnapshot).Result;
+    }
+
+    [IterationCleanup]
+    public void IterationCleanup()
+    {
+        _project?.Dispose();
+        _project = null!;
+    }
+}
+#pragma warning restore VSTHRD002

--- a/backend/FwLite/FwLiteProjectSync.Tests/SyncBenchmark.cs
+++ b/backend/FwLite/FwLiteProjectSync.Tests/SyncBenchmark.cs
@@ -53,9 +53,10 @@ public class SyncBenchmark(Sena3Fixture fixture, ITestOutputHelper output)
 
 public class FirstSyncBench
 {
-    // CI baseline (no index):      mean 52.34s, StdDev 0.27s (low variance) => 57s (~10%)
-    // CI with commits order index: mean 44.35s, StdDev 1.10s (med variance) => 51s (~15%)
-    public const double ThresholdSeconds = 51.0;
+    // Bound catches large regressions, not tight perf budgets — CI variance is too high for that.
+    // baseline:   ~52.3s
+    // with index: ~44.4s (real ~15% gain; can drift to ~53s under hosted-runner variance)
+    public const double ThresholdSeconds = 65.0;
 
     internal static Sena3Fixture Fixture = null!;
 

--- a/backend/FwLite/FwLiteProjectSync.Tests/SyncBenchmark.cs
+++ b/backend/FwLite/FwLiteProjectSync.Tests/SyncBenchmark.cs
@@ -52,9 +52,9 @@ public class SyncBenchmark(Sena3Fixture fixture, ITestOutputHelper output)
 
 public class FirstSyncBench
 {
-    // CI initial result:           mean 49.5s, StdDev 2.4s (medium variance) => 57s (~3σ above mean)
-    // CI with commits order index: mean 44.5s, StdDev 3.5s (medium variance) => 55s (~3σ above mean)
-    public const double ThresholdSeconds = 55.0;
+    // CI baseline (no index):      mean 52.34s, StdDev 0.27s (low variance) => 53s (~3σ above mean)
+    // CI with commits order index: mean 44.35s, StdDev 1.10s (low variance) => 50s (~5σ above mean, generous for run-to-run drift)
+    public const double ThresholdSeconds = 50.0;
 
     internal static Sena3Fixture Fixture = null!;
 

--- a/backend/FwLite/FwLiteProjectSync.Tests/SyncBenchmark.cs
+++ b/backend/FwLite/FwLiteProjectSync.Tests/SyncBenchmark.cs
@@ -25,8 +25,7 @@ public class SyncBenchmark(Sena3Fixture fixture, ITestOutputHelper output)
     {
         FirstSyncBench.Fixture = fixture;
 #if DEBUG
-        // Debug timings are unreliable (no JIT optimizations + BDN harness flags Debug builds).
-        // Run once for code-path coverage; thresholds enforced in Release only (CI benchmark job).
+        // Debug timings are unreliable (no JIT optimizations); thresholds enforced in Release only.
         output.WriteLine("Debug build: running once for coverage; threshold enforced in Release only.");
         var bench = new FirstSyncBench();
         bench.IterationSetup();

--- a/backend/FwLite/FwLiteProjectSync.Tests/SyncBenchmark.cs
+++ b/backend/FwLite/FwLiteProjectSync.Tests/SyncBenchmark.cs
@@ -53,8 +53,7 @@ public class SyncBenchmark(Sena3Fixture fixture, ITestOutputHelper output)
 public class FirstSyncBench
 {
     // Bound catches large regressions, not tight perf budgets — CI variance is too high for that.
-    // baseline:   ~52.3s
-    // with index: ~44.4s (real ~15% gain; can drift to ~53s under hosted-runner variance)
+    // Rough mean from a ubuntu-latest CI run, as a baseline for future work: ~57s.
     public const double ThresholdSeconds = 65.0;
 
     internal static Sena3Fixture Fixture = null!;

--- a/backend/FwLite/FwLiteProjectSync.Tests/SyncBenchmark.cs
+++ b/backend/FwLite/FwLiteProjectSync.Tests/SyncBenchmark.cs
@@ -53,8 +53,8 @@ public class SyncBenchmark(Sena3Fixture fixture, ITestOutputHelper output)
 public class FirstSyncBench
 {
     // Bound catches large regressions, not tight perf budgets — CI variance is too high for that.
-    // Rough mean from a ubuntu-latest CI run, as a baseline for future work: ~57s.
-    public const double ThresholdSeconds = 65.0;
+    // round(mean * 1.4); rough mean from a ubuntu-latest CI run is ~57s.
+    public const double ThresholdSeconds = 80;
 
     internal static Sena3Fixture Fixture = null!;
 

--- a/backend/FwLite/FwLiteProjectSync.Tests/SyncBenchmark.cs
+++ b/backend/FwLite/FwLiteProjectSync.Tests/SyncBenchmark.cs
@@ -52,9 +52,9 @@ public class SyncBenchmark(Sena3Fixture fixture, ITestOutputHelper output)
 
 public class FirstSyncBench
 {
-    // CI baseline (no index):      mean 52.34s, StdDev 0.27s (low variance) => 53s (~3σ above mean)
-    // CI with commits order index: mean 44.35s, StdDev 1.10s (low variance) => 50s (~5σ above mean, generous for run-to-run drift)
-    public const double ThresholdSeconds = 50.0;
+    // CI baseline (no index):      mean 52.34s, StdDev 0.27s (low variance) => 57s (~10%)
+    // CI with commits order index: mean 44.35s, StdDev 1.10s (med variance) => 51s (~15%)
+    public const double ThresholdSeconds = 51.0;
 
     internal static Sena3Fixture Fixture = null!;
 

--- a/backend/FwLite/FwLiteProjectSync.Tests/SyncBenchmark.cs
+++ b/backend/FwLite/FwLiteProjectSync.Tests/SyncBenchmark.cs
@@ -52,8 +52,9 @@ public class SyncBenchmark(Sena3Fixture fixture, ITestOutputHelper output)
 
 public class FirstSyncBench
 {
-    // CI 2026-05-06: mean 49.5s, StdDev 2.4s (medium variance) => 57s (~3σ above mean)
-    public const double ThresholdSeconds = 1;//57.0;
+    // CI initial result:           mean 49.5s, StdDev 2.4s (medium variance) => 57s (~3σ above mean)
+    // CI with commits order index: mean 44.5s, StdDev 3.5s (medium variance) => 55s (~3σ above mean)
+    public const double ThresholdSeconds = 55.0;
 
     internal static Sena3Fixture Fixture = null!;
 

--- a/backend/FwLite/FwLiteProjectSync.Tests/SyncBenchmark.cs
+++ b/backend/FwLite/FwLiteProjectSync.Tests/SyncBenchmark.cs
@@ -21,7 +21,7 @@ namespace FwLiteProjectSync.Tests;
 public class SyncBenchmark(Sena3Fixture fixture, ITestOutputHelper output)
 {
     [Fact]
-    public void First_Sync_Sena3()
+    public async Task First_Sync_Sena3()
     {
         FirstSyncBench.Fixture = fixture;
 #if DEBUG
@@ -30,7 +30,7 @@ public class SyncBenchmark(Sena3Fixture fixture, ITestOutputHelper output)
         output.WriteLine("Debug build: running once for coverage; threshold enforced in Release only.");
         var bench = new FirstSyncBench();
         bench.IterationSetup();
-        try { _ = bench.SyncFromEmpty(); }
+        try { _ = await bench.SyncFromEmpty(); }
         finally { bench.IterationCleanup(); }
 #else
         using var scope = new AssertionScope();
@@ -47,7 +47,8 @@ public class SyncBenchmark(Sena3Fixture fixture, ITestOutputHelper output)
     }
 }
 
-// BenchmarkDotNet has no async support. .Result is intentional and will not deadlock.
+// BenchmarkDotNet doesn't support async [IterationSetup]/[IterationCleanup] signatures,
+// so GetAwaiter().GetResult() below is intentional.
 #pragma warning disable VSTHRD002
 
 public class FirstSyncBench
@@ -77,9 +78,9 @@ public class FirstSyncBench
     }
 
     [Benchmark]
-    public SyncResult SyncFromEmpty()
+    public async Task<SyncResult> SyncFromEmpty()
     {
-        return _syncService.Sync(_project.CrdtApi, _project.FwDataApi, _projectSnapshot).Result;
+        return await _syncService.Sync(_project.CrdtApi, _project.FwDataApi, _projectSnapshot);
     }
 
     [IterationCleanup]

--- a/backend/FwLite/FwLiteProjectSync.Tests/SyncMutationBenchmark.cs
+++ b/backend/FwLite/FwLiteProjectSync.Tests/SyncMutationBenchmark.cs
@@ -70,15 +70,15 @@ public class MutationSyncBench
     public static readonly IReadOnlyDictionary<string, double> ThresholdSecondsByProfile = new Dictionary<string, double>
     {
         // CI 2026-05-06: mean 58.3s, StdDev 4.1s (high variance) => 72s (~4σ above mean)
-        ["component-heavy"] = 72.0,
+        ["component-heavy"] = 1,//72.0,
         // CI 2026-05-06: mean 94.3s, StdDev 5.7s (high variance) => 115s (~4σ above mean)
-        ["delete-heavy"] = 115.0,
+        ["delete-heavy"] = 1,//115.0,
         // CI 2026-05-06: mean 36.2s, StdDev 3.3s (medium variance) => 45s (~3σ above mean)
-        ["mixed-realistic"] = 45.0,
+        ["mixed-realistic"] = 1,//45.0,
         // CI 2026-05-06: mean 5.05s, StdDev 0.4s (low variance) => 7s (generous margin since it's already pretty fast and we want to avoid false positives from noise).
-        ["patch-heavy"] = 7.0,
+        ["patch-heavy"] = 1,//7.0,
         // CI 2026-05-06: mean 0.77s, StdDev 0.2s (low variance) => 3s (super fast, so meh)
-        ["reorder-heavy"] = 3.0,
+        ["reorder-heavy"] = 1,//3.0,
     };
 
     public static IEnumerable<string> Profiles => ThresholdSecondsByProfile.Keys;

--- a/backend/FwLite/FwLiteProjectSync.Tests/SyncMutationBenchmark.cs
+++ b/backend/FwLite/FwLiteProjectSync.Tests/SyncMutationBenchmark.cs
@@ -1,0 +1,250 @@
+using BenchmarkDotNet.Attributes;
+#if !DEBUG
+using BenchmarkDotNet.Running;
+using FluentAssertions.Execution;
+#endif
+using FwLiteProjectSync.Tests.Fixtures;
+using LexCore.Sync;
+using Microsoft.Extensions.DependencyInjection;
+using MiniLcm;
+using MiniLcm.Models;
+using MiniLcm.SyncHelpers;
+using Soenneker.Utils.AutoBogus;
+using Xunit.Abstractions;
+
+namespace FwLiteProjectSync.Tests;
+
+/// <summary>
+/// Times sync after applying a profile-specific batch of mutations to the FwData side of
+/// a fully-imported Sena-3 project. Each profile stresses a different change kind.
+/// </summary>
+[Trait("Category", "Integration")]
+[Trait("Category", "Benchmark")]
+[Collection(Sena3Collection.Name)]
+public class SyncMutationBenchmark(Sena3Fixture fixture, ITestOutputHelper output)
+{
+    [Fact]
+    public void Sync_AfterMutations_Sena3()
+    {
+        MutationSyncBench.Fixture = fixture;
+#if DEBUG
+        // Debug timings are unreliable (no JIT optimizations + BDN harness flags Debug builds).
+        // Run each profile once for code-path coverage; thresholds enforced in Release only (CI benchmark job).
+        output.WriteLine("Debug build: running each profile once for coverage; thresholds enforced in Release only.");
+        var bench = new MutationSyncBench();
+        foreach (var profile in MutationSyncBench.ThresholdSecondsByProfile.Keys)
+        {
+            bench.Profile = profile;
+            bench.IterationSetup();
+            try { _ = bench.SyncAfterMutations(); }
+            finally { bench.IterationCleanup(); }
+        }
+#else
+        using var scope = new AssertionScope();
+        var summary = BenchmarkRunner.Run<MutationSyncBench>(BenchmarkSupport.ConfigFor(output));
+        BenchmarkSupport.AssertRunWasSuccessful(summary);
+
+        foreach (var report in summary.Reports)
+        {
+            // ResultStatistics is guaranteed non-null by AssertRunWasSuccessful, but the scope
+            // keeps going on failure so we still need a defensive null-check before dereferencing.
+            if (report.ResultStatistics is null) continue;
+
+            var profile = report.BenchmarkCase.Parameters["Profile"]?.ToString()
+                ?? throw new InvalidOperationException("Expected Profile parameter on benchmark case");
+            var meanSeconds = report.ResultStatistics.Mean / 1_000_000_000.0;
+            var bound = MutationSyncBench.ThresholdSecondsByProfile[profile];
+            output.WriteLine($"{profile} mean = {meanSeconds:F2}s (bound={bound:F2}s)");
+
+            meanSeconds.Should().BeLessThan(bound,
+                $"profile {profile} should not regress past its threshold — see {nameof(MutationSyncBench)}.{nameof(MutationSyncBench.ThresholdSecondsByProfile)}");
+        }
+#endif
+    }
+}
+
+#pragma warning disable VSTHRD002
+
+public class MutationSyncBench
+{
+    public static readonly IReadOnlyDictionary<string, double> ThresholdSecondsByProfile = new Dictionary<string, double>
+    {
+        // CI 2026-05-06: mean 58.3s, StdDev 4.1s (high variance) => 72s (~4σ above mean)
+        ["component-heavy"] = 72.0,
+        // CI 2026-05-06: mean 94.3s, StdDev 5.7s (high variance) => 115s (~4σ above mean)
+        ["delete-heavy"] = 115.0,
+        // CI 2026-05-06: mean 36.2s, StdDev 3.3s (medium variance) => 45s (~3σ above mean)
+        ["mixed-realistic"] = 45.0,
+        // CI 2026-05-06: mean 5.05s, StdDev 0.4s (low variance) => 7s (generous margin since it's already pretty fast and we want to avoid false positives from noise).
+        ["patch-heavy"] = 7.0,
+        // CI 2026-05-06: mean 0.77s, StdDev 0.2s (low variance) => 3s (super fast, so meh)
+        ["reorder-heavy"] = 3.0,
+    };
+
+    public static IEnumerable<string> Profiles => ThresholdSecondsByProfile.Keys;
+
+    [ParamsSource(nameof(Profiles))]
+    public string Profile { get; set; } = "";
+
+    private const int MutationCount = 400;
+
+    private static readonly AutoFaker AutoFaker = new();
+
+    internal static Sena3Fixture Fixture = null!;
+
+    private TestProject _project = null!;
+    private ProjectSnapshot _projectSnapshot = null!;
+    private CrdtFwdataProjectSyncService _syncService = null!;
+
+    [IterationSetup]
+    public void IterationSetup()
+    {
+        _project = Fixture.SetupProjects().GetAwaiter().GetResult();
+        var services = _project.Services;
+        _syncService = services.GetRequiredService<CrdtFwdataProjectSyncService>();
+        var snapshotService = services.GetRequiredService<ProjectSnapshotService>();
+
+        _syncService.Import(_project.CrdtApi, _project.FwDataApi).GetAwaiter().GetResult();
+        snapshotService.RegenerateProjectSnapshot(_project.CrdtApi, _project.FwDataProject, keepBackup: false)
+            .GetAwaiter().GetResult();
+        _projectSnapshot = snapshotService.GetProjectSnapshot(_project.FwDataProject).GetAwaiter().GetResult()
+            ?? throw new InvalidOperationException("Expected snapshot to exist after regeneration");
+
+        ApplyProfile(Profile, _project.FwDataApi, MutationCount).GetAwaiter().GetResult();
+    }
+
+    [Benchmark]
+    public SyncResult SyncAfterMutations()
+    {
+        return _syncService.Sync(_project.CrdtApi, _project.FwDataApi, _projectSnapshot).Result;
+    }
+
+    [IterationCleanup]
+    public void IterationCleanup()
+    {
+        _project?.Dispose();
+        _project = null!;
+    }
+
+    private static async Task ApplyProfile(string profile, IMiniLcmApi api, int count)
+    {
+        var allEntries = await api.GetAllEntries().ToListAsync();
+        var shuffled = AutoFaker.Faker.Random.Shuffle(allEntries).ToList();
+
+        switch (profile)
+        {
+            case "delete-heavy":
+                await DeleteEntries(api, shuffled.Take(count));
+                break;
+            case "patch-heavy":
+                await PatchLexemes(api, shuffled.Take(count));
+                break;
+            case "reorder-heavy":
+                await ReorderSenses(api, shuffled.Take(count));
+                break;
+            case "component-heavy":
+                await AndCompleteFormComponents(api, shuffled, count);
+                break;
+            case "mixed-realistic":
+                await MixedRealistic(api, shuffled, count);
+                break;
+            default:
+                throw new ArgumentException($"Unknown profile: {profile}", nameof(profile));
+        }
+    }
+
+    // Disjoint slices so each kind of mutation operates on a different set of entries.
+    private static async Task MixedRealistic(IMiniLcmApi api, List<Entry> entries, int totalCount)
+    {
+        var per = totalCount / 4;
+        await DeleteEntries(api, entries.Take(per));
+        await PatchLexemes(api, entries.Skip(per).Take(per));
+        await ReorderSenses(api, entries.Skip(per * 2).Take(per));
+        await AndCompleteFormComponents(api, [.. entries.Skip(per * 3)], per);
+    }
+
+    private static async Task DeleteEntries(IMiniLcmApi api, IEnumerable<Entry> entries)
+    {
+        foreach (var entry in entries)
+            await api.DeleteEntry(entry.Id);
+    }
+
+    private static async Task PatchLexemes(IMiniLcmApi api, IEnumerable<Entry> entries)
+    {
+        foreach (var entry in entries)
+        {
+            var after = entry.Copy();
+            // Mutate the first existing lexeme WS, or fall back to citation.
+            if (after.LexemeForm.Values.Count > 0)
+            {
+                var (wsId, val) = after.LexemeForm.Values.First();
+                after.LexemeForm[wsId] = val + "_mut";
+            }
+            else if (after.CitationForm.Values.Count > 0)
+            {
+                var (wsId, val) = after.CitationForm.Values.First();
+                after.CitationForm[wsId] = val + "_mut";
+            }
+            else
+            {
+                continue;
+            }
+            await api.UpdateEntry(entry, after);
+        }
+    }
+
+    private static async Task ReorderSenses(IMiniLcmApi api, IEnumerable<Entry> entries)
+    {
+        // Only entries with 2+ senses can be reordered; move the first sense to the end.
+        foreach (var entry in entries.Where(e => e.Senses.Count >= 2))
+        {
+            var first = entry.Senses[0];
+            var last = entry.Senses[^1];
+            if (first.Id == last.Id) continue;
+            await api.MoveSense(entry.Id, first.Id, new BetweenPosition(last.Id, null));
+        }
+    }
+
+    private static async Task AndCompleteFormComponents(IMiniLcmApi api, List<Entry> pool, int targetCount)
+    {
+        var attempted = new HashSet<(Guid, Guid)>(
+            pool.SelectMany(e => e.Components.Select(c => (c.ComplexFormEntryId, c.ComponentEntryId))));
+
+        var applied = 0;
+        var attempts = 0;
+        var maxAttempts = targetCount * 10;
+        while (applied < targetCount && attempts < maxAttempts)
+        {
+            attempts++;
+            var cfIdx = AutoFaker.Faker.Random.Int(0, pool.Count - 1);
+            var compIdx = AutoFaker.Faker.Random.Int(0, pool.Count - 1);
+            if (cfIdx == compIdx) continue;
+            var cf = pool[cfIdx];
+            var comp = pool[compIdx];
+            if (!attempted.Add((cf.Id, comp.Id))) continue;
+
+            try
+            {
+                await api.CreateComplexFormComponent(new ComplexFormComponent
+                {
+                    Id = Guid.NewGuid(),
+                    ComplexFormEntryId = cf.Id,
+                    ComponentEntryId = comp.Id,
+                    ComponentSenseId = comp.Senses.Any() ? AutoFaker.Faker.PickRandom(comp.Senses).Id : null,
+                });
+                applied++;
+            }
+            catch
+            {
+                // Some components are invalid. Just skip and try another.
+            }
+        }
+
+        if (applied < targetCount)
+        {
+            throw new InvalidOperationException(
+                $"Failed to apply {targetCount} complex form links after {attempts} attempts; only applied {applied}");
+        }
+    }
+}
+#pragma warning restore VSTHRD002

--- a/backend/FwLite/FwLiteProjectSync.Tests/SyncMutationBenchmark.cs
+++ b/backend/FwLite/FwLiteProjectSync.Tests/SyncMutationBenchmark.cs
@@ -158,14 +158,19 @@ public class MutationSyncBench
         }
     }
 
-    // Disjoint slices so each kind of mutation operates on a different set of entries.
+    // Disjoint slices, one per mutation kind. Reorder only does anything to entries with 2+ senses,
+    // so it gets first pick of those; the remaining entries are split among the other three kinds.
     private static async Task MixedRealistic(IMiniLcmApi api, List<Entry> entries, int totalCount)
     {
         var per = totalCount / 4;
-        await DeleteEntries(api, entries.Take(per));
-        await PatchLexemes(api, entries.Skip(per).Take(per));
-        await ReorderSenses(api, entries.Skip(per * 2).Take(per));
-        await AndCompleteFormComponents(api, [.. entries.Skip(per * 3)], per);
+        var reorderSlice = entries.Where(e => e.Senses.Count >= 2).Take(per).ToList();
+        var reorderIds = reorderSlice.Select(e => e.Id).ToHashSet();
+        var rest = entries.Where(e => !reorderIds.Contains(e.Id)).ToList();
+
+        await DeleteEntries(api, rest.Take(per));
+        await PatchLexemes(api, rest.Skip(per).Take(per));
+        await ReorderSenses(api, reorderSlice);
+        await AndCompleteFormComponents(api, [.. rest.Skip(per * 2)], per);
     }
 
     private static async Task DeleteEntries(IMiniLcmApi api, IEnumerable<Entry> entries)

--- a/backend/FwLite/FwLiteProjectSync.Tests/SyncMutationBenchmark.cs
+++ b/backend/FwLite/FwLiteProjectSync.Tests/SyncMutationBenchmark.cs
@@ -67,23 +67,24 @@ public class SyncMutationBenchmark(Sena3Fixture fixture, ITestOutputHelper outpu
 
 public class MutationSyncBench
 {
+    // Bounds catch large regressions, not tight perf budgets — CI variance is too high for that.
     public static readonly IReadOnlyDictionary<string, double> ThresholdSecondsByProfile = new Dictionary<string, double>
     {
-        // CI baseline (no index):      mean 52.40s, StdDev 1.51s (med variance) => 60s (~15%)
-        // CI with commits order index: mean 50.49s, StdDev 0.87s (low variance) => 55s (~10%)
-        ["component-heavy"] = 55.0,
-        // CI baseline (no index):      mean 87.02s, StdDev 3.85s (hi variance)  => 100s (~15%)
-        // CI with commits order index: mean 87.92s, StdDev 1.42s (med variance) => 100s (~15%)
-        ["delete-heavy"] = 100.0,
-        // CI baseline (no index):      mean 32.99s, StdDev 0.77s (low variance) => 36s (~10%)
-        // CI with commits order index: mean 32.95s, StdDev 1.08s (low variance) => 36s (~10%)
-        ["mixed-realistic"] = 36.0,
-        // CI baseline (no index):      mean 4.52s, StdDev 0.08s (low variance) => 5s (~10%)
-        // CI with commits order index: mean 3.53s, StdDev 0.10s (low variance) => 4s (~10%)
-        ["patch-heavy"] = 4.0,
-        // CI baseline (no index):      mean 0.69s, StdDev 0.08s (low variance)  => 2s (super fast, so meh)
-        // CI with commits order index: mean 0.57s, StdDev 0.05s (low variance)  => 1.5s (super fast, so meh)
-        ["reorder-heavy"] = 1.5,
+        // baseline:   ~52.4s
+        // with index: ~50.5s (within noise)
+        ["component-heavy"] = 65.0,
+        // baseline:   ~87.0s
+        // with index: ~87.9s (no change; high variance)
+        ["delete-heavy"] = 110.0,
+        // baseline:   ~33.0s
+        // with index: ~33.0s (no change)
+        ["mixed-realistic"] = 45.0,
+        // baseline:   ~4.52s
+        // with index: ~3.53s (real ~20% gain; can drift to ~4.3s under variance)
+        ["patch-heavy"] = 6.0,
+        // baseline:   ~0.69s
+        // with index: ~0.57s (sub-second; bound is just a sanity check)
+        ["reorder-heavy"] = 2.0,
     };
 
     public static IEnumerable<string> Profiles => ThresholdSecondsByProfile.Keys;

--- a/backend/FwLite/FwLiteProjectSync.Tests/SyncMutationBenchmark.cs
+++ b/backend/FwLite/FwLiteProjectSync.Tests/SyncMutationBenchmark.cs
@@ -218,6 +218,7 @@ public class MutationSyncBench
         var applied = 0;
         var attempts = 0;
         var maxAttempts = targetCount * 10;
+        Exception? lastError = null;
         while (applied < targetCount && attempts < maxAttempts)
         {
             attempts++;
@@ -239,16 +240,19 @@ public class MutationSyncBench
                 });
                 applied++;
             }
-            catch
+            catch (Exception e)
             {
-                // Some components are invalid. Just skip and try another.
+                // Some randomly-paired components are invalid; skip and try another. Keep the last
+                // error so a regression that rejects *every* pair is diagnosable rather than silent.
+                lastError = e;
             }
         }
 
         if (applied < targetCount)
         {
             throw new InvalidOperationException(
-                $"Failed to apply {targetCount} complex form links after {attempts} attempts; only applied {applied}");
+                $"Failed to apply {targetCount} complex form links after {attempts} attempts; only applied {applied}",
+                lastError);
         }
     }
 }

--- a/backend/FwLite/FwLiteProjectSync.Tests/SyncMutationBenchmark.cs
+++ b/backend/FwLite/FwLiteProjectSync.Tests/SyncMutationBenchmark.cs
@@ -69,16 +69,21 @@ public class MutationSyncBench
 {
     public static readonly IReadOnlyDictionary<string, double> ThresholdSecondsByProfile = new Dictionary<string, double>
     {
-        // CI 2026-05-06: mean 58.3s, StdDev 4.1s (high variance) => 72s (~4σ above mean)
-        ["component-heavy"] = 1,//72.0,
-        // CI 2026-05-06: mean 94.3s, StdDev 5.7s (high variance) => 115s (~4σ above mean)
-        ["delete-heavy"] = 1,//115.0,
-        // CI 2026-05-06: mean 36.2s, StdDev 3.3s (medium variance) => 45s (~3σ above mean)
-        ["mixed-realistic"] = 1,//45.0,
-        // CI 2026-05-06: mean 5.05s, StdDev 0.4s (low variance) => 7s (generous margin since it's already pretty fast and we want to avoid false positives from noise).
-        ["patch-heavy"] = 1,//7.0,
-        // CI 2026-05-06: mean 0.77s, StdDev 0.2s (low variance) => 3s (super fast, so meh)
-        ["reorder-heavy"] = 1,//3.0,
+        // CI 2026-05-06:               mean 58.3s, StdDev 4.1s (high variance) => 72s (~4σ above mean)
+        // CI with commits order index: mean 46.9s, StdDev 2.2s (medium variance) => 53s (~3σ above mean)
+        ["component-heavy"] = 53.0,
+        // CI 2026-05-06:               mean 94.3s, StdDev 5.7s (high variance) => 115s (~4σ above mean)
+        // CI with commits order index: mean 91.6s, StdDev 4.3s (high variance) => 105s (~4σ above mean)
+        ["delete-heavy"] = 105.0,
+        // CI 2026-05-06:               mean 36.2s, StdDev 3.3s (medium variance) => 45s (~3σ above mean)
+        // CI with commits order index: mean 33.4s, StdDev 0.8s (low variance) => 36s (~3σ above mean)
+        ["mixed-realistic"] = 36.0,
+        // CI 2026-05-06:               mean 5.05s, StdDev 0.4s (low variance) => 7s (generous margin since it's already pretty fast and we want to avoid false positives from noise).
+        // CI with commits order index: mean 3.7s, StdDev 0.1s (low variance) => 5s (pretty fast, so meh)
+        ["patch-heavy"] = 5.0,
+        // CI 2026-05-06:               mean 0.77s, StdDev 0.2s (low variance) => 3s (super fast, so meh)
+        // CI with commits order index: mean 0.58s, StdDev 0.02s (low variance) => 2s (super fast, so meh)
+        ["reorder-heavy"] = 2.0,
     };
 
     public static IEnumerable<string> Profiles => ThresholdSecondsByProfile.Keys;

--- a/backend/FwLite/FwLiteProjectSync.Tests/SyncMutationBenchmark.cs
+++ b/backend/FwLite/FwLiteProjectSync.Tests/SyncMutationBenchmark.cs
@@ -67,19 +67,19 @@ public class SyncMutationBenchmark(Sena3Fixture fixture, ITestOutputHelper outpu
 public class MutationSyncBench
 {
     // Bounds catch large regressions, not tight perf budgets — CI variance is too high for that.
-    // Per-profile comments are rough mean sync times from a ubuntu-latest CI run — a baseline for future work.
+    // Each bound is round(mean * 1.4); the // comment is the rough mean from a ubuntu-latest CI run.
     public static readonly IReadOnlyDictionary<string, double> ThresholdSecondsByProfile = new Dictionary<string, double>
     {
         // ~40s
-        ["component-heavy"] = 65.0,
+        ["component-heavy"] = 56,
         // ~63s
-        ["delete-heavy"] = 110.0,
+        ["delete-heavy"] = 88,
         // ~25s
-        ["mixed-realistic"] = 45.0,
-        // ~4.5s
-        ["patch-heavy"] = 6.0,
-        // ~0.6s
-        ["reorder-heavy"] = 2.0,
+        ["mixed-realistic"] = 35,
+        // ~4.6s
+        ["patch-heavy"] = 7,
+        // ~1.9s
+        ["reorder-heavy"] = 3,
     };
 
     public static IEnumerable<string> Profiles => ThresholdSecondsByProfile.Keys;
@@ -131,7 +131,6 @@ public class MutationSyncBench
     {
         var allEntries = await api.GetAllEntries().ToListAsync();
         var shuffled = AutoFaker.Faker.Random.Shuffle(allEntries).ToList();
-        Console.WriteLine($"[REORDER-COUNT] {shuffled.Count(e => e.Senses.Count >= 2)} of {shuffled.Count} entries have 2+ senses"); // TEMP
 
         switch (profile)
         {

--- a/backend/FwLite/FwLiteProjectSync.Tests/SyncMutationBenchmark.cs
+++ b/backend/FwLite/FwLiteProjectSync.Tests/SyncMutationBenchmark.cs
@@ -69,21 +69,21 @@ public class MutationSyncBench
 {
     public static readonly IReadOnlyDictionary<string, double> ThresholdSecondsByProfile = new Dictionary<string, double>
     {
-        // CI baseline (no index):      mean 52.40s, StdDev 1.51s (low variance) => 61s (~5σ above mean)
-        // CI with commits order index: mean 50.49s, StdDev 0.87s (low variance) => 61s (~12σ above mean — kept generous, run-to-run drift can be ~3s here)
-        ["component-heavy"] = 61.0,
-        // CI baseline (no index):      mean 87.02s, StdDev 3.85s (medium variance) => 97s (~3σ above mean)
-        // CI with commits order index: mean 87.92s, StdDev 1.42s (low variance)    => 97s (~6σ above mean — kept generous, run-to-run drift can be ~2s here)
-        ["delete-heavy"] = 97.0,
-        // CI baseline (no index):      mean 32.99s, StdDev 0.77s (low variance) => 38s (~7σ above mean)
-        // CI with commits order index: mean 32.95s, StdDev 1.08s (low variance) => 38s (~5σ above mean)
-        ["mixed-realistic"] = 38.0,
-        // CI baseline (no index):      mean 4.52s, StdDev 0.08s (low variance) => 5s (generous margin since it's already pretty fast and we want to avoid false positives from noise)
-        // CI with commits order index: mean 3.53s, StdDev 0.10s (low variance) => 5s (pretty fast, so meh — same margin works)
-        ["patch-heavy"] = 5.0,
+        // CI baseline (no index):      mean 52.40s, StdDev 1.51s (med variance) => 60s (~15%)
+        // CI with commits order index: mean 50.49s, StdDev 0.87s (low variance) => 55s (~10%)
+        ["component-heavy"] = 55.0,
+        // CI baseline (no index):      mean 87.02s, StdDev 3.85s (hi variance)  => 100s (~15%)
+        // CI with commits order index: mean 87.92s, StdDev 1.42s (med variance) => 100s (~15%)
+        ["delete-heavy"] = 100.0,
+        // CI baseline (no index):      mean 32.99s, StdDev 0.77s (low variance) => 36s (~10%)
+        // CI with commits order index: mean 32.95s, StdDev 1.08s (low variance) => 36s (~10%)
+        ["mixed-realistic"] = 36.0,
+        // CI baseline (no index):      mean 4.52s, StdDev 0.08s (low variance) => 5s (~10%)
+        // CI with commits order index: mean 3.53s, StdDev 0.10s (low variance) => 4s (~10%)
+        ["patch-heavy"] = 4.0,
         // CI baseline (no index):      mean 0.69s, StdDev 0.08s (low variance)  => 2s (super fast, so meh)
-        // CI with commits order index: mean 0.57s, StdDev 0.05s (low variance)  => 2s (super fast, so meh)
-        ["reorder-heavy"] = 2.0,
+        // CI with commits order index: mean 0.57s, StdDev 0.05s (low variance)  => 1.5s (super fast, so meh)
+        ["reorder-heavy"] = 1.5,
     };
 
     public static IEnumerable<string> Profiles => ThresholdSecondsByProfile.Keys;

--- a/backend/FwLite/FwLiteProjectSync.Tests/SyncMutationBenchmark.cs
+++ b/backend/FwLite/FwLiteProjectSync.Tests/SyncMutationBenchmark.cs
@@ -24,7 +24,7 @@ namespace FwLiteProjectSync.Tests;
 public class SyncMutationBenchmark(Sena3Fixture fixture, ITestOutputHelper output)
 {
     [Fact]
-    public void Sync_AfterMutations_Sena3()
+    public async Task Sync_AfterMutations_Sena3()
     {
         MutationSyncBench.Fixture = fixture;
 #if DEBUG
@@ -36,7 +36,7 @@ public class SyncMutationBenchmark(Sena3Fixture fixture, ITestOutputHelper outpu
         {
             bench.Profile = profile;
             bench.IterationSetup();
-            try { _ = bench.SyncAfterMutations(); }
+            try { _ = await bench.SyncAfterMutations(); }
             finally { bench.IterationCleanup(); }
         }
 #else
@@ -119,9 +119,9 @@ public class MutationSyncBench
     }
 
     [Benchmark]
-    public SyncResult SyncAfterMutations()
+    public async Task<SyncResult> SyncAfterMutations()
     {
-        return _syncService.Sync(_project.CrdtApi, _project.FwDataApi, _projectSnapshot).Result;
+        return await _syncService.Sync(_project.CrdtApi, _project.FwDataApi, _projectSnapshot);
     }
 
     [IterationCleanup]

--- a/backend/FwLite/FwLiteProjectSync.Tests/SyncMutationBenchmark.cs
+++ b/backend/FwLite/FwLiteProjectSync.Tests/SyncMutationBenchmark.cs
@@ -28,8 +28,7 @@ public class SyncMutationBenchmark(Sena3Fixture fixture, ITestOutputHelper outpu
     {
         MutationSyncBench.Fixture = fixture;
 #if DEBUG
-        // Debug timings are unreliable (no JIT optimizations + BDN harness flags Debug builds).
-        // Run each profile once for code-path coverage; thresholds enforced in Release only (CI benchmark job).
+        // Debug timings are unreliable (no JIT optimizations); thresholds enforced in Release only.
         output.WriteLine("Debug build: running each profile once for coverage; thresholds enforced in Release only.");
         var bench = new MutationSyncBench();
         foreach (var profile in MutationSyncBench.ThresholdSecondsByProfile.Keys)

--- a/backend/FwLite/FwLiteProjectSync.Tests/SyncMutationBenchmark.cs
+++ b/backend/FwLite/FwLiteProjectSync.Tests/SyncMutationBenchmark.cs
@@ -67,22 +67,18 @@ public class SyncMutationBenchmark(Sena3Fixture fixture, ITestOutputHelper outpu
 public class MutationSyncBench
 {
     // Bounds catch large regressions, not tight perf budgets — CI variance is too high for that.
+    // Per-profile comments are rough mean sync times from a ubuntu-latest CI run — a baseline for future work.
     public static readonly IReadOnlyDictionary<string, double> ThresholdSecondsByProfile = new Dictionary<string, double>
     {
-        // baseline:   ~52.4s
-        // with index: ~50.5s (within noise)
+        // ~40s
         ["component-heavy"] = 65.0,
-        // baseline:   ~87.0s
-        // with index: ~87.9s (no change; high variance)
+        // ~63s
         ["delete-heavy"] = 110.0,
-        // baseline:   ~33.0s
-        // with index: ~33.0s (no change)
+        // ~25s
         ["mixed-realistic"] = 45.0,
-        // baseline:   ~4.52s
-        // with index: ~3.53s (real ~20% gain; can drift to ~4.3s under variance)
+        // ~4.5s
         ["patch-heavy"] = 6.0,
-        // baseline:   ~0.69s
-        // with index: ~0.57s (sub-second; bound is just a sanity check)
+        // ~0.6s
         ["reorder-heavy"] = 2.0,
     };
 

--- a/backend/FwLite/FwLiteProjectSync.Tests/SyncMutationBenchmark.cs
+++ b/backend/FwLite/FwLiteProjectSync.Tests/SyncMutationBenchmark.cs
@@ -69,20 +69,20 @@ public class MutationSyncBench
 {
     public static readonly IReadOnlyDictionary<string, double> ThresholdSecondsByProfile = new Dictionary<string, double>
     {
-        // CI 2026-05-06:               mean 58.3s, StdDev 4.1s (high variance) => 72s (~4σ above mean)
-        // CI with commits order index: mean 46.9s, StdDev 2.2s (medium variance) => 53s (~3σ above mean)
-        ["component-heavy"] = 53.0,
-        // CI 2026-05-06:               mean 94.3s, StdDev 5.7s (high variance) => 115s (~4σ above mean)
-        // CI with commits order index: mean 91.6s, StdDev 4.3s (high variance) => 105s (~4σ above mean)
-        ["delete-heavy"] = 105.0,
-        // CI 2026-05-06:               mean 36.2s, StdDev 3.3s (medium variance) => 45s (~3σ above mean)
-        // CI with commits order index: mean 33.4s, StdDev 0.8s (low variance) => 36s (~3σ above mean)
-        ["mixed-realistic"] = 36.0,
-        // CI 2026-05-06:               mean 5.05s, StdDev 0.4s (low variance) => 7s (generous margin since it's already pretty fast and we want to avoid false positives from noise).
-        // CI with commits order index: mean 3.7s, StdDev 0.1s (low variance) => 5s (pretty fast, so meh)
+        // CI baseline (no index):      mean 52.40s, StdDev 1.51s (low variance) => 61s (~5σ above mean)
+        // CI with commits order index: mean 50.49s, StdDev 0.87s (low variance) => 61s (~12σ above mean — kept generous, run-to-run drift can be ~3s here)
+        ["component-heavy"] = 61.0,
+        // CI baseline (no index):      mean 87.02s, StdDev 3.85s (medium variance) => 97s (~3σ above mean)
+        // CI with commits order index: mean 87.92s, StdDev 1.42s (low variance)    => 97s (~6σ above mean — kept generous, run-to-run drift can be ~2s here)
+        ["delete-heavy"] = 97.0,
+        // CI baseline (no index):      mean 32.99s, StdDev 0.77s (low variance) => 38s (~7σ above mean)
+        // CI with commits order index: mean 32.95s, StdDev 1.08s (low variance) => 38s (~5σ above mean)
+        ["mixed-realistic"] = 38.0,
+        // CI baseline (no index):      mean 4.52s, StdDev 0.08s (low variance) => 5s (generous margin since it's already pretty fast and we want to avoid false positives from noise)
+        // CI with commits order index: mean 3.53s, StdDev 0.10s (low variance) => 5s (pretty fast, so meh — same margin works)
         ["patch-heavy"] = 5.0,
-        // CI 2026-05-06:               mean 0.77s, StdDev 0.2s (low variance) => 3s (super fast, so meh)
-        // CI with commits order index: mean 0.58s, StdDev 0.02s (low variance) => 2s (super fast, so meh)
+        // CI baseline (no index):      mean 0.69s, StdDev 0.08s (low variance)  => 2s (super fast, so meh)
+        // CI with commits order index: mean 0.57s, StdDev 0.05s (low variance)  => 2s (super fast, so meh)
         ["reorder-heavy"] = 2.0,
     };
 

--- a/backend/FwLite/FwLiteProjectSync.Tests/SyncMutationBenchmark.cs
+++ b/backend/FwLite/FwLiteProjectSync.Tests/SyncMutationBenchmark.cs
@@ -131,6 +131,7 @@ public class MutationSyncBench
     {
         var allEntries = await api.GetAllEntries().ToListAsync();
         var shuffled = AutoFaker.Faker.Random.Shuffle(allEntries).ToList();
+        Console.WriteLine($"[REORDER-COUNT] {shuffled.Count(e => e.Senses.Count >= 2)} of {shuffled.Count} entries have 2+ senses"); // TEMP
 
         switch (profile)
         {
@@ -141,7 +142,9 @@ public class MutationSyncBench
                 await PatchLexemes(api, shuffled.Take(count));
                 break;
             case "reorder-heavy":
-                await ReorderSenses(api, shuffled.Take(count));
+                // Filter to reorderable entries before taking count, else we'd reorder only the
+                // 2+-sense fraction that happens to land in the first `count` shuffled entries.
+                await ReorderSenses(api, Reorderable(shuffled).Take(count));
                 break;
             case "component-heavy":
                 await AndCompleteFormComponents(api, shuffled, count);
@@ -159,7 +162,7 @@ public class MutationSyncBench
     private static async Task MixedRealistic(IMiniLcmApi api, List<Entry> entries, int totalCount)
     {
         var per = totalCount / 4;
-        var reorderSlice = entries.Where(e => e.Senses.Count >= 2).Take(per).ToList();
+        var reorderSlice = Reorderable(entries).Take(per).ToList();
         var reorderIds = reorderSlice.Select(e => e.Id).ToHashSet();
         var rest = entries.Where(e => !reorderIds.Contains(e.Id)).ToList();
 
@@ -199,10 +202,14 @@ public class MutationSyncBench
         }
     }
 
+    // A reorder only changes entries with 2+ senses; callers filter to these before slicing a count.
+    private static IEnumerable<Entry> Reorderable(IEnumerable<Entry> entries) =>
+        entries.Where(e => e.Senses.Count >= 2);
+
     private static async Task ReorderSenses(IMiniLcmApi api, IEnumerable<Entry> entries)
     {
-        // Only entries with 2+ senses can be reordered; move the first sense to the end.
-        foreach (var entry in entries.Where(e => e.Senses.Count >= 2))
+        // Entries are pre-filtered to 2+ senses (see Reorderable); move the first sense to the end.
+        foreach (var entry in entries)
         {
             var first = entry.Senses[0];
             var last = entry.Senses[^1];

--- a/backend/FwLite/FwLiteProjectSync.Tests/XUnitBenchmarkLogger.cs
+++ b/backend/FwLite/FwLiteProjectSync.Tests/XUnitBenchmarkLogger.cs
@@ -1,0 +1,40 @@
+using System.Text;
+using BenchmarkDotNet.Loggers;
+using Xunit.Abstractions;
+
+namespace FwLiteProjectSync.Tests;
+
+/// <summary>
+/// Bridges BenchmarkDotNet's line-buffered logger calls to xUnit's <see cref="ITestOutputHelper"/>.
+/// BDN writes one line via several <see cref="Write"/> calls followed by <see cref="WriteLine()"/>;
+/// we accumulate fragments in <see cref="_line"/> and flush on each line break.
+/// </summary>
+internal sealed class XUnitBenchmarkLogger(ITestOutputHelper output) : ILogger
+{
+    public string Id => nameof(XUnitBenchmarkLogger);
+    public int Priority => 0;
+    private readonly StringBuilder _line = new();
+
+    public void Write(LogKind logKind, string text)
+    {
+        _line.Append(text);
+    }
+
+    public void WriteLine()
+    {
+        output.WriteLine(_line.ToString());
+        _line.Clear();
+    }
+
+    public void WriteLine(LogKind logKind, string text)
+    {
+        _line.Append(text);
+        WriteLine();
+    }
+
+    public void Flush()
+    {
+        if (_line.Length == 0) return;
+        WriteLine();
+    }
+}

--- a/backend/FwLite/FwLiteProjectSync.Tests/XUnitBenchmarkLogger.cs
+++ b/backend/FwLite/FwLiteProjectSync.Tests/XUnitBenchmarkLogger.cs
@@ -5,9 +5,8 @@ using Xunit.Abstractions;
 namespace FwLiteProjectSync.Tests;
 
 /// <summary>
-/// Bridges BenchmarkDotNet's line-buffered logger calls to xUnit's <see cref="ITestOutputHelper"/>.
-/// BDN writes one line via several <see cref="Write"/> calls followed by <see cref="WriteLine()"/>;
-/// we accumulate fragments in <see cref="_line"/> and flush on each line break.
+/// Bridges BenchmarkDotNet's line-buffered logger to xUnit's <see cref="ITestOutputHelper"/>.
+/// BDN emits one line via several <c>Write</c> calls followed by <c>WriteLine</c>; we buffer and flush.
 /// </summary>
 internal sealed class XUnitBenchmarkLogger(ITestOutputHelper output) : ILogger
 {


### PR DESCRIPTION
Adds BenchmarkDotNet-based sync benchmarks for `FwLiteProjectSync` so we can actually measure sync-performance work. This started as exploration of perf optimizations and gives us a baseline to measure future speedups against.

- `SyncBenchmark` — first sync of the full Sena-3 project from an empty CRDT snapshot.
- `SyncMutationBenchmark` — post-mutation syncs across several profiles (patch-heavy, reorder, complex-form components, mixed) to stress different change paths.
- New Release-only CI job runs the `Category=Benchmark` tests and uploads BenchmarkDotNet artifacts; the main test job excludes them. Benchmark comments record the approximate speedup from the commits-order index.

**No schema/migration changes.** An earlier revision of this branch added a DB migration for the commits-order index; that was dropped during rebase because the index now ships from the Harmony submodule already on `develop` (`CommitEntityConfig` via `EFCore.ComplexIndexes`). `dotnet ef migrations has-pending-model-changes` is clean.

**CI trigger:** the benchmark job runs post-merge on `develop` only — not on PRs (too slow / too variance-prone on shared runners to gate every PR) and not on `main` (so it can't delay releases). We can move it onto the PR critical path once it's fast enough.

Also note: `Sena3SyncTests` moved from `IClassFixture` to a shared `[Collection]` so it serializes with the benchmark classes against the shared on-disk Sena-3 fixture.

(Reopening of #2254, which got accidentally merged into develop via the VS Code "Sync" button.)
