### PR TITLE
Gitignore Claude Code local-only runtime files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,4 +42,6 @@ failedSyncs/
 .claude/worktrees/
 .claude/settings.local.json
 .claude/CLAUDE.local.md
+.claude/scheduled_tasks.lock
+.claude/agent-memory-local/
 screenshots/


### PR DESCRIPTION
Add .claude/scheduled_tasks.lock and .claude/agent-memory-local/ to .gitignore alongside the existing local-only patterns. These are machine-specific runtime state and should not be tracked.