### PR TITLE
Restore Android system-bar layout after MAUI 10 edge-to-edge

### DIFF
--- a/backend/FwLite/FwLiteMaui/MainPage.xaml
+++ b/backend/FwLite/FwLiteMaui/MainPage.xaml
@@ -3,7 +3,8 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              xmlns:local="clr-namespace:FwLiteMaui"
              xmlns:shared="clr-namespace:FwLiteShared;assembly=FwLiteShared"
-             x:Class="FwLiteMaui.MainPage">
+             x:Class="FwLiteMaui.MainPage"
+             SafeAreaEdges="Container">
     <BlazorWebView x:Name="blazorWebView" HostPage="wwwroot/index.html">
         <BlazorWebView.RootComponents>
             <RootComponent Selector="#app" ComponentType="{x:Type shared:Root}"/>

--- a/backend/FwLite/FwLiteMaui/MainPage.xaml.Android.cs
+++ b/backend/FwLite/FwLiteMaui/MainPage.xaml.Android.cs
@@ -36,11 +36,6 @@ public partial class MainPage
             ? (e.WebView.WebChromeClient ?? new Android.Webkit.WebChromeClient())
             : new Android.Webkit.WebChromeClient();
         e.WebView.SetWebChromeClient(new PermissionManagingBlazorWebChromeClient(baseClient, activity));
-
-        // Edge-to-edge handling: MAUI 10 unconditionally opts the activity into
-        // edge-to-edge on Android, and MainPage's SafeAreaEdges="Container" pads
-        // the BlazorWebView inside the system-bar safe area. MainActivity paints
-        // the surrounding gutter with the brand color (colorPrimaryDark).
     }
 
     private partial void BlazorWebViewOnUrlLoading(object? sender, UrlLoadingEventArgs e)

--- a/backend/FwLite/FwLiteMaui/MainPage.xaml.Android.cs
+++ b/backend/FwLite/FwLiteMaui/MainPage.xaml.Android.cs
@@ -37,12 +37,10 @@ public partial class MainPage
             : new Android.Webkit.WebChromeClient();
         e.WebView.SetWebChromeClient(new PermissionManagingBlazorWebChromeClient(baseClient, activity));
 
-        // Edge-to-edge handling is delegated to MAUI 10's built-in SafeAreaEdges
-        // support on ContentPage (see MainPage.xaml: SafeAreaEdges="Container").
-        // MAUI 10 unconditionally calls WindowCompat.SetDecorFitsSystemWindows(false)
-        // in MauiAppCompatActivity.OnCreate, then pads the ContentViewGroup so the
-        // BlazorWebView lives inside the system-bar safe area. No manual JS-injected
-        // CSS variables needed.
+        // Edge-to-edge handling: MAUI 10 unconditionally opts the activity into
+        // edge-to-edge on Android, and MainPage's SafeAreaEdges="Container" pads
+        // the BlazorWebView inside the system-bar safe area. MainActivity paints
+        // the surrounding gutter with the brand color (colorPrimaryDark).
     }
 
     private partial void BlazorWebViewOnUrlLoading(object? sender, UrlLoadingEventArgs e)

--- a/backend/FwLite/FwLiteMaui/MainPage.xaml.Android.cs
+++ b/backend/FwLite/FwLiteMaui/MainPage.xaml.Android.cs
@@ -36,6 +36,13 @@ public partial class MainPage
             ? (e.WebView.WebChromeClient ?? new Android.Webkit.WebChromeClient())
             : new Android.Webkit.WebChromeClient();
         e.WebView.SetWebChromeClient(new PermissionManagingBlazorWebChromeClient(baseClient, activity));
+
+        // Edge-to-edge handling is delegated to MAUI 10's built-in SafeAreaEdges
+        // support on ContentPage (see MainPage.xaml: SafeAreaEdges="Container").
+        // MAUI 10 unconditionally calls WindowCompat.SetDecorFitsSystemWindows(false)
+        // in MauiAppCompatActivity.OnCreate, then pads the ContentViewGroup so the
+        // BlazorWebView lives inside the system-bar safe area. No manual JS-injected
+        // CSS variables needed.
     }
 
     private partial void BlazorWebViewOnUrlLoading(object? sender, UrlLoadingEventArgs e)

--- a/backend/FwLite/FwLiteMaui/Platforms/Android/MainActivity.cs
+++ b/backend/FwLite/FwLiteMaui/Platforms/Android/MainActivity.cs
@@ -25,15 +25,9 @@ public class MainActivity : MauiAppCompatActivity
     public override void OnConfigurationChanged(Configuration newConfig)
     {
         base.OnConfigurationChanged(newConfig);
-        // MAUI re-decides system-bar icon appearance on config changes, so
-        // re-pin it after the base call.
         ApplyBrandedSystemBars();
     }
 
