### PR TITLE
Trim verbose comments on CFC no-anchor guard

### DIFF
--- a/backend/FwLite/LcmCrdt/CrdtMiniLcmApi.cs
+++ b/backend/FwLite/LcmCrdt/CrdtMiniLcmApi.cs
@@ -313,11 +313,8 @@ public class CrdtMiniLcmApi(
             return await repo.FindComplexFormComponent(addEntryComponentChange.EntityId);
         }
 
-        // BetweenPosition(null, null) carries no positional intent — it's what the
-        // orderable diff hands in for a lone or unanchored item. Treat it as a no-op
-        // here; otherwise MoveComplexFormComponent walks PickOrder and bumps Order
-        // to max+1 every time the same CFC is revisited (e.g. via SyncComplexForms
-        // and SyncComplexFormComponents in one sync). Matches FwDataMiniLcmApi.
+        // The orderable diff sends (null, null) for singletons; skip the move so
+        // revisits in one sync don't bump Order via PickOrder.
         if (between is { Previous: not null } or { Next: not null })
         {
             await MoveComplexFormComponent(existing, between);

--- a/backend/FwLite/MiniLcm.Tests/ComplexFormComponentTestsBase.cs
+++ b/backend/FwLite/MiniLcm.Tests/ComplexFormComponentTestsBase.cs
@@ -98,12 +98,8 @@ public abstract class ComplexFormComponentTestsBase : MiniLcmTestBase
     [Fact]
     public async Task CreateComplexFormComponent_BetweenWithNoAnchors_DoesNotReorderExisting()
     {
-        // The orderable diff in EntrySync hands BetweenPosition(null, null) to Add when
-        // no stable neighbours exist (e.g. a singleton component). The same CFC can be
-        // reached twice in one sync — once via SyncComplexForms on the component-side
-        // entry (no between) and once via SyncComplexFormComponents on the complex-form
-        // entry (between with both neighbours null). The second call must be a no-op,
-        // not a spurious reorder that bumps Order from 1 → 2.
+        // Sync can revisit the same CFC with (null, null) — once via SyncComplexForms,
+        // again via SyncComplexFormComponents. The second call must not reorder.
         var first = await Api.CreateComplexFormComponent(
             ComplexFormComponent.FromEntries(_complexFormEntry, _componentEntry));
         var second = await Api.CreateComplexFormComponent(


### PR DESCRIPTION
Keep just the WHY: where (null, null) comes from and what skipping the move prevents. The full sync trace belongs in the commit history, not the source.