### PR TITLE
Restore: Normalize user CRDT writes to NFD (#2146)

### DIFF
--- a/backend/FwLite/FwDataMiniLcmBridge.Tests/MiniLcmTests/UpdateEntryTests.cs
+++ b/backend/FwLite/FwDataMiniLcmBridge.Tests/MiniLcmTests/UpdateEntryTests.cs
@@ -81,7 +81,10 @@ public class UpdateEntryTests(ProjectLoaderFixture fixture) : UpdateEntryTestsBa
 
         var before = entry.Copy();
         var exampleSentence = entry.Senses[0].ExampleSentences[0];
-        exampleSentence.Translations = [new() { Text = { { "en", new RichString("updated") } } }];
+        exampleSentence.Translations =
+        [
+            new() { Id = Guid.NewGuid(), Text = { { "en", new RichString("updated") } } }
+        ];
 
         // Act
         var updatedEntry = await Api.UpdateEntry(before, entry);

--- a/backend/FwLite/FwLiteProjectSync/CrdtFwdataProjectSyncService.cs
+++ b/backend/FwLite/FwLiteProjectSync/CrdtFwdataProjectSyncService.cs
@@ -4,7 +4,6 @@ using LcmCrdt;
 using LexCore.Sync;
 using Microsoft.Extensions.Logging;
 using MiniLcm;
-using MiniLcm.Normalization;
 using MiniLcm.SyncHelpers;
 using MiniLcm.Validators;
 
@@ -12,8 +11,7 @@ namespace FwLiteProjectSync;
 
 public class CrdtFwdataProjectSyncService(MiniLcmImport miniLcmImport,
     ILogger<CrdtFwdataProjectSyncService> logger,
-    MiniLcmApiValidationWrapperFactory validationWrapperFactory,
-    MiniLcmApiStringNormalizationWrapperFactory normalizationWrapperFactory)
+    MiniLcmApiValidationWrapperFactory validationWrapperFactory)
 {
     public record DryRunSyncResult(
         int CrdtChanges,
@@ -63,8 +61,10 @@ public class CrdtFwdataProjectSyncService(MiniLcmImport miniLcmImport,
             throw new InvalidOperationException("Project sync state does not match presence of snapshot.");
         }
 
-        crdtApi = normalizationWrapperFactory.Create(validationWrapperFactory.Create(crdtApi));
-        fwdataApi = normalizationWrapperFactory.Create(validationWrapperFactory.Create(fwdataApi));
+        // No write normalization: Data is already normalised on both sides.
+        // No query normalization: The sync doesn't do any querying.
+        crdtApi = validationWrapperFactory.Create(crdtApi);
+        fwdataApi = validationWrapperFactory.Create(fwdataApi);
 
         if (dryRun)
         {

--- a/backend/FwLite/FwLiteShared/Services/MiniLcmJsInvokable.cs
+++ b/backend/FwLite/FwLiteShared/Services/MiniLcmJsInvokable.cs
@@ -5,8 +5,6 @@ using Microsoft.JSInterop;
 using MiniLcm;
 using MiniLcm.Media;
 using MiniLcm.Models;
-using MiniLcm.Normalization;
-using MiniLcm.Validators;
 using MiniLcm.Wrappers;
 using Reinforced.Typings.Attributes;
 
@@ -18,11 +16,10 @@ public class MiniLcmJsInvokable(
     IProjectIdentifier project,
     ILogger<MiniLcmJsInvokable> logger,
     MiniLcmApiNotifyWrapperFactory notificationWrapperFactory,
-    MiniLcmApiValidationWrapperFactory validationWrapperFactory,
-    MiniLcmApiStringNormalizationWrapperFactory normalizationWrapperFactory
+    MiniLcmApiUserFacingWrappers userFacingWrappers
     ) : IDisposable
 {
-    private readonly IMiniLcmApi _wrappedApi = api.WrapWith([normalizationWrapperFactory, validationWrapperFactory, notificationWrapperFactory], project);
+    private readonly IMiniLcmApi _wrappedApi = userFacingWrappers.Apply(api, project, notificationWrapperFactory);
 
     public record MiniLcmFeatures(bool? History, bool? Write, bool? OpenWithFlex, bool? Feedback, bool? Sync, bool? Audio, bool? CustomViews);
     private bool SupportsSync => project.DataFormat == ProjectDataFormat.Harmony && api is CrdtMiniLcmApi;

--- a/backend/FwLite/FwLiteWeb/Hubs/CrdtMiniLcmApiHub.cs
+++ b/backend/FwLite/FwLiteWeb/Hubs/CrdtMiniLcmApiHub.cs
@@ -1,15 +1,13 @@
-using FwLiteShared;
 using FwLiteShared.Events;
 using FwLiteShared.Projects;
 using FwLiteShared.Sync;
 using LcmCrdt;
 using LcmCrdt.Data;
-using FwLiteWeb.Services;
 using Microsoft.AspNetCore.SignalR;
 using Microsoft.Extensions.Caching.Memory;
 using MiniLcm;
 using MiniLcm.Models;
-using MiniLcm.Validators;
+using MiniLcm.Wrappers;
 using SystemTextJsonPatch;
 
 namespace FwLiteWeb.Hubs;
@@ -23,8 +21,8 @@ public class CrdtMiniLcmApiHub(
     LexboxProjectService lexboxProjectService,
     IMemoryCache memoryCache,
     IHubContext<CrdtMiniLcmApiHub, ILexboxHubClient> hubContext,
-    MiniLcmApiValidationWrapperFactory validationWrapperFactory
-) : MiniLcmApiHubBase(miniLcmApi, validationWrapperFactory)
+    MiniLcmApiUserFacingWrappers userFacingWrappers
+) : MiniLcmApiHubBase(miniLcmApi, userFacingWrappers, projectContext.Project)
 {
     public const string ProjectRouteKey = "project";
     public static string ProjectGroup(string projectName) => "crdt-" + projectName;

--- a/backend/FwLite/FwLiteWeb/Hubs/FwDataMiniLcmHub.cs
+++ b/backend/FwLite/FwLiteWeb/Hubs/FwDataMiniLcmHub.cs
@@ -1,10 +1,7 @@
 using FwDataMiniLcmBridge;
-using Microsoft.AspNetCore.SignalR;
-using Microsoft.Extensions.Options;
 using MiniLcm;
-using MiniLcm.Validators;
+using MiniLcm.Wrappers;
 using SIL.LCModel;
-using SystemTextJsonPatch;
 
 namespace FwLiteWeb.Hubs;
 
@@ -13,8 +10,9 @@ public class FwDataMiniLcmHub(
     IMiniLcmApi miniLcmApi,
     FwDataFactory fwDataFactory,
     FwDataProjectContext context,
-    MiniLcmApiValidationWrapperFactory validationWrapperFactory
-) : MiniLcmApiHubBase(miniLcmApi, validationWrapperFactory)
+    MiniLcmApiUserFacingWrappers userFacingWrappers
+)
+: MiniLcmApiHubBase(miniLcmApi, userFacingWrappers, context.Project ?? throw new InvalidOperationException("No project is set in the context."))
 {
     public const string ProjectRouteKey = "fwdata";
     public override async Task OnConnectedAsync()

--- a/backend/FwLite/FwLiteWeb/Hubs/MiniLcmApiHubBase.cs
+++ b/backend/FwLite/FwLiteWeb/Hubs/MiniLcmApiHubBase.cs
@@ -1,16 +1,17 @@
 using Microsoft.AspNetCore.SignalR;
-using Microsoft.Extensions.Options;
 using MiniLcm;
 using MiniLcm.Models;
-using MiniLcm.Validators;
+using MiniLcm.Wrappers;
 using SystemTextJsonPatch;
 
 namespace FwLiteWeb.Hubs;
 
-public abstract class MiniLcmApiHubBase(IMiniLcmApi miniLcmApi,
-    MiniLcmApiValidationWrapperFactory validationWrapperFactory) : Hub<ILexboxHubClient>
+public abstract class MiniLcmApiHubBase(
+    IMiniLcmApi miniLcmApi,
+    MiniLcmApiUserFacingWrappers userFacingWrappers,
+    IProjectIdentifier projectIdentifier) : Hub<ILexboxHubClient>
 {
-    private readonly IMiniLcmApi _miniLcmApi = validationWrapperFactory.Create(miniLcmApi);
+    private readonly IMiniLcmApi _miniLcmApi = userFacingWrappers.Apply(miniLcmApi, projectIdentifier);
 
     public async Task<WritingSystems> GetWritingSystems()
     {

--- a/backend/FwLite/FwLiteWeb/Routes/MiniLcmRoutes.cs
+++ b/backend/FwLite/FwLiteWeb/Routes/MiniLcmRoutes.cs
@@ -7,6 +7,7 @@ using MiniLcm.Filtering;
 using MiniLcm.Models;
 using MiniLcm.Project;
 using MiniLcm.Validators;
+using MiniLcm.Wrappers;
 using System.Text.Json.Nodes;
 
 namespace FwLiteWeb.Routes;
@@ -86,12 +87,11 @@ public static class MiniLcmRoutes
                     return Results.Problem($"Project {projectCode} not found");
                 }
 
-                var validationWrapperFactory = context.HttpContext.RequestServices
-                    .GetRequiredService<MiniLcmApiValidationWrapperFactory>();
+                var services = context.HttpContext.RequestServices;
+                var userFacingWrappers = services.GetRequiredService<MiniLcmApiUserFacingWrappers>();
 
-                miniLcmHolder.MiniLcmApi = validationWrapperFactory.Create(
-                    await projectProvider.OpenProject(project, context.HttpContext.RequestServices)
-                );
+                miniLcmHolder.MiniLcmApi = userFacingWrappers.Apply(
+                    await projectProvider.OpenProject(project, services), project);
                 return await next(context);
             });
 

--- a/backend/FwLite/MiniLcm.Tests/CreateEntryTestsBase.cs
+++ b/backend/FwLite/MiniLcm.Tests/CreateEntryTestsBase.cs
@@ -22,7 +22,7 @@ public abstract class CreateEntryTestsBase : MiniLcmTestBase
             .For(e => e.Components).Exclude(e => e.Id)
             .For(e => e.ComplexForms).Exclude(e => e.Id)
             .Excluding(e => e.HomographNumber) // FwData auto-assigns to fix broken CRDT numbering
-            );
+            .Excluding(member => member.Name == nameof(IOrderable.Order)));
     }
 
     [Fact]

--- a/backend/FwLite/MiniLcm.Tests/ExampleSentenceTestsBase.cs
+++ b/backend/FwLite/MiniLcm.Tests/ExampleSentenceTestsBase.cs
@@ -49,13 +49,21 @@ public abstract class ExampleSentenceTestsBase : MiniLcmTestBase
     {
         var expectedExampleSentence = new ExampleSentence()
         {
+            Id = Guid.NewGuid(),
             SenseId = _senseId,
             Reference = new RichString("This is a reference", "en"),
             Sentence = { { "en", new RichString("test", "en") } },
-            Translations = { new Translation() { Text = { { "en", new RichString("test", "en") } } } }
+            Translations = {
+                new Translation()
+                {
+                    Id = Guid.NewGuid(),
+                    Text = { { "en", new RichString("test", "en") } },
+                }
+            }
         };
         var actualSentence = await Api.CreateExampleSentence(_entryId, _senseId, expectedExampleSentence);
-        actualSentence.Should().BeEquivalentTo(expectedExampleSentence);
+        actualSentence.Should().BeEquivalentTo(expectedExampleSentence,
+            options => options.Excluding(s => s.Order));
     }
 
     [Fact]
@@ -63,10 +71,12 @@ public abstract class ExampleSentenceTestsBase : MiniLcmTestBase
     {
         var expectedExampleSentence = new ExampleSentence()
         {
+            Id = Guid.NewGuid(),
             SenseId = _senseId
         };
         var actualSentence = await Api.CreateExampleSentence(_entryId, _senseId, expectedExampleSentence);
-        actualSentence.Should().BeEquivalentTo(expectedExampleSentence);
+        actualSentence.Should().BeEquivalentTo(expectedExampleSentence,
+            options => options.Excluding(s => s.Order));
     }
 
     [Fact]

