### PR TITLE
Fix NFC/NFD media-path twin crash and surface batch-load errors

### DIFF
--- a/backend/FwLite/FwDataMiniLcmBridge.Tests/LocalMediaAdapterTests.cs
+++ b/backend/FwLite/FwDataMiniLcmBridge.Tests/LocalMediaAdapterTests.cs
@@ -1,0 +1,50 @@
+using FwDataMiniLcmBridge.Media;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace FwDataMiniLcmBridge.Tests;
+
+public class LocalMediaAdapterTests : IDisposable
+{
+    private readonly string _root;
+    private readonly string _audioVisual;
+
+    public LocalMediaAdapterTests()
+    {
+        _root = Path.Combine(Path.GetTempPath(), "LocalMediaAdapterTests-" + Guid.NewGuid().ToString("N")[..8]);
+        _audioVisual = Path.Combine(_root, "AudioVisual");
+        Directory.CreateDirectory(_audioVisual);
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_root)) Directory.Delete(_root, recursive: true);
+    }
+
+    // FW stores audio references in NFD via MiniLcm's normalisation wrapper. A real user's
+    // LinkedFiles\AudioVisual directory was observed to contain both an NFC and an NFD copy of
+    // the same audio (e.g. süülda.wav written on Windows alongside its NFD twin from a macOS
+    // hg pull). UUIDNext.NewNameBased normalises before hashing, so both copies produce the same
+    // FileId — and the dictionary build in LocalMediaAdapter.Paths used to throw
+    // "An item with the same key has already been added", crashing every entry fetch.
+    [Fact]
+    public void EnumerationOfNfcAndNfdTwinsDoesNotCrash()
+    {
+        // explicit escape sequences so the source file's encoding cannot collapse the two literals.
+        const string nfc = "süülda.wav";          // precomposed ü
+        const string nfd = "süülda.wav";        // u + combining diaeresis
+        nfc.Should().NotBe(nfd, "test setup is vacuous if the two literals are equal");
+
+        File.WriteAllBytes(Path.Combine(_audioVisual, nfc), [1]);
+        File.WriteAllBytes(Path.Combine(_audioVisual, nfd), [2]);
+        Directory.EnumerateFiles(_audioVisual).Count().Should().Be(2, "both physical files must coexist on disk");
+
+        var dict = LocalMediaAdapter.BuildPathsDictionary(_root, NullLogger<LocalMediaAdapter>.Instance);
+
+        // The build did not throw, and the surviving entry resolves to a real file (whichever
+        // enumeration order returned first — FW's NFD lookup will hit it regardless because
+        // UUIDNext gives both twins the same FileId).
+        dict.Should().HaveCount(1);
+        File.Exists(dict.Single().Value).Should().BeTrue();
+    }
+}

--- a/backend/FwLite/FwDataMiniLcmBridge.Tests/MediaFileTests.cs
+++ b/backend/FwLite/FwDataMiniLcmBridge.Tests/MediaFileTests.cs
@@ -130,6 +130,22 @@ public class MediaFileTests : IAsyncLifetime
     }
 
     [Fact]
