### PR TITLE
Fix LocalMediaAdapter crash on NFC/NFD media filename twins

### DIFF
--- a/backend/FwLite/FwDataMiniLcmBridge.Tests/LocalMediaAdapterTests.cs
+++ b/backend/FwLite/FwDataMiniLcmBridge.Tests/LocalMediaAdapterTests.cs
@@ -21,10 +21,11 @@ public class LocalMediaAdapterTests : IDisposable
         if (Directory.Exists(_root)) Directory.Delete(_root, recursive: true);
     }
 
-    // Regression: NFC + NFD twins of the same audio used to crash Paths() because
-    // UUIDNext.NewNameBased normalises before hashing -> same FileId for both.
+    // NFC + NFD twins of the same audio collapse to a single entry (UUIDNext.NewNameBased
+    // normalises before hashing -> same FileId). The kept path is the NFD one, since
+    // that's the only form FW addresses audio with.
     [Fact]
-    public void EnumerationOfNfcAndNfdTwinsDoesNotCrash()
+    public void NfcAndNfdTwinsCollapseToNfd()
     {
         const string nfc = "süülda.wav";
         const string nfd = "süülda.wav";
@@ -40,5 +41,6 @@ public class LocalMediaAdapterTests : IDisposable
 
         dict.Should().HaveCount(1);
         File.Exists(dict.Single().Value).Should().BeTrue();
+        dict.Single().Value.Should().EndWith(nfd);
     }
 }

--- a/backend/FwLite/FwDataMiniLcmBridge.Tests/LocalMediaAdapterTests.cs
+++ b/backend/FwLite/FwDataMiniLcmBridge.Tests/LocalMediaAdapterTests.cs
@@ -40,7 +40,5 @@ public class LocalMediaAdapterTests : IDisposable
 
         dict.Should().HaveCount(1);
         File.Exists(dict.Single().Value).Should().BeTrue();
-        // FW stores audio refs as NFD so only NFD file names are useable i.e. collisions don't matter
-        dict.Single().Value.Should().EndWith(nfd);
     }
 }

--- a/backend/FwLite/FwDataMiniLcmBridge.Tests/LocalMediaAdapterTests.cs
+++ b/backend/FwLite/FwDataMiniLcmBridge.Tests/LocalMediaAdapterTests.cs
@@ -1,0 +1,46 @@
+using System.Text;
+using FwDataMiniLcmBridge.Media;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace FwDataMiniLcmBridge.Tests;
+
+public class LocalMediaAdapterTests : IDisposable
+{
+    private readonly string _root;
+    private readonly string _audioVisual;
+
+    public LocalMediaAdapterTests()
+    {
+        _root = Path.Combine(Path.GetTempPath(), "LocalMediaAdapterTests-" + Guid.NewGuid().ToString("N")[..8]);
+        _audioVisual = Path.Combine(_root, "AudioVisual");
+        Directory.CreateDirectory(_audioVisual);
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_root)) Directory.Delete(_root, recursive: true);
+    }
+
+    // Regression: NFC + NFD twins of the same audio used to crash Paths() because
+    // UUIDNext.NewNameBased normalises before hashing -> same FileId for both.
+    [Fact]
+    public void EnumerationOfNfcAndNfdTwinsDoesNotCrash()
+    {
+        const string nfc = "süülda.wav";
+        const string nfd = "süülda.wav";
+        nfc.Should().Be(nfc.Normalize(NormalizationForm.FormC));
+        nfd.Should().Be(nfd.Normalize(NormalizationForm.FormD));
+        nfc.Should().NotBe(nfd, "test setup is vacuous if the two literals are equal");
+
+        File.WriteAllBytes(Path.Combine(_audioVisual, nfc), [1]);
+        File.WriteAllBytes(Path.Combine(_audioVisual, nfd), [2]);
+        Directory.EnumerateFiles(_audioVisual).Count().Should().Be(2, "both physical files must coexist on disk");
+
+        var dict = LocalMediaAdapter.BuildPathsDictionary(_root, NullLogger<LocalMediaAdapter>.Instance);
+
+        dict.Should().HaveCount(1);
+        File.Exists(dict.Single().Value).Should().BeTrue();
+        // FW stores audio refs as NFD so only NFD file names are useable i.e. collisions don't matter
+        dict.Single().Value.Should().EndWith(nfd);
+    }
+}