-    // Paints the system-bar gutter left around the BlazorWebView (by
-    // MainPage's SafeAreaEdges="Container") with the brand color and pins
-    // the icons to light so they stay readable regardless of system theme
-    // or in-app theme overrides.
     private void ApplyBrandedSystemBars()
     {
         if (Window is null) return;

--- a/backend/FwLite/FwLiteMaui/Platforms/Android/MainActivity.cs
+++ b/backend/FwLite/FwLiteMaui/Platforms/Android/MainActivity.cs
@@ -1,7 +1,9 @@
 using Android.App;
 using Android.Content;
 using Android.Content.PM;
+using Android.Content.Res;
 using Android.OS;
+using AndroidX.Core.View;
 using FwLiteShared.Auth;
 using Microsoft.Identity.Client;
 
@@ -16,9 +18,30 @@ public class MainActivity : MauiAppCompatActivity
 {
     protected override void OnCreate(Bundle? savedInstanceState)
     {
-        //custom style, declared in Android/Resources/values/styles.xml, values-v35 is used based on the android version
-        Theme?.ApplyStyle(Resource.Style.OptOutEdgeToEdgeEnforcement, force: false);
         base.OnCreate(savedInstanceState);
+        ApplyBrandedSystemBars();
+    }
+
+    public override void OnConfigurationChanged(Configuration newConfig)
+    {
+        base.OnConfigurationChanged(newConfig);
+        // MAUI re-decides system-bar icon appearance on config changes, so
+        // re-pin it after the base call.
+        ApplyBrandedSystemBars();
+    }
+
+    // Paints the system-bar gutter left around the BlazorWebView (by
+    // MainPage's SafeAreaEdges="Container") with the brand color and pins
+    // the icons to light so they stay readable regardless of system theme
+    // or in-app theme overrides.
+    private void ApplyBrandedSystemBars()
+    {
+        if (Window is null) return;
+        Window.SetBackgroundDrawableResource(Resource.Color.colorPrimaryDark);
+        var controller = WindowCompat.GetInsetsController(Window, Window.DecorView);
+        if (controller is null) return;
+        controller.AppearanceLightStatusBars = false;
+        controller.AppearanceLightNavigationBars = false;
     }
 
     protected override void OnActivityResult(int requestCode, Result resultCode, Intent? data)

--- a/backend/FwLite/FwLiteMaui/Platforms/Android/Resources/values-v35/styles.xml
+++ b/backend/FwLite/FwLiteMaui/Platforms/Android/Resources/values-v35/styles.xml
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="utf-8" ?>
-<resources>
-    <style name="OptOutEdgeToEdgeEnforcement">
-        <item name="android:windowOptOutEdgeToEdgeEnforcement">true</item>
-    </style>
-</resources>

--- a/backend/FwLite/FwLiteMaui/Platforms/Android/Resources/values/styles.xml
+++ b/backend/FwLite/FwLiteMaui/Platforms/Android/Resources/values/styles.xml
@@ -1,5 +1,0 @@
-<?xml version="1.0" encoding="utf-8" ?>
-<resources>
-    <style name="OptOutEdgeToEdgeEnforcement">
-    </style>
-</resources>


### PR DESCRIPTION
TL;DR - Android's `windowOptOutEdgeToEdgeEnforcement` got deprecated. This PR uses the MAUI-provided alternative. A difference now is that we have our "brand navy-blue" in the notches of phones in landscape mode, which feels a bit odd. The pro-fix is in: https://github.com/sillsdev/languageforge-lexbox/pull/2283

Develop has been broken on Android since the .NET 10 / MAUI 10 bump (#2264): `MauiAppCompatActivity.OnCreate` now calls `WindowCompat.SetDecorFitsSystemWindows(false)` unconditionally, the old `windowOptOutEdgeToEdgeEnforcement` style is deprecated on API ≥ 36, and the BlazorWebView drew under the status / nav bars.

This restores the pre-MAUI-10 look:

- `MainPage.xaml` sets `SafeAreaEdges="Container"` (MAUI 10's official replacement for the deprecated opt-out), which pads the BlazorWebView back inside the safe area.
- `MainActivity` paints the surrounding gutter with `colorPrimaryDark` (the existing brand navy) and pins the system-bar icons to light. Re-applied on `OnConfigurationChanged` because MAUI re-decides icon appearance on config changes.
- The deprecated `values-v35/styles.xml` opt-out and the now-empty `values/styles.xml` are deleted.

Visually verified on a Pixel 9 / Android 16 emulator across portrait + landscape, system theme toggle, and the in-app theme override.

Considered and rejected: `try/android-targetsdk-pin` (5-line manifest pin to SDK 35 — doesn't help because MAUI calls `SetDecorFitsSystemWindows(false)` regardless of targetSdk), `try/android-shrink-webview` (Agent 2's ~120-line native-band approach, also works but larger), `fix/android-edge-to-edge` (the embrace-edge-to-edge branch with ~220 lines of CSS / Svelte adjustments). This branch is the smallest of the four that actually fixes the issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)