### PR TITLE
Simplify to rely on Harmony's duplicate commit handling

### DIFF
--- a/backend/FwLite/LcmCrdt/CurrentProjectService.cs
+++ b/backend/FwLite/LcmCrdt/CurrentProjectService.cs
@@ -110,13 +110,9 @@ public class CurrentProjectService(
 
                 // Seed morph-types if missing (for existing projects created before morph-type support).
                 // Must happen BEFORE FTS regeneration so headwords include morph-type tokens.
-                // (querying Commits instead of MorphTypes, because the commit may not be projected yet)
+                var dataModel = services.GetRequiredService<DataModel>();
                 var projectData = await dbContext.ProjectData.AsNoTracking().FirstAsync();
-                if (!await dbContext.Set<Commit>().AsNoTracking().AnyAsync(c => c.Id == PreDefinedData.MorphTypesSeedCommitId(projectData.Id)))
-                {
-                    var dataModel = services.GetRequiredService<DataModel>();
-                    await PreDefinedData.AddPredefinedMorphTypes(dataModel, projectData);
-                }
+                await PreDefinedData.AddPredefinedMorphTypes(dataModel, projectData);
 
                 if (EntrySearchServiceFactory is not null)
                 {


### PR DESCRIPTION
Drops the MigrateDb pre-check. With Harmon's HasCommit check fix (sillsdev/harmony#66) it's now just an optimization, not a race guard.

In the future we want to use Project version check instead of relying on commit-ID, which is much less intuitive and a complex detail for e.g. a future project "template" to remember.