### PR TITLE
2 Dictionary Preview style fixes

### DIFF
--- a/frontend/viewer/src/lib/components/ui/radio-group/index.ts
+++ b/frontend/viewer/src/lib/components/ui/radio-group/index.ts
@@ -1,10 +1,13 @@
 import Item from './radio-group-item.svelte';
+import Option from './radio-group-option.svelte';
 import Root from './radio-group.svelte';
 
 export {
   Item,
+  Option,
   //
   Root as RadioGroup,
   Item as RadioGroupItem,
+  Option as RadioGroupOption,
   Root,
 };

--- a/frontend/viewer/src/lib/components/ui/radio-group/radio-group-item.svelte
+++ b/frontend/viewer/src/lib/components/ui/radio-group/radio-group-item.svelte
@@ -34,7 +34,7 @@
 {#if label}
   <Label class={cn('flex items-center gap-4 md:gap-2 max-md:py-3', restProps.disabled || 'cursor-pointer')}>
     {@render control()}
-    <span class="min-w-0 flex-1 text-sm leading-none truncate">{label}</span>
+    <span>{label}</span>
   </Label>
 {:else}
   {@render control()}

--- a/frontend/viewer/src/lib/components/ui/radio-group/radio-group-item.svelte
+++ b/frontend/viewer/src/lib/components/ui/radio-group/radio-group-item.svelte
@@ -1,29 +1,25 @@
 <script lang="ts">
   import {RadioGroup as RadioGroupPrimitive} from 'bits-ui';
   import {Icon} from '../icon';
-  import Label from '../label/label.svelte';
-  import {cn, type WithoutChild} from '$lib/utils.js';
+  import {cn} from '$lib/utils.js';
 
-  let {ref = $bindable(null), class: className, children, ...restProps}: WithoutChild<RadioGroupPrimitive.ItemProps> = $props();
+  let {ref = $bindable(null), class: className, ...restProps}: RadioGroupPrimitive.ItemProps = $props();
 </script>
 
-<Label class={cn('flex items-center gap-4 md:gap-2 max-md:py-3', restProps.disabled || 'cursor-pointer')}>
-  <RadioGroupPrimitive.Item
-    bind:ref
-    data-slot="radio-group-item"
-    class={cn(
-      'border-input text-primary focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:bg-input/30 aspect-square size-4 shrink-0 rounded-full border shadow-xs transition-[color,box-shadow] outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50',
-      className,
-    )}
-    {...restProps}
-  >
-    {#snippet children({checked})}
-      <div data-slot="radio-group-indicator" class="relative flex items-center justify-center">
-        {#if checked}
-          <Icon icon="i-mdi-circle" class="size-2.5 fill-current text-current" />
-        {/if}
-      </div>
-    {/snippet}
-  </RadioGroupPrimitive.Item>
-  {@render children?.()}
-</Label>
+<RadioGroupPrimitive.Item
+  bind:ref
+  data-slot="radio-group-item"
+  class={cn(
+    'border-input text-primary focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:bg-input/30 aspect-square size-4 shrink-0 rounded-full border shadow-xs transition-[color,box-shadow] outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50',
+    className,
+  )}
+  {...restProps}
+>
+  {#snippet children({checked})}
+    <div data-slot="radio-group-indicator" class="relative flex items-center justify-center">
+      {#if checked}
+        <Icon icon="i-mdi-circle" class="size-2.5 fill-current text-current" />
+      {/if}
+    </div>
+  {/snippet}
+</RadioGroupPrimitive.Item>

--- a/frontend/viewer/src/lib/components/ui/radio-group/radio-group-item.svelte
+++ b/frontend/viewer/src/lib/components/ui/radio-group/radio-group-item.svelte
@@ -1,9 +1,13 @@
 <script lang="ts">
   import {RadioGroup as RadioGroupPrimitive} from 'bits-ui';
   import {Icon} from '../icon';
-  import {cn} from '$lib/utils.js';
+  import {cn, type WithoutChildrenOrChild} from '$lib/utils.js';
 
-  let {ref = $bindable(null), class: className, ...restProps}: RadioGroupPrimitive.ItemProps = $props();
+  let {
+    ref = $bindable(null),
+    class: className,
+    ...restProps
+  }: WithoutChildrenOrChild<RadioGroupPrimitive.ItemProps> = $props();
 </script>
 
 <RadioGroupPrimitive.Item

--- a/frontend/viewer/src/lib/components/ui/radio-group/radio-group-item.svelte
+++ b/frontend/viewer/src/lib/components/ui/radio-group/radio-group-item.svelte
@@ -34,7 +34,7 @@
 {#if label}
   <Label class={cn('flex items-center gap-4 md:gap-2 max-md:py-3', restProps.disabled || 'cursor-pointer')}>
     {@render control()}
-    <span class="min-w-0 flex-1 text-sm truncate">{label}</span>
+    <span class="min-w-0 flex-1 text-sm leading-none truncate">{label}</span>
   </Label>
 {:else}
   {@render control()}

--- a/frontend/viewer/src/lib/components/ui/radio-group/radio-group-item.svelte
+++ b/frontend/viewer/src/lib/components/ui/radio-group/radio-group-item.svelte
@@ -2,16 +2,12 @@
   import {RadioGroup as RadioGroupPrimitive} from 'bits-ui';
   import {Icon} from '../icon';
   import Label from '../label/label.svelte';
-  import {cn, type WithoutChildrenOrChild} from '$lib/utils.js';
+  import {cn, type WithoutChild} from '$lib/utils.js';
 
-  type Props = {
-    label?: string;
-  } & WithoutChildrenOrChild<RadioGroupPrimitive.ItemProps>;
-
-  let {ref = $bindable(null), class: className, label, ...restProps}: Props = $props();
+  let {ref = $bindable(null), class: className, children, ...restProps}: WithoutChild<RadioGroupPrimitive.ItemProps> = $props();
 </script>
 
-{#snippet control()}
+<Label class={cn('flex items-center gap-4 md:gap-2 max-md:py-3', restProps.disabled || 'cursor-pointer')}>
   <RadioGroupPrimitive.Item
     bind:ref
     data-slot="radio-group-item"
@@ -29,13 +25,5 @@
       </div>
     {/snippet}
   </RadioGroupPrimitive.Item>
-{/snippet}
-
-{#if label}
-  <Label class={cn('flex items-center gap-4 md:gap-2 max-md:py-3', restProps.disabled || 'cursor-pointer')}>
-    {@render control()}
-    <span>{label}</span>
-  </Label>
-{:else}
-  {@render control()}
-{/if}
+  {@render children?.()}
+</Label>

--- a/frontend/viewer/src/lib/components/ui/radio-group/radio-group-option.svelte
+++ b/frontend/viewer/src/lib/components/ui/radio-group/radio-group-option.svelte
@@ -1,0 +1,13 @@
+<script lang="ts">
+  import {RadioGroup as RadioGroupPrimitive} from 'bits-ui';
+  import Label from '../label/label.svelte';
+  import Item from './radio-group-item.svelte';
+  import {cn} from '$lib/utils.js';
+
+  let {ref = $bindable(null), class: className, children, ...restProps}: RadioGroupPrimitive.ItemProps = $props();
+</script>
+
+<Label class={cn('flex items-center gap-4 md:gap-2 max-md:py-3', restProps.disabled || 'cursor-pointer')}>
+  <Item bind:ref {...restProps} />
+  {@render children?.()}
+</Label>

--- a/frontend/viewer/src/lib/components/ui/radio-group/radio-group-option.svelte
+++ b/frontend/viewer/src/lib/components/ui/radio-group/radio-group-option.svelte
@@ -1,10 +1,15 @@
 <script lang="ts">
-  import {RadioGroup as RadioGroupPrimitive} from 'bits-ui';
+  import {type RadioGroup as RadioGroupPrimitive} from 'bits-ui';
   import Label from '../label/label.svelte';
   import Item from './radio-group-item.svelte';
-  import {cn} from '$lib/utils.js';
+  import {cn, type WithoutChildrenOrChild} from '$lib/utils.js';
+  import {type Snippet} from 'svelte';
 
-  let {ref = $bindable(null), class: className, children, ...restProps}: RadioGroupPrimitive.ItemProps = $props();
+  type Props = WithoutChildrenOrChild<RadioGroupPrimitive.ItemProps> & {
+    children?: Snippet;
+  };
+
+  let {ref = $bindable(null), class: className, children, ...restProps}: Props = $props();
 </script>
 
 <Label class={cn('flex items-center gap-4 md:gap-2 max-md:py-3', restProps.disabled || 'cursor-pointer')}>

--- a/frontend/viewer/src/lib/components/ui/radio-group/radio-group-option.svelte
+++ b/frontend/viewer/src/lib/components/ui/radio-group/radio-group-option.svelte
@@ -9,5 +9,5 @@
 
 <Label class={cn('flex items-center gap-4 md:gap-2 max-md:py-3', restProps.disabled || 'cursor-pointer')}>
   <Item bind:ref {...restProps} />
-  {@render children?.()}
+  <span>{@render children?.()}</span>
 </Label>

--- a/frontend/viewer/src/lib/components/ui/radio-group/radio-group-option.svelte
+++ b/frontend/viewer/src/lib/components/ui/radio-group/radio-group-option.svelte
@@ -12,7 +12,7 @@
   let {ref = $bindable(null), class: className, children, ...restProps}: Props = $props();
 </script>
 
-<Label class={cn('flex items-center gap-4 md:gap-2 max-md:py-3', restProps.disabled || 'cursor-pointer')}>
+<Label class={cn('flex items-center gap-4 md:gap-2 max-md:py-3', restProps.disabled || 'cursor-pointer', className)}>
   <Item bind:ref {...restProps} />
   {@render children?.()}
 </Label>

--- a/frontend/viewer/src/lib/components/ui/radio-group/radio-group-option.svelte
+++ b/frontend/viewer/src/lib/components/ui/radio-group/radio-group-option.svelte
@@ -9,5 +9,5 @@
 
 <Label class={cn('flex items-center gap-4 md:gap-2 max-md:py-3', restProps.disabled || 'cursor-pointer')}>
   <Item bind:ref {...restProps} />
-  <span>{@render children?.()}</span>
+  {@render children?.()}
 </Label>

--- a/frontend/viewer/src/lib/views/custom/CustomViewForm.svelte
+++ b/frontend/viewer/src/lib/views/custom/CustomViewForm.svelte
@@ -92,8 +92,8 @@
     <div class="flex flex-col gap-2">
       <div class="text-sm font-medium">{$t`Based on`}</div>
       <RadioGroup.Root bind:value={value.base}>
-        <RadioGroup.Item value={ViewBase.FwLite}>{FW_LITE_VIEW.name}</RadioGroup.Item>
-        <RadioGroup.Item value={ViewBase.FieldWorks}>{FW_CLASSIC_VIEW.name}</RadioGroup.Item>
+        <RadioGroup.Option value={ViewBase.FwLite}>{FW_LITE_VIEW.name}</RadioGroup.Option>
+        <RadioGroup.Option value={ViewBase.FieldWorks}>{FW_CLASSIC_VIEW.name}</RadioGroup.Option>
       </RadioGroup.Root>
     </div>
 

--- a/frontend/viewer/src/lib/views/custom/CustomViewForm.svelte
+++ b/frontend/viewer/src/lib/views/custom/CustomViewForm.svelte
@@ -92,8 +92,8 @@
     <div class="flex flex-col gap-2">
       <div class="text-sm font-medium">{$t`Based on`}</div>
       <RadioGroup.Root bind:value={value.base}>
-        <RadioGroup.Item value={ViewBase.FwLite} label={FW_LITE_VIEW.name} />
-        <RadioGroup.Item value={ViewBase.FieldWorks} label={FW_CLASSIC_VIEW.name} />
+        <RadioGroup.Item value={ViewBase.FwLite}>{FW_LITE_VIEW.name}</RadioGroup.Item>
+        <RadioGroup.Item value={ViewBase.FieldWorks}>{FW_CLASSIC_VIEW.name}</RadioGroup.Item>
       </RadioGroup.Root>
     </div>
 

--- a/frontend/viewer/src/lib/views/custom/CustomViewWritingSystems.svelte
+++ b/frontend/viewer/src/lib/views/custom/CustomViewWritingSystems.svelte
@@ -63,8 +63,8 @@
     {/if}
   </div>
   <RadioGroup.Root value={isAllMode ? 'all' : 'custom'} onValueChange={handleModeChange}>
-    <RadioGroup.Item value="all">{$t`All`}</RadioGroup.Item>
-    <RadioGroup.Item value="custom">{$t`Custom`}</RadioGroup.Item>
+    <RadioGroup.Option value="all">{$t`All`}</RadioGroup.Option>
+    <RadioGroup.Option value="custom">{$t`Custom`}</RadioGroup.Option>
   </RadioGroup.Root>
 
   <Checkbox.Group class="md:mt-4 ms-2">

--- a/frontend/viewer/src/lib/views/custom/CustomViewWritingSystems.svelte
+++ b/frontend/viewer/src/lib/views/custom/CustomViewWritingSystems.svelte
@@ -63,8 +63,8 @@
     {/if}
   </div>
   <RadioGroup.Root value={isAllMode ? 'all' : 'custom'} onValueChange={handleModeChange}>
-    <RadioGroup.Item value="all" label={$t`All`} />
-    <RadioGroup.Item value="custom" label={$t`Custom`} />
+    <RadioGroup.Item value="all">{$t`All`}</RadioGroup.Item>
+    <RadioGroup.Item value="custom">{$t`Custom`}</RadioGroup.Item>
   </RadioGroup.Root>
 
   <Checkbox.Group class="md:mt-4 ms-2">

--- a/frontend/viewer/src/project/browse/EditorViewOptions.svelte
+++ b/frontend/viewer/src/project/browse/EditorViewOptions.svelte
@@ -23,9 +23,9 @@
   <div class="space-y-2 md:space-y-4">
     <h3 class="font-normal max-md:mb-1">{$t`Dictionary Preview`}</h3>
     <RadioGroup.Root bind:value={dictionaryPreview}>
-      <RadioGroup.Item value="show">{$t`Show`}</RadioGroup.Item>
-      <RadioGroup.Item value="hide">{$t`Hide`}</RadioGroup.Item>
-      <RadioGroup.Item value="sticky">{$t`Pinned`}</RadioGroup.Item>
+      <RadioGroup.Option value="show">{$t`Show`}</RadioGroup.Option>
+      <RadioGroup.Option value="hide">{$t`Hide`}</RadioGroup.Option>
+      <RadioGroup.Option value="sticky">{$t`Pinned`}</RadioGroup.Option>
     </RadioGroup.Root>
     <ViewPicker onClose={() => open = false} />
     <DevContent>

--- a/frontend/viewer/src/project/browse/EditorViewOptions.svelte
+++ b/frontend/viewer/src/project/browse/EditorViewOptions.svelte
@@ -23,9 +23,9 @@
   <div class="space-y-2 md:space-y-4">
     <h3 class="font-normal max-md:mb-1">{$t`Dictionary Preview`}</h3>
     <RadioGroup.Root bind:value={dictionaryPreview}>
-      <RadioGroup.Item value="show" label={$t`Show`} />
-      <RadioGroup.Item value="hide" label={$t`Hide`}/>
-      <RadioGroup.Item value="sticky" label={$t`Pinned`}/>
+      <RadioGroup.Item value="show">{$t`Show`}</RadioGroup.Item>
+      <RadioGroup.Item value="hide">{$t`Hide`}</RadioGroup.Item>
+      <RadioGroup.Item value="sticky">{$t`Pinned`}</RadioGroup.Item>
     </RadioGroup.Root>
     <ViewPicker onClose={() => open = false} />
     <DevContent>

--- a/frontend/viewer/src/project/browse/EditorViewOptions.svelte
+++ b/frontend/viewer/src/project/browse/EditorViewOptions.svelte
@@ -21,8 +21,8 @@
     <Button {...props} size="icon" variant="ghost" icon="i-mdi-layers" />
   {/snippet}
   <div class="space-y-2 md:space-y-4">
+    <h3 class="font-normal max-md:mb-1">{$t`Dictionary Preview`}</h3>
     <RadioGroup.Root bind:value={dictionaryPreview}>
-      <h3 class="font-normal max-md:mb-1">{$t`Dictionary Preview`}</h3>
       <RadioGroup.Item value="show" label={$t`Show`} />
       <RadioGroup.Item value="hide" label={$t`Hide`}/>
       <RadioGroup.Item value="sticky" label={$t`Pinned`}/>

--- a/frontend/viewer/src/project/browse/EntryView.svelte
+++ b/frontend/viewer/src/project/browse/EntryView.svelte
@@ -168,7 +168,7 @@
           {@render preview(entry)}
         </div>
       {/if}
-      <div class="max-md:p-2 md:pb-2 md:px-2">
+      <div class={cn('max-md:p-2 md:pb-2 md:px-2', dictionaryPreview !== 'show' && 'md:pt-1')}>
         {#key entry.id}
           <EntryEditor
             bind:this={editor}

--- a/frontend/viewer/src/project/browse/EntryView.svelte
+++ b/frontend/viewer/src/project/browse/EntryView.svelte
@@ -113,22 +113,20 @@
 </script>
 
 {#snippet preview(entry: IEntry)}
-  <div class="md:pb-4">
-    <DictionaryEntry {entry} showLinks class={cn('rounded bg-muted/80 dark:bg-muted/50 p-4')}>
-      {#snippet actions()}
-        <Toggle bind:pressed={() => sticky, (value) => void dictionaryPreviewStorage.set(value ? 'sticky' : 'show')}
-          aria-label={$t`Toggle pinned`} class="aspect-square" size="sm">
-          <Icon icon="i-mdi-pin-outline" class="size-5" />
-        </Toggle>
-      {/snippet}
-    </DictionaryEntry>
-  </div>
+  <DictionaryEntry {entry} showLinks class={cn('rounded bg-muted/80 dark:bg-muted/50 p-4')}>
+    {#snippet actions()}
+      <Toggle bind:pressed={() => sticky, (value) => void dictionaryPreviewStorage.set(value ? 'sticky' : 'show')}
+        aria-label={$t`Toggle pinned`} class="aspect-square" size="sm">
+        <Icon icon="i-mdi-pin-outline" class="size-5" />
+      </Toggle>
+    {/snippet}
+  </DictionaryEntry>
 {/snippet}
 
 <div class="h-full flex flex-col relative">
   {#if entry}
     <header>
-      <div class={cn('max-md:p-2 flex justify-between', dictionaryPreview === 'show' ? 'md:mb-4' : 'md:mb-3')}>
+      <div class="max-md:p-2 md:mb-4 flex justify-between">
         {#if showClose && onClose}
           <XButton onclick={onClose} size="icon" />
         {/if}
@@ -157,14 +155,14 @@
         </div>
       {/if}
       {#if dictionaryPreview === 'sticky'}
-        <div class="md:px-2">
+        <div class="md:px-2 md:pb-3">
           {@render preview(entry)}
         </div>
       {/if}
     </header>
     <ScrollArea bind:viewportRef={entryScrollViewportRef} class={cn('grow md:pr-2')}>
       {#if dictionaryPreview === 'show'}
-        <div class="md:pl-2">
+        <div class="md:pl-2 md:pb-4">
           {@render preview(entry)}
         </div>
       {/if}

--- a/frontend/viewer/src/project/browse/EntryView.svelte
+++ b/frontend/viewer/src/project/browse/EntryView.svelte
@@ -113,14 +113,16 @@
 </script>
 
 {#snippet preview(entry: IEntry)}
-  <DictionaryEntry {entry} showLinks class={cn('rounded bg-muted/80 dark:bg-muted/50 p-4')}>
-    {#snippet actions()}
-      <Toggle bind:pressed={() => sticky, (value) => void dictionaryPreviewStorage.set(value ? 'sticky' : 'show')}
-        aria-label={$t`Toggle pinned`} class="aspect-square" size="sm">
-        <Icon icon="i-mdi-pin-outline" class="size-5" />
-      </Toggle>
-    {/snippet}
-  </DictionaryEntry>
+  <div class="md:pb-3">
+    <DictionaryEntry {entry} showLinks class={cn('rounded bg-muted/80 dark:bg-muted/50 p-4')}>
+      {#snippet actions()}
+        <Toggle bind:pressed={() => sticky, (value) => void dictionaryPreviewStorage.set(value ? 'sticky' : 'show')}
+          aria-label={$t`Toggle pinned`} class="aspect-square" size="sm">
+          <Icon icon="i-mdi-pin-outline" class="size-5" />
+        </Toggle>
+      {/snippet}
+    </DictionaryEntry>
+  </div>
 {/snippet}
 
 <div class="h-full flex flex-col relative">
@@ -155,18 +157,18 @@
         </div>
       {/if}
       {#if dictionaryPreview === 'sticky'}
-        <div class="md:px-2 md:pb-3">
+        <div class="md:px-2">
           {@render preview(entry)}
         </div>
       {/if}
     </header>
     <ScrollArea bind:viewportRef={entryScrollViewportRef} class={cn('grow md:pr-2')}>
       {#if dictionaryPreview === 'show'}
-        <div class="md:pl-2 md:pb-4">
+        <div class="md:pl-2">
           {@render preview(entry)}
         </div>
       {/if}
-      <div class={cn('max-md:p-2 md:pb-2 md:px-2', dictionaryPreview !== 'show' && 'md:pt-1')}>
+      <div class="max-md:p-2 md:pt-1 md:pb-2 md:px-2">
         {#key entry.id}
           <EntryEditor
             bind:this={editor}

--- a/frontend/viewer/src/project/browse/EntryView.svelte
+++ b/frontend/viewer/src/project/browse/EntryView.svelte
@@ -128,7 +128,7 @@
 <div class="h-full flex flex-col relative">
   {#if entry}
     <header>
-      <div class="max-md:p-2 md:mb-4 flex justify-between">
+      <div class={cn('max-md:p-2 flex justify-between', dictionaryPreview === 'show' ? 'md:mb-4' : 'md:mb-3')}>
         {#if showClose && onClose}
           <XButton onclick={onClose} size="icon" />
         {/if}

--- a/frontend/viewer/src/project/browse/ViewPicker.svelte
+++ b/frontend/viewer/src/project/browse/ViewPicker.svelte
@@ -7,7 +7,6 @@
   import ManageCustomViewsButton from '$lib/views/custom/ManageCustomViewsButton.svelte';
   import Markdown from 'svelte-exmarkdown';
   import {t} from 'svelte-i18n-lingui';
-  import {Label} from '$lib/components/ui/label';
   import {isCustomView} from '$lib/views/view-data';
   import {ViewBase} from '$lib/dotnet-types';
 
@@ -50,15 +49,12 @@
 
 <RadioGroup.Root bind:value={getCurrentView, setCurrentView}>
   {#each viewService.views as view (view.id)}
-    <Label class="flex items-center gap-4 md:gap-2 max-md:py-3 cursor-pointer">
-      <RadioGroup.Item value={view.id} />
-      <span>
-        {view.name}
-        {#if isCustomView(view)}
-          <span class="text-muted-foreground">({view.base === ViewBase.FieldWorks ? 'Classic' : 'Lite'})</span>
-        {/if}
-      </span>
-    </Label>
+    <RadioGroup.Item value={view.id}>
+      {view.name}
+      {#if isCustomView(view)}
+        <span class="text-muted-foreground">({view.base === ViewBase.FieldWorks ? 'Classic' : 'Lite'})</span>
+      {/if}
+    </RadioGroup.Item>
   {/each}
 </RadioGroup.Root>
 

--- a/frontend/viewer/src/project/browse/ViewPicker.svelte
+++ b/frontend/viewer/src/project/browse/ViewPicker.svelte
@@ -49,12 +49,12 @@
 
 <RadioGroup.Root bind:value={getCurrentView, setCurrentView}>
   {#each viewService.views as view (view.id)}
-    <RadioGroup.Item value={view.id}>
+    <RadioGroup.Option value={view.id}>
       {view.name}
       {#if isCustomView(view)}
         <span class="text-muted-foreground">({view.base === ViewBase.FieldWorks ? 'Classic' : 'Lite'})</span>
       {/if}
-    </RadioGroup.Item>
+    </RadioGroup.Option>
   {/each}
 </RadioGroup.Root>
 

--- a/frontend/viewer/src/project/browse/ViewPicker.svelte
+++ b/frontend/viewer/src/project/browse/ViewPicker.svelte
@@ -50,10 +50,12 @@
 <RadioGroup.Root bind:value={getCurrentView, setCurrentView}>
   {#each viewService.views as view (view.id)}
     <RadioGroup.Option value={view.id}>
-      {view.name}
-      {#if isCustomView(view)}
-        <span class="text-muted-foreground">({view.base === ViewBase.FieldWorks ? 'Classic' : 'Lite'})</span>
-      {/if}
+      <span>
+        {view.name}
+        {#if isCustomView(view)}
+          <span class="text-muted-foreground">({view.base === ViewBase.FieldWorks ? 'Classic' : 'Lite'})</span>
+        {/if}
+      </span>
     </RadioGroup.Option>
   {/each}
 </RadioGroup.Root>


### PR DESCRIPTION
1) Adjust margins/paddings so that the focus-ring on the first/top text field is not clipped when the dictionary preview is hidden or pinned (or shown, but that already worked)
2) The dictionary preview radio-button list did not have our standard sizing. That's largely, because I made the radio-button-item "label aware" at one point, but not in a way that was easy for all consumers to use (i.e. as a strong prop). Instead of making the component **more** different than the base shadcn component, I introduced a sibling component that take the label as the default snippet. Now all radio-buttons lists should share same layout code/css.

Before: (outline is clipped)
<img width="1091" height="296" alt="image" src="https://github.com/user-attachments/assets/47a794bd-352f-49b4-8235-146c51aa30db" />

After:
<img width="1094" height="276" alt="image" src="https://github.com/user-attachments/assets/815f6b32-8528-4442-969d-251a52e9bb8c" />

Before: (inconsistent radio-button lists)
<img width="339" height="433" alt="image" src="https://github.com/user-attachments/assets/deadaed4-40f8-4447-8fd3-95ba2a8c77d0" />

After:
<img width="373" height="399" alt="image" src="https://github.com/user-attachments/assets/c5542665-ad2a-4141-b0ed-f5c49636d43d" />