### PR TITLE
Document Harmony projected tables and soft-delete filtering

### DIFF
--- a/backend/FwLite/AGENTS.md
+++ b/backend/FwLite/AGENTS.md
@@ -240,6 +240,15 @@ if (entity?.DeletedAt is not null) return;
 
 ---
 
+## 🚨 Harmony Projected Tables (`LcmCrdtDbContext`)
+
+`LcmCrdtDbContext` DbSets (`Entries`, `Senses`, etc.) are Harmony's **projected snapshot tables**. They contain only the latest, **un-deleted** state.
+
+- ❌ **Do NOT** add `DeletedAt is null` filters when querying these DbSets — soft-deleted rows are never present. The `DeletedAt` column exists on the entity types (it's used inside Change classes during change application — see above), but the projection drops deleted rows entirely, so filtering on it is dead code that misleads readers.
+- ✅ If you need deleted history, query the change/commit tables directly (see `HistoryService.cs`, `SnapshotAtCommitService.cs`).
+
+---
+
 ## Important Files Quick Reference
 
 | File | Purpose | Risk Level |


### PR DESCRIPTION
## Summary
Added documentation to AGENTS.md clarifying how Harmony's projected snapshot tables work in `LcmCrdtDbContext` and providing guidance on soft-delete filtering patterns.

## Changes
- Added new section "🚨 Harmony Projected Tables (`LcmCrdtDbContext`)" explaining that DbSets like `Entries` and `Senses` contain only the latest, un-deleted state
- Documented that `DeletedAt is null` filters should NOT be added to queries against these DbSets, as soft-deleted rows are never present in the projection
- Clarified that the `DeletedAt` column exists on entity types for use in Change classes during change application, but the projection itself filters out deleted rows
- Provided guidance to query change/commit tables directly when deleted history is needed, with references to relevant services (`HistoryService.cs`, `SnapshotAtCommitService.cs`)

## Implementation Details
This documentation prevents a common anti-pattern where developers might add unnecessary `DeletedAt is null` filters to projected table queries, which would be dead code that misleads future readers about the actual data filtering behavior.

https://claude.ai/code/session_01FdDSZE6KXahr36nWMDsAto