### PR TITLE
Fix three small bugs surfaced from log triage

### DIFF
--- a/backend/FwLite/FwDataMiniLcmBridge/Api/FwDataMiniLcmApi.cs
+++ b/backend/FwLite/FwDataMiniLcmBridge/Api/FwDataMiniLcmApi.cs
@@ -33,7 +33,18 @@ public class FwDataMiniLcmApi(
 {
     private FwDataBridgeConfig Config => config.Value;
     public const string AudioVisualFolder = "AudioVisual";
-    public LcmCache Cache => cacheLazy.Value;
+    public LcmCache Cache
+    {
+        get
+        {
+            var cache = cacheLazy.Value;
+            // Guard against use-after-dispose (e.g. "Open in FieldWorks" closed the cache mid-request).
+            if (cache.IsDisposed)
+                throw new ObjectDisposedException(nameof(LcmCache),
+                    $"FwData project '{Project.FileName}' was closed during this request (likely opened in FieldWorks or evicted from cache).");
+            return cache;
+        }
+    }
     public FwDataProject Project { get; } = project;
     public Guid ProjectId => Cache.LangProject.Guid;
 
@@ -66,7 +77,7 @@ public class FwDataMiniLcmApi(
 
     public void Save()
     {
-        if (Cache.IsDisposed) return;
+        if (cacheLazy.Value.IsDisposed) return;
         logger.LogInformation("Saving FW data file {Name}", Cache.ProjectId.Name);
         Cache.ActionHandlerAccessor.Commit();
     }

--- a/backend/FwLite/FwDataMiniLcmBridge/Media/LocalMediaAdapter.cs
+++ b/backend/FwLite/FwDataMiniLcmBridge/Media/LocalMediaAdapter.cs
@@ -20,8 +20,10 @@ public class LocalMediaAdapter(IMemoryCache memoryCache) : IMediaAdapter
             entry =>
             {
                 entry.SlidingExpiration = TimeSpan.FromMinutes(10);
+                // Distinct(): EnumerateFiles can repeat a path if a file is renamed mid-enumeration (cloud-sync providers do this).
                 return Directory
                     .EnumerateFiles(cache.LangProject.LinkedFilesRootDir, "*", SearchOption.AllDirectories)
+                    .Distinct()
                     .ToDictionary(file => PathToUri(file).FileId, file => file);
             }) ?? throw new Exception("Failed to get paths");
     }

--- a/frontend/viewer/src/project/browse/EntriesList.svelte
+++ b/frontend/viewer/src/project/browse/EntriesList.svelte
@@ -138,6 +138,7 @@
     const index = await entryLoader.getOrLoadEntryIndex(entryId);
     if (entryId !== selectedEntryId) return false;
     if (index < 0) return false;
+    if (!vList) return false; // may have unmounted during the await
 
     const visibleStart = vList.getScrollOffset();
     const visibleSize = vList.getViewportSize();


### PR DESCRIPTION
Three independent, defensive fixes; each one line of real change.

- **`LocalMediaAdapter`**: `Distinct()` before `ToDictionary` — Win32 `FindNextFile` can repeat a path when a cloud-sync provider renames a file mid-enumeration. Was crashing every entry fetch on one user's project. See #2290. Don't know if this is actually the cause, but Larry H actually get an exception here (`An item with the same key has already been added. Key: d12fdc2a-0697-5c9d-93fc-dddaecadbea9`), so presumably this will fix that.
- **`FwDataMiniLcmApi.Cache`**: throw `ObjectDisposedException` (with project filename) when the underlying `LcmCache` was disposed mid-request — clearer than the NRE bursts we saw in Larry's log. `Save()` updated to check the lazy directly so `Dispose()` still no-ops gracefully.
- **`EntriesList.svelte`**: re-check `vList` after the `await` in `tryToScrollToEntry` — component can unmount between `getOrLoadEntryIndex` resolving and `getScrollOffset()` being called.

No new tests — each case is timing-dependent and a deterministic repro isn't worth its own scaffolding. Build is clean.