### PR TITLE
Fix Troubleshoot dialog gating on mobile and for broken projects

### DIFF
--- a/backend/FwLite/AGENTS.md
+++ b/backend/FwLite/AGENTS.md
@@ -32,7 +32,7 @@ dotnet build FwLiteMaui/FwLiteMaui.csproj --framework net10.0-windows10.0.19041.
 
 ## Testing on Android (agents)
 
-If you need to verify a change on Android and no emulator is running, **start one yourself** — don't ask. List AVDs with `emulator -list-avds` (try `$ANDROID_HOME/emulator/emulator`, `$LOCALAPPDATA/Android/Sdk/emulator/emulator.exe`, or whatever the local SDK path is). Pick an `fwlite_*` image if one exists, start it in the background with `-no-snapshot-load -no-boot-anim`, wait for `adb -e get-state` to return `device` AND `adb -e shell getprop sys.boot_completed` to return `1`, then `task android-emulator-dev`. A connected physical device is a fine fallback (use `task android-dev`). Drive the UI with `adb -e shell input tap/swipe` and read screencaps with `adb -e exec-out screencap -p > path.png`.
+No emulator running? Start one yourself — don't ask. `emulator -list-avds` (try `$ANDROID_HOME/emulator/`, `$LOCALAPPDATA/Android/Sdk/emulator/`, etc.) → pick an `fwlite_*` image → launch in background with `-no-snapshot-load -no-boot-anim` → wait until `adb -e get-state` is `device` and `sys.boot_completed` is `1` → `task android-emulator-dev`. Physical device fallback: `task android-dev`. Drive UI with `adb -e shell input tap/swipe` + `adb -e exec-out screencap -p > path.png`.
 
 ## Generated Types (TypeScript)
 

