### PR TITLE
Silence FwLite update-available toast in MAUI dev builds

### DIFF
--- a/backend/FwLite/FwLiteMaui/FwLiteMauiKernel.cs
+++ b/backend/FwLite/FwLiteMaui/FwLiteMauiKernel.cs
@@ -92,7 +92,7 @@ public static class FwLiteMauiKernel
             {
                 config.Os = FwLitePlatform.Other;
             }
-            // MAUI doesn't support appsettings.{Environment}.json — gate dev-only settings in code instead.
+            // MAUI doesn't support appsettings.json — gate dev-only settings in code instead.
             // See https://github.com/dotnet/maui/issues/4408
             if (env.IsDevelopment())
             {

--- a/backend/FwLite/FwLiteMaui/FwLiteMauiKernel.cs
+++ b/backend/FwLite/FwLiteMaui/FwLiteMauiKernel.cs
@@ -19,7 +19,9 @@ public static class FwLiteMauiKernel
         ILoggingBuilder logging)
     {
         services.AddTransient<MainPage>();
-        configuration.AddJsonFile("appsettings.json", optional: true);
+        // MAUI has no built-in appsettings.json loading like ASP.NET Core, so this is a no-op today.
+        // See https://github.com/dotnet/maui/issues/4408
+        //configuration.AddJsonFile("appsettings.json", optional: true);
 
         string environment = "Production";
 #if DEBUG
@@ -90,6 +92,8 @@ public static class FwLiteMauiKernel
             {
                 config.Os = FwLitePlatform.Other;
             }
+            // MAUI doesn't support appsettings.{Environment}.json — gate dev-only settings in code instead.
+            // See https://github.com/dotnet/maui/issues/4408
             if (env.IsDevelopment())
             {
                 config.UpdateCheckCondition = UpdateCheckCondition.Never;

--- a/backend/FwLite/FwLiteMaui/FwLiteMauiKernel.cs
+++ b/backend/FwLite/FwLiteMaui/FwLiteMauiKernel.cs
@@ -90,6 +90,10 @@ public static class FwLiteMauiKernel
             {
                 config.Os = FwLitePlatform.Other;
             }
+            if (env.IsDevelopment())
+            {
+                config.UpdateCheckCondition = UpdateCheckCondition.Never;
+            }
         });
 
 


### PR DESCRIPTION
Mirrors the FwLiteWeb appsettings.Development.json behavior so local debug builds of FwLiteMaui (including Android) don't show the "new version available" notification on every launch.