--- a/backend/FwLite/MiniLcm.Tests/Helpers/NfcTestData.cs
+++ b/backend/FwLite/MiniLcm.Tests/Helpers/NfcTestData.cs
@@ -1,0 +1,202 @@
+namespace MiniLcm.Tests.Helpers;
+
+public static class NfcTestData
+{
+    // U+00EF LATIN SMALL LETTER I WITH DIAERESIS (composed)
+    public const string Nfc = "naïve";
+    // U+0069 LATIN SMALL LETTER I + U+0308 COMBINING DIAERESIS (decomposed)
+    public const string Nfd = "naïve";
+
+    // D: ï C: ï
+
+    public static MultiString CreateNfcMultiString()
+    {
+        return new() { Values = { { "en", Nfc }, { "fr", Nfc } } };
+    }
+
+    public static RichString CreateNfcRichString()
+    {
+        return new([
+            new RichSpan { Text = Nfc, Ws = "en" },
+            new RichSpan { Text = Nfc, Ws = "en", Bold = RichTextToggle.On }
+        ]);
+    }
+
+    public static RichMultiString CreateNfcRichMultiString()
+    {
+        return new()
+        {
+            { "en", CreateNfcRichString() },
+            { "fr", CreateNfcRichString() }
+        };
+    }
+
+    public static WritingSystem CreateNfcWritingSystem()
+    {
+        return new()
+        {
+            Id = Guid.NewGuid(),
+            WsId = "en",
+            Type = WritingSystemType.Analysis,
+            Name = Nfc,
+            Abbreviation = Nfc,
+            Font = Nfc,
+            Exemplars = [Nfc, Nfc]
+        };
+    }
+
+    public static PartOfSpeech CreateNfcPartOfSpeech()
+    {
+        return new()
+        {
+            Id = Guid.NewGuid(),
+            Name = CreateNfcMultiString()
+        };
+    }
+
+    public static Publication CreateNfcPublication()
+    {
+        return new()
+        {
+            Id = Guid.NewGuid(),
+            Name = CreateNfcMultiString()
+        };
+    }
+
+    public static SemanticDomain CreateNfcSemanticDomain()
+    {
+        return new()
+        {
+            Id = Guid.NewGuid(),
+            Code = Nfc,
+            Name = CreateNfcMultiString()
+        };
+    }
+
+    public static ComplexFormType CreateNfcComplexFormType()
+    {
+        return new()
+        {
+            Id = Guid.NewGuid(),
+            Name = CreateNfcMultiString()
+        };
+    }
+
+    public static MorphType CreateNfcMorphType()
+    {
+        return new()
+        {
+            Id = Guid.NewGuid(),
+            Kind = MorphTypeKind.Stem,
+            Name = CreateNfcMultiString(),
+            Abbreviation = CreateNfcMultiString(),
+            Description = CreateNfcRichMultiString(),
+            Prefix = Nfc,
+            Postfix = Nfc
+        };
+    }
+
+    public static Translation CreateNfcTranslation()
+    {
+        return new()
+        {
+            Id = Guid.NewGuid(),
+            Text = CreateNfcRichMultiString()
+        };
+    }
+
+    public static ExampleSentence CreateNfcExampleSentence()
+    {
+        return new()
+        {
+            Id = Guid.NewGuid(),
+            Sentence = CreateNfcRichMultiString(),
+            Reference = CreateNfcRichString()
+        };
+    }
+
+    public static ExampleSentence CreateNfcExampleSentenceWithTranslations()
+    {
+        return new()
+        {
+            Id = Guid.NewGuid(),
+            Sentence = CreateNfcRichMultiString(),
+            Reference = CreateNfcRichString(),
+            Translations = [CreateNfcTranslation(), CreateNfcTranslation()]
+        };
+    }
+
+    public static Sense CreateNfcSense()
+    {
+        return new()
+        {
+            Id = Guid.NewGuid(),
+            Gloss = CreateNfcMultiString(),
+            Definition = CreateNfcRichMultiString()
+        };
+    }
+
+    public static Sense CreateNfcSenseWithExamples()
+    {
+        return new()
+        {
+            Id = Guid.NewGuid(),
+            Gloss = CreateNfcMultiString(),
+            Definition = CreateNfcRichMultiString(),
+            SemanticDomains = [CreateNfcSemanticDomain()],
+            PartOfSpeech = CreateNfcPartOfSpeech(),
+            ExampleSentences = [CreateNfcExampleSentenceWithTranslations()]
+        };
+    }
+
+    public static ComplexFormComponent CreateNfcComplexFormComponent()
+    {
+        return new()
+        {
+            Id = Guid.NewGuid(),
+            ComplexFormEntryId = Guid.NewGuid(),
+            ComponentEntryId = Guid.NewGuid(),
+            ComplexFormHeadword = Nfc,
+            ComponentHeadword = Nfc
+        };
+    }
+
+    public static Entry CreateNfcEntry()
+    {
+        return new()
+        {
+            Id = Guid.NewGuid(),
+            LexemeForm = CreateNfcMultiString(),
+            CitationForm = CreateNfcMultiString(),
+            LiteralMeaning = CreateNfcRichMultiString(),
+            Note = CreateNfcRichMultiString()
+        };
+    }
+
+    public static Entry CreateNfcEntryWithSenses()
+    {
+        return new()
+        {
+            Id = Guid.NewGuid(),
+            LexemeForm = CreateNfcMultiString(),
+            CitationForm = CreateNfcMultiString(),
+            LiteralMeaning = CreateNfcRichMultiString(),
+            Note = CreateNfcRichMultiString(),
+            Senses = [CreateNfcSenseWithExamples()]
+        };
+    }
+
+    public static Entry CreateNfcEntryWithComponents()
+    {
+        return new()
+        {
+            Id = Guid.NewGuid(),
+            LexemeForm = CreateNfcMultiString(),
+            CitationForm = CreateNfcMultiString(),
+            LiteralMeaning = CreateNfcRichMultiString(),
+            Note = CreateNfcRichMultiString(),
+            Components = [CreateNfcComplexFormComponent()],
+            ComplexForms = [CreateNfcComplexFormComponent()]
+        };
+    }
+}

--- a/backend/FwLite/MiniLcm.Tests/Helpers/NormalizationAssert.cs
+++ b/backend/FwLite/MiniLcm.Tests/Helpers/NormalizationAssert.cs
@@ -1,0 +1,137 @@
+using System.Collections;
+using System.Reflection;
+using System.Text;
+
+namespace MiniLcm.Tests.Helpers;
+
+/// <summary>
+/// For verifying that every string-bearing property of an object is normalized (NFC or NFD).
+/// </summary>
+public static class NormalizationAssert
+{
+    private static readonly Dictionary<Type, HashSet<string>> SkippedProperties = new()
+    {
+        // WritingSystem fields are generally LDML-managed and seem to not be normalized by FieldWorks
+        [typeof(WritingSystem)] =
+        [
+            nameof(WritingSystem.WsId),
+            nameof(WritingSystem.Name),
+            nameof(WritingSystem.Abbreviation),
+            nameof(WritingSystem.Font),
+            nameof(WritingSystem.Exemplars),
+        ],
+    };
+
+    public static void AssertAllNfc(object? obj)
+    {
+        Assert(obj, NormalizationForm.FormC);
+    }
+
+    public static void AssertAllNfd(object? obj)
+    {
+        Assert(obj, NormalizationForm.FormD);
+    }
+
+    public static bool IsAllNfd(object obj)
+    {
+        return FindIssues(obj, NormalizationForm.FormD).Count == 0;
+    }
+
+    private static void Assert(object? obj, NormalizationForm form)
+    {
+        if (obj is null) throw new Xunit.Sdk.XunitException("Expected object to be non-null but was null");
+        var issues = FindIssues(obj, form);
+        if (issues.Count == 0) return;
+        var name = FormName(form);
+        throw new Xunit.Sdk.XunitException(
+            $"Expected all normalizable properties to contain {name} strings, but found issues:\n" +
+            string.Join("\n", issues.Select(i => "  - " + i))
+        );
+    }
+
+    private static List<string> FindIssues(object obj, NormalizationForm form)
+    {
+        var issues = new List<string>();
+        Visit(obj, "", form, issues);
+        return issues;
+    }
+
+    private static void Visit(object? obj, string path, NormalizationForm form, List<string> issues)
+    {
+        switch (obj)
+        {
+            case null:
+                return;
+            case string s:
+                CheckString(s, path, form, issues);
+                return;
+            case MultiString ms:
+                if (ms.Values.Count == 0) issues.Add($"{path}: MultiString has no values (must have at least one for testing)");
+                foreach (var (key, value) in ms.Values) CheckString(value, $"{path}.Values[{key}]", form, issues);
+                return;
+            case RichString rs:
+                if (rs.Spans.Count == 0) issues.Add($"{path}: RichString has no spans (must have at least one for testing)");
+                for (var i = 0; i < rs.Spans.Count; i++) CheckString(rs.Spans[i].Text, $"{path}.Spans[{i}].Text", form, issues);
+                return;
+            case RichMultiString rms:
+                if (rms.Count == 0) issues.Add($"{path}: RichMultiString has no values (must have at least one for testing)");
+                foreach (var (key, value) in rms) Visit(value, $"{path}[{key}]", form, issues);
+                return;
+            case IEnumerable seq:
+                var i2 = 0;
+                foreach (var item in seq) Visit(item, $"{path}[{i2++}]", form, issues);
+                return;
+            default:
+                break;
+        }
+
+        VisitModelProperties(obj, path, form, issues);
+    }
+
+    private static void VisitModelProperties(object obj, string path, NormalizationForm form, List<string> issues)
+    {
+        var type = obj.GetType();
+        if (type.Namespace?.StartsWith("MiniLcm.Models", StringComparison.Ordinal) != true)
+            throw new Xunit.Sdk.XunitException($"Unexpected type {type.FullName} at {(string.IsNullOrEmpty(path) ? "<root>" : path)}");
+
+        var skipped = SkippedProperties.GetValueOrDefault(type);
+        foreach (var prop in type.GetProperties(BindingFlags.Public | BindingFlags.Instance))
+        {
+            if (!prop.CanRead || skipped?.Contains(prop.Name) == true) continue;
+            if (IsIgnoredType(prop.PropertyType)) continue;
+
+            var value = prop.GetValue(obj);
+            if (value is null) continue;
+
+            var propPath = string.IsNullOrEmpty(path) ? prop.Name : $"{path}.{prop.Name}";
+            Visit(value, propPath, form, issues);
+        }
+    }
+
+    private static bool IsIgnoredType(Type type)
+    {
+        var underlying = Nullable.GetUnderlyingType(type) ?? type;
+        return underlying.IsPrimitive || underlying.IsEnum ||
+               underlying == typeof(Guid) || underlying == typeof(DateTime) ||
+               underlying == typeof(DateTimeOffset) || underlying == typeof(decimal);
+    }
+
+    private static void CheckString(string? value, string path, NormalizationForm form, List<string> issues)
+    {
+        if (string.IsNullOrEmpty(value))
+        {
+            issues.Add($"{path}: string is null or empty (must have a value for testing)");
+            return;
+        }
+        if (!value.IsNormalized(form))
+        {
+            var name = FormName(form);
+            issues.Add($"{path}: expected {name} but \"{value}\" is not {name}-normalized");
+        }
+    }
+
+    private static string FormName(NormalizationForm form)
+    {
+        return form == NormalizationForm.FormC ? "NFC" : "NFD";
+    }
+}

--- a/backend/FwLite/MiniLcm.Tests/MiniLcmTestBase.cs
+++ b/backend/FwLite/MiniLcm.Tests/MiniLcmTestBase.cs
@@ -17,7 +17,10 @@ public abstract class MiniLcmTestBase : IAsyncLifetime
     {
         BaseApi = await NewApi();
         BaseApi.Should().NotBeNull();
-        Api = BaseApi.WrapWith([new MiniLcmApiStringNormalizationWrapperFactory()], null!);
+        Api = BaseApi.WrapWith([
+            new MiniLcmApiQueryNormalizationWrapperFactory(),
+            new MiniLcmApiWriteNormalizationWrapperFactory(),
+        ], null!);
         Api.Should().NotBeNull();
     }
 