+    public async Task AudioWsValuesAreStoredAsNfdByLcm()
+    {
+        // Documents the LCM behaviour that LocalMediaAdapter.BuildPathsDictionary relies on
+        // (first-wins on NFC/NFD twins is safe because FW only ever asks for the NFD form).
+        // Escape sequences keep the source file ASCII so editor/normalisation cannot collapse the literals.
+        const string nfc = "süülda.wav";       // precomposed ü
+        const string nfd = "süülda.wav";     // u + combining diaeresis
+        nfc.Should().NotBe(nfd, "test is vacuous if the two literals are equal");
+
+        var entryId = await AddFileDirectly(nfc, contents: "test");
+
+        // Set via LCM with the NFC form; LCM should serve back the NFD form.
+        GetFwAudioValue(entryId).Should().Be(nfd);
+    }
+
+    [Fact]
     public async Task CanOpenAFile()
     {
         var fileName = "CanOpenAFile.txt";

--- a/backend/FwLite/FwDataMiniLcmBridge/Media/LocalMediaAdapter.cs
+++ b/backend/FwLite/FwDataMiniLcmBridge/Media/LocalMediaAdapter.cs
@@ -1,5 +1,6 @@
 using System.Diagnostics.CodeAnalysis;
 using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.Logging;
 using MiniLcm;
 using MiniLcm.Exceptions;
 using MiniLcm.Media;
@@ -8,7 +9,7 @@ using UUIDNext;
 
 namespace FwDataMiniLcmBridge.Media;
 
-public class LocalMediaAdapter(IMemoryCache memoryCache) : IMediaAdapter
+public class LocalMediaAdapter(IMemoryCache memoryCache, ILogger<LocalMediaAdapter> logger) : IMediaAdapter
 {
     //probably don't change this
     private static readonly Guid LocalMediaNamespace = new Guid("45e563a3-f5a6-4d7a-9722-8d7d4d3adfa2");
@@ -20,12 +21,28 @@ public class LocalMediaAdapter(IMemoryCache memoryCache) : IMediaAdapter
             entry =>
             {
                 entry.SlidingExpiration = TimeSpan.FromMinutes(10);
-                // Distinct(): EnumerateFiles can repeat a path if a file is renamed mid-enumeration (cloud-sync providers do this).
-                return Directory
-                    .EnumerateFiles(cache.LangProject.LinkedFilesRootDir, "*", SearchOption.AllDirectories)
-                    .Distinct()
-                    .ToDictionary(file => PathToUri(file).FileId, file => file);
+                return BuildPathsDictionary(cache.LangProject.LinkedFilesRootDir, logger);
             }) ?? throw new Exception("Failed to get paths");
+    }
+
+    // First-wins on duplicate FileId. Two real causes seen in the wild:
+    //  - the same path emitted twice by FindNextFile mid-rename (cloud-sync providers),
+    //  - NFC + NFD twins of the same audio name (e.g. an NFD süülda.wav from a macOS hg peer
+    //    alongside its NFC twin): UUIDNext.NewNameBased normalises before hashing, so twins share
+    //    a FileId. FW stores audio refs as NFD so any lookup FW makes still hits the surviving entry.
+    internal static Dictionary<Guid, string> BuildPathsDictionary(string root, ILogger logger)
+    {
+        var paths = new Dictionary<Guid, string>();
+        foreach (var file in Directory.EnumerateFiles(root, "*", SearchOption.AllDirectories))
+        {
+            var fileId = PathToUri(file).FileId;
+            if (!paths.TryAdd(fileId, file))
+            {
+                logger.LogWarning("Duplicate media FileId {FileId} in {Root}: kept {Existing}, skipped {Skipped}",
+                    fileId, root, paths[fileId], file);
+            }
+        }
+        return paths;
     }
 
     //path is expected to be relative to the LinkedFilesRootDir

--- a/frontend/viewer/src/lib/services/entry-loader-service.svelte.test.ts
+++ b/frontend/viewer/src/lib/services/entry-loader-service.svelte.test.ts
@@ -106,6 +106,16 @@ describe('EntryLoaderService', () => {
 
       expect(api.getEntries).toHaveBeenCalledTimes(1);
     });
+
+    it('surfaces batch-load failures on service.error so consumers can show a toast', async () => {
+      const entries = makeEntries(3);
+      const {api, service} = await createService(entries);
+      const failure = new Error('boom');
+      api.getEntries.mockRejectedValueOnce(failure);
+
+      await expect(service.getOrLoadEntryByIndex(2 * BATCH_SIZE)).rejects.toBe(failure);
+      expect(service.error).toBe(failure);
+    });
   });
 
   describe('quiet reset', () => {

--- a/frontend/viewer/src/lib/services/entry-loader-service.svelte.ts
+++ b/frontend/viewer/src/lib/services/entry-loader-service.svelte.ts
@@ -213,6 +213,14 @@ export class EntryLoaderService {
       const entries = await promise;
       if (gen !== this.#generation) return;
       this.#cache.storeBatches([batch], entries);
+    } catch (e) {
+      // Without this, the rejection is swallowed by Delayed.svelte (per-row component) and the
+      // user sees perpetual skeletons with no toast. Surfacing it on the service triggers the
+      // top-level error UI + toast in EntriesList.
+      if (gen === this.#generation) {
+        this.error = e instanceof Error ? e : new Error(String(e));
+      }
+      throw e;
     } finally {
       this.#cache.clearPendingBatch(batch, promise);
     }


### PR DESCRIPTION
Two independent fixes from continued log triage:

- **`LocalMediaAdapter.BuildPathsDictionary`** — switched to `TryAdd` + `LogWarning` so duplicate `FileId`s collapse (first-wins) instead of crashing the dictionary build. The trigger in the wild was an NFC + NFD twin of the same audio filename in `LinkedFiles\AudioVisual` (likely from a macOS hg peer alongside a Windows-written file). `UUIDNext.NewNameBased` Unicode-normalises before hashing, so both physical files mapped to the same `FileId`. FW stores audio refs as NFD, so the surviving entry satisfies any lookup; the warning log gives us telemetry next time it fires. New test in `LocalMediaAdapterTests.cs` reproduces the twin scenario.
- **`EntryLoaderService.#loadBatch`** — catches the rejection, stores it on `service.error` (gated by generation), re-throws. The existing top-level `$effect` in `EntriesList.svelte` then renders the error UI and fires the toast. Without this, `Delayed.svelte` swallowed batch failures silently and the user got perpetual skeletons. New vitest case covers it.

Build is clean. Bridge + viewer unit tests pass locally.