--- a/backend/FwLite/AGENTS.md
+++ b/backend/FwLite/AGENTS.md
@@ -30,6 +30,10 @@ dotnet test FwLiteOnly.slnf
 dotnet build FwLiteMaui/FwLiteMaui.csproj --framework net10.0-windows10.0.19041.0
 ```
 
+## Testing on Android (agents)
+
+If you need to verify a change on Android and no emulator is running, **start one yourself** — don't ask. List AVDs with `emulator -list-avds` (try `$ANDROID_HOME/emulator/emulator`, `$LOCALAPPDATA/Android/Sdk/emulator/emulator.exe`, or whatever the local SDK path is). Pick an `fwlite_*` image if one exists, start it in the background with `-no-snapshot-load -no-boot-anim`, wait for `adb -e get-state` to return `device` AND `adb -e shell getprop sys.boot_completed` to return `1`, then `task android-emulator-dev`. A connected physical device is a fine fallback (use `task android-dev`). Drive the UI with `adb -e shell input tap/swipe` and read screencaps with `adb -e exec-out screencap -p > path.png`.
+
 ## Generated Types (TypeScript)
 
 The frontend viewer uses TypeScript types and API interfaces generated from .NET using **Reinforced.Typings**. These are automatically updated when you build the **FwLiteShared** project (or any project that depends on it like `FwLiteMaui` or `FwLiteWeb`).

--- a/backend/FwLite/Taskfile.yml
+++ b/backend/FwLite/Taskfile.yml
@@ -65,7 +65,11 @@ tasks:
 
   run-maui-android:
     dir: ./FwLiteMaui
-    cmd: task build-maui-android FLAVOR={{.FLAVOR}} -- "-t:InstallAndroidDependencies;Run {{.EXTRA_ARGS}}"
+    cmds:
+      - task: build-maui-android
+        vars:
+          FLAVOR: '{{.FLAVOR}}'
+          EXTRA_ARGS: '-t:Run {{.EXTRA_ARGS}}'
 
   run-maui-android-dev:
     desc: Build & run the "Dev" flavor (installs alongside the prod app)
@@ -82,7 +86,8 @@ tasks:
   build-maui-android:
     deps: [ ui:build-viewer ]
     dir: ./FwLiteMaui
-    cmd: dotnet build -f net10.0-android -t:InstallAndroidDependencies -p:AcceptAndroidSdkLicenses=True -p:FwLiteFlavor={{.FLAVOR}} {{.CLI_ARGS}} # "-p:AndroidSdkDirectory=D:\tools\android"
+    # EXTRA_ARGS goes through a Task var so multi-token values stay separate; CLI_ARGS gets re-quoted into a single shell arg.
+    cmd: dotnet build -f net10.0-android -t:InstallAndroidDependencies -p:AcceptAndroidSdkLicenses=True -p:FwLiteFlavor={{.FLAVOR}} {{.EXTRA_ARGS}} {{.CLI_ARGS}}
 
   install-maui-android:
     desc: Retry install + run without rebuilding (for when you miss the permission prompt) - uses existing build artifacts

--- a/frontend/viewer/src/lib/troubleshoot/TroubleshootDialog.svelte
+++ b/frontend/viewer/src/lib/troubleshoot/TroubleshootDialog.svelte
@@ -9,6 +9,7 @@
   import {CopyButton} from '$lib/components/ui/button';
   import ResponsiveDialog from '$lib/components/responsive-dialog/responsive-dialog.svelte';
   import {resource} from 'runed';
+  import {FwLitePlatform} from '$lib/dotnet-types/generated-types/FwLiteShared/FwLitePlatform';
 
   const openQueryParam = new QueryParamStateBool({
     key: 'troubleshootDialogOpen',
@@ -25,6 +26,8 @@
   const config = useFwLiteConfig();
   let projectCode = $state<string>();
   let canShare = resource(() => service, async (s) => await s?.getCanShare());
+  // Mobile platforms keep app data in private storage that no file manager can open.
+  const canOpenDataDirectory = $derived(config.os !== FwLitePlatform.Android && config.os !== FwLitePlatform.iOS);
 
   async function tryOpenDataDirectory() {
     if (!await service?.tryOpenDataDirectory()) {
@@ -67,8 +70,10 @@
           {#await service?.getDataDirectory() then value}
             {value}
           {/await}
-          <Button variant="ghost" icon="i-mdi-folder-search" size="icon-xs" title={$t`Open Data Directory`}
-                  onclick={() => tryOpenDataDirectory()}/>
+          {#if canOpenDataDirectory}
+            <Button variant="ghost" icon="i-mdi-folder-search" size="icon-xs" title={$t`Open Data Directory`}
+                    onclick={() => tryOpenDataDirectory()}/>
+          {/if}
         </InputShell>
       </div>
     {/if}

--- a/frontend/viewer/src/lib/troubleshoot/TroubleshootDialog.svelte
+++ b/frontend/viewer/src/lib/troubleshoot/TroubleshootDialog.svelte
@@ -10,6 +10,7 @@
   import ResponsiveDialog from '$lib/components/responsive-dialog/responsive-dialog.svelte';
   import {resource} from 'runed';
   import {FwLitePlatform} from '$lib/dotnet-types/generated-types/FwLiteShared/FwLitePlatform';
+  import {isDev} from '$lib/layout/DevContent.svelte';
 
   const openQueryParam = new QueryParamStateBool({
     key: 'troubleshootDialogOpen',
@@ -63,7 +64,7 @@
         <span class="font-semibold">{config.os}</span>
       </p>
     </div>
-    {#if service}
+    {#if service && (canOpenDataDirectory || $isDev)}
       <div class="w-full">
         <Label>{$t`Data Directory`}</Label>
         <InputShell class="ps-2 pe-1">

--- a/frontend/viewer/src/project/ProjectSidebar.svelte
+++ b/frontend/viewer/src/project/ProjectSidebar.svelte
@@ -197,7 +197,7 @@
           </Sidebar.MenuButton>
         </Sidebar.MenuItem>
         <Sidebar.MenuItem>
-          <Sidebar.MenuButton onclick={() => troubleshootDialog?.open(projectContext.projectData?.code)}>
+          <Sidebar.MenuButton onclick={() => troubleshootDialog?.open(projectContext.projectCode)}>
             <Icon icon="i-mdi-help-circle" />
             <span>{$t`Troubleshoot`}</span>
           </Sidebar.MenuButton>


### PR DESCRIPTION
The sidebar Troubleshoot button was passing `projectContext.projectData?.code` — undefined until `openCrdtProject()` resolves — so when a project failed to load, opening Troubleshoot gave you a dialog with no project context and the "Share project data file" button hidden. That's exactly the case where you want it. Switched to `projectContext.projectCode`, which is set synchronously from the route.

The "Open Data Directory" button was also showing on Android, where it can't work: app-private storage isn't browsable by any file manager, and `Browser.OpenAsync("file://...")` throws `FileUriExposedException` since Android N. The button now hides on Android/iOS via a client-side `config.os` check (no new JS-interop method needed).

Verified on an Android emulator (API 36, x86_64): from the project sidebar, Troubleshoot shows the Share button; the Data Directory row no longer has the folder-search icon next to the path.

Bundled in: a fix for the `run-maui-android-emulator-dev` Task command, which was double-quoting EXTRA_ARGS so dotnet saw the entire `-t:...;Run -p:... -p:...` blob as one target name. Encountered while testing this PR; the testing was the motivation but the fix is independent of the dialog change.