### PR TITLE
Remove unused null parameter from CrdtFwdataProjectSyncService mock

### DIFF
--- a/backend/Testing/FwHeadless/Services/SyncWorkerTestHarness.cs
+++ b/backend/Testing/FwHeadless/Services/SyncWorkerTestHarness.cs
@@ -252,7 +252,6 @@ internal sealed class SyncWorkerTestHarness : IDisposable
             MockBehavior.Strict,
             null!,
             NullLogger<CrdtFwdataProjectSyncService>.Instance,
-            null!,
             null!);
 
         syncService


### PR DESCRIPTION
## Summary
Removed an unused null parameter from the `CrdtFwdataProjectSyncService` mock instantiation in the test harness.

## Changes
- Removed one `null!` parameter from the `CrdtFwdataProjectSyncService` constructor call in `SyncWorkerTestHarness.BuildServiceProvider()`, reducing the parameter count from 5 to 4 arguments

## Details
This change aligns the test mock with the actual constructor signature of `CrdtFwdataProjectSyncService`, eliminating a superfluous null argument that was previously being passed.

https://claude.ai/code/session_01AMmw7JB5F7vBpQhum6mtKE