--- a/backend/FwLite/MiniLcm.Tests/NormalizationTests.cs
+++ b/backend/FwLite/MiniLcm.Tests/NormalizationTests.cs
@@ -33,14 +33,14 @@ public class NormalizationTests
     {
         MockApi = Mock.Of<IMiniLcmApi>();
         // Mock.Get(MockApi).Setup(api => api.SearchEntries(It.IsAny<string>(), null)).Returns(new List<Entry>().ToAsyncEnumerable());
-        var factory = new MiniLcmApiStringNormalizationWrapperFactory();
+        var factory = new MiniLcmApiQueryNormalizationWrapperFactory();
         NormalizingApi = factory.Create(MockApi);
     }
 
     [Fact]
     public void SearchEntriesIsNormalized()
     {
-        NormalizingApi.Should().BeOfType<MiniLcmApiStringNormalizationWrapper>();
+        NormalizingApi.Should().BeOfType<MiniLcmApiQueryNormalizationWrapper>();
         var results = NormalizingApi.SearchEntries(NFCString, null);
         Mock.Get(MockApi).Verify(api => api.SearchEntries(NFDString, null));
     }
@@ -48,7 +48,7 @@ public class NormalizationTests
     [Fact]
     public void SearchEntriesWithQueryOptionsAreNormalized()
     {
-        NormalizingApi.Should().BeOfType<MiniLcmApiStringNormalizationWrapper>();
+        NormalizingApi.Should().BeOfType<MiniLcmApiQueryNormalizationWrapper>();
         var results = NormalizingApi.SearchEntries(NFCString, NFCQueryOptions);
         Mock.Get(MockApi).Verify(api => api.SearchEntries(NFDString, It.Is<QueryOptions>(
             opt => opt.Exemplar!.Value == NFDOptions.Exemplar!.Value &&
@@ -58,7 +58,7 @@ public class NormalizationTests
     [Fact]
     public void CountEntriesIsNormalized()
     {
-        NormalizingApi.Should().BeOfType<MiniLcmApiStringNormalizationWrapper>();
+        NormalizingApi.Should().BeOfType<MiniLcmApiQueryNormalizationWrapper>();
         var results = NormalizingApi.CountEntries(NFCString, null);
         Mock.Get(MockApi).Verify(api => api.CountEntries(NFDString, null));
     }
@@ -66,7 +66,7 @@ public class NormalizationTests
     [Fact]
     public void CountEntriesWithFilterQueryOptionsIsNormalized()
     {
-        NormalizingApi.Should().BeOfType<MiniLcmApiStringNormalizationWrapper>();
+        NormalizingApi.Should().BeOfType<MiniLcmApiQueryNormalizationWrapper>();
         var results = NormalizingApi.CountEntries(NFCString, NFCOptions);
         Mock.Get(MockApi).Verify(api => api.CountEntries(NFDString, It.Is<FilterQueryOptions>(
             opt => opt.Exemplar!.Value == NFDOptions.Exemplar!.Value &&
@@ -76,7 +76,7 @@ public class NormalizationTests
     [Fact]
     public void GetEntriesIsNormalized()
     {
-        NormalizingApi.Should().BeOfType<MiniLcmApiStringNormalizationWrapper>();
+        NormalizingApi.Should().BeOfType<MiniLcmApiQueryNormalizationWrapper>();
         var results = NormalizingApi.GetEntries(NFCQueryOptions);
         Mock.Get(MockApi).Verify(api => api.GetEntries(It.Is<QueryOptions>(
             opt => opt.Exemplar!.Value == NFDOptions.Exemplar!.Value &&

--- a/backend/FwLite/MiniLcm.Tests/QueryEntryTestsBase.cs
+++ b/backend/FwLite/MiniLcm.Tests/QueryEntryTestsBase.cs
@@ -410,12 +410,10 @@ public abstract class QueryEntryTestsBase : MiniLcmTestBase
     {
         // identical is to make the test cases more readable when they only differ in their normalization
         (searchTerm == word).Should().Be(identical);
-        // remove next line in https://github.com/sillsdev/languageforge-lexbox/issues/2065
-        word = word.Normalize(NormalizationForm.FormD);
         await Api.CreateEntry(new Entry { LexemeForm = { ["en"] = word } });
         var words = await Api.SearchEntries(searchTerm).Select(e => e.LexemeForm["en"]).ToArrayAsync();
         words.Should().NotBeEmpty();
-        // Like LicLCM the MiniLcm API should normalize to NFD
+        // The API normalizes to NFD on write, so results should be NFD regardless of input
         words.Should().Contain(word.Normalize(NormalizationForm.FormD));
     }
 
@@ -427,12 +425,10 @@ public abstract class QueryEntryTestsBase : MiniLcmTestBase
     [InlineData("É", "È")] // Different accents
     public async Task NegativeMatches(string searchTerm, string word)
     {
-        word = word.Normalize(NormalizationForm.FormD);
-        //should we be normalizing the search term internally?
-        searchTerm = searchTerm.Normalize(NormalizationForm.FormD);
         await Api.CreateEntry(new Entry { LexemeForm = { ["en"] = word } });
         var words = await Api.SearchEntries(searchTerm).Select(e => e.LexemeForm["en"]).ToArrayAsync();
         words.Should().NotContain(word);
+        words.Should().NotContain(word.Normalize(NormalizationForm.FormD));
     }
 
     [Theory]

--- a/backend/FwLite/MiniLcm.Tests/SortingTestsBase.cs
+++ b/backend/FwLite/MiniLcm.Tests/SortingTestsBase.cs
@@ -143,7 +143,7 @@ public abstract class SortingTestsBase : MiniLcmTestBase
         var lastLongestContainsMatches = CreateSortedEntrySet("ccaaaa");
 
         var entryId = Guid.NewGuid();
-        Entry nonHeadwordMatch = new() { Id = entryId, Senses = [new() { EntryId = entryId, Gloss = { ["en"] = "aaaa" } }] };
+        Entry nonHeadwordMatch = new() { Id = entryId, Senses = [new() { Id = Guid.NewGuid(), EntryId = entryId, Gloss = { ["en"] = "aaaa" } }] };
 
         Entry[] expected = [
             .. exactMatches,
@@ -167,10 +167,9 @@ public abstract class SortingTestsBase : MiniLcmTestBase
             .Where(e => ids.Contains(e.Id))
             .ToList();
 
-        results.Should().BeEquivalentTo(expected,
-            options => options);
-        results.Should().BeEquivalentTo(expected,
-            options => options.WithStrictOrdering());
+        results.Should().BeEquivalentTo(expected, options => options
+            .WithStrictOrdering()
+            .For(e => e.Senses).Exclude(s => s.Order));
     }
 
     [Theory]
@@ -201,7 +200,7 @@ public abstract class SortingTestsBase : MiniLcmTestBase
         var lastLongestContainsMatches = CreateSortedEntrySet("ccaaaa");
 
         var entryId = Guid.NewGuid();
-        Entry nonHeadwordMatch = new() { Id = entryId, Senses = [new() { EntryId = entryId, Gloss = { ["en"] = "aaaa" } }] };
+        Entry nonHeadwordMatch = new() { Id = entryId, Senses = [new() { Id = Guid.NewGuid(), EntryId = entryId, Gloss = { ["en"] = "aaaa" } }] };
 
         Entry[] expected = [
             .. exactMatches,
@@ -225,10 +224,9 @@ public abstract class SortingTestsBase : MiniLcmTestBase
             .Where(e => ids.Contains(e.Id))
             .ToList();
 
-        results.Should().BeEquivalentTo(expected,
-            options => options);
-        results.Should().BeEquivalentTo(expected,
-            options => options.WithStrictOrdering());
+        results.Should().BeEquivalentTo(expected, options => options
+            .WithStrictOrdering()
+            .For(e => e.Senses).Exclude(s => s.Order));
     }
 
     [Theory]
@@ -260,8 +258,6 @@ public abstract class SortingTestsBase : MiniLcmTestBase
             .Where(e => ids.Contains(e.Id))
             .ToList();
 
-        results.Should().BeEquivalentTo(expected,
-            options => options);
         results.Should().BeEquivalentTo(expected,
             options => options.WithStrictOrdering());
     }
@@ -295,8 +291,6 @@ public abstract class SortingTestsBase : MiniLcmTestBase
             .Where(e => ids.Contains(e.Id))
             .ToList();
 
-        results.Should().BeEquivalentTo(expected,
-            options => options);
         results.Should().BeEquivalentTo(expected,
             options => options.WithStrictOrdering());
     }

--- a/backend/FwLite/MiniLcm.Tests/UpdateEntryTestsBase.cs
+++ b/backend/FwLite/MiniLcm.Tests/UpdateEntryTestsBase.cs
@@ -169,7 +169,9 @@ public abstract class UpdateEntryTestsBase : MiniLcmTestBase
         afterEntry.Senses = afterSenses;
 
         // sanity checks
-        beforeEntry.Senses.Should().BeEquivalentTo(beforeSenses, options => options.WithStrictOrdering());
+        beforeEntry.Senses.Should().BeEquivalentTo(beforeSenses, options => options
+            .WithStrictOrdering()
+            .Excluding(s => s.Order));
         if (!ApiUsesImplicitOrdering)
         {
             beforeEntry.Senses.Select(s => s.Order).Should()
@@ -231,7 +233,9 @@ public abstract class UpdateEntryTestsBase : MiniLcmTestBase
         afterSense.ExampleSentences = afterExamples;
 
         // sanity checks
-        beforeSense.ExampleSentences.Should().BeEquivalentTo(beforeExamples, options => options.WithStrictOrdering());
+        beforeSense.ExampleSentences.Should().BeEquivalentTo(beforeExamples, options => options
+            .WithStrictOrdering()
+            .Excluding(s => s.Order));
         if (!ApiUsesImplicitOrdering)
         {
             beforeSense.ExampleSentences.Select(s => s.Order).Should()
@@ -309,7 +313,8 @@ public abstract class UpdateEntryTestsBase : MiniLcmTestBase
         // sanity checks
         beforeEntry.Components.Should().BeEquivalentTo(beforeComponents, options => options
             .WithStrictOrdering()
-            .Excluding(c => c.Id));
+            .Excluding(c => c.Id)
+            .Excluding(c => c.Order));
         if (!ApiUsesImplicitOrdering)
         {
             beforeEntry.Components.Select(s => s.Order).Should()

--- a/backend/FwLite/MiniLcm.Tests/WriteNormalizationTests.cs
+++ b/backend/FwLite/MiniLcm.Tests/WriteNormalizationTests.cs
@@ -1,0 +1,783 @@
+using System.Text.Json;
+using MiniLcm.Normalization;
+using MiniLcm.SyncHelpers;
+using Moq;
+using SystemTextJsonPatch.Operations;
+using MiniLcm.Tests.Helpers;
+using static MiniLcm.Tests.Helpers.NormalizationAssert;
+
+namespace MiniLcm.Tests;
+
+public class WriteNormalizationTests
+{
+    private readonly IMiniLcmApi _mockApi;
+    private readonly IMiniLcmApi _normalizingApi;
+
+    public WriteNormalizationTests()
+    {
+        _mockApi = Mock.Of<IMiniLcmApi>();
+        var factory = new MiniLcmApiWriteNormalizationWrapperFactory();
+        _normalizingApi = factory.Create(_mockApi);
+    }
+
+    #region WritingSystem Tests
+
+    // WritingSystem.{Name, Abbreviation, Font, Exemplars} are plain strings; in liblcm they are
+    // LDML-managed by WritingSystemManager rather than stored as TsString, so the wrapper passes
+    // them through unchanged (no NFD normalization).
+
+    [Fact]
+    public async Task CreateWritingSystem_DoesNotNormalize()
+    {
+        var ws = NfcTestData.CreateNfcWritingSystem();
+
+        WritingSystem? captured = null;
+        Mock.Get(_mockApi)
+            .Setup(api => api.CreateWritingSystem(It.IsAny<WritingSystem>(), It.IsAny<BetweenPosition<WritingSystemId?>?>()))
+            .Callback<WritingSystem, BetweenPosition<WritingSystemId?>?>((w, _) => captured = w)
+            .ReturnsAsync(ws);
+
+        await _normalizingApi.CreateWritingSystem(ws);
+
+        captured.Should().NotBeNull();
+        captured.Name.Should().Be(NfcTestData.Nfc);
+        captured.Abbreviation.Should().Be(NfcTestData.Nfc);
+        captured.Font.Should().Be(NfcTestData.Nfc);
+        captured.Exemplars.Should().Equal(NfcTestData.Nfc, NfcTestData.Nfc);
+    }
+
+    [Fact]
+    public async Task UpdateWritingSystem_BeforeAfter_DoesNotNormalize()
+    {
+        var before = NfcTestData.CreateNfcWritingSystem();
+        var after = NfcTestData.CreateNfcWritingSystem();
+
+        WritingSystem? captured = null;
+        Mock.Get(_mockApi)
+            .Setup(api => api.UpdateWritingSystem(It.IsAny<WritingSystem>(), It.IsAny<WritingSystem>(), It.IsAny<IMiniLcmApi>()))
+            .Callback<WritingSystem, WritingSystem, IMiniLcmApi?>((_, a, _) => captured = a)
+            .ReturnsAsync(after);
+
+        await _normalizingApi.UpdateWritingSystem(before, after);
+
+        captured.Should().NotBeNull();
+        captured.Name.Should().Be(NfcTestData.Nfc);
+        captured.Abbreviation.Should().Be(NfcTestData.Nfc);
+        captured.Font.Should().Be(NfcTestData.Nfc);
+        captured.Exemplars.Should().Equal(NfcTestData.Nfc, NfcTestData.Nfc);
+    }
+
+    #endregion
+
+    #region PartOfSpeech Tests
+
+    [Fact]
+    public async Task CreatePartOfSpeech_NormalizesToNfd()
+    {
+        var pos = NfcTestData.CreateNfcPartOfSpeech();
+
+        PartOfSpeech? captured = null;
+        Mock.Get(_mockApi)
+            .Setup(api => api.CreatePartOfSpeech(It.IsAny<PartOfSpeech>()))
+            .Callback<PartOfSpeech>(p => captured = p)
+            .ReturnsAsync(pos);
+
+        await _normalizingApi.CreatePartOfSpeech(pos);
+
+        captured.Should().NotBeNull();
+        AssertAllNfd(captured);
+    }
+
+    [Fact]
+    public async Task UpdatePartOfSpeech_BeforeAfter_NormalizesBothToNfd()
+    {
+        var before = NfcTestData.CreateNfcPartOfSpeech();
+        var after = NfcTestData.CreateNfcPartOfSpeech();
+
+        PartOfSpeech? capturedBefore = null;
+        PartOfSpeech? capturedAfter = null;
+        Mock.Get(_mockApi)
+            .Setup(api => api.UpdatePartOfSpeech(It.IsAny<PartOfSpeech>(), It.IsAny<PartOfSpeech>(), It.IsAny<IMiniLcmApi>()))
+            .Callback<PartOfSpeech, PartOfSpeech, IMiniLcmApi?>((b, a, _) => { capturedBefore = b; capturedAfter = a; })
+            .ReturnsAsync(after);
+
+        await _normalizingApi.UpdatePartOfSpeech(before, after);
+
+        AssertAllNfd(capturedBefore);
+        AssertAllNfd(capturedAfter);
+    }
+
+    #endregion
+
+    #region Publication Tests
+
+    [Fact]
+    public async Task CreatePublication_NormalizesToNfd()
+    {
+        var pub = NfcTestData.CreateNfcPublication();
+
+        Publication? captured = null;
+        Mock.Get(_mockApi)
+            .Setup(api => api.CreatePublication(It.IsAny<Publication>()))
+            .Callback<Publication>(p => captured = p)
+            .ReturnsAsync(pub);
+
+        await _normalizingApi.CreatePublication(pub);
+
+        captured.Should().NotBeNull();
+        AssertAllNfd(captured);
+    }
+
+    [Fact]
+    public async Task UpdatePublication_BeforeAfter_NormalizesBothToNfd()
+    {
+        var before = NfcTestData.CreateNfcPublication();
+        var after = NfcTestData.CreateNfcPublication();
+
+        Publication? capturedBefore = null;
+        Publication? capturedAfter = null;
+        Mock.Get(_mockApi)
+            .Setup(api => api.UpdatePublication(It.IsAny<Publication>(), It.IsAny<Publication>(), It.IsAny<IMiniLcmApi>()))
+            .Callback<Publication, Publication, IMiniLcmApi?>((b, a, _) => { capturedBefore = b; capturedAfter = a; })
+            .ReturnsAsync(after);
+
+        await _normalizingApi.UpdatePublication(before, after);
+
+        AssertAllNfd(capturedBefore);
+        AssertAllNfd(capturedAfter);
+    }
+
+    #endregion
+
+    #region SemanticDomain Tests
+
+    [Fact]
+    public async Task CreateSemanticDomain_NormalizesToNfd()
+    {
+        var sd = NfcTestData.CreateNfcSemanticDomain();
+
+        SemanticDomain? captured = null;
+        Mock.Get(_mockApi)
+            .Setup(api => api.CreateSemanticDomain(It.IsAny<SemanticDomain>()))
+            .Callback<SemanticDomain>(s => captured = s)
+            .ReturnsAsync(sd);
+
+        await _normalizingApi.CreateSemanticDomain(sd);
+
+        captured.Should().NotBeNull();
+        AssertAllNfd(captured);
+    }
+
+    [Fact]
+    public async Task UpdateSemanticDomain_BeforeAfter_NormalizesBothToNfd()
+    {
+        var before = NfcTestData.CreateNfcSemanticDomain();
+        var after = NfcTestData.CreateNfcSemanticDomain();
+
+        SemanticDomain? capturedBefore = null;
+        SemanticDomain? capturedAfter = null;
+        Mock.Get(_mockApi)
+            .Setup(api => api.UpdateSemanticDomain(It.IsAny<SemanticDomain>(), It.IsAny<SemanticDomain>(), It.IsAny<IMiniLcmApi>()))
+            .Callback<SemanticDomain, SemanticDomain, IMiniLcmApi?>((b, a, _) => { capturedBefore = b; capturedAfter = a; })
+            .ReturnsAsync(after);
+
+        await _normalizingApi.UpdateSemanticDomain(before, after);
+
+        AssertAllNfd(capturedBefore);
+        AssertAllNfd(capturedAfter);
+    }
+
+    [Fact]
+    public async Task AddSemanticDomainToSense_NormalizesToNfd()
+    {
+        var sd = NfcTestData.CreateNfcSemanticDomain();
+
+        SemanticDomain? captured = null;
+        Mock.Get(_mockApi)
+            .Setup(api => api.AddSemanticDomainToSense(It.IsAny<Guid>(), It.IsAny<SemanticDomain>()))
+            .Callback<Guid, SemanticDomain>((_, s) => captured = s)
+            .Returns(Task.CompletedTask);
+
+        await _normalizingApi.AddSemanticDomainToSense(Guid.NewGuid(), sd);
+
+        captured.Should().NotBeNull();
+        AssertAllNfd(captured);
+    }
+
+    [Fact]
+    public async Task BulkImportSemanticDomains_NormalizesToNfd()
+    {
+        var domains = new[] { NfcTestData.CreateNfcSemanticDomain(), NfcTestData.CreateNfcSemanticDomain() };
+
+        var captured = new List<SemanticDomain>();
+        Mock.Get(_mockApi)
+            .Setup(api => api.BulkImportSemanticDomains(It.IsAny<IAsyncEnumerable<SemanticDomain>>()))
+            .Returns(async (IAsyncEnumerable<SemanticDomain> stream) =>
+            {
+                await foreach (var sd in stream) captured.Add(sd);
+            });
+
+        await _normalizingApi.BulkImportSemanticDomains(domains.ToAsyncEnumerable());
+
+        captured.Should().HaveCount(2);
+        AssertAllNfd(captured);
+    }
+
+    #endregion
+
+    #region ComplexFormType Tests
+
+    [Fact]
+    public async Task CreateComplexFormType_NormalizesToNfd()
+    {
+        var cft = NfcTestData.CreateNfcComplexFormType();
+
+        ComplexFormType? captured = null;
+        Mock.Get(_mockApi)
+            .Setup(api => api.CreateComplexFormType(It.IsAny<ComplexFormType>()))
+            .Callback<ComplexFormType>(c => captured = c)
+            .ReturnsAsync(cft);
+
+        await _normalizingApi.CreateComplexFormType(cft);
+
+        captured.Should().NotBeNull();
+        AssertAllNfd(captured);
+    }
+
+    [Fact]
+    public async Task UpdateComplexFormType_BeforeAfter_NormalizesBothToNfd()
+    {
+        var before = NfcTestData.CreateNfcComplexFormType();
+        var after = NfcTestData.CreateNfcComplexFormType();
+
+        ComplexFormType? capturedBefore = null;
+        ComplexFormType? capturedAfter = null;
+        Mock.Get(_mockApi)
+            .Setup(api => api.UpdateComplexFormType(It.IsAny<ComplexFormType>(), It.IsAny<ComplexFormType>(), It.IsAny<IMiniLcmApi>()))
+            .Callback<ComplexFormType, ComplexFormType, IMiniLcmApi?>((b, a, _) => { capturedBefore = b; capturedAfter = a; })
+            .ReturnsAsync(after);
+
+        await _normalizingApi.UpdateComplexFormType(before, after);
+
+        AssertAllNfd(capturedBefore);
+        AssertAllNfd(capturedAfter);
+    }
+
+    #endregion
+
+    #region MorphType Tests
+
+    [Fact]
+    public async Task UpdateMorphType_BeforeAfter_NormalizesBothToNfd()
+    {
+        var before = NfcTestData.CreateNfcMorphType();
+        var after = NfcTestData.CreateNfcMorphType();
+
+        MorphType? capturedBefore = null;
+        MorphType? capturedAfter = null;
+        Mock.Get(_mockApi)
+            .Setup(api => api.UpdateMorphType(It.IsAny<MorphType>(), It.IsAny<MorphType>(), It.IsAny<IMiniLcmApi>()))
+            .Callback<MorphType, MorphType, IMiniLcmApi?>((b, a, _) => { capturedBefore = b; capturedAfter = a; })
+            .ReturnsAsync(after);
+
+        await _normalizingApi.UpdateMorphType(before, after);
+
+        AssertAllNfd(capturedBefore);
+        AssertAllNfd(capturedAfter);
+    }
+
+    [Fact]
+    public async Task UpdateMorphType_JsonPatch_NormalizesToNfd()
+    {
+        var update = new UpdateObjectInput<MorphType>()
+            .Set(m => m.Name, NfcTestData.CreateNfcMultiString())
+            .Set(m => m.Prefix, NfcTestData.Nfc)
+            .Set(m => m.Postfix, NfcTestData.Nfc);
+
+        UpdateObjectInput<MorphType>? captured = null;
+        Mock.Get(_mockApi)
+            .Setup(api => api.UpdateMorphType(It.IsAny<Guid>(), It.IsAny<UpdateObjectInput<MorphType>>()))
+            .Callback<Guid, UpdateObjectInput<MorphType>>((_, patch) => captured = patch)
+            .ReturnsAsync(NfcTestData.CreateNfcMorphType());
+
+        await _normalizingApi.UpdateMorphType(Guid.NewGuid(), update);
+
+        captured.Should().NotBeNull();
+        var byPath = captured.Patch.Operations.ToDictionary(o => o.Path!, o => o.Value);
+        AssertAllNfd(byPath["/Name"].Should().BeOfType<MultiString>().Subject);
+        byPath["/Prefix"].Should().Be(NfcTestData.Nfd);
+        byPath["/Postfix"].Should().Be(NfcTestData.Nfd);
+    }
+
+    #endregion
+
+    #region Entry Tests
+
+    [Fact]
+    public async Task CreateEntry_NormalizesToNfd()
+    {
+        var entry = NfcTestData.CreateNfcEntry();
+
+        Entry? captured = null;
+        Mock.Get(_mockApi)
+            .Setup(api => api.CreateEntry(It.IsAny<Entry>(), It.IsAny<CreateEntryOptions?>()))
+            .Callback<Entry, CreateEntryOptions?>((e, _) => captured = e)
+            .ReturnsAsync(entry);
+
+        await _normalizingApi.CreateEntry(entry);
+
+        captured.Should().NotBeNull();
+        AssertAllNfd(captured);
+    }
+
+    [Fact]
+    public async Task UpdateEntry_BeforeAfter_NormalizesBothToNfd()
+    {
+        var before = NfcTestData.CreateNfcEntry();
+        var after = NfcTestData.CreateNfcEntry();
+
+        Entry? capturedBefore = null;
+        Entry? capturedAfter = null;
+        Mock.Get(_mockApi)
+            .Setup(api => api.UpdateEntry(It.IsAny<Entry>(), It.IsAny<Entry>(), It.IsAny<IMiniLcmApi>()))
+            .Callback<Entry, Entry, IMiniLcmApi?>((b, a, _) => { capturedBefore = b; capturedAfter = a; })
+            .ReturnsAsync(after);
+
+        await _normalizingApi.UpdateEntry(before, after);
+
+        AssertAllNfd(capturedBefore);
+        AssertAllNfd(capturedAfter);
+    }
+
+    [Fact]
+    public async Task CreateEntry_WithNestedSenses_NormalizesToNfd()
+    {
+        var entry = NfcTestData.CreateNfcEntryWithSenses();
+
+        Entry? captured = null;
+        Mock.Get(_mockApi)
+            .Setup(api => api.CreateEntry(It.IsAny<Entry>(), It.IsAny<CreateEntryOptions?>()))
+            .Callback<Entry, CreateEntryOptions?>((e, _) => captured = e)
+            .ReturnsAsync(entry);
+
+        await _normalizingApi.CreateEntry(entry);
+
+        captured.Should().NotBeNull();
+        AssertAllNfd(captured);
+    }
+
+    [Fact]
+    public async Task CreateEntry_WithComplexFormComponents_NormalizesToNfd()
+    {
+        var entry = NfcTestData.CreateNfcEntryWithComponents();
+
+        Entry? captured = null;
+        Mock.Get(_mockApi)
+            .Setup(api => api.CreateEntry(It.IsAny<Entry>(), It.IsAny<CreateEntryOptions?>()))
+            .Callback<Entry, CreateEntryOptions?>((e, _) => captured = e)
+            .ReturnsAsync(entry);
+
+        await _normalizingApi.CreateEntry(entry);
+
+        captured.Should().NotBeNull();
+        AssertAllNfd(captured);
+    }
+
+    [Fact]
+    public async Task BulkCreateEntries_NormalizesToNfd()
+    {
+        var entries = new[] { NfcTestData.CreateNfcEntry(), NfcTestData.CreateNfcEntryWithSenses() };
+
+        var captured = new List<Entry>();
+        Mock.Get(_mockApi)
+            .Setup(api => api.BulkCreateEntries(It.IsAny<IAsyncEnumerable<Entry>>()))
+            .Returns(async (IAsyncEnumerable<Entry> stream) =>
+            {
+                await foreach (var e in stream) captured.Add(e);
+            });
+
+        await _normalizingApi.BulkCreateEntries(entries.ToAsyncEnumerable());
+
+        captured.Should().HaveCount(2);
+        AssertAllNfd(captured);
+    }
+
+    #endregion
+
+    #region JsonPatch Tests
+
+    [Fact]
+    public async Task UpdateEntry_JsonPatch_NormalizesValuesToNfd()
+    {
+        var update = new UpdateObjectInput<Entry>()
+            .Set(e => e.LexemeForm["en"], NfcTestData.Nfc)
+            .Set(e => e.CitationForm, NfcTestData.CreateNfcMultiString())
+            .Set(e => e.Note["en"], NfcTestData.CreateNfcRichString())
+            .Set(e => e.LiteralMeaning, NfcTestData.CreateNfcRichMultiString());
+
+        UpdateObjectInput<Entry>? captured = null;
+        Mock.Get(_mockApi)
+            .Setup(api => api.UpdateEntry(It.IsAny<Guid>(), It.IsAny<UpdateObjectInput<Entry>>()))
+            .Callback<Guid, UpdateObjectInput<Entry>>((_, patch) => captured = patch)
+            .ReturnsAsync(NfcTestData.CreateNfcEntry());
+
+        await _normalizingApi.UpdateEntry(Guid.NewGuid(), update);
+
+        captured.Should().NotBeNull();
+        captured.Should().NotBeSameAs(update); // rebuilt because Entry path normalizes
+        AssertAllPatchValuesNfd(captured);
+    }
+
+    [Fact]
+    public async Task UpdateEntry_JsonPatch_NormalizesJsonElementString()
+    {
+        using var document = JsonDocument.Parse($"\"{NfcTestData.Nfc}\"");
+        var update = new UpdateObjectInput<Entry>();
+        update.Patch.Operations.Add(new Operation<Entry>("replace", "/LexemeForm/en", null, document.RootElement));
+
+        UpdateObjectInput<Entry>? captured = null;
+        Mock.Get(_mockApi)
+            .Setup(api => api.UpdateEntry(It.IsAny<Guid>(), It.IsAny<UpdateObjectInput<Entry>>()))
+            .Callback<Guid, UpdateObjectInput<Entry>>((_, patch) => captured = patch)
+            .ReturnsAsync(NfcTestData.CreateNfcEntry());
+
+        await _normalizingApi.UpdateEntry(Guid.NewGuid(), update);
+
+        captured.Should().NotBeNull();
+        captured.Patch.Operations.Single().Value
+            .Should().BeOfType<string>()
+            .Which.Should().Be(NfcTestData.Nfd);
+    }
+
+    [Fact]
+    public async Task UpdateWritingSystem_JsonPatch_DoesNotNormalize()
+    {
+        var update = new UpdateObjectInput<WritingSystem>()
+            .Set(ws => ws.Name, NfcTestData.Nfc)
+            .Set(ws => ws.Exemplars, [NfcTestData.Nfc, NfcTestData.Nfc]);
+
+        UpdateObjectInput<WritingSystem>? captured = null;
+        Mock.Get(_mockApi)
+            .Setup(api => api.UpdateWritingSystem(It.IsAny<WritingSystemId>(), It.IsAny<WritingSystemType>(),
+                It.IsAny<UpdateObjectInput<WritingSystem>>()))
+            .Callback<WritingSystemId, WritingSystemType, UpdateObjectInput<WritingSystem>>((_, _, patch) =>
+                captured = patch)
+            .ReturnsAsync(NfcTestData.CreateNfcWritingSystem());
+
+        await _normalizingApi.UpdateWritingSystem("en", WritingSystemType.Analysis, update);
+
+        captured.Should().BeSameAs(update); // pass-through, not rebuilt
+        var byPath = captured.Patch.Operations.ToDictionary(o => o.Path!, o => o.Value);
+        byPath.Should().HaveCount(2);
+        byPath["/Name"].Should().Be(NfcTestData.Nfc);
+        byPath["/Exemplars"].Should().BeOfType<string[]>()
+            .Which.Should().Equal(NfcTestData.Nfc, NfcTestData.Nfc);
+    }
+
+    /// <summary>
+    /// Asserts every non-null operation value in the patch is NFD. Delegates to
+    /// <see cref="AssertAllNfd"/>, which already understands string,
+    /// string[], MultiString, RichString, and RichMultiString — so failures report a property path.
+    /// </summary>
+    private static void AssertAllPatchValuesNfd<T>(UpdateObjectInput<T> update) where T : class
+    {
+        update.Patch.Operations.Should().NotBeEmpty();
+        foreach (var op in update.Patch.Operations)
+        {
+            if (op.Value is not null) AssertAllNfd(op.Value);
+        }
+    }
+
+    #endregion
+
+    #region ComplexFormComponent Tests
+
+    [Fact]
+    public async Task CreateComplexFormComponent_NormalizesToNfd()
+    {
+        var cfc = NfcTestData.CreateNfcComplexFormComponent();
+
+        ComplexFormComponent? captured = null;
+        Mock.Get(_mockApi)
+            .Setup(api => api.CreateComplexFormComponent(
+                It.IsAny<ComplexFormComponent>(), It.IsAny<BetweenPosition<ComplexFormComponent>?>()))
+            .Callback<ComplexFormComponent, BetweenPosition<ComplexFormComponent>?>((c, _) => captured = c)
+            .ReturnsAsync(cfc);
+
+        await _normalizingApi.CreateComplexFormComponent(cfc);
+
+        captured.Should().NotBeNull();
+        AssertAllNfd(captured);
+    }
+
+    #endregion
+
+    #region Sense Tests
+
+    [Fact]
+    public async Task CreateSense_NormalizesToNfd()
+    {
+        var sense = NfcTestData.CreateNfcSense();
+
+        Sense? captured = null;
+        Mock.Get(_mockApi)
+            .Setup(api => api.CreateSense(It.IsAny<Guid>(), It.IsAny<Sense>(), It.IsAny<BetweenPosition?>()))
+            .Callback<Guid, Sense, BetweenPosition?>((_, s, _) => captured = s)
+            .ReturnsAsync(sense);
+
+        await _normalizingApi.CreateSense(Guid.NewGuid(), sense);
+
+        captured.Should().NotBeNull();
+        AssertAllNfd(captured);
+    }
+
+    [Fact]
+    public async Task UpdateSense_BeforeAfter_NormalizesBothToNfd()
+    {
+        var entryId = Guid.NewGuid();
+        var before = NfcTestData.CreateNfcSense();
+        var after = NfcTestData.CreateNfcSense();
+
+        Sense? capturedBefore = null;
+        Sense? capturedAfter = null;
+        Mock.Get(_mockApi)
+            .Setup(api => api.UpdateSense(It.IsAny<Guid>(), It.IsAny<Sense>(), It.IsAny<Sense>(), It.IsAny<IMiniLcmApi>()))
+            .Callback<Guid, Sense, Sense, IMiniLcmApi?>((_, b, a, _) => { capturedBefore = b; capturedAfter = a; })
+            .ReturnsAsync(after);
+
+        await _normalizingApi.UpdateSense(entryId, before, after);
+
+        AssertAllNfd(capturedBefore);
+        AssertAllNfd(capturedAfter);
+    }
+
+    [Fact]
+    public async Task CreateSense_WithNestedExampleSentences_NormalizesToNfd()
+    {
+        var sense = NfcTestData.CreateNfcSenseWithExamples();
+
+        Sense? captured = null;
+        Mock.Get(_mockApi)
+            .Setup(api => api.CreateSense(It.IsAny<Guid>(), It.IsAny<Sense>(), It.IsAny<BetweenPosition?>()))
+            .Callback<Guid, Sense, BetweenPosition?>((_, s, _) => captured = s)
+            .ReturnsAsync(sense);
+
+        await _normalizingApi.CreateSense(Guid.NewGuid(), sense);
+
+        captured.Should().NotBeNull();
+        AssertAllNfd(captured);
+    }
+
+    #endregion
+
+    #region ExampleSentence Tests
+
+    [Fact]
+    public async Task CreateExampleSentence_NormalizesToNfd()
+    {
+        var example = NfcTestData.CreateNfcExampleSentence();
+
+        ExampleSentence? captured = null;
+        Mock.Get(_mockApi)
+            .Setup(api => api.CreateExampleSentence(
+                It.IsAny<Guid>(), It.IsAny<Guid>(), It.IsAny<ExampleSentence>(), It.IsAny<BetweenPosition?>()))
+            .Callback<Guid, Guid, ExampleSentence, BetweenPosition?>((_, _, e, _) => captured = e)
+            .ReturnsAsync(example);
+
+        await _normalizingApi.CreateExampleSentence(Guid.NewGuid(), Guid.NewGuid(), example);
+
+        captured.Should().NotBeNull();
+        AssertAllNfd(captured);
+    }
+
+    [Fact]
+    public async Task UpdateExampleSentence_BeforeAfter_NormalizesBothToNfd()
+    {
+        var entryId = Guid.NewGuid();
+        var senseId = Guid.NewGuid();
+        var before = NfcTestData.CreateNfcExampleSentence();
+        var after = NfcTestData.CreateNfcExampleSentence();
+
+        ExampleSentence? capturedBefore = null;
+        ExampleSentence? capturedAfter = null;
+        Mock.Get(_mockApi)
+            .Setup(api => api.UpdateExampleSentence(
+                It.IsAny<Guid>(), It.IsAny<Guid>(),
+                It.IsAny<ExampleSentence>(), It.IsAny<ExampleSentence>(),
+                It.IsAny<IMiniLcmApi>()))
+            .Callback<Guid, Guid, ExampleSentence, ExampleSentence, IMiniLcmApi?>((_, _, b, a, _) => { capturedBefore = b; capturedAfter = a; })
+            .ReturnsAsync(after);
+
+        await _normalizingApi.UpdateExampleSentence(entryId, senseId, before, after);
+
+        AssertAllNfd(capturedBefore);
+        AssertAllNfd(capturedAfter);
+    }
+
+    [Fact]
+    public async Task CreateExampleSentence_WithTranslations_NormalizesToNfd()
+    {
+        var example = NfcTestData.CreateNfcExampleSentenceWithTranslations();
+
+        ExampleSentence? captured = null;
+        Mock.Get(_mockApi)
+            .Setup(api => api.CreateExampleSentence(
+                It.IsAny<Guid>(), It.IsAny<Guid>(), It.IsAny<ExampleSentence>(), It.IsAny<BetweenPosition?>()))
+            .Callback<Guid, Guid, ExampleSentence, BetweenPosition?>((_, _, e, _) => captured = e)
+            .ReturnsAsync(example);
+
+        await _normalizingApi.CreateExampleSentence(Guid.NewGuid(), Guid.NewGuid(), example);
+
+        captured.Should().NotBeNull();
+        AssertAllNfd(captured);
+    }
+
+    #endregion
+
+    #region Translation Tests
+
+    [Fact]
+    public async Task AddTranslation_NormalizesToNfd()
+    {
+        var translation = NfcTestData.CreateNfcTranslation();
+
+        Translation? captured = null;
+        Mock.Get(_mockApi)
+            .Setup(api => api.AddTranslation(
+                It.IsAny<Guid>(), It.IsAny<Guid>(), It.IsAny<Guid>(), It.IsAny<Translation>()))
+            .Callback<Guid, Guid, Guid, Translation>((_, _, _, t) => captured = t)
+            .Returns(Task.CompletedTask);
+
+        await _normalizingApi.AddTranslation(Guid.NewGuid(), Guid.NewGuid(), Guid.NewGuid(), translation);
+
+        captured.Should().NotBeNull();
+        AssertAllNfd(captured);
+    }
+
+    #endregion
+}
+
+
+public class NormalizationAssertTests
+{
+    [Fact]
+    public void AllNfcFactories_ProduceNfcData()
+    {
+        AssertAllNfc(NfcTestData.CreateNfcWritingSystem());
+        AssertAllNfc(NfcTestData.CreateNfcPartOfSpeech());
+        AssertAllNfc(NfcTestData.CreateNfcPublication());
+        AssertAllNfc(NfcTestData.CreateNfcSemanticDomain());
+        AssertAllNfc(NfcTestData.CreateNfcComplexFormType());
+        AssertAllNfc(NfcTestData.CreateNfcMorphType());
+        AssertAllNfc(NfcTestData.CreateNfcTranslation());
+        AssertAllNfc(NfcTestData.CreateNfcExampleSentence());
+        AssertAllNfc(NfcTestData.CreateNfcExampleSentenceWithTranslations());
+        AssertAllNfc(NfcTestData.CreateNfcSense());
+        AssertAllNfc(NfcTestData.CreateNfcSenseWithExamples());
+        AssertAllNfc(NfcTestData.CreateNfcComplexFormComponent());
+        AssertAllNfc(NfcTestData.CreateNfcEntry());
+        AssertAllNfc(NfcTestData.CreateNfcEntryWithSenses());
+        AssertAllNfc(NfcTestData.CreateNfcEntryWithComponents());
+    }
+
+    [Fact]
+    public void AssertAllNfc_WithNfcData_DoesNotThrow()
+    {
+        AssertAllNfc(NfcTestData.CreateNfcEntry());
+    }
+
+    [Fact]
+    public void AssertAllNfc_WithNfdData_Throws()
+    {
+        var entry = new Entry
+        {
+            Id = Guid.NewGuid(),
+            LexemeForm = new MultiString { Values = { { "en", NfcTestData.Nfd } } }, // NFD should fail
+            CitationForm = new MultiString { Values = { { "en", NfcTestData.Nfc } } },
+            LiteralMeaning = new RichMultiString { { "en", new RichString(NfcTestData.Nfc) } },
+            Note = new RichMultiString { { "en", new RichString(NfcTestData.Nfc) } }
+        };
+
+        var act = () => AssertAllNfc(entry);
+
+        act.Should().Throw<Xunit.Sdk.XunitException>().WithMessage("*NFC*");
+    }
+
+    [Fact]
+    public void AssertAllNfd_WithNfdData_DoesNotThrow()
+    {
+        var entry = new Entry
+        {
+            Id = Guid.NewGuid(),
+            LexemeForm = new MultiString { Values = { { "en", NfcTestData.Nfd } } },
+            CitationForm = new MultiString { Values = { { "en", NfcTestData.Nfd } } },
+            LiteralMeaning = new RichMultiString { { "en", new RichString(NfcTestData.Nfd) } },
+            Note = new RichMultiString { { "en", new RichString(NfcTestData.Nfd) } }
+        };
+
+        AssertAllNfd(entry);
+    }
+
+    [Fact]
+    public void AssertAllNfd_WithNfcData_Throws()
+    {
+        var act = () => AssertAllNfd(NfcTestData.CreateNfcEntry());
+
+        act.Should().Throw<Xunit.Sdk.XunitException>().WithMessage("*NFD*");
+    }
+
+    [Fact]
+    public void AssertAllNfc_WithEmptyMultiString_Throws()
+    {
+        var entry = new Entry
+        {
+            Id = Guid.NewGuid(),
+            LexemeForm = [], // Empty - should fail
+            CitationForm = NfcTestData.CreateNfcMultiString()
+        };
+
+        var act = () => AssertAllNfc(entry);
+
+        act.Should().Throw<Xunit.Sdk.XunitException>().WithMessage("*no values*");
+    }
+
+    [Fact]
+    public void AssertAllNfc_WithNestedNfdData_Throws()
+    {
+        var entry = new Entry
+        {
+            Id = Guid.NewGuid(),
+            LexemeForm = NfcTestData.CreateNfcMultiString(),
+            CitationForm = NfcTestData.CreateNfcMultiString(),
+            LiteralMeaning = NfcTestData.CreateNfcRichMultiString(),
+            Note = NfcTestData.CreateNfcRichMultiString(),
+            Senses =
+            [
+                new Sense
+                {
+                    Id = Guid.NewGuid(),
+                    Gloss = new MultiString { Values = { { "en", NfcTestData.Nfd } } }, // NFD nested in sense
+                    Definition = NfcTestData.CreateNfcRichMultiString()
+                }
+            ]
+        };
+
+        var act = () => AssertAllNfc(entry);
+
+        act.Should().Throw<Xunit.Sdk.XunitException>().WithMessage("*Senses*Gloss*");
+    }
+
+    [Fact]
+    public void IsAllNfd_WithNfdData_ReturnsTrue()
+    {
+        var multiString = new MultiString { Values = { { "en", NfcTestData.Nfd } } };
+
+        IsAllNfd(multiString).Should().BeTrue();
+    }
+
+    [Fact]
+    public void IsAllNfd_WithNfcData_ReturnsFalse()
+    {
+        IsAllNfd(NfcTestData.CreateNfcMultiString()).Should().BeFalse();
+    }
+}

--- a/backend/FwLite/MiniLcm/Normalization/MiniLcmApiQueryNormalizationWrapper.cs
+++ b/backend/FwLite/MiniLcm/Normalization/MiniLcmApiQueryNormalizationWrapper.cs
@@ -4,17 +4,17 @@ using MiniLcm.Wrappers;
 
 namespace MiniLcm.Normalization;
 
-public class MiniLcmApiStringNormalizationWrapperFactory() : IMiniLcmWrapperFactory
+public class MiniLcmApiQueryNormalizationWrapperFactory() : IMiniLcmWrapperFactory
 {
     public IMiniLcmApi Create(IMiniLcmApi api, IProjectIdentifier _unused) => Create(api);
 
     public IMiniLcmApi Create(IMiniLcmApi api)
     {
-        return new MiniLcmApiStringNormalizationWrapper(api);
+        return new MiniLcmApiQueryNormalizationWrapper(api);
     }
 }
 
-public partial class MiniLcmApiStringNormalizationWrapper(
+public partial class MiniLcmApiQueryNormalizationWrapper(
     IMiniLcmApi api) : IMiniLcmApi
 {
     public const NormalizationForm Form = NormalizationForm.FormD;

--- a/backend/FwLite/MiniLcm/Normalization/MiniLcmApiWriteNormalizationWrapper.cs
+++ b/backend/FwLite/MiniLcm/Normalization/MiniLcmApiWriteNormalizationWrapper.cs
@@ -1,0 +1,573 @@
+using System.Diagnostics.CodeAnalysis;
+using System.Text.Json;
+using MiniLcm.Media;
+using MiniLcm.Models;
+using MiniLcm.SyncHelpers;
+using MiniLcm.Wrappers;
+
+namespace MiniLcm.Normalization;
+
+public class MiniLcmApiWriteNormalizationWrapperFactory : IMiniLcmWrapperFactory
+{
+    public IMiniLcmApi Create(IMiniLcmApi api, IProjectIdentifier _unused)
+    {
+        return Create(api);
+    }
+
+
+    public IMiniLcmApi Create(IMiniLcmApi api)
+    {
+        return new MiniLcmApiWriteNormalizationWrapper(api);
+    }
+}
+
+/// <summary>
+/// Normalizes user-entered linguistic text to NFD on write operations.
+///
+/// Design notes:
+/// - Read operations are forwarded automatically via BeaKona.AutoInterface.
+/// - Write operations need to be manually implemented so nothing is missed (compile-time enforced by IMiniLcmApi).
+/// - Should mirror what LibLcm/FieldWorks normalizes, which seems to be EVERYTHING in the "standard editor" UI
+///   (so entry fields, but also list fields e.g. Semantic Domains, Morph Types, etc. - not only multi-strings)
+/// - For update methods that take both "before" and "after" objects, BOTH are normalized to ensure that any string comparisons done by the API are normalized.
+///   This prevents potential diff-noise caused by "before" being bad-data even though we expect it to always already be normalized (because we presumably served it).
+///   Non-normalized data that is already persisted (before this wrapper was introduced) will be normalized by LibLcm. That's not something we want to fix here.
+/// - Properties that liblcm/FieldWorks does not NFD-normalize are passed through unchanged.
+///   Currently only WritingSystem properties.
+/// - JsonPatch overloads normalize string-ish values best-effort (string, RichString, MultiString, RichMultiString).
+///   JsonElement values are only normalized when they are simple strings; complex JSON values are left as-is
+///   to avoid guessing the target type.
+/// </summary>
+public partial class MiniLcmApiWriteNormalizationWrapper(IMiniLcmApi api) : IMiniLcmApi
+{
+    private readonly IMiniLcmApi _api = api;
+
+    // BeaKona.AutoInterface only forwards IMiniLcmReadApi methods.
+    // IMiniLcmWriteApi methods are NOT auto-forwarded, ensuring compile-time
+    // enforcement that all write methods are manually implemented below.
+    [BeaKona.AutoInterface]
+    private IMiniLcmReadApi ReadApi => _api;
+
+    #region WritingSystem
+
+    // Intentionally NOT normalized, because FieldWorks/LibLcm doesn't seem to either
+    public Task<WritingSystem> CreateWritingSystem(WritingSystem writingSystem, BetweenPosition<WritingSystemId?>? between = null)
+    {
+        return _api.CreateWritingSystem(writingSystem, between);
+    }
+
+    public Task<WritingSystem> UpdateWritingSystem(WritingSystemId id, WritingSystemType type, UpdateObjectInput<WritingSystem> update)
+    {
+        return _api.UpdateWritingSystem(id, type, update);
+    }
+
+
+    public Task<WritingSystem> UpdateWritingSystem(WritingSystem before, WritingSystem after, IMiniLcmApi? api = null)
+    {
+        return _api.UpdateWritingSystem(before, after, api);
+    }
+
+    public Task MoveWritingSystem(WritingSystemId id, WritingSystemType type, BetweenPosition<WritingSystemId?> between)
+    {
+        return _api.MoveWritingSystem(id, type, between);
+    }
+
+    #endregion
+
+    #region PartOfSpeech
+
+    public async Task<PartOfSpeech> CreatePartOfSpeech(PartOfSpeech partOfSpeech)
+    {
+        return await _api.CreatePartOfSpeech(NormalizePartOfSpeech(partOfSpeech));
+    }
+
+    public Task<PartOfSpeech> UpdatePartOfSpeech(Guid id, UpdateObjectInput<PartOfSpeech> update)
+    {
+        return _api.UpdatePartOfSpeech(id, NormalizePatch(update));
+    }
+
+
+    public async Task<PartOfSpeech> UpdatePartOfSpeech(PartOfSpeech before, PartOfSpeech after, IMiniLcmApi? api = null)
+    {
+        return await _api.UpdatePartOfSpeech(NormalizePartOfSpeech(before), NormalizePartOfSpeech(after), api);
+    }
+
+    public Task DeletePartOfSpeech(Guid id)
+    {
+        return _api.DeletePartOfSpeech(id);
+    }
+
+    private static PartOfSpeech NormalizePartOfSpeech(PartOfSpeech pos)
+    {
+        return new PartOfSpeech
+        {
+            Id = pos.Id,
+            Name = StringNormalizer.Normalize(pos.Name),
+            DeletedAt = pos.DeletedAt,
+            Predefined = pos.Predefined
+        };
+    }
+
+    #endregion
+
+    #region Publication
+
+    public async Task<Publication> CreatePublication(Publication pub)
+    {
+        return await _api.CreatePublication(NormalizePublication(pub));
+    }
+
+    public Task<Publication> UpdatePublication(Guid id, UpdateObjectInput<Publication> update)
+    {
+        return _api.UpdatePublication(id, NormalizePatch(update));
+    }
+
+
+    public async Task<Publication> UpdatePublication(Publication before, Publication after, IMiniLcmApi? api = null)
+    {
+        return await _api.UpdatePublication(NormalizePublication(before), NormalizePublication(after), api);
+    }
+
+    public Task DeletePublication(Guid id)
+    {
+        return _api.DeletePublication(id);
+    }
+
+    private static Publication NormalizePublication(Publication pub)
+    {
+        return new Publication
+        {
+            Id = pub.Id,
+            Name = StringNormalizer.Normalize(pub.Name),
+            DeletedAt = pub.DeletedAt
+        };
+    }
+
+    #endregion
+
+    #region SemanticDomain
+
+    public async Task<SemanticDomain> CreateSemanticDomain(SemanticDomain semanticDomain)
+    {
+        return await _api.CreateSemanticDomain(NormalizeSemanticDomain(semanticDomain));
+    }
+
+    public Task<SemanticDomain> UpdateSemanticDomain(Guid id, UpdateObjectInput<SemanticDomain> update)
+    {
+        return _api.UpdateSemanticDomain(id, NormalizePatch(update));
+    }
+
+
+    public async Task<SemanticDomain> UpdateSemanticDomain(SemanticDomain before, SemanticDomain after, IMiniLcmApi? api = null)
+    {
+        return await _api.UpdateSemanticDomain(NormalizeSemanticDomain(before), NormalizeSemanticDomain(after), api);
+    }
+
+    public Task DeleteSemanticDomain(Guid id)
+    {
+        return _api.DeleteSemanticDomain(id);
+    }
+
+    private static SemanticDomain NormalizeSemanticDomain(SemanticDomain sd)
+    {
+        return new SemanticDomain
+        {
+            Id = sd.Id,
+            Name = StringNormalizer.Normalize(sd.Name),
+            Code = StringNormalizer.Normalize(sd.Code), // yes, LibLcm normalizes this too
+            DeletedAt = sd.DeletedAt,
+            Predefined = sd.Predefined
+        };
+    }
+
+    #endregion
+
+    #region ComplexFormType
+
+    public async Task<ComplexFormType> CreateComplexFormType(ComplexFormType complexFormType)
+    {
+        return await _api.CreateComplexFormType(NormalizeComplexFormType(complexFormType));
+    }
+
+    public Task<ComplexFormType> UpdateComplexFormType(Guid id, UpdateObjectInput<ComplexFormType> update)
+    {
+        return _api.UpdateComplexFormType(id, NormalizePatch(update));
+    }
+
+
+    public async Task<ComplexFormType> UpdateComplexFormType(ComplexFormType before, ComplexFormType after, IMiniLcmApi? api = null)
+    {
+        return await _api.UpdateComplexFormType(NormalizeComplexFormType(before), NormalizeComplexFormType(after), api);
+    }
+
+    public Task DeleteComplexFormType(Guid id)
+    {
+        return _api.DeleteComplexFormType(id);
+    }
+
+    private static ComplexFormType NormalizeComplexFormType(ComplexFormType cft)
+    {
+        return cft with
+        {
+            Name = StringNormalizer.Normalize(cft.Name)
+        };
+    }
+
+    #endregion
+
+    #region MorphType
+
+    public Task<MorphType> UpdateMorphType(Guid id, UpdateObjectInput<MorphType> update)
+    {
+        return _api.UpdateMorphType(id, NormalizePatch(update));
+    }
+
+
+    public async Task<MorphType> UpdateMorphType(MorphType before, MorphType after, IMiniLcmApi? api = null)
+    {
+        return await _api.UpdateMorphType(NormalizeMorphType(before), NormalizeMorphType(after), api);
+    }
+
+    private static MorphType NormalizeMorphType(MorphType mt)
+    {
+        return new MorphType
+        {
+            Id = mt.Id,
+            Kind = mt.Kind,
+            Name = StringNormalizer.Normalize(mt.Name),
+            Abbreviation = StringNormalizer.Normalize(mt.Abbreviation),
+            Description = StringNormalizer.Normalize(mt.Description),
+            Prefix = StringNormalizer.Normalize(mt.Prefix),
+            Postfix = StringNormalizer.Normalize(mt.Postfix),
+            SecondaryOrder = mt.SecondaryOrder,
+            DeletedAt = mt.DeletedAt
+        };
+    }
+
+    #endregion
+
+    #region Entry
+
+    public async Task<Entry> CreateEntry(Entry entry, CreateEntryOptions? options = null)
+    {
+        return await _api.CreateEntry(NormalizeEntry(entry), options);
+    }
+
+    public Task<Entry> UpdateEntry(Guid id, UpdateObjectInput<Entry> update)
+    {
+        return _api.UpdateEntry(id, NormalizePatch(update));
+    }
+
+
+    public async Task<Entry> UpdateEntry(Entry before, Entry after, IMiniLcmApi? api = null)
+    {
+        return await _api.UpdateEntry(NormalizeEntry(before), NormalizeEntry(after), api);
+    }
+
+    public Task DeleteEntry(Guid id)
+    {
+        return _api.DeleteEntry(id);
+    }
+
+    public async Task<ComplexFormComponent> CreateComplexFormComponent(ComplexFormComponent complexFormComponent, BetweenPosition<ComplexFormComponent>? position = null)
+    {
+        return await _api.CreateComplexFormComponent(NormalizeComplexFormComponent(complexFormComponent), position);
+    }
+
+    public Task MoveComplexFormComponent(ComplexFormComponent complexFormComponent, BetweenPosition<ComplexFormComponent> between)
+    {
+        return _api.MoveComplexFormComponent(complexFormComponent, between);
+    }
+
+    public Task DeleteComplexFormComponent(ComplexFormComponent complexFormComponent)
+    {
+        return _api.DeleteComplexFormComponent(complexFormComponent);
+    }
+
+    public Task AddComplexFormType(Guid entryId, Guid complexFormTypeId)
+    {
+        return _api.AddComplexFormType(entryId, complexFormTypeId);
+    }
+
+    public Task RemoveComplexFormType(Guid entryId, Guid complexFormTypeId)
+    {
+        return _api.RemoveComplexFormType(entryId, complexFormTypeId);
+    }
+
+    public Task AddPublication(Guid entryId, Guid publicationId)
+    {
+        return _api.AddPublication(entryId, publicationId);
+    }
+
+    public Task RemovePublication(Guid entryId, Guid publicationId)
+    {
+        return _api.RemovePublication(entryId, publicationId);
+    }
+
+    private static Entry NormalizeEntry(Entry entry)
+    {
+        return entry with
+        {
+            LexemeForm = StringNormalizer.Normalize(entry.LexemeForm),
+            CitationForm = StringNormalizer.Normalize(entry.CitationForm),
+            LiteralMeaning = StringNormalizer.Normalize(entry.LiteralMeaning),
+            Note = StringNormalizer.Normalize(entry.Note),
+            Senses = [.. entry.Senses.Select(NormalizeSense)],
+            Components = [.. entry.Components.Select(NormalizeComplexFormComponent)],
+            ComplexForms = [.. entry.ComplexForms.Select(NormalizeComplexFormComponent)]
+        };
+    }
+
+    private static ComplexFormComponent NormalizeComplexFormComponent(ComplexFormComponent cfc)
+    {
+        return cfc with
+        {
+            ComplexFormHeadword = StringNormalizer.Normalize(cfc.ComplexFormHeadword),
+            ComponentHeadword = StringNormalizer.Normalize(cfc.ComponentHeadword)
+        };
+    }
+
+    #endregion
+
+    #region Sense
+
+    public async Task<Sense> CreateSense(Guid entryId, Sense sense, BetweenPosition? position = null)
+    {
+        return await _api.CreateSense(entryId, NormalizeSense(sense), position);
+    }
+
+    public Task<Sense> UpdateSense(Guid entryId, Guid senseId, UpdateObjectInput<Sense> update)
+    {
+        return _api.UpdateSense(entryId, senseId, NormalizePatch(update));
+    }
+
+
+    public async Task<Sense> UpdateSense(Guid entryId, Sense before, Sense after, IMiniLcmApi? api = null)
+    {
+        return await _api.UpdateSense(entryId, NormalizeSense(before), NormalizeSense(after), api);
+    }
+
+    public Task MoveSense(Guid entryId, Guid senseId, BetweenPosition position)
+    {
+        return _api.MoveSense(entryId, senseId, position);
+    }
+
+    public Task DeleteSense(Guid entryId, Guid senseId)
+    {
+        return _api.DeleteSense(entryId, senseId);
+    }
+
+    public Task AddSemanticDomainToSense(Guid senseId, SemanticDomain semanticDomain)
+    {
+        return _api.AddSemanticDomainToSense(senseId, NormalizeSemanticDomain(semanticDomain));
+    }
+
+    public Task RemoveSemanticDomainFromSense(Guid senseId, Guid semanticDomainId)
+    {
+        return _api.RemoveSemanticDomainFromSense(senseId, semanticDomainId);
+    }
+
+    public Task SetSensePartOfSpeech(Guid senseId, Guid? partOfSpeechId)
+    {
+        return _api.SetSensePartOfSpeech(senseId, partOfSpeechId);
+    }
+
+    private static Sense NormalizeSense(Sense sense)
+    {
+        return new Sense
+        {
+            Id = sense.Id,
+            Order = sense.Order,
+            DeletedAt = sense.DeletedAt,
+            EntryId = sense.EntryId,
+            Definition = StringNormalizer.Normalize(sense.Definition),
+            Gloss = StringNormalizer.Normalize(sense.Gloss),
+            PartOfSpeech = sense.PartOfSpeech is not null ? NormalizePartOfSpeech(sense.PartOfSpeech) : null,
+            PartOfSpeechId = sense.PartOfSpeechId,
+            SemanticDomains = [.. sense.SemanticDomains.Select(NormalizeSemanticDomain)],
+            ExampleSentences = [.. sense.ExampleSentences.Select(NormalizeExampleSentence)]
+        };
+    }
+
+    #endregion
+
+    #region ExampleSentence
+
+    public async Task<ExampleSentence> CreateExampleSentence(Guid entryId, Guid senseId, ExampleSentence exampleSentence, BetweenPosition? position = null)
+    {
+        return await _api.CreateExampleSentence(entryId, senseId, NormalizeExampleSentence(exampleSentence), position);
+    }
+
+    public Task<ExampleSentence> UpdateExampleSentence(Guid entryId, Guid senseId, Guid exampleSentenceId, UpdateObjectInput<ExampleSentence> update)
+    {
+        return _api.UpdateExampleSentence(entryId, senseId, exampleSentenceId, NormalizePatch(update));
+    }
+
+
+    public async Task<ExampleSentence> UpdateExampleSentence(Guid entryId, Guid senseId, ExampleSentence before, ExampleSentence after, IMiniLcmApi? api = null)
+    {
+        return await _api.UpdateExampleSentence(entryId, senseId, NormalizeExampleSentence(before), NormalizeExampleSentence(after), api);
+    }
+
+    public Task MoveExampleSentence(Guid entryId, Guid senseId, Guid exampleSentenceId, BetweenPosition position)
+    {
+        return _api.MoveExampleSentence(entryId, senseId, exampleSentenceId, position);
+    }
+
+    public Task DeleteExampleSentence(Guid entryId, Guid senseId, Guid exampleSentenceId)
+    {
+        return _api.DeleteExampleSentence(entryId, senseId, exampleSentenceId);
+    }
+
+    public Task AddTranslation(Guid entryId, Guid senseId, Guid exampleSentenceId, Translation translation)
+    {
+        return _api.AddTranslation(entryId, senseId, exampleSentenceId, NormalizeTranslation(translation));
+    }
+
+    public Task RemoveTranslation(Guid entryId, Guid senseId, Guid exampleSentenceId, Guid translationId)
+    {
+        return _api.RemoveTranslation(entryId, senseId, exampleSentenceId, translationId);
+    }
+
+    public Task UpdateTranslation(Guid entryId, Guid senseId, Guid exampleSentenceId, Guid translationId, UpdateObjectInput<Translation> update)
+    {
+        return _api.UpdateTranslation(entryId, senseId, exampleSentenceId, translationId, NormalizePatch(update));
+    }
+
+
+    private static ExampleSentence NormalizeExampleSentence(ExampleSentence example)
+    {
+        return new ExampleSentence
+        {
+            Id = example.Id,
+            Order = example.Order,
+            DeletedAt = example.DeletedAt,
+            SenseId = example.SenseId,
+            Sentence = StringNormalizer.Normalize(example.Sentence),
+            Translations = [.. example.Translations.Select(NormalizeTranslation)],
+            Reference = StringNormalizer.Normalize(example.Reference)
+        };
+    }
+
+    private static Translation NormalizeTranslation(Translation translation)
+    {
+        return new Translation
+        {
+            Id = translation.Id,
+            Text = StringNormalizer.Normalize(translation.Text)
+        };
+    }
+
+    #endregion
+
+    #region Bulk Import
+
+    // Normalizing the bulk import methods may seem unintuitive:
+    // We currently only use them for importing from LibLcm, which should NOT be normalized.
+    // However, we don't use this normalization wrapper in that context and ít's likely that we'll
+    // start importing from other sources (Paratext 9, The Combine, Language Forge) in which case we DO want to normalize on import.
+
+    public Task BulkImportSemanticDomains(IAsyncEnumerable<SemanticDomain> semanticDomains)
+    {
+        return _api.BulkImportSemanticDomains(NormalizeStream(semanticDomains, NormalizeSemanticDomain));
+    }
+
+    public Task BulkCreateEntries(IAsyncEnumerable<Entry> entries)
+    {
+        return _api.BulkCreateEntries(NormalizeStream(entries, NormalizeEntry));
+    }
+
+    private static async IAsyncEnumerable<T> NormalizeStream<T>(
+        IAsyncEnumerable<T> source,
+        Func<T, T> normalize)
+    {
+        await foreach (var item in source)
+        {
+            yield return normalize(item);
+        }
+    }
+
+    #endregion
+
+    #region CustomView
+
+    // CustomView data is view configuration, not user-entered linguistic text, so no normalization is applied.
+    public async Task<CustomView> CreateCustomView(CustomView customView)
+    {
+        return await _api.CreateCustomView(customView);
+    }
+
+    public async Task<CustomView> UpdateCustomView(CustomView customView)
+    {
+        return await _api.UpdateCustomView(customView);
+    }
+
+    public Task DeleteCustomView(Guid id)
+    {
+        return _api.DeleteCustomView(id);
+    }
+
+    #endregion
+
+    #region File Operations
+
+    public Task<UploadFileResponse> SaveFile(Stream stream, LcmFileMetadata metadata)
+    {
+        // File metadata is not user-entered text, so don't normalize
+        return _api.SaveFile(stream, metadata);
+    }
+
+    #endregion
+
+    #region Patch Normalization
+
+    private static UpdateObjectInput<T> NormalizePatch<T>(UpdateObjectInput<T> update) where T : class
+    {
+        if (update.Patch.Operations.Count == 0) return update;
+
+        var normalizedPatch = new SystemTextJsonPatch.JsonPatchDocument<T>();
+        foreach (var op in update.Patch.Operations)
+        {
+            var normalizedValue = NormalizePatchValue(op.Value);
+            var normalizedOp = new SystemTextJsonPatch.Operations.Operation<T>
+            {
+                Op = op.Op,
+                Path = op.Path,
+                From = op.From,
+                Value = normalizedValue,
+            };
+            normalizedPatch.Operations.Add(normalizedOp);
+        }
+        return new UpdateObjectInput<T>(normalizedPatch);
+    }
+
+    [return: NotNullIfNotNull(nameof(value))]
+    private static object? NormalizePatchValue(object? value)
+    {
+        return value switch
+        {
+            null => null,
+            string s => s.Normalize(StringNormalizer.Form),
+            RichString richString => StringNormalizer.Normalize(richString),
+            MultiString multiString => StringNormalizer.Normalize(multiString),
+            RichMultiString richMultiString => StringNormalizer.Normalize(richMultiString),
+            JsonElement jsonElement => NormalizeJsonElement(jsonElement),
+            _ => value
+        };
+    }
+
+    private static object? NormalizeJsonElement(JsonElement element)
+    {
+        if (element.ValueKind != JsonValueKind.String) return element;
+        var value = element.GetString();
+        return value?.Normalize(StringNormalizer.Form);
+    }
+
+    #endregion
+
+    void IDisposable.Dispose()
+    {
+        // No resources to dispose
+    }
+
+}

--- a/backend/FwLite/MiniLcm/Normalization/StringNormalizer.cs
+++ b/backend/FwLite/MiniLcm/Normalization/StringNormalizer.cs
@@ -1,0 +1,46 @@
+using System.Diagnostics.CodeAnalysis;
+using System.Text;
+using MiniLcm.Models;
+
+namespace MiniLcm.Normalization;
+
+public static class StringNormalizer
+{
+    public const NormalizationForm Form = NormalizationForm.FormD;
+
+    [return: NotNullIfNotNull(nameof(value))]
+    public static string? Normalize(string? value)
+    {
+        return value?.Normalize(Form);
+    }
+
+    public static MultiString Normalize(MultiString multiString)
+    {
+        var normalized = new MultiString(multiString.Values.Count);
+        foreach (var (key, value) in multiString.Values)
+        {
+            normalized.Values[key] = string.IsNullOrEmpty(value) ? value : value.Normalize(Form);
+        }
+        return normalized;
+    }
+
+    [return: NotNullIfNotNull(nameof(richString))]
+    public static RichString? Normalize(RichString? richString)
+    {
+        if (richString is null) return null;
+        return new RichString([.. richString.Spans.Select(span => span with
+        {
+            Text = span.Text.Normalize(Form)
+        })]);
+    }
+
+    public static RichMultiString Normalize(RichMultiString richMultiString)
+    {
+        var normalized = new RichMultiString(richMultiString.Count);
+        foreach (var (key, value) in richMultiString)
+        {
+            normalized[key] = Normalize(value);
+        }
+        return normalized;
+    }
+}

--- a/backend/FwLite/MiniLcm/Validators/MiniLcmValidators.cs
+++ b/backend/FwLite/MiniLcm/Validators/MiniLcmValidators.cs
@@ -2,6 +2,7 @@ using FluentValidation;
 using Microsoft.Extensions.DependencyInjection;
 using MiniLcm.Models;
 using MiniLcm.Normalization;
+using MiniLcm.Wrappers;
 
 namespace MiniLcm.Validators;
 
@@ -91,7 +92,9 @@ public static class MiniLcmValidatorsExtensions
         services.AddTransient<IValidator<Publication>, PublicationValidator>();
         services.AddTransient<IValidator<UpdateObjectInput<MorphType>>, MorphTypeUpdateValidator>();
         services.AddTransient<IValidator<UpdateObjectInput<WritingSystem>>, WritingSystemUpdateValidator>();
-        services.AddTransient<MiniLcmApiStringNormalizationWrapperFactory>();
+        services.AddTransient<MiniLcmApiQueryNormalizationWrapperFactory>();
+        services.AddTransient<MiniLcmApiWriteNormalizationWrapperFactory>();
+        services.AddTransient<MiniLcmApiUserFacingWrappers>();
         return services;
     }
 }

--- a/backend/FwLite/MiniLcm/Wrappers/MiniLcmApiUserFacingWrappers.cs
+++ b/backend/FwLite/MiniLcm/Wrappers/MiniLcmApiUserFacingWrappers.cs
@@ -1,0 +1,27 @@
+using MiniLcm.Models;
+using MiniLcm.Normalization;
+using MiniLcm.Validators;
+
+namespace MiniLcm.Wrappers;
+
+/// <summary>
+/// The standard wrapper stack applied at every user-facing API entry point:
+/// MiniLcmJsInvokable, MiniLcmApiHubBase, and MiniLcmRoutes.
+/// </summary>
+public class MiniLcmApiUserFacingWrappers(
+    MiniLcmApiQueryNormalizationWrapperFactory readNormalization,
+    MiniLcmApiWriteNormalizationWrapperFactory writeNormalization,
+    MiniLcmApiValidationWrapperFactory validation)
+{
+    public IMiniLcmApi Apply(IMiniLcmApi api, IProjectIdentifier project, params IMiniLcmWrapperFactory[] innerWrappers)
+    {
+        // Validation before write normalisation: bad input is rejected with a clear error
+        // before the normaliser sees it, so the normaliser can assume structurally valid data.
+        // Write normalisation is applied uniformly to both CRDT and FwData:
+        // It's redundant for FwData (because LibLCM also normalises internally),
+        // but the uniformity is simpler and the normaliser creates new instances when it normalises.
+        // We want that behaviour to always be in place for simplicity.
+        // FwData is desktop-only, so the redundant pass is inconsequential cost-wise.
+        return api.WrapWith([readNormalization, validation, writeNormalization, .. innerWrappers], project);
+    }
+}

--- a/backend/FwLite/MiniLcm/Wrappers/MiniLcmWrappers.cs
+++ b/backend/FwLite/MiniLcm/Wrappers/MiniLcmWrappers.cs
@@ -9,6 +9,10 @@ public interface IMiniLcmWrapperFactory
 
 public static class MiniLcmWrapperExtensions
 {
+    /// <summary>
+    /// Wraps <paramref name="api"/> with <paramref name="factories"/> in runtime call order
+    /// (outermost to innermost). The first factory becomes the outermost wrapper.
+    /// </summary>
     public static IMiniLcmApi WrapWith(this IMiniLcmApi api, IEnumerable<IMiniLcmWrapperFactory> factories, IProjectIdentifier project)
     {
         var wrappedApi = api;


### PR DESCRIPTION
Re-applies PR #2146 (commit 79c015a2), which was lost from `develop` in a force-push ~9 days ago 🫨 

Single-commit cherry-pick onto current `develop`. Two trivial textual conflicts resolved (kept both sides):
- `FwLiteWeb/Routes/MiniLcmRoutes.cs`: union of using directives
- `MiniLcm.Tests/CreateEntryTestsBase.cs`: kept both `HomographNumber` and `Order` exclusions in `CanCreateEntry_AutoFaker`

Local builds: FwLiteWeb, FwLiteMaui (win), MiniLcm.Tests, FwLiteProjectSync.Tests, FwDataMiniLcmBridge.Tests, LcmCrdt.Tests all green.