### PR TITLE
Surface entry-loader batch errors so they show as toasts

### DIFF
--- a/frontend/viewer/src/lib/services/entry-loader-service.svelte.test.ts
+++ b/frontend/viewer/src/lib/services/entry-loader-service.svelte.test.ts
@@ -106,6 +106,16 @@ describe('EntryLoaderService', () => {
 
       expect(api.getEntries).toHaveBeenCalledTimes(1);
     });
+
+    it('surfaces batch-load failures on service.error so consumers can show a toast', async () => {
+      const entries = makeEntries(3);
+      const {api, service} = await createService(entries);
+      const failure = new Error('boom');
+      api.getEntries.mockRejectedValueOnce(failure);
+
+      await expect(service.getOrLoadEntryByIndex(2 * BATCH_SIZE)).rejects.toBe(failure);
+      expect(service.error).toBe(failure);
+    });
   });
 
   describe('quiet reset', () => {

--- a/frontend/viewer/src/lib/services/entry-loader-service.svelte.ts
+++ b/frontend/viewer/src/lib/services/entry-loader-service.svelte.ts
@@ -213,6 +213,12 @@ export class EntryLoaderService {
       const entries = await promise;
       if (gen !== this.#generation) return;
       this.#cache.storeBatches([batch], entries);
+    } catch (e) {
+      // Surfacing this on the service triggers the top-level error UI + toast in EntriesList.
+      if (gen === this.#generation) {
+        this.error = e instanceof Error ? e : new Error(String(e));
+      }
+      throw e;
     } finally {
       this.#cache.clearPendingBatch(batch, promise);
     }


### PR DESCRIPTION
Failures inside `loadBatch` were swallowed: the rejected promise propagated to the caller, but `service.error` stayed null, so `EntriesList`'s top-level error UI / toast never fired. Set `service.error` in the catch.

Pairs with #2302 — that's the kind of backend crash this lets users actually see.