### PR TITLE
Tidy state_referenced_locally suppressions in viewer to use untrack()

### DIFF
--- a/frontend/viewer/src/DotnetProjectView.svelte
+++ b/frontend/viewer/src/DotnetProjectView.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import ProjectView from './ProjectView.svelte';
-  import {onDestroy, onMount} from 'svelte';
+  import {onDestroy, onMount, untrack} from 'svelte';
   import {DotnetService} from '$lib/dotnet-types';
   import {useProjectServicesProvider} from '$lib/services/service-provider';
   import {wrapInProxy} from '$lib/services/service-provider-dotnet';
@@ -22,8 +22,7 @@
     paratext?: boolean;
   } = $props();
   const projectContext = initProjectContext();
-  // svelte-ignore state_referenced_locally
-  const code = _code;
+  const code = untrack(() => _code);
   projectContext.projectCode = code;
 
   initProjectStorage(code);

--- a/frontend/viewer/src/lib/components/SubmitOrCancel.svelte
+++ b/frontend/viewer/src/lib/components/SubmitOrCancel.svelte
@@ -2,6 +2,7 @@
   import {Button} from '$lib/components/ui/button';
   import {cn} from '$lib/utils';
   import {watch} from 'runed';
+  import {untrack} from 'svelte';
   import {t} from 'svelte-i18n-lingui';
 
   interface Props {
@@ -22,8 +23,7 @@
     class: className,
   }: Props = $props();
 
-  // svelte-ignore state_referenced_locally
-  let wasSubmittable = $state(canSubmit);
+  let wasSubmittable = $state(untrack(() => canSubmit));
 
   watch(
     () => canSubmit,

--- a/frontend/viewer/src/lib/components/if-once/if-once.svelte
+++ b/frontend/viewer/src/lib/components/if-once/if-once.svelte
@@ -2,8 +2,7 @@
   import {type Snippet, untrack} from 'svelte';
 
   const {show, children}: {show: boolean; children: Snippet} = $props();
-  // svelte-ignore state_referenced_locally
-  let render = $state(show);
+  let render = $state(untrack(() => show));
   $effect(() => {
     //this should cleanup the effect so it only runs once
     if (untrack(() => render)) return;

--- a/frontend/viewer/src/lib/entry-editor/NewEntryDialog.svelte
+++ b/frontend/viewer/src/lib/entry-editor/NewEntryDialog.svelte
@@ -6,6 +6,7 @@
 
 <script lang="ts">
   import type {IEntry, ISense} from '$lib/dotnet-types';
+  import {untrack} from 'svelte';
   import {t} from 'svelte-i18n-lingui';
   import {useViewService} from '$lib/views/view-service.svelte';
   import {Button} from '$lib/components/ui/button';
@@ -31,8 +32,7 @@
   let loading = $state(false);
 
   let entry = $state(defaultEntry());
-  // svelte-ignore state_referenced_locally
-  let sense = $state<ISense | undefined>(defaultSense(entry.id));
+  let sense = $state<ISense | undefined>(untrack(() => defaultSense(entry.id)));
 
   const viewService = useViewService();
   const writingSystemService = useWritingSystemService();

--- a/frontend/viewer/src/lib/views/custom/CustomViewForm.svelte
+++ b/frontend/viewer/src/lib/views/custom/CustomViewForm.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import {watch} from 'runed';
+  import {untrack} from 'svelte';
   import * as RadioGroup from '$lib/components/ui/radio-group';
   import {Button} from '$lib/components/ui/button';
   import {Input} from '$lib/components/ui/input';
@@ -26,10 +27,8 @@
 
   let {value: editingValue, submitLabel, onSubmit, onCancel}: Props = $props();
 
-  // svelte-ignore state_referenced_locally
-  let fieldSelectionDirty = $state(!!editingValue);
-  // svelte-ignore state_referenced_locally
-  const value = $state(editingValue ?? defaultCustomView());
+  let fieldSelectionDirty = $state(untrack(() => !!editingValue));
+  const value = $state(untrack(() => editingValue ?? defaultCustomView()));
 
   function defaultCustomView(base: ViewBase = ViewBase.FwLite): ICustomView {
     const root = base === ViewBase.FieldWorks ? FW_CLASSIC_VIEW : FW_LITE_VIEW;

--- a/frontend/viewer/src/project/browse/filter/FieldSelect.svelte
+++ b/frontend/viewer/src/project/browse/filter/FieldSelect.svelte
@@ -9,6 +9,7 @@
 
 <script lang="ts">
   import * as Select from '$lib/components/ui/select';
+  import {untrack} from 'svelte';
   import {t} from 'svelte-i18n-lingui';
   import {pt, tvt} from '$lib/views/view-text';
   import {useViewService} from '$lib/views/view-service.svelte';
@@ -26,8 +27,7 @@
   type LabeledSelectedField = SelectedField & { label: string };
 
   const labeledValue = $derived(fields.find(f => f.id === value?.id) ?? fields[0]);
-  // svelte-ignore state_referenced_locally
-  value ??= labeledValue;
+  value ??= untrack(() => labeledValue);
 </script>
 
 <Select.Root type="single" bind:value={() => (value ?? fields[0]).id, (newId) => value = fields.find(f => f.id === newId) ?? fields[0]}>

--- a/frontend/viewer/src/project/detached-resource/DetachedApiResourceConsumer.svelte
+++ b/frontend/viewer/src/project/detached-resource/DetachedApiResourceConsumer.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import type {ResourceReturn} from 'runed';
+  import {untrack} from 'svelte';
   import {useProjectContext} from '../project-context.svelte';
 
   const props: {
@@ -10,8 +11,7 @@
   const projectContext = useProjectContext();
   const resource = projectContext.apiResource([], () => props.fetchData());
 
-  // svelte-ignore state_referenced_locally
-  props.onResource(resource);
+  untrack(() => props.onResource(resource));
 </script>
 
 <span data-testid="consumer-count">{resource.current.length}</span>

--- a/frontend/viewer/src/project/detached-resource/DetachedApiResourceHarness.svelte
+++ b/frontend/viewer/src/project/detached-resource/DetachedApiResourceHarness.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import type {IMiniLcmJsInvokable} from '$lib/dotnet-types';
+  import {untrack} from 'svelte';
   import type {ResourceReturn} from 'runed';
   import type {HarnessControls} from './detached-api-resource-test-types';
   import {initProjectContext} from '../project-context.svelte';
@@ -45,8 +46,7 @@
     },
   };
 
-  // svelte-ignore state_referenced_locally
-  props.onReady(controls);
+  untrack(() => props.onReady(controls));
 </script>
 
 {#if consumer}


### PR DESCRIPTION
Replaces 9 `// svelte-ignore state_referenced_locally` comments in the viewer with the [maintainer-recommended `untrack(() => ...)` idiom](https://github.com/sveltejs/svelte/issues/17669). Same runtime behaviour; self-documenting at the read site; no dependence on preprocessor leaving the comment intact.

Drive-by from #2309. Viewer `svelte-check` + `eslint` + recursive build green.