--- a/backend/FwLite/FwDataMiniLcmBridge.Tests/MediaFileTests.cs
+++ b/backend/FwLite/FwDataMiniLcmBridge.Tests/MediaFileTests.cs
@@ -133,8 +133,8 @@ public class MediaFileTests : IAsyncLifetime
     [Fact]
     public async Task AudioWsValuesAreStoredAsNfdByLcm()
     {
-        // LocalMediaAdapter.BuildPathsDictionary "squashes" normalized duplicates,
-        // which is OK, beacuse only NFD names are useable i.e. collisions don't matter
+        // LocalMediaAdapter.BuildPathsDictionary prefers NFD when collapsing twins;
+        // this test proves LCM also only ever serves audio refs as NFD, so the two align.
         const string nfc = "süülda.wav";
         const string nfd = "süülda.wav";
         nfc.Should().Be(nfc.Normalize(NormalizationForm.FormC));

--- a/backend/FwLite/FwDataMiniLcmBridge.Tests/MediaFileTests.cs
+++ b/backend/FwLite/FwDataMiniLcmBridge.Tests/MediaFileTests.cs
@@ -1,3 +1,4 @@
+using System.Text;
 using FwDataMiniLcmBridge.Api;
 using FwDataMiniLcmBridge.Media;
 using FwDataMiniLcmBridge.Tests.Fixtures;
@@ -127,6 +128,23 @@ public class MediaFileTests : IAsyncLifetime
         entry.CitationForm[_audioWs].Should().Be(mediaUri.ToString());
         var fwAudioValue = GetFwAudioValue(entry.Id);
         fwAudioValue.Should().Be(fileName);
+    }
+
+    [Fact]
+    public async Task AudioWsValuesAreStoredAsNfdByLcm()
+    {
+        // LocalMediaAdapter.BuildPathsDictionary "squashes" normalized duplicates,
+        // which is OK, beacuse only NFD names are useable i.e. collisions don't matter
+        const string nfc = "süülda.wav";
+        const string nfd = "süülda.wav";
+        nfc.Should().Be(nfc.Normalize(NormalizationForm.FormC));
+        nfd.Should().Be(nfd.Normalize(NormalizationForm.FormD));
+        nfc.Should().NotBe(nfd, "test is vacuous if the two literals are equal");
+
+        var entryId = await AddFileDirectly(nfc, contents: "test");
+
+        // Set via LCM with the NFC form; LCM serves back the NFD form.
+        GetFwAudioValue(entryId).Should().Be(nfd);
     }
 
     [Fact]

--- a/backend/FwLite/FwDataMiniLcmBridge/Media/LocalMediaAdapter.cs
+++ b/backend/FwLite/FwDataMiniLcmBridge/Media/LocalMediaAdapter.cs
@@ -47,12 +47,12 @@ public class LocalMediaAdapter(IMemoryCache memoryCache, ILogger<LocalMediaAdapt
         return paths;
     }
 
-    private static string PreferNfd(string a, string b)
+    private static string PreferNfd(string curr, string @new)
     {
-        var aNfd = Path.GetFileName(a).IsNormalized(NormalizationForm.FormD);
-        var bNfd = Path.GetFileName(b).IsNormalized(NormalizationForm.FormD);
-        if (aNfd != bNfd) return aNfd ? a : b;
-        return StringComparer.Ordinal.Compare(a, b) <= 0 ? a : b;
+        var newIsNfd = Path.GetFileName(@new).IsNormalized(NormalizationForm.FormD);
+        var currIsNfd = Path.GetFileName(curr).IsNormalized(NormalizationForm.FormD);
+        // only replace curr if new is a strict NFD improvement; otherwise leave the cache stable
+        return newIsNfd && !currIsNfd ? @new : curr;
     }
 
     //path is expected to be relative to the LinkedFilesRootDir

--- a/backend/FwLite/FwDataMiniLcmBridge/Media/LocalMediaAdapter.cs
+++ b/backend/FwLite/FwDataMiniLcmBridge/Media/LocalMediaAdapter.cs
@@ -1,31 +1,42 @@
-using System.Diagnostics.CodeAnalysis;
 using Microsoft.Extensions.Caching.Memory;
-using MiniLcm;
-using MiniLcm.Exceptions;
+using Microsoft.Extensions.Logging;
 using MiniLcm.Media;
 using SIL.LCModel;
 using UUIDNext;
 
 namespace FwDataMiniLcmBridge.Media;
 
-public class LocalMediaAdapter(IMemoryCache memoryCache) : IMediaAdapter
+public class LocalMediaAdapter(IMemoryCache memoryCache, ILogger<LocalMediaAdapter> logger) : IMediaAdapter
 {
     //probably don't change this
-    private static readonly Guid LocalMediaNamespace = new Guid("45e563a3-f5a6-4d7a-9722-8d7d4d3adfa2");
+    private static readonly Guid LocalMediaNamespace = new("45e563a3-f5a6-4d7a-9722-8d7d4d3adfa2");
     private const string LocalMediaAuthority = "localhost";
 
     private Dictionary<Guid, string> Paths(LcmCache cache)
     {
-        return memoryCache.GetOrCreate<Dictionary<Guid, string>>("LocalMediaPath|" + cache.ProjectId.ProjectFolder,
+        return memoryCache.GetOrCreate("LocalMediaPath|" + cache.ProjectId.ProjectFolder,
             entry =>
             {
                 entry.SlidingExpiration = TimeSpan.FromMinutes(10);
-                // Distinct(): EnumerateFiles can repeat a path if a file is renamed mid-enumeration (cloud-sync providers do this).
-                return Directory
-                    .EnumerateFiles(cache.LangProject.LinkedFilesRootDir, "*", SearchOption.AllDirectories)
-                    .Distinct()
-                    .ToDictionary(file => PathToUri(file).FileId, file => file);
+                return BuildPathsDictionary(cache.LangProject.LinkedFilesRootDir, logger);
             }) ?? throw new Exception("Failed to get paths");
+    }
+
+    internal static Dictionary<Guid, string> BuildPathsDictionary(string root, ILogger logger)
+    {
+        var paths = new Dictionary<Guid, string>();
+        foreach (var file in Directory.EnumerateFiles(root, "*", SearchOption.AllDirectories))
+        {
+            var fileId = PathToUri(file).FileId;
+            if (!paths.TryAdd(fileId, file))
+            {
+                // duplicates are possible, because UUIDNext.NewNameBased normalises unicode before hashing
+                // FW stores audio refs as NFD so only NFD file names are useable i.e. collisions don't matter
+                logger.LogWarning("Duplicate media FileId {FileId} in {Root}: kept {Existing}, skipped {Skipped}",
+                    fileId, root, paths[fileId], file);
+            }
+        }
+        return paths;
     }
 
     //path is expected to be relative to the LinkedFilesRootDir

--- a/backend/FwLite/FwDataMiniLcmBridge/Media/LocalMediaAdapter.cs
+++ b/backend/FwLite/FwDataMiniLcmBridge/Media/LocalMediaAdapter.cs
@@ -49,10 +49,9 @@ public class LocalMediaAdapter(IMemoryCache memoryCache, ILogger<LocalMediaAdapt
 
     private static string PreferNfd(string curr, string @new)
     {
-        var newIsNfd = Path.GetFileName(@new).IsNormalized(NormalizationForm.FormD);
-        var currIsNfd = Path.GetFileName(curr).IsNormalized(NormalizationForm.FormD);
         // only replace curr if new is a strict NFD improvement; otherwise leave the cache stable
-        return newIsNfd && !currIsNfd ? @new : curr;
+        if (Path.GetFileName(curr).IsNormalized(NormalizationForm.FormD)) return curr;
+        return Path.GetFileName(@new).IsNormalized(NormalizationForm.FormD) ? @new : curr;
     }
 
     //path is expected to be relative to the LinkedFilesRootDir

--- a/backend/FwLite/FwDataMiniLcmBridge/Media/LocalMediaAdapter.cs
+++ b/backend/FwLite/FwDataMiniLcmBridge/Media/LocalMediaAdapter.cs
@@ -1,3 +1,4 @@
+using System.Text;
 using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.Logging;
 using MiniLcm.Media;
@@ -28,15 +29,30 @@ public class LocalMediaAdapter(IMemoryCache memoryCache, ILogger<LocalMediaAdapt
         foreach (var file in Directory.EnumerateFiles(root, "*", SearchOption.AllDirectories))
         {
             var fileId = PathToUri(file).FileId;
-            if (!paths.TryAdd(fileId, file))
+            if (paths.TryGetValue(fileId, out var existing))
             {
                 // duplicates are possible, because UUIDNext.NewNameBased normalises unicode before hashing
-                // FW stores audio refs as NFD so only NFD file names are useable i.e. collisions don't matter
-                logger.LogWarning("Duplicate media FileId {FileId} in {Root}: kept {Existing}, skipped {Skipped}",
-                    fileId, root, paths[fileId], file);
+                // keep the NFD path: FW only ever refers to audio via NFD names
+                var kept = PreferNfd(existing, file);
+                var skipped = ReferenceEquals(kept, existing) ? file : existing;
+                paths[fileId] = kept;
+                logger.LogWarning("Duplicate media FileId {FileId} in {Root}: kept {Kept}, skipped {Skipped}",
+                    fileId, root, kept, skipped);
+            }
+            else
+            {
+                paths[fileId] = file;
             }
         }
         return paths;
+    }
+
+    private static string PreferNfd(string a, string b)
+    {
+        var aNfd = Path.GetFileName(a).IsNormalized(NormalizationForm.FormD);
+        var bNfd = Path.GetFileName(b).IsNormalized(NormalizationForm.FormD);
+        if (aNfd != bNfd) return aNfd ? a : b;
+        return StringComparer.Ordinal.Compare(a, b) <= 0 ? a : b;
     }
 
     //path is expected to be relative to the LinkedFilesRootDir


### PR DESCRIPTION
`UUIDNext.NewNameBased` normalises before hashing, so an audio file present on disk as both NFC and NFD twins hashes to the same `FileId` and crashes `Paths()` (which calls `ToDictionary`). Skip the duplicate and log a warning. FW stores audio refs as NFD, so the NFD entry is the useable one and collisions don't matter.