### PR TITLE
Add Android Dev flavor + emulator-dev task variants

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -123,7 +123,17 @@ tasks:
     aliases: [android]
     deps: [fw-lite:run-maui-android]
 
+  fw-lite-android-dev:
+    aliases: [android-dev]
+    desc: Build & run the "Dev" flavor on Android (installs alongside the prod app)
+    deps: [fw-lite:run-maui-android-dev]
+
   fw-lite-android-install:
     aliases: [android-install]
     desc: Install without building
     deps: [fw-lite:install-maui-android]
+
+  fw-lite-android-install-dev:
+    aliases: [android-install-dev]
+    desc: Install the "Dev" flavor without building
+    deps: [fw-lite:install-maui-android-dev]

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -128,6 +128,11 @@ tasks:
     desc: Build & run the "Dev" flavor on Android (installs alongside the prod app)
     deps: [fw-lite:run-maui-android-dev]
 
+  fw-lite-android-emulator-dev:
+    aliases: [android-emulator-dev]
+    desc: Build & run the "Dev" flavor on a running x86_64 emulator (installs alongside the prod app)
+    deps: [fw-lite:run-maui-android-emulator-dev]
+
   fw-lite-android-install:
     aliases: [android-install]
     desc: Install without building
@@ -137,3 +142,8 @@ tasks:
     aliases: [android-install-dev]
     desc: Install the "Dev" flavor without building
     deps: [fw-lite:install-maui-android-dev]
+
+  fw-lite-android-install-emulator-dev:
+    aliases: [android-install-emulator-dev]
+    desc: Install the "Dev" flavor on a running x86_64 emulator without building
+    deps: [fw-lite:install-maui-android-emulator-dev]

--- a/backend/FwLite/FwLiteMaui/FwLiteMaui.csproj
+++ b/backend/FwLite/FwLiteMaui/FwLiteMaui.csproj
@@ -40,6 +40,12 @@
     <TargetPlatformMinVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'windows'">10.0.19041.0</TargetPlatformMinVersion>
     <SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'tizen'">6.5</SupportedOSPlatformVersion>
   </PropertyGroup>
+  <!-- Side-by-side "Dev" flavor: set -p:FwLiteFlavor=Dev to install alongside the prod app
+       (different package name + label so both can coexist on a device). -->
+  <PropertyGroup Condition="'$(FwLiteFlavor)' == 'Dev'">
+    <ApplicationId>org.sil.FwLiteMaui.dev</ApplicationId>
+    <ApplicationTitle>FieldWorks Lite Dev</ApplicationTitle>
+  </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)' == 'Debug' ">
     <WindowsPackageType>None</WindowsPackageType>
     <PublishReadyToRun>false</PublishReadyToRun>

--- a/backend/FwLite/Taskfile.yml
+++ b/backend/FwLite/Taskfile.yml
@@ -65,9 +65,7 @@ tasks:
 
   run-maui-android:
     dir: ./FwLiteMaui
-    vars:
-      FLAVOR: ""
-    cmd: task build-maui-android FLAVOR={{.FLAVOR}} -- "-t:InstallAndroidDependencies;Run"
+    cmd: task build-maui-android FLAVOR={{.FLAVOR}} -- "-t:InstallAndroidDependencies;Run {{.EXTRA_ARGS}}"
 
   run-maui-android-dev:
     desc: Build & run the "Dev" flavor (installs alongside the prod app)
@@ -75,25 +73,33 @@ tasks:
       - task: run-maui-android
         vars: { FLAVOR: 'Dev' }
 
+  run-maui-android-emulator-dev:
+    desc: Build & run the "Dev" flavor on a running x86_64 emulator (installs alongside the prod app; targets `adb -e`)
+    cmds:
+      - task: run-maui-android
+        vars: { FLAVOR: 'Dev', EXTRA_ARGS: '-p:RuntimeIdentifiers=android-x64 -p:RuntimeIdentifier=android-x64 -p:AdbTarget=-e' }
+
   build-maui-android:
     deps: [ ui:build-viewer ]
     dir: ./FwLiteMaui
-    vars:
-      FLAVOR: ""
     cmd: dotnet build -f net10.0-android -t:InstallAndroidDependencies -p:AcceptAndroidSdkLicenses=True -p:FwLiteFlavor={{.FLAVOR}} {{.CLI_ARGS}} # "-p:AndroidSdkDirectory=D:\tools\android"
 
   install-maui-android:
     desc: Retry install + run without rebuilding (for when you miss the permission prompt) - uses existing build artifacts
     dir: ./FwLiteMaui
-    vars:
-      FLAVOR: ""
-    cmd: dotnet build -f net10.0-android -t:Install,Run --no-restore --no-dependencies -p:FwLiteFlavor={{.FLAVOR}}
+    cmd: dotnet build -f net10.0-android -t:Install,Run --no-restore --no-dependencies -p:FwLiteFlavor={{.FLAVOR}} {{.EXTRA_ARGS}}
 
   install-maui-android-dev:
     desc: Retry install + run for the "Dev" flavor without rebuilding
     cmds:
       - task: install-maui-android
         vars: { FLAVOR: 'Dev' }
+
+  install-maui-android-emulator-dev:
+    desc: Retry install + run for the "Dev" flavor on a running x86_64 emulator without rebuilding (targets `adb -e`)
+    cmds:
+      - task: install-maui-android
+        vars: { FLAVOR: 'Dev', EXTRA_ARGS: '-p:RuntimeIdentifiers=android-x64 -p:RuntimeIdentifier=android-x64 -p:AdbTarget=-e' }
 
   build-mini-lcm-sdk:
     desc: Builds the sdk, a zip with the FwLiteWeb server with a project and config to run locally

--- a/backend/FwLite/Taskfile.yml
+++ b/backend/FwLite/Taskfile.yml
@@ -65,17 +65,35 @@ tasks:
 
   run-maui-android:
     dir: ./FwLiteMaui
-    cmd: task build-maui-android -- "-t:InstallAndroidDependencies;Run"
+    vars:
+      FLAVOR: ""
+    cmd: task build-maui-android FLAVOR={{.FLAVOR}} -- "-t:InstallAndroidDependencies;Run"
+
+  run-maui-android-dev:
+    desc: Build & run the "Dev" flavor (installs alongside the prod app)
+    cmds:
+      - task: run-maui-android
+        vars: { FLAVOR: 'Dev' }
 
   build-maui-android:
     deps: [ ui:build-viewer ]
     dir: ./FwLiteMaui
-    cmd: dotnet build -f net10.0-android -t:InstallAndroidDependencies -p:AcceptAndroidSdkLicenses=True {{.CLI_ARGS}} # "-p:AndroidSdkDirectory=D:\tools\android"
+    vars:
+      FLAVOR: ""
+    cmd: dotnet build -f net10.0-android -t:InstallAndroidDependencies -p:AcceptAndroidSdkLicenses=True -p:FwLiteFlavor={{.FLAVOR}} {{.CLI_ARGS}} # "-p:AndroidSdkDirectory=D:\tools\android"
 
   install-maui-android:
     desc: Retry install + run without rebuilding (for when you miss the permission prompt) - uses existing build artifacts
     dir: ./FwLiteMaui
-    cmd: dotnet build -f net10.0-android -t:Install,Run --no-restore --no-dependencies
+    vars:
+      FLAVOR: ""
+    cmd: dotnet build -f net10.0-android -t:Install,Run --no-restore --no-dependencies -p:FwLiteFlavor={{.FLAVOR}}
+
+  install-maui-android-dev:
+    desc: Retry install + run for the "Dev" flavor without rebuilding
+    cmds:
+      - task: install-maui-android
+        vars: { FLAVOR: 'Dev' }
 
   build-mini-lcm-sdk:
     desc: Builds the sdk, a zip with the FwLiteWeb server with a project and config to run locally


### PR DESCRIPTION
Adds a `Dev` Android flavor (`-p:FwLiteFlavor=Dev`) that overrides
ApplicationId / ApplicationTitle so the dev build installs side-by-side
with the prod app, plus four `task` wrappers:

- `android-dev` / `android-install-dev` — run/install the Dev flavor on the default adb target
- `android-emulator-dev` / `android-install-emulator-dev` — same, but pin `RuntimeIdentifier(s)=android-x64` and `AdbTarget=-e` so the build targets the running emulator instead of an attached physical device

Drive-by fix: the parent tasks had `vars: { FLAVOR: "" }` defaults that silently overrode caller-supplied values in go-task 3.x, so `android-dev` / `android-install-dev` were emitting `-p:FwLiteFlavor=` (empty). Removing the empty defaults lets caller vars reach the template.

🤖 Generated with [Claude Code](https://claude.com/claude-code)