### PR TITLE
Fix "Last sync" relative time appearing in the future (#2150)

### DIFF
--- a/frontend/viewer/src/lib/components/ui/format/format-relative-date.svelte
+++ b/frontend/viewer/src/lib/components/ui/format/format-relative-date.svelte
@@ -40,7 +40,9 @@
   // so if "date" changes, "now" should be refreshed
   watch(
     () => date,
-    () => now.setTime(Date.now()),
+    () => {
+      now.setTime(Date.now());
+    },
   );
 
   $effect(() => {

--- a/frontend/viewer/src/lib/components/ui/format/format-relative-date.svelte
+++ b/frontend/viewer/src/lib/components/ui/format/format-relative-date.svelte
@@ -36,6 +36,8 @@
   const now = new SvelteDate();
   let intervalId: ReturnType<typeof setInterval> | undefined;
 
+  // "now" represents when we first saw the current "date"
+  // so if "date" changes, "now" should be refreshed
   watch(
     () => date,
     () => now.setTime(Date.now()),

--- a/frontend/viewer/src/lib/components/ui/format/format-relative-date.svelte
+++ b/frontend/viewer/src/lib/components/ui/format/format-relative-date.svelte
@@ -6,6 +6,7 @@
   import Icon from '../icon/icon.svelte';
   import * as Popover from '../popover';
   import type {SmallestUnit} from './format-duration';
+  import {watch} from 'runed';
 
   type Props = HTMLAttributes<HTMLTimeElement> & {
     date: Date | string | undefined | null;
@@ -35,12 +36,10 @@
   const now = new SvelteDate();
   let intervalId: ReturnType<typeof setInterval> | undefined;
 
-  $effect(() => {
-    // Re-sync `now` when the target date changes so a freshly updated date
-    // (e.g. just after a sync completes) can never compute as being in the future.
-    void date;
-    now.setTime(Date.now());
-  });
+  watch(
+    () => date,
+    () => now.setTime(Date.now()),
+  );
 
   $effect(() => {
     if (live) {

--- a/frontend/viewer/src/lib/components/ui/format/format-relative-date.svelte
+++ b/frontend/viewer/src/lib/components/ui/format/format-relative-date.svelte
@@ -36,6 +36,13 @@
   let intervalId: ReturnType<typeof setInterval> | undefined;
 
   $effect(() => {
+    // Re-sync `now` when the target date changes so a freshly updated date
+    // (e.g. just after a sync completes) can never compute as being in the future.
+    void date;
+    now.setTime(Date.now());
+  });
+
+  $effect(() => {
     if (live) {
       intervalId = setInterval(
         () => {

--- a/frontend/viewer/src/project/sync/SyncStatusPrimitive.svelte
+++ b/frontend/viewer/src/project/sync/SyncStatusPrimitive.svelte
@@ -80,7 +80,7 @@
           {#if !lastLocalSyncDate}
             <span>{$t`Never`}</span>
           {:else}
-            <FormatRelativeDate date={lastLocalSyncDate} showActualDate live={15000} />
+            <FormatRelativeDate date={lastLocalSyncDate} showActualDate live />
           {/if}
         </T>
       </span>

--- a/frontend/viewer/src/project/sync/SyncStatusPrimitive.svelte
+++ b/frontend/viewer/src/project/sync/SyncStatusPrimitive.svelte
@@ -80,7 +80,7 @@
           {#if !lastLocalSyncDate}
             <span>{$t`Never`}</span>
           {:else}
-            <FormatRelativeDate date={lastLocalSyncDate} showActualDate />
+            <FormatRelativeDate date={lastLocalSyncDate} showActualDate live={15000} />
           {/if}
         </T>
       </span>


### PR DESCRIPTION
Resolves #2150

- SyncStatusPrimitive: enable `live` on the Last-sync display so the relative time refreshes while the dialog is open.
- FormatRelativeDate: also resync `now` whenever the input `date` changes