### PR TITLE
Use dev-{shortSha}[-dirty] in dev builds

### DIFF
--- a/backend/Directory.Build.props
+++ b/backend/Directory.Build.props
@@ -15,4 +15,21 @@
     <Nullable>enable</Nullable>
     <WarningsAsErrors>Nullable</WarningsAsErrors>
   </PropertyGroup>
+  <Target Name="AppendGitShaToDevInformationalVersion"
+          BeforeTargets="GetAssemblyVersion;GenerateAssemblyInfo;CoreCompile"
+          Condition="'$(InformationalVersion)' == 'dev'">
+    <Exec Command="git rev-parse --short=8 HEAD"
+          ConsoleToMSBuild="true"
+          IgnoreExitCode="true"
+          IgnoreStandardErrorWarningFormat="true"
+          StandardOutputImportance="Low"
+          StandardErrorImportance="Low"
+          WorkingDirectory="$(MSBuildThisFileDirectory)">
+      <Output TaskParameter="ConsoleOutput" PropertyName="_GitShortSha" />
+      <Output TaskParameter="ExitCode" PropertyName="_GitShortShaExitCode" />
+    </Exec>
+    <PropertyGroup Condition="'$(_GitShortShaExitCode)' == '0' And '$(_GitShortSha)' != ''">
+      <InformationalVersion>dev-$(_GitShortSha)</InformationalVersion>
+    </PropertyGroup>
+  </Target>
 </Project>

--- a/backend/Directory.Build.props
+++ b/backend/Directory.Build.props
@@ -28,8 +28,20 @@
       <Output TaskParameter="ConsoleOutput" PropertyName="_GitShortSha" />
       <Output TaskParameter="ExitCode" PropertyName="_GitShortShaExitCode" />
     </Exec>
+    <Exec Command="git status --porcelain"
+          ConsoleToMSBuild="true"
+          IgnoreExitCode="true"
+          IgnoreStandardErrorWarningFormat="true"
+          StandardOutputImportance="Low"
+          StandardErrorImportance="Low"
+          WorkingDirectory="$(MSBuildThisFileDirectory)"
+          Condition="'$(_GitShortShaExitCode)' == '0'">
+      <Output TaskParameter="ConsoleOutput" PropertyName="_GitStatus" />
+      <Output TaskParameter="ExitCode" PropertyName="_GitStatusExitCode" />
+    </Exec>
     <PropertyGroup Condition="'$(_GitShortShaExitCode)' == '0' And '$(_GitShortSha)' != ''">
       <InformationalVersion>dev-$(_GitShortSha)</InformationalVersion>
+      <InformationalVersion Condition="'$(_GitStatusExitCode)' == '0' And '$(_GitStatus)' != ''">dev-$(_GitShortSha)-dirty</InformationalVersion>
     </PropertyGroup>
   </Target>
 </Project>

--- a/backend/Directory.Build.props
+++ b/backend/Directory.Build.props
@@ -15,6 +15,7 @@
     <Nullable>enable</Nullable>
     <WarningsAsErrors>Nullable</WarningsAsErrors>
   </PropertyGroup>
+  <!-- Dev only: Add hash and if dirty to InformationalVersion. -->
   <Target Name="AppendGitShaToDevInformationalVersion"
           BeforeTargets="GetAssemblyVersion;GenerateAssemblyInfo;CoreCompile"
           Condition="'$(InformationalVersion)' == 'dev'">


### PR DESCRIPTION
Makes it easier to verify the state of e.g. dev installations on my phone.

The Updates and Troubleshoot UI previously showed just "dev" for local builds.
Append the git short SHA when InformationalVersion hasn't been overridden (e.g. by CI's -p:InformationalVersion=v...) so dev builds are identifiable like prod releases.