### PR TITLE
Persist entry list view mode and dictionary preview pin per project

### DIFF
--- a/frontend/viewer/src/lib/storage/project-storage.svelte.ts
+++ b/frontend/viewer/src/lib/storage/project-storage.svelte.ts
@@ -35,9 +35,13 @@ class ProjectStorageProp extends StorageProp {
 export class ProjectStorage {
   readonly selectedTaskId: ProjectStorageProp;
   readonly currentView: ProjectStorageProp;
+  readonly entryListViewMode: ProjectStorageProp;
+  readonly dictionaryPreview: ProjectStorageProp;
 
   constructor(projectCode: string, backend: IPreferencesService) {
     this.selectedTaskId = new ProjectStorageProp(projectCode, 'selectedTaskId', backend);
     this.currentView = new ProjectStorageProp(projectCode, 'currentView', backend);
+    this.entryListViewMode = new ProjectStorageProp(projectCode, 'entryListViewMode', backend);
+    this.dictionaryPreview = new ProjectStorageProp(projectCode, 'dictionaryPreview', backend);
   }
 }

--- a/frontend/viewer/src/project/browse/BrowseView.svelte
+++ b/frontend/viewer/src/project/browse/BrowseView.svelte
@@ -20,12 +20,11 @@
   import type {EntryListViewMode} from './EntryListViewOptions.svelte';
   import EntryListViewOptions from './EntryListViewOptions.svelte';
   import {useProjectStorage} from '$lib/storage/project-storage.svelte';
-  import {untrack} from 'svelte';
 
   const projectContext = useProjectContext();
   const viewService = useViewService();
   const dialogsService = useDialogsService();
-  const projectStorage = useProjectStorage();
+  const entryListViewMode = useProjectStorage().entryListViewMode;
 
   // DESKTOP: the entry is a sibling of the list (it's a split view). We can switch between selected entries.
   // So, selectedEntryId itself drives navigation.
@@ -40,23 +39,7 @@
   let semanticDomain = $state<ISemanticDomain>();
   let partOfSpeech = $state<IPartOfSpeech>();
   let sort = $state<SortConfig>();
-  let entryMode: EntryListViewMode = $state('simple');
-  let entryModeLoaded = false;
-  $effect(() => {
-    if (untrack(() => !projectStorage.entryListViewMode.loading)) {
-      untrack(() => {
-        const stored = projectStorage.entryListViewMode.current;
-        if (stored === 'preview' || stored === 'simple') entryMode = stored;
-      });
-      entryModeLoaded = true;
-      return;
-    }
-    // eslint-disable-next-line @typescript-eslint/no-unused-expressions
-    projectStorage.entryListViewMode.loading;
-  });
-  $effect(() => {
-    if (entryModeLoaded) void projectStorage.entryListViewMode.set(entryMode);
-  });
+  const entryMode: EntryListViewMode = $derived(entryListViewMode.current === 'preview' ? 'preview' : 'simple');
 
   async function newEntry() {
     const entry = await dialogsService.createNewEntry(undefined, {
@@ -104,7 +87,7 @@
             <div class="my-2 flex items-center justify-between">
               <SortMenu bind:value={sort}
                 autoSelector={() => search ? SortField.SearchRelevance : SortField.Headword} />
-              <EntryListViewOptions bind:entryMode />
+              <EntryListViewOptions bind:entryMode={() => entryMode, (v) => void entryListViewMode.set(v)} />
             </div>
           </div>
           <EntriesList bind:this={entriesList}

--- a/frontend/viewer/src/project/browse/BrowseView.svelte
+++ b/frontend/viewer/src/project/browse/BrowseView.svelte
@@ -20,6 +20,7 @@
   import type {EntryListViewMode} from './EntryListViewOptions.svelte';
   import EntryListViewOptions from './EntryListViewOptions.svelte';
   import {useProjectStorage} from '$lib/storage/project-storage.svelte';
+  import {untrack} from 'svelte';
 
   const projectContext = useProjectContext();
   const viewService = useViewService();
@@ -40,16 +41,21 @@
   let partOfSpeech = $state<IPartOfSpeech>();
   let sort = $state<SortConfig>();
   let entryMode: EntryListViewMode = $state('simple');
-  let entryModeReady = $state(false);
+  let entryModeLoaded = false;
   $effect(() => {
-    if (!entryModeReady && !projectStorage.entryListViewMode.loading) {
-      const stored = projectStorage.entryListViewMode.current;
-      if (stored === 'preview' || stored === 'simple') entryMode = stored;
-      entryModeReady = true;
+    if (untrack(() => !projectStorage.entryListViewMode.loading)) {
+      untrack(() => {
+        const stored = projectStorage.entryListViewMode.current;
+        if (stored === 'preview' || stored === 'simple') entryMode = stored;
+      });
+      entryModeLoaded = true;
+      return;
     }
+    // eslint-disable-next-line @typescript-eslint/no-unused-expressions
+    projectStorage.entryListViewMode.loading;
   });
   $effect(() => {
-    if (entryModeReady) void projectStorage.entryListViewMode.set(entryMode);
+    if (entryModeLoaded) void projectStorage.entryListViewMode.set(entryMode);
   });
 
   async function newEntry() {

--- a/frontend/viewer/src/project/browse/BrowseView.svelte
+++ b/frontend/viewer/src/project/browse/BrowseView.svelte
@@ -19,10 +19,12 @@
   import {useProjectContext} from '$project/project-context.svelte';
   import type {EntryListViewMode} from './EntryListViewOptions.svelte';
   import EntryListViewOptions from './EntryListViewOptions.svelte';
+  import {useProjectStorage} from '$lib/storage/project-storage.svelte';
 
   const projectContext = useProjectContext();
   const viewService = useViewService();
   const dialogsService = useDialogsService();
+  const projectStorage = useProjectStorage();
 
   // DESKTOP: the entry is a sibling of the list (it's a split view). We can switch between selected entries.
   // So, selectedEntryId itself drives navigation.
@@ -38,6 +40,17 @@
   let partOfSpeech = $state<IPartOfSpeech>();
   let sort = $state<SortConfig>();
   let entryMode: EntryListViewMode = $state('simple');
+  let entryModeReady = $state(false);
+  $effect(() => {
+    if (!entryModeReady && !projectStorage.entryListViewMode.loading) {
+      const stored = projectStorage.entryListViewMode.current;
+      if (stored === 'preview' || stored === 'simple') entryMode = stored;
+      entryModeReady = true;
+    }
+  });
+  $effect(() => {
+    if (entryModeReady) void projectStorage.entryListViewMode.set(entryMode);
+  });
 
   async function newEntry() {
     const entry = await dialogsService.createNewEntry(undefined, {

--- a/frontend/viewer/src/project/browse/EntryView.svelte
+++ b/frontend/viewer/src/project/browse/EntryView.svelte
@@ -24,6 +24,7 @@
   import {pt} from '$lib/views/view-text';
   import {useViewService} from '$lib/views/view-service.svelte';
   import {useProjectStorage} from '$lib/storage/project-storage.svelte';
+  import {untrack} from 'svelte';
 
   const writingSystemService = useWritingSystemService();
   const eventBus = useProjectEventBus();
@@ -91,16 +92,21 @@
   const headword = $derived((entry && writingSystemService.headword(entry)) || $t`Untitled`);
   const loadingDebounced = new Debounced(() => entryResource.loading, 50);
   let dictionaryPreview: 'show' | 'hide' | 'sticky' = $state('show');
-  let dictionaryPreviewReady = $state(false);
+  let dictionaryPreviewLoaded = false;
   $effect(() => {
-    if (!dictionaryPreviewReady && !projectStorage.dictionaryPreview.loading) {
-      const stored = projectStorage.dictionaryPreview.current;
-      if (stored === 'show' || stored === 'hide' || stored === 'sticky') dictionaryPreview = stored;
-      dictionaryPreviewReady = true;
+    if (untrack(() => !projectStorage.dictionaryPreview.loading)) {
+      untrack(() => {
+        const stored = projectStorage.dictionaryPreview.current;
+        if (stored === 'show' || stored === 'hide' || stored === 'sticky') dictionaryPreview = stored;
+      });
+      dictionaryPreviewLoaded = true;
+      return;
     }
+    // eslint-disable-next-line @typescript-eslint/no-unused-expressions
+    projectStorage.dictionaryPreview.loading;
   });
   $effect(() => {
-    if (dictionaryPreviewReady) void projectStorage.dictionaryPreview.set(dictionaryPreview);
+    if (dictionaryPreviewLoaded) void projectStorage.dictionaryPreview.set(dictionaryPreview);
   });
   const sticky = $derived.by(() => dictionaryPreview === 'sticky');
 

--- a/frontend/viewer/src/project/browse/EntryView.svelte
+++ b/frontend/viewer/src/project/browse/EntryView.svelte
@@ -95,9 +95,6 @@
   const dictionaryPreview: DictionaryPreviewMode = $derived(
     isDictionaryPreviewMode(dictionaryPreviewStorage.current) ? dictionaryPreviewStorage.current : 'show'
   );
-  function setDictionaryPreview(value: DictionaryPreviewMode): void {
-    void dictionaryPreviewStorage.set(value);
-  }
   function isDictionaryPreviewMode(value: string): value is DictionaryPreviewMode {
     return value === 'show' || value === 'hide' || value === 'sticky';
   }
@@ -119,7 +116,7 @@
   <div class="md:pb-4">
     <DictionaryEntry {entry} showLinks class={cn('rounded bg-muted/80 dark:bg-muted/50 p-4')}>
       {#snippet actions()}
-        <Toggle bind:pressed={() => sticky, (value) => setDictionaryPreview(value ? 'sticky' : 'show')}
+        <Toggle bind:pressed={() => sticky, (value) => void dictionaryPreviewStorage.set(value ? 'sticky' : 'show')}
           aria-label={$t`Toggle pinned`} class="aspect-square" size="sm">
           <Icon icon="i-mdi-pin-outline" class="size-5" />
         </Toggle>
@@ -137,7 +134,7 @@
         {/if}
         <h2 class="ml-4 text-2xl font-semibold mb-2 inline">{headword}</h2>
         <div class="flex">
-          <ViewPicker bind:dictionaryPreview={() => dictionaryPreview, setDictionaryPreview} bind:readonly />
+          <ViewPicker bind:dictionaryPreview={() => dictionaryPreview, (v) => void dictionaryPreviewStorage.set(v)} bind:readonly />
           <EntryMenu {entry} />
         </div>
       </div>

--- a/frontend/viewer/src/project/browse/EntryView.svelte
+++ b/frontend/viewer/src/project/browse/EntryView.svelte
@@ -23,12 +23,14 @@
   import * as Alert from '$lib/components/ui/alert';
   import {pt} from '$lib/views/view-text';
   import {useViewService} from '$lib/views/view-service.svelte';
+  import {useProjectStorage} from '$lib/storage/project-storage.svelte';
 
   const writingSystemService = useWritingSystemService();
   const eventBus = useProjectEventBus();
   const miniLcmApi = useMiniLcmApi();
   const features = useFeatures();
   const viewService = useViewService();
+  const projectStorage = useProjectStorage();
   const {
     entryId,
     onClose,
@@ -89,6 +91,17 @@
   const headword = $derived((entry && writingSystemService.headword(entry)) || $t`Untitled`);
   const loadingDebounced = new Debounced(() => entryResource.loading, 50);
   let dictionaryPreview: 'show' | 'hide' | 'sticky' = $state('show');
+  let dictionaryPreviewReady = $state(false);
+  $effect(() => {
+    if (!dictionaryPreviewReady && !projectStorage.dictionaryPreview.loading) {
+      const stored = projectStorage.dictionaryPreview.current;
+      if (stored === 'show' || stored === 'hide' || stored === 'sticky') dictionaryPreview = stored;
+      dictionaryPreviewReady = true;
+    }
+  });
+  $effect(() => {
+    if (dictionaryPreviewReady) void projectStorage.dictionaryPreview.set(dictionaryPreview);
+  });
   const sticky = $derived.by(() => dictionaryPreview === 'sticky');
 
   let readonly = $state(false);

--- a/frontend/viewer/src/project/browse/EntryView.svelte
+++ b/frontend/viewer/src/project/browse/EntryView.svelte
@@ -24,14 +24,15 @@
   import {pt} from '$lib/views/view-text';
   import {useViewService} from '$lib/views/view-service.svelte';
   import {useProjectStorage} from '$lib/storage/project-storage.svelte';
-  import {untrack} from 'svelte';
+
+  type DictionaryPreviewMode = 'show' | 'hide' | 'sticky';
 
   const writingSystemService = useWritingSystemService();
   const eventBus = useProjectEventBus();
   const miniLcmApi = useMiniLcmApi();
   const features = useFeatures();
   const viewService = useViewService();
-  const projectStorage = useProjectStorage();
+  const dictionaryPreviewStorage = useProjectStorage().dictionaryPreview;
   const {
     entryId,
     onClose,
@@ -91,24 +92,16 @@
   let entry = $derived(entryResource.current ?? undefined);
   const headword = $derived((entry && writingSystemService.headword(entry)) || $t`Untitled`);
   const loadingDebounced = new Debounced(() => entryResource.loading, 50);
-  let dictionaryPreview: 'show' | 'hide' | 'sticky' = $state('show');
-  let dictionaryPreviewLoaded = false;
-  $effect(() => {
-    if (untrack(() => !projectStorage.dictionaryPreview.loading)) {
-      untrack(() => {
-        const stored = projectStorage.dictionaryPreview.current;
-        if (stored === 'show' || stored === 'hide' || stored === 'sticky') dictionaryPreview = stored;
-      });
-      dictionaryPreviewLoaded = true;
-      return;
-    }
-    // eslint-disable-next-line @typescript-eslint/no-unused-expressions
-    projectStorage.dictionaryPreview.loading;
-  });
-  $effect(() => {
-    if (dictionaryPreviewLoaded) void projectStorage.dictionaryPreview.set(dictionaryPreview);
-  });
-  const sticky = $derived.by(() => dictionaryPreview === 'sticky');
+  const dictionaryPreview: DictionaryPreviewMode = $derived(
+    isDictionaryPreviewMode(dictionaryPreviewStorage.current) ? dictionaryPreviewStorage.current : 'show'
+  );
+  function setDictionaryPreview(value: DictionaryPreviewMode): void {
+    void dictionaryPreviewStorage.set(value);
+  }
+  function isDictionaryPreviewMode(value: string): value is DictionaryPreviewMode {
+    return value === 'show' || value === 'hide' || value === 'sticky';
+  }
+  const sticky = $derived(dictionaryPreview === 'sticky');
 
   let readonly = $state(false);
   let deleted = $state(false);
@@ -126,7 +119,7 @@
   <div class="md:pb-4">
     <DictionaryEntry {entry} showLinks class={cn('rounded bg-muted/80 dark:bg-muted/50 p-4')}>
       {#snippet actions()}
-        <Toggle bind:pressed={() => sticky, (value) => dictionaryPreview = value ? 'sticky' : 'show'}
+        <Toggle bind:pressed={() => sticky, (value) => setDictionaryPreview(value ? 'sticky' : 'show')}
           aria-label={$t`Toggle pinned`} class="aspect-square" size="sm">
           <Icon icon="i-mdi-pin-outline" class="size-5" />
         </Toggle>
@@ -144,7 +137,7 @@
         {/if}
         <h2 class="ml-4 text-2xl font-semibold mb-2 inline">{headword}</h2>
         <div class="flex">
-          <ViewPicker bind:dictionaryPreview bind:readonly />
+          <ViewPicker bind:dictionaryPreview={() => dictionaryPreview, setDictionaryPreview} bind:readonly />
           <EntryMenu {entry} />
         </div>
       </div>


### PR DESCRIPTION
## Summary
- Persists the entry list view mode (`simple` / `preview`) per project so it survives reloads.
- Persists the dictionary preview state (`show` / `hide` / `sticky`) per project, including the pin toggle.
- Both use the existing `ProjectStorage` infrastructure (project-scoped localStorage via `IPreferencesService`).

## Implementation
- Added `entryListViewMode` and `dictionaryPreview` props to `ProjectStorage`.
- In `BrowseView.svelte` and `EntryView.svelte`, the preference is read via `$derived` from the storage prop's reactive `current`, with a fallback default and type guard. Writes go through Svelte 5's function-pair `bind:foo={getter, setter}` syntax — no effects or init flags needed.

## Test plan
- [ ] Open a project, switch entry list to Preview, reload — list still in Preview.
- [ ] Pin the dictionary preview, reload — still pinned.
- [ ] Toggle dictionary preview to Hide, reload — still hidden.
- [ ] Verify a different project keeps its own setting independently.

https://claude.ai/code/session_01XwVXy1GdK7kKAbbfhxKTp2

---
_Generated by [Claude Code](https://claude.ai/code/session_01XwVXy1GdK7kKAbbfhxKTp2)_