### PR TITLE
Harden NFD write-normalization against dropped fields

### DIFF
--- a/backend/FwLite/MiniLcm.Tests/Helpers/NfcTestData.cs
+++ b/backend/FwLite/MiniLcm.Tests/Helpers/NfcTestData.cs
@@ -50,7 +50,8 @@ public static class NfcTestData
         return new()
         {
             Id = Guid.NewGuid(),
-            Name = CreateNfcMultiString()
+            Name = CreateNfcMultiString(),
+            Predefined = true,
         };
     }
 
@@ -69,7 +70,8 @@ public static class NfcTestData
         {
             Id = Guid.NewGuid(),
             Code = Nfc,
-            Name = CreateNfcMultiString()
+            Name = CreateNfcMultiString(),
+            Predefined = true,
         };
     }
 
@@ -105,11 +107,17 @@ public static class NfcTestData
         };
     }
 
+    // Non-string scalars below are deliberately populated with non-default values so that
+    // identity-preservation assertions (e.g. BeEquivalentTo on the wrapper's output) actually
+    // exercise those fields. A default-valued field can't catch a normalizer that drops it.
+
     public static ExampleSentence CreateNfcExampleSentence()
     {
         return new()
         {
             Id = Guid.NewGuid(),
+            Order = 2.5,
+            SenseId = Guid.NewGuid(),
             Sentence = CreateNfcRichMultiString(),
             Reference = CreateNfcRichString()
         };
@@ -120,6 +128,8 @@ public static class NfcTestData
         return new()
         {
             Id = Guid.NewGuid(),
+            Order = 2.5,
+            SenseId = Guid.NewGuid(),
             Sentence = CreateNfcRichMultiString(),
             Reference = CreateNfcRichString(),
             Translations = [CreateNfcTranslation(), CreateNfcTranslation()]
@@ -131,6 +141,9 @@ public static class NfcTestData
         return new()
         {
             Id = Guid.NewGuid(),
+            Order = 1.5,
+            EntryId = Guid.NewGuid(),
+            PartOfSpeechId = Guid.NewGuid(),
             Gloss = CreateNfcMultiString(),
             Definition = CreateNfcRichMultiString()
         };
@@ -138,13 +151,17 @@ public static class NfcTestData
 
     public static Sense CreateNfcSenseWithExamples()
     {
+        var pos = CreateNfcPartOfSpeech();
         return new()
         {
             Id = Guid.NewGuid(),
+            Order = 1.5,
+            EntryId = Guid.NewGuid(),
             Gloss = CreateNfcMultiString(),
             Definition = CreateNfcRichMultiString(),
             SemanticDomains = [CreateNfcSemanticDomain()],
-            PartOfSpeech = CreateNfcPartOfSpeech(),
+            PartOfSpeech = pos,
+            PartOfSpeechId = pos.Id,
             ExampleSentences = [CreateNfcExampleSentenceWithTranslations()]
         };
     }
@@ -154,8 +171,10 @@ public static class NfcTestData
         return new()
         {
             Id = Guid.NewGuid(),
+            Order = 1.5,
             ComplexFormEntryId = Guid.NewGuid(),
             ComponentEntryId = Guid.NewGuid(),
+            ComponentSenseId = Guid.NewGuid(),
             ComplexFormHeadword = Nfc,
             ComponentHeadword = Nfc
         };
@@ -166,6 +185,8 @@ public static class NfcTestData
         return new()
         {
             Id = Guid.NewGuid(),
+            HomographNumber = 3,
+            MorphType = MorphTypeKind.Root,
             LexemeForm = CreateNfcMultiString(),
             CitationForm = CreateNfcMultiString(),
             LiteralMeaning = CreateNfcRichMultiString(),
@@ -178,6 +199,8 @@ public static class NfcTestData
         return new()
         {
             Id = Guid.NewGuid(),
+            HomographNumber = 3,
+            MorphType = MorphTypeKind.Root,
             LexemeForm = CreateNfcMultiString(),
             CitationForm = CreateNfcMultiString(),
             LiteralMeaning = CreateNfcRichMultiString(),
@@ -191,6 +214,8 @@ public static class NfcTestData
         return new()
         {
             Id = Guid.NewGuid(),
+            HomographNumber = 3,
+            MorphType = MorphTypeKind.Root,
             LexemeForm = CreateNfcMultiString(),
             CitationForm = CreateNfcMultiString(),
             LiteralMeaning = CreateNfcRichMultiString(),

--- a/backend/FwLite/MiniLcm.Tests/Helpers/NormalizationAssert.cs
+++ b/backend/FwLite/MiniLcm.Tests/Helpers/NormalizationAssert.cs
@@ -22,25 +22,25 @@ public static class NormalizationAssert
         ],
     };
 
-    public static void AssertAllNfc(object? obj)
+    public static void AssertAllNfc(object? obj, bool requireNonTrivial = false)
     {
-        Assert(obj, NormalizationForm.FormC);
+        Assert(obj, NormalizationForm.FormC, requireNonTrivial);
     }
 
-    public static void AssertAllNfd(object? obj)
+    public static void AssertAllNfd(object? obj, bool requireNonTrivial = false)
     {
-        Assert(obj, NormalizationForm.FormD);
+        Assert(obj, NormalizationForm.FormD, requireNonTrivial);
     }
 
     public static bool IsAllNfd(object obj)
     {
-        return FindIssues(obj, NormalizationForm.FormD).Count == 0;
+        return FindIssues(obj, NormalizationForm.FormD, requireNonTrivial: false).Count == 0;
     }
 
-    private static void Assert(object? obj, NormalizationForm form)
+    private static void Assert(object? obj, NormalizationForm form, bool requireNonTrivial)
     {
         if (obj is null) throw new Xunit.Sdk.XunitException("Expected object to be non-null but was null");
-        var issues = FindIssues(obj, form);
+        var issues = FindIssues(obj, form, requireNonTrivial);
         if (issues.Count == 0) return;
         var name = FormName(form);
         throw new Xunit.Sdk.XunitException(
@@ -49,46 +49,46 @@ public static class NormalizationAssert
         );
     }
 
-    private static List<string> FindIssues(object obj, NormalizationForm form)
+    private static List<string> FindIssues(object obj, NormalizationForm form, bool requireNonTrivial)
     {
         var issues = new List<string>();
-        Visit(obj, "", form, issues);
+        Visit(obj, "", form, requireNonTrivial, issues);
         return issues;
     }
 
-    private static void Visit(object? obj, string path, NormalizationForm form, List<string> issues)
+    private static void Visit(object? obj, string path, NormalizationForm form, bool requireNonTrivial, List<string> issues)
     {
         switch (obj)
         {
             case null:
                 return;
             case string s:
-                CheckString(s, path, form, issues);
+                CheckString(s, path, form, requireNonTrivial, issues);
                 return;
             case MultiString ms:
                 if (ms.Values.Count == 0) issues.Add($"{path}: MultiString has no values (must have at least one for testing)");
-                foreach (var (key, value) in ms.Values) CheckString(value, $"{path}.Values[{key}]", form, issues);
+                foreach (var (key, value) in ms.Values) CheckString(value, $"{path}.Values[{key}]", form, requireNonTrivial, issues);
                 return;
             case RichString rs:
                 if (rs.Spans.Count == 0) issues.Add($"{path}: RichString has no spans (must have at least one for testing)");
-                for (var i = 0; i < rs.Spans.Count; i++) CheckString(rs.Spans[i].Text, $"{path}.Spans[{i}].Text", form, issues);
+                for (var i = 0; i < rs.Spans.Count; i++) CheckString(rs.Spans[i].Text, $"{path}.Spans[{i}].Text", form, requireNonTrivial, issues);
                 return;
             case RichMultiString rms:
                 if (rms.Count == 0) issues.Add($"{path}: RichMultiString has no values (must have at least one for testing)");
-                foreach (var (key, value) in rms) Visit(value, $"{path}[{key}]", form, issues);
+                foreach (var (key, value) in rms) Visit(value, $"{path}[{key}]", form, requireNonTrivial, issues);
                 return;
             case IEnumerable seq:
                 var i2 = 0;
-                foreach (var item in seq) Visit(item, $"{path}[{i2++}]", form, issues);
+                foreach (var item in seq) Visit(item, $"{path}[{i2++}]", form, requireNonTrivial, issues);
                 return;
             default:
                 break;
         }
 
-        VisitModelProperties(obj, path, form, issues);
+        VisitModelProperties(obj, path, form, requireNonTrivial, issues);
     }
 
-    private static void VisitModelProperties(object obj, string path, NormalizationForm form, List<string> issues)
+    private static void VisitModelProperties(object obj, string path, NormalizationForm form, bool requireNonTrivial, List<string> issues)
     {
         var type = obj.GetType();
         if (type.Namespace?.StartsWith("MiniLcm.Models", StringComparison.Ordinal) != true)
@@ -104,7 +104,7 @@ public static class NormalizationAssert
             if (value is null) continue;
 
             var propPath = string.IsNullOrEmpty(path) ? prop.Name : $"{path}.{prop.Name}";
-            Visit(value, propPath, form, issues);
+            Visit(value, propPath, form, requireNonTrivial, issues);
         }
     }
 
@@ -116,7 +116,7 @@ public static class NormalizationAssert
                underlying == typeof(DateTimeOffset) || underlying == typeof(decimal);
     }
 
-    private static void CheckString(string? value, string path, NormalizationForm form, List<string> issues)
+    private static void CheckString(string? value, string path, NormalizationForm form, bool requireNonTrivial, List<string> issues)
     {
         if (string.IsNullOrEmpty(value))
         {
@@ -127,6 +127,21 @@ public static class NormalizationAssert
         {
             var name = FormName(form);
             issues.Add($"{path}: expected {name} but \"{value}\" is not {name}-normalized");
+            return;
+        }
+        // Non-trivial check: the string must differ from its conversion to the OTHER form.
+        // If they're equal, the string is byte-identical in both NFC and NFD (e.g., pure ASCII),
+        // so it doesn't actually exercise normalization. This catches dead test coverage where
+        // a field gets ASCII content and silently bypasses the normalizer.
+        if (requireNonTrivial)
+        {
+            var otherForm = form == NormalizationForm.FormC ? NormalizationForm.FormD : NormalizationForm.FormC;
+            if (value == value.Normalize(otherForm))
+            {
+                var name = FormName(form);
+                var otherName = FormName(otherForm);
+                issues.Add($"{path}: \"{value}\" is trivially {name} (identical to its {otherName} form); use content that actually exercises normalization");
+            }
         }
     }
 

--- a/backend/FwLite/MiniLcm.Tests/Helpers/NormalizationAssert.cs
+++ b/backend/FwLite/MiniLcm.Tests/Helpers/NormalizationAssert.cs
@@ -49,7 +49,7 @@ public static class NormalizationAssert
 
     public static void AssertAllDecomposed(object? obj)
     {
-        Assert(obj, NormalizationForm.FormD, requireNonTrivial: false);
+        Assert(obj, "NFD", CheckNfd);
     }
 
     /// <summary>
@@ -59,7 +59,7 @@ public static class NormalizationAssert
     /// </summary>
     public static void AssertAllDecomposable(object? obj)
     {
-        Assert(obj, NormalizationForm.FormC, requireNonTrivial: true);
+        Assert(obj, "decomposable NFC", CheckDecomposableNfc);
     }
 
     /// <summary>
@@ -75,58 +75,57 @@ public static class NormalizationAssert
         captured.Should().BeEquivalentTo(input, opts => opts.NormalizedStrings());
     }
 
-private static void Assert(object? obj, NormalizationForm form, bool requireNonTrivial)
+    private static void Assert(object? obj, string description, Action<string, string, List<string>> check)
     {
         if (obj is null) throw new Xunit.Sdk.XunitException("Expected object to be non-null but was null");
-        var issues = FindIssues(obj, form, requireNonTrivial);
+        var issues = FindIssues(obj, check);
         if (issues.Count == 0) return;
-        var name = FormName(form);
         throw new Xunit.Sdk.XunitException(
-            $"Expected all normalizable properties to contain {name} strings, but found issues:\n" +
+            $"Expected all normalizable properties to contain {description} strings, but found issues:\n" +
             string.Join("\n", issues.Select(i => "  - " + i))
         );
     }
 
-    private static List<string> FindIssues(object obj, NormalizationForm form, bool requireNonTrivial)
+    private static List<string> FindIssues(object obj, Action<string, string, List<string>> check)
     {
         var issues = new List<string>();
-        Visit(obj, "", form, requireNonTrivial, issues);
+        Visit(obj, "", check, issues);
         return issues;
     }
 
-    private static void Visit(object? obj, string path, NormalizationForm form, bool requireNonTrivial, List<string> issues)
+    private static void Visit(object? obj, string path, Action<string, string, List<string>> check, List<string> issues)
     {
         switch (obj)
         {
             case null:
                 return;
             case string s:
-                CheckString(s, path, form, requireNonTrivial, issues);
+                CheckString(s, path, check, issues);
                 return;
             case MultiString ms:
                 if (ms.Values.Count == 0) issues.Add($"{path}: MultiString has no values (must have at least one for testing)");
-                foreach (var (key, value) in ms.Values) CheckString(value, $"{path}.Values[{key}]", form, requireNonTrivial, issues);
+                foreach (var (key, value) in ms.Values) CheckString(value, $"{path}.Values[{key}]", check, issues);
                 return;
             case RichString rs:
                 if (rs.Spans.Count == 0) issues.Add($"{path}: RichString has no spans (must have at least one for testing)");
-                for (var i = 0; i < rs.Spans.Count; i++) CheckString(rs.Spans[i].Text, $"{path}.Spans[{i}].Text", form, requireNonTrivial, issues);
+                for (var i = 0; i < rs.Spans.Count; i++) CheckString(rs.Spans[i].Text, $"{path}.Spans[{i}].Text", check, issues);
                 return;
             case RichMultiString rms:
                 if (rms.Count == 0) issues.Add($"{path}: RichMultiString has no values (must have at least one for testing)");
-                foreach (var (key, value) in rms) Visit(value, $"{path}[{key}]", form, requireNonTrivial, issues);
+                foreach (var (key, value) in rms) Visit(value, $"{path}[{key}]", check, issues);
                 return;
             case IEnumerable seq:
                 var i2 = 0;
-                foreach (var item in seq) Visit(item, $"{path}[{i2++}]", form, requireNonTrivial, issues);
+                foreach (var item in seq) Visit(item, $"{path}[{i2++}]", check, issues);
                 return;
             default:
                 break;
         }
 
-        VisitModelProperties(obj, path, form, requireNonTrivial, issues);
+        VisitModelProperties(obj, path, check, issues);
     }
 
-    private static void VisitModelProperties(object obj, string path, NormalizationForm form, bool requireNonTrivial, List<string> issues)
+    private static void VisitModelProperties(object obj, string path, Action<string, string, List<string>> check, List<string> issues)
     {
         var type = obj.GetType();
         if (type.Namespace?.StartsWith("MiniLcm.Models", StringComparison.Ordinal) != true)
@@ -142,7 +141,7 @@ private static void Assert(object? obj, NormalizationForm form, bool requireNonT
             if (value is null) continue;
 
             var propPath = string.IsNullOrEmpty(path) ? prop.Name : $"{path}.{prop.Name}";
-            Visit(value, propPath, form, requireNonTrivial, issues);
+            Visit(value, propPath, check, issues);
         }
     }
 
@@ -154,33 +153,32 @@ private static void Assert(object? obj, NormalizationForm form, bool requireNonT
                underlying == typeof(DateTimeOffset) || underlying == typeof(decimal);
     }
 
-    private static void CheckString(string? value, string path, NormalizationForm form, bool requireNonTrivial, List<string> issues)
+    private static void CheckString(string? value, string path, Action<string, string, List<string>> check, List<string> issues)
     {
         if (string.IsNullOrEmpty(value))
         {
             issues.Add($"{path}: string is null or empty (must have a value for testing)");
             return;
         }
-        if (!value.IsNormalized(form))
-        {
-            var name = FormName(form);
-            issues.Add($"{path}: expected {name} but \"{value}\" is not {name}-normalized");
-            return;
-        }
-        if (requireNonTrivial)
-        {
-            var otherForm = form == NormalizationForm.FormC ? NormalizationForm.FormD : NormalizationForm.FormC;
-            if (value == value.Normalize(otherForm))
-            {
-                var name = FormName(form);
-                var otherName = FormName(otherForm);
-                issues.Add($"{path}: \"{value}\" is trivially {name} (identical to its {otherName} form); use content that actually exercises normalization");
-            }
-        }
+        check(value, path, issues);
     }
 
-    private static string FormName(NormalizationForm form)
+    // Per-form leaf checks. AssertAllDecomposed verifies wrapper OUTPUT is NFD; AssertAllDecomposable verifies
+    // INPUT test data is NFC AND actually decomposes (rejecting ASCII that would silently no-op the normalizer).
+    private static void CheckNfd(string value, string path, List<string> issues)
     {
-        return form == NormalizationForm.FormC ? "NFC" : "NFD";
+        if (!value.IsNormalized(NormalizationForm.FormD))
+            issues.Add($"{path}: expected NFD but \"{value}\" is not NFD-normalized");
+    }
+
+    private static void CheckDecomposableNfc(string value, string path, List<string> issues)
+    {
+        if (!value.IsNormalized(NormalizationForm.FormC))
+        {
+            issues.Add($"{path}: expected NFC but \"{value}\" is not NFC-normalized");
+            return;
+        }
+        if (value == value.Normalize(NormalizationForm.FormD))
+            issues.Add($"{path}: \"{value}\" is trivially NFC (identical to its NFD form); use content that actually exercises normalization");
     }
 }

--- a/backend/FwLite/MiniLcm.Tests/Helpers/NormalizationAssert.cs
+++ b/backend/FwLite/MiniLcm.Tests/Helpers/NormalizationAssert.cs
@@ -54,7 +54,7 @@ public static class NormalizationAssert
 
     /// <summary>
     /// Strict NFC plus a non-triviality check: every string must differ from its NFD form.
-    /// Catches ASCII-only test data, which is byte-identical in NFC and NFD and would
+    /// Catches test data, which is byte-identical in NFC and NFD (e.g. ASCII) and would
     /// silently bypass the normalizer.
     /// </summary>
     public static void AssertAllDecomposable(object? obj)
@@ -68,7 +68,7 @@ public static class NormalizationAssert
     /// (BeEquivalentTo on the input, with NFC≡NFD string equivalence).
     /// Catches the field-drop regression class that pure string-form checks ignore.
     /// </summary>
-    public static void AssertNormalized<T>(T? captured, T input) where T : class
+    public static void AssertNormalizedToNfd<T>(T? captured, T input) where T : class
     {
         captured.Should().NotBeNull();
         AssertAllDecomposed(captured);
@@ -164,7 +164,7 @@ public static class NormalizationAssert
     }
 
     // Per-form leaf checks. AssertAllDecomposed verifies wrapper OUTPUT is NFD; AssertAllDecomposable verifies
-    // INPUT test data is NFC AND actually decomposes (rejecting ASCII that would silently no-op the normalizer).
+    // INPUT test data is NFC AND actually decomposes — content byte-identical in NFC and NFD (e.g. ASCII) would silently no-op the normalizer.
     private static void CheckNfd(string value, string path, List<string> issues)
     {
         if (!value.IsNormalized(NormalizationForm.FormD))

--- a/backend/FwLite/MiniLcm.Tests/Helpers/NormalizationAssert.cs
+++ b/backend/FwLite/MiniLcm.Tests/Helpers/NormalizationAssert.cs
@@ -1,8 +1,33 @@
 using System.Collections;
 using System.Reflection;
 using System.Text;
+using FluentAssertions.Equivalency;
 
 namespace MiniLcm.Tests.Helpers;
+
+public static class NormalizationEquivalency
+{
+    /// <summary>
+    /// Configure BeEquivalentTo so strings compare equal modulo NFC/NFD normalization,
+    /// catching non-string fields the wrapper drops (HomographNumber, Order, etc.)
+    /// that the form-only check ignores.
+    /// </summary>
+    public static EquivalencyOptions<T> NormalizedStrings<T>(this EquivalencyOptions<T> options)
+    {
+        return options
+            .Using<string>(ctx =>
+            {
+                if (ctx.Subject is null || ctx.Expectation is null)
+                {
+                    ctx.Subject.Should().Be(ctx.Expectation);
+                    return;
+                }
+                ctx.Subject.Normalize(NormalizationForm.FormD)
+                    .Should().Be(ctx.Expectation.Normalize(NormalizationForm.FormD));
+            })
+            .WhenTypeIs<string>();
+    }
+}
 
 /// <summary>
 /// For verifying that every string-bearing property of an object is normalized (NFC or NFD).
@@ -22,22 +47,35 @@ public static class NormalizationAssert
         ],
     };
 
-    public static void AssertAllNfc(object? obj, bool requireNonTrivial = false)
+    public static void AssertAllDecomposed(object? obj)
     {
-        Assert(obj, NormalizationForm.FormC, requireNonTrivial);
+        Assert(obj, NormalizationForm.FormD, requireNonTrivial: false);
     }
 
-    public static void AssertAllNfd(object? obj, bool requireNonTrivial = false)
+    /// <summary>
+    /// Strict NFC plus a non-triviality check: every string must differ from its NFD form.
+    /// Catches ASCII-only test data, which is byte-identical in NFC and NFD and would
+    /// silently bypass the normalizer.
+    /// </summary>
+    public static void AssertAllDecomposable(object? obj)
     {
-        Assert(obj, NormalizationForm.FormD, requireNonTrivial);
+        Assert(obj, NormalizationForm.FormC, requireNonTrivial: true);
     }
 
-    public static bool IsAllNfd(object obj)
+    /// <summary>
+    /// For verifying the output of the write-normalization wrapper:
+    /// asserts every string is NFD AND that no non-string field was dropped or mutated
+    /// (BeEquivalentTo on the input, with NFC≡NFD string equivalence).
+    /// Catches the field-drop regression class that pure string-form checks ignore.
+    /// </summary>
+    public static void AssertNormalized<T>(T? captured, T input) where T : class
     {
-        return FindIssues(obj, NormalizationForm.FormD, requireNonTrivial: false).Count == 0;
+        captured.Should().NotBeNull();
+        AssertAllDecomposed(captured);
+        captured.Should().BeEquivalentTo(input, opts => opts.NormalizedStrings());
     }
 
-    private static void Assert(object? obj, NormalizationForm form, bool requireNonTrivial)
+private static void Assert(object? obj, NormalizationForm form, bool requireNonTrivial)
     {
         if (obj is null) throw new Xunit.Sdk.XunitException("Expected object to be non-null but was null");
         var issues = FindIssues(obj, form, requireNonTrivial);
@@ -129,10 +167,6 @@ public static class NormalizationAssert
             issues.Add($"{path}: expected {name} but \"{value}\" is not {name}-normalized");
             return;
         }
-        // Non-trivial check: the string must differ from its conversion to the OTHER form.
-        // If they're equal, the string is byte-identical in both NFC and NFD (e.g., pure ASCII),
-        // so it doesn't actually exercise normalization. This catches dead test coverage where
-        // a field gets ASCII content and silently bypasses the normalizer.
         if (requireNonTrivial)
         {
             var otherForm = form == NormalizationForm.FormC ? NormalizationForm.FormD : NormalizationForm.FormC;

--- a/backend/FwLite/MiniLcm.Tests/Helpers/NormalizationAssert.cs
+++ b/backend/FwLite/MiniLcm.Tests/Helpers/NormalizationAssert.cs
@@ -49,7 +49,7 @@ public static class NormalizationAssert
 
     public static void AssertAllDecomposed(object? obj)
     {
-        Assert(obj, "NFD", CheckNfd);
+        Assert(obj, Nfd);
     }
 
     /// <summary>
@@ -59,7 +59,7 @@ public static class NormalizationAssert
     /// </summary>
     public static void AssertAllDecomposable(object? obj)
     {
-        Assert(obj, "decomposable NFC", CheckDecomposableNfc);
+        Assert(obj, DecomposableNfc);
     }
 
     /// <summary>
@@ -75,25 +75,25 @@ public static class NormalizationAssert
         captured.Should().BeEquivalentTo(input, opts => opts.NormalizedStrings());
     }
 
-    private static void Assert(object? obj, string description, Action<string, string, List<string>> check)
+    private static void Assert(object? obj, StringCheck check)
     {
         if (obj is null) throw new Xunit.Sdk.XunitException("Expected object to be non-null but was null");
         var issues = FindIssues(obj, check);
         if (issues.Count == 0) return;
         throw new Xunit.Sdk.XunitException(
-            $"Expected all normalizable properties to contain {description} strings, but found issues:\n" +
+            $"Expected all normalizable properties to contain {check.Label} strings, but found issues:\n" +
             string.Join("\n", issues.Select(i => "  - " + i))
         );
     }
 
-    private static List<string> FindIssues(object obj, Action<string, string, List<string>> check)
+    private static List<string> FindIssues(object obj, StringCheck check)
     {
         var issues = new List<string>();
         Visit(obj, "", check, issues);
         return issues;
     }
 
-    private static void Visit(object? obj, string path, Action<string, string, List<string>> check, List<string> issues)
+    private static void Visit(object? obj, string path, StringCheck check, List<string> issues)
     {
         switch (obj)
         {
@@ -125,7 +125,7 @@ public static class NormalizationAssert
         VisitModelProperties(obj, path, check, issues);
     }
 
-    private static void VisitModelProperties(object obj, string path, Action<string, string, List<string>> check, List<string> issues)
+    private static void VisitModelProperties(object obj, string path, StringCheck check, List<string> issues)
     {
         var type = obj.GetType();
         if (type.Namespace?.StartsWith("MiniLcm.Models", StringComparison.Ordinal) != true)
@@ -153,32 +153,32 @@ public static class NormalizationAssert
                underlying == typeof(DateTimeOffset) || underlying == typeof(decimal);
     }
 
-    private static void CheckString(string? value, string path, Action<string, string, List<string>> check, List<string> issues)
+    private static void CheckString(string? value, string path, StringCheck check, List<string> issues)
     {
         if (string.IsNullOrEmpty(value))
         {
             issues.Add($"{path}: string is null or empty (must have a value for testing)");
             return;
         }
-        check(value, path, issues);
+        var issue = check.Validate(value);
+        if (issue != null) issues.Add($"{path}: {issue}");
     }
 
-    // Per-form leaf checks. AssertAllDecomposed verifies wrapper OUTPUT is NFD; AssertAllDecomposable verifies
-    // INPUT test data is NFC AND actually decomposes — content byte-identical in NFC and NFD (e.g. ASCII) would silently no-op the normalizer.
-    private static void CheckNfd(string value, string path, List<string> issues)
-    {
-        if (!value.IsNormalized(NormalizationForm.FormD))
-            issues.Add($"{path}: expected NFD but \"{value}\" is not NFD-normalized");
-    }
+    // A check pairs the failure-header label with a validator that returns an issue for one string
+    // (or null if it is fine), so a caller can't mismatch label and logic.
+    private sealed record StringCheck(string Label, Func<string, string?> Validate);
 
-    private static void CheckDecomposableNfc(string value, string path, List<string> issues)
-    {
-        if (!value.IsNormalized(NormalizationForm.FormC))
-        {
-            issues.Add($"{path}: expected NFC but \"{value}\" is not NFC-normalized");
-            return;
-        }
-        if (value == value.Normalize(NormalizationForm.FormD))
-            issues.Add($"{path}: \"{value}\" is trivially NFC (identical to its NFD form); use content that actually exercises normalization");
-    }
+    // AssertAllDecomposed verifies wrapper OUTPUT is NFD; AssertAllDecomposable verifies INPUT test data is
+    // NFC AND actually decomposes — content byte-identical in NFC and NFD (e.g. ASCII) would silently no-op the normalizer.
+    private static readonly StringCheck Nfd = new("NFD", value =>
+        value.IsNormalized(NormalizationForm.FormD)
+            ? null
+            : $"expected NFD but \"{value}\" is not NFD-normalized");
+
+    private static readonly StringCheck DecomposableNfc = new("decomposable NFC", value =>
+        !value.IsNormalized(NormalizationForm.FormC)
+            ? $"expected NFC but \"{value}\" is not NFC-normalized"
+            : value == value.Normalize(NormalizationForm.FormD)
+                ? $"\"{value}\" is trivially NFC (identical to its NFD form); use content that actually exercises normalization"
+                : null);
 }

--- a/backend/FwLite/MiniLcm.Tests/Helpers/NormalizationAssert.cs
+++ b/backend/FwLite/MiniLcm.Tests/Helpers/NormalizationAssert.cs
@@ -168,8 +168,6 @@ public static class NormalizationAssert
     // (or null if it is fine), so a caller can't mismatch label and logic.
     private sealed record StringCheck(string Label, Func<string, string?> Validate);
 
-    // AssertAllDecomposed verifies wrapper OUTPUT is NFD; AssertAllDecomposable verifies INPUT test data is
-    // NFC AND actually decomposes — content byte-identical in NFC and NFD (e.g. ASCII) would silently no-op the normalizer.
     private static readonly StringCheck Nfd = new("NFD", value =>
         value.IsNormalized(NormalizationForm.FormD)
             ? null

--- a/backend/FwLite/MiniLcm.Tests/WriteNormalizationTests.cs
+++ b/backend/FwLite/MiniLcm.Tests/WriteNormalizationTests.cs
@@ -84,8 +84,7 @@ public class WriteNormalizationTests
 
         await _normalizingApi.CreatePartOfSpeech(pos);
 
-        captured.Should().NotBeNull();
-        AssertAllNfd(captured);
+        AssertNormalized(captured, pos);
     }
 
     [Fact]
@@ -103,8 +102,8 @@ public class WriteNormalizationTests
 
         await _normalizingApi.UpdatePartOfSpeech(before, after);
 
-        AssertAllNfd(capturedBefore);
-        AssertAllNfd(capturedAfter);
+        AssertNormalized(capturedBefore, before);
+        AssertNormalized(capturedAfter, after);
     }
 
     #endregion
@@ -124,8 +123,7 @@ public class WriteNormalizationTests
 
         await _normalizingApi.CreatePublication(pub);
 
-        captured.Should().NotBeNull();
-        AssertAllNfd(captured);
+        AssertNormalized(captured, pub);
     }
 
     [Fact]
@@ -143,8 +141,8 @@ public class WriteNormalizationTests
 
         await _normalizingApi.UpdatePublication(before, after);
 
-        AssertAllNfd(capturedBefore);
-        AssertAllNfd(capturedAfter);
+        AssertNormalized(capturedBefore, before);
+        AssertNormalized(capturedAfter, after);
     }
 
     #endregion
@@ -164,8 +162,7 @@ public class WriteNormalizationTests
 
         await _normalizingApi.CreateSemanticDomain(sd);
 
-        captured.Should().NotBeNull();
-        AssertAllNfd(captured);
+        AssertNormalized(captured, sd);
     }
 
     [Fact]
@@ -183,8 +180,8 @@ public class WriteNormalizationTests
 
         await _normalizingApi.UpdateSemanticDomain(before, after);
 
-        AssertAllNfd(capturedBefore);
-        AssertAllNfd(capturedAfter);
+        AssertNormalized(capturedBefore, before);
+        AssertNormalized(capturedAfter, after);
     }
 
     [Fact]
@@ -200,8 +197,7 @@ public class WriteNormalizationTests
 
         await _normalizingApi.AddSemanticDomainToSense(Guid.NewGuid(), sd);
 
-        captured.Should().NotBeNull();
-        AssertAllNfd(captured);
+        AssertNormalized(captured, sd);
     }
 
     [Fact]
@@ -219,8 +215,9 @@ public class WriteNormalizationTests
 
         await _normalizingApi.BulkImportSemanticDomains(domains.ToAsyncEnumerable());
 
-        captured.Should().HaveCount(2);
-        AssertAllNfd(captured);
+        captured.Should().HaveCount(domains.Length);
+        AssertAllDecomposed(captured);
+        captured.Should().BeEquivalentTo(domains, opts => opts.NormalizedStrings().WithStrictOrdering());
     }
 
     #endregion
@@ -240,8 +237,7 @@ public class WriteNormalizationTests
 
         await _normalizingApi.CreateComplexFormType(cft);
 
-        captured.Should().NotBeNull();
-        AssertAllNfd(captured);
+        AssertNormalized(captured, cft);
     }
 
     [Fact]
@@ -259,8 +255,8 @@ public class WriteNormalizationTests
 
         await _normalizingApi.UpdateComplexFormType(before, after);
 
-        AssertAllNfd(capturedBefore);
-        AssertAllNfd(capturedAfter);
+        AssertNormalized(capturedBefore, before);
+        AssertNormalized(capturedAfter, after);
     }
 
     #endregion
@@ -282,8 +278,8 @@ public class WriteNormalizationTests
 
         await _normalizingApi.UpdateMorphType(before, after);
 
-        AssertAllNfd(capturedBefore);
-        AssertAllNfd(capturedAfter);
+        AssertNormalized(capturedBefore, before);
+        AssertNormalized(capturedAfter, after);
     }
 
     [Fact]
@@ -304,7 +300,7 @@ public class WriteNormalizationTests
 
         captured.Should().NotBeNull();
         var byPath = captured.Patch.Operations.ToDictionary(o => o.Path!, o => o.Value);
-        AssertAllNfd(byPath["/Name"].Should().BeOfType<MultiString>().Subject);
+        AssertAllDecomposed(byPath["/Name"].Should().BeOfType<MultiString>().Subject);
         byPath["/Prefix"].Should().Be(NfcTestData.Nfd);
         byPath["/Postfix"].Should().Be(NfcTestData.Nfd);
     }
@@ -326,8 +322,7 @@ public class WriteNormalizationTests
 
         await _normalizingApi.CreateEntry(entry);
 
-        captured.Should().NotBeNull();
-        AssertAllNfd(captured);
+        AssertNormalized(captured, entry);
     }
 
     [Fact]
@@ -345,8 +340,8 @@ public class WriteNormalizationTests
 
         await _normalizingApi.UpdateEntry(before, after);
 
-        AssertAllNfd(capturedBefore);
-        AssertAllNfd(capturedAfter);
+        AssertNormalized(capturedBefore, before);
+        AssertNormalized(capturedAfter, after);
     }
 
     [Fact]
@@ -362,8 +357,7 @@ public class WriteNormalizationTests
 
         await _normalizingApi.CreateEntry(entry);
 
-        captured.Should().NotBeNull();
-        AssertAllNfd(captured);
+        AssertNormalized(captured, entry);
     }
 
     [Fact]
@@ -379,8 +373,7 @@ public class WriteNormalizationTests
 
         await _normalizingApi.CreateEntry(entry);
 
-        captured.Should().NotBeNull();
-        AssertAllNfd(captured);
+        AssertNormalized(captured, entry);
     }
 
     [Fact]
@@ -398,8 +391,9 @@ public class WriteNormalizationTests
 
         await _normalizingApi.BulkCreateEntries(entries.ToAsyncEnumerable());
 
-        captured.Should().HaveCount(2);
-        AssertAllNfd(captured);
+        captured.Should().HaveCount(entries.Length);
+        AssertAllDecomposed(captured);
+        captured.Should().BeEquivalentTo(entries, opts => opts.NormalizedStrings().WithStrictOrdering());
     }
 
     #endregion
@@ -425,7 +419,7 @@ public class WriteNormalizationTests
 
         captured.Should().NotBeNull();
         captured.Should().NotBeSameAs(update); // rebuilt because Entry path normalizes
-        AssertAllPatchValuesNfd(captured);
+        AssertAllPatchValuesDecomposed(captured);
     }
 
     [Fact]
@@ -475,16 +469,16 @@ public class WriteNormalizationTests
     }
 
     /// <summary>
-    /// Asserts every non-null operation value in the patch is NFD. Delegates to
-    /// <see cref="AssertAllNfd"/>, which already understands string,
+    /// Asserts every non-null operation value in the patch is decomposed. Delegates to
+    /// <see cref="AssertAllDecomposed"/>, which already understands string,
     /// string[], MultiString, RichString, and RichMultiString — so failures report a property path.
     /// </summary>
-    private static void AssertAllPatchValuesNfd<T>(UpdateObjectInput<T> update) where T : class
+    private static void AssertAllPatchValuesDecomposed<T>(UpdateObjectInput<T> update) where T : class
     {
         update.Patch.Operations.Should().NotBeEmpty();
         foreach (var op in update.Patch.Operations)
         {
-            if (op.Value is not null) AssertAllNfd(op.Value);
+            if (op.Value is not null) AssertAllDecomposed(op.Value);
         }
     }
 
@@ -506,8 +500,7 @@ public class WriteNormalizationTests
 
         await _normalizingApi.CreateComplexFormComponent(cfc);
 
-        captured.Should().NotBeNull();
-        AssertAllNfd(captured);
+        AssertNormalized(captured, cfc);
     }
 
     #endregion
@@ -527,8 +520,7 @@ public class WriteNormalizationTests
 
         await _normalizingApi.CreateSense(Guid.NewGuid(), sense);
 
-        captured.Should().NotBeNull();
-        AssertAllNfd(captured);
+        AssertNormalized(captured, sense);
     }
 
     [Fact]
@@ -547,8 +539,8 @@ public class WriteNormalizationTests
 
         await _normalizingApi.UpdateSense(entryId, before, after);
 
-        AssertAllNfd(capturedBefore);
-        AssertAllNfd(capturedAfter);
+        AssertNormalized(capturedBefore, before);
+        AssertNormalized(capturedAfter, after);
     }
 
     [Fact]
@@ -564,8 +556,7 @@ public class WriteNormalizationTests
 
         await _normalizingApi.CreateSense(Guid.NewGuid(), sense);
 
-        captured.Should().NotBeNull();
-        AssertAllNfd(captured);
+        AssertNormalized(captured, sense);
     }
 
     #endregion
@@ -586,8 +577,7 @@ public class WriteNormalizationTests
 
         await _normalizingApi.CreateExampleSentence(Guid.NewGuid(), Guid.NewGuid(), example);
 
-        captured.Should().NotBeNull();
-        AssertAllNfd(captured);
+        AssertNormalized(captured, example);
     }
 
     [Fact]
@@ -610,8 +600,8 @@ public class WriteNormalizationTests
 
         await _normalizingApi.UpdateExampleSentence(entryId, senseId, before, after);
 
-        AssertAllNfd(capturedBefore);
-        AssertAllNfd(capturedAfter);
+        AssertNormalized(capturedBefore, before);
+        AssertNormalized(capturedAfter, after);
     }
 
     [Fact]
@@ -628,8 +618,7 @@ public class WriteNormalizationTests
 
         await _normalizingApi.CreateExampleSentence(Guid.NewGuid(), Guid.NewGuid(), example);
 
-        captured.Should().NotBeNull();
-        AssertAllNfd(captured);
+        AssertNormalized(captured, example);
     }
 
     #endregion
@@ -650,8 +639,7 @@ public class WriteNormalizationTests
 
         await _normalizingApi.AddTranslation(Guid.NewGuid(), Guid.NewGuid(), Guid.NewGuid(), translation);
 
-        captured.Should().NotBeNull();
-        AssertAllNfd(captured);
+        AssertNormalized(captured, translation);
     }
 
     #endregion
@@ -661,52 +649,27 @@ public class WriteNormalizationTests
 public class NormalizationAssertTests
 {
     [Fact]
-    public void AllNfcFactories_ProduceNonTriviallyNfcData()
+    public void AllNfcFactories_ProduceDecomposableData()
     {
-        // requireNonTrivial: every string must differ from its NFD form. Catches ASCII-only test data,
-        // which would silently bypass the normalizer (ASCII is byte-identical in NFC and NFD).
-        AssertAllNfc(NfcTestData.CreateNfcWritingSystem(), requireNonTrivial: true);
-        AssertAllNfc(NfcTestData.CreateNfcPartOfSpeech(), requireNonTrivial: true);
-        AssertAllNfc(NfcTestData.CreateNfcPublication(), requireNonTrivial: true);
-        AssertAllNfc(NfcTestData.CreateNfcSemanticDomain(), requireNonTrivial: true);
-        AssertAllNfc(NfcTestData.CreateNfcComplexFormType(), requireNonTrivial: true);
-        AssertAllNfc(NfcTestData.CreateNfcMorphType(), requireNonTrivial: true);
-        AssertAllNfc(NfcTestData.CreateNfcTranslation(), requireNonTrivial: true);
-        AssertAllNfc(NfcTestData.CreateNfcExampleSentence(), requireNonTrivial: true);
-        AssertAllNfc(NfcTestData.CreateNfcExampleSentenceWithTranslations(), requireNonTrivial: true);
-        AssertAllNfc(NfcTestData.CreateNfcSense(), requireNonTrivial: true);
-        AssertAllNfc(NfcTestData.CreateNfcSenseWithExamples(), requireNonTrivial: true);
-        AssertAllNfc(NfcTestData.CreateNfcComplexFormComponent(), requireNonTrivial: true);
-        AssertAllNfc(NfcTestData.CreateNfcEntry(), requireNonTrivial: true);
-        AssertAllNfc(NfcTestData.CreateNfcEntryWithSenses(), requireNonTrivial: true);
-        AssertAllNfc(NfcTestData.CreateNfcEntryWithComponents(), requireNonTrivial: true);
+        AssertAllDecomposable(NfcTestData.CreateNfcWritingSystem());
+        AssertAllDecomposable(NfcTestData.CreateNfcPartOfSpeech());
+        AssertAllDecomposable(NfcTestData.CreateNfcPublication());
+        AssertAllDecomposable(NfcTestData.CreateNfcSemanticDomain());
+        AssertAllDecomposable(NfcTestData.CreateNfcComplexFormType());
+        AssertAllDecomposable(NfcTestData.CreateNfcMorphType());
+        AssertAllDecomposable(NfcTestData.CreateNfcTranslation());
+        AssertAllDecomposable(NfcTestData.CreateNfcExampleSentence());
+        AssertAllDecomposable(NfcTestData.CreateNfcExampleSentenceWithTranslations());
+        AssertAllDecomposable(NfcTestData.CreateNfcSense());
+        AssertAllDecomposable(NfcTestData.CreateNfcSenseWithExamples());
+        AssertAllDecomposable(NfcTestData.CreateNfcComplexFormComponent());
+        AssertAllDecomposable(NfcTestData.CreateNfcEntry());
+        AssertAllDecomposable(NfcTestData.CreateNfcEntryWithSenses());
+        AssertAllDecomposable(NfcTestData.CreateNfcEntryWithComponents());
     }
 
     [Fact]
-    public void AssertAllNfc_WithNfcData_DoesNotThrow()
-    {
-        AssertAllNfc(NfcTestData.CreateNfcEntry());
-    }
-
-    [Fact]
-    public void AssertAllNfc_WithNfdData_Throws()
-    {
-        var entry = new Entry
-        {
-            Id = Guid.NewGuid(),
-            LexemeForm = new MultiString { Values = { { "en", NfcTestData.Nfd } } }, // NFD should fail
-            CitationForm = new MultiString { Values = { { "en", NfcTestData.Nfc } } },
-            LiteralMeaning = new RichMultiString { { "en", new RichString(NfcTestData.Nfc) } },
-            Note = new RichMultiString { { "en", new RichString(NfcTestData.Nfc) } }
-        };
-
-        var act = () => AssertAllNfc(entry);
-
-        act.Should().Throw<Xunit.Sdk.XunitException>().WithMessage("*NFC*");
-    }
-
-    [Fact]
-    public void AssertAllNfd_WithNfdData_DoesNotThrow()
+    public void AssertAllDecomposed_WithDecomposedData_DoesNotThrow()
     {
         var entry = new Entry
         {
@@ -717,19 +680,19 @@ public class NormalizationAssertTests
             Note = new RichMultiString { { "en", new RichString(NfcTestData.Nfd) } }
         };
 
-        AssertAllNfd(entry);
+        AssertAllDecomposed(entry);
     }
 
     [Fact]
-    public void AssertAllNfd_WithNfcData_Throws()
+    public void AssertAllDecomposed_WithComposedData_Throws()
     {
-        var act = () => AssertAllNfd(NfcTestData.CreateNfcEntry());
+        var act = () => AssertAllDecomposed(NfcTestData.CreateNfcEntry());
 
         act.Should().Throw<Xunit.Sdk.XunitException>().WithMessage("*NFD*");
     }
 
     [Fact]
-    public void AssertAllNfc_WithEmptyMultiString_Throws()
+    public void AssertAllDecomposable_WithEmptyMultiString_Throws()
     {
         var entry = new Entry
         {
@@ -738,13 +701,13 @@ public class NormalizationAssertTests
             CitationForm = NfcTestData.CreateNfcMultiString()
         };
 
-        var act = () => AssertAllNfc(entry);
+        var act = () => AssertAllDecomposable(entry);
 
         act.Should().Throw<Xunit.Sdk.XunitException>().WithMessage("*no values*");
     }
 
     [Fact]
-    public void AssertAllNfc_WithNestedNfdData_Throws()
+    public void AssertAllDecomposable_WithNestedNfdData_Throws()
     {
         var entry = new Entry
         {
@@ -764,22 +727,26 @@ public class NormalizationAssertTests
             ]
         };
 
-        var act = () => AssertAllNfc(entry);
+        var act = () => AssertAllDecomposable(entry);
 
         act.Should().Throw<Xunit.Sdk.XunitException>().WithMessage("*Senses*Gloss*");
     }
 
     [Fact]
-    public void IsAllNfd_WithNfdData_ReturnsTrue()
+    public void AssertAllDecomposable_WithAsciiData_Throws()
     {
-        var multiString = new MultiString { Values = { { "en", NfcTestData.Nfd } } };
+        var entry = new Entry
+        {
+            Id = Guid.NewGuid(),
+            LexemeForm = new MultiString { Values = { { "en", "naive" } } }, // ASCII -> trivially NFC
+            CitationForm = NfcTestData.CreateNfcMultiString(),
+            LiteralMeaning = NfcTestData.CreateNfcRichMultiString(),
+            Note = NfcTestData.CreateNfcRichMultiString()
+        };
 
-        IsAllNfd(multiString).Should().BeTrue();
+        var act = () => AssertAllDecomposable(entry);
+
+        act.Should().Throw<Xunit.Sdk.XunitException>().WithMessage("*trivially*");
     }
 
-    [Fact]
-    public void IsAllNfd_WithNfcData_ReturnsFalse()
-    {
-        IsAllNfd(NfcTestData.CreateNfcMultiString()).Should().BeFalse();
-    }
 }

--- a/backend/FwLite/MiniLcm.Tests/WriteNormalizationTests.cs
+++ b/backend/FwLite/MiniLcm.Tests/WriteNormalizationTests.cs
@@ -84,7 +84,7 @@ public class WriteNormalizationTests
 
         await _normalizingApi.CreatePartOfSpeech(pos);
 
-        AssertNormalized(captured, pos);
+        AssertNormalizedToNfd(captured, pos);
     }
 
     [Fact]
@@ -102,8 +102,8 @@ public class WriteNormalizationTests
 
         await _normalizingApi.UpdatePartOfSpeech(before, after);
 
-        AssertNormalized(capturedBefore, before);
-        AssertNormalized(capturedAfter, after);
+        AssertNormalizedToNfd(capturedBefore, before);
+        AssertNormalizedToNfd(capturedAfter, after);
     }
 
     #endregion
@@ -123,7 +123,7 @@ public class WriteNormalizationTests
 
         await _normalizingApi.CreatePublication(pub);
 
-        AssertNormalized(captured, pub);
+        AssertNormalizedToNfd(captured, pub);
     }
 
     [Fact]
@@ -141,8 +141,8 @@ public class WriteNormalizationTests
 
         await _normalizingApi.UpdatePublication(before, after);
 
-        AssertNormalized(capturedBefore, before);
-        AssertNormalized(capturedAfter, after);
+        AssertNormalizedToNfd(capturedBefore, before);
+        AssertNormalizedToNfd(capturedAfter, after);
     }
 
     #endregion
@@ -162,7 +162,7 @@ public class WriteNormalizationTests
 
         await _normalizingApi.CreateSemanticDomain(sd);
 
-        AssertNormalized(captured, sd);
+        AssertNormalizedToNfd(captured, sd);
     }
 
     [Fact]
@@ -180,8 +180,8 @@ public class WriteNormalizationTests
 
         await _normalizingApi.UpdateSemanticDomain(before, after);
 
-        AssertNormalized(capturedBefore, before);
-        AssertNormalized(capturedAfter, after);
+        AssertNormalizedToNfd(capturedBefore, before);
+        AssertNormalizedToNfd(capturedAfter, after);
     }
 
     [Fact]
@@ -197,7 +197,7 @@ public class WriteNormalizationTests
 
         await _normalizingApi.AddSemanticDomainToSense(Guid.NewGuid(), sd);
 
-        AssertNormalized(captured, sd);
+        AssertNormalizedToNfd(captured, sd);
     }
 
     [Fact]
@@ -237,7 +237,7 @@ public class WriteNormalizationTests
 
         await _normalizingApi.CreateComplexFormType(cft);
 
-        AssertNormalized(captured, cft);
+        AssertNormalizedToNfd(captured, cft);
     }
 
     [Fact]
@@ -255,8 +255,8 @@ public class WriteNormalizationTests
 
         await _normalizingApi.UpdateComplexFormType(before, after);
 
-        AssertNormalized(capturedBefore, before);
-        AssertNormalized(capturedAfter, after);
+        AssertNormalizedToNfd(capturedBefore, before);
+        AssertNormalizedToNfd(capturedAfter, after);
     }
 
     #endregion
@@ -278,8 +278,8 @@ public class WriteNormalizationTests
 
         await _normalizingApi.UpdateMorphType(before, after);
 
-        AssertNormalized(capturedBefore, before);
-        AssertNormalized(capturedAfter, after);
+        AssertNormalizedToNfd(capturedBefore, before);
+        AssertNormalizedToNfd(capturedAfter, after);
     }
 
     [Fact]
@@ -322,7 +322,7 @@ public class WriteNormalizationTests
 
         await _normalizingApi.CreateEntry(entry);
 
-        AssertNormalized(captured, entry);
+        AssertNormalizedToNfd(captured, entry);
     }
 
     [Fact]
@@ -340,8 +340,8 @@ public class WriteNormalizationTests
 
         await _normalizingApi.UpdateEntry(before, after);
 
-        AssertNormalized(capturedBefore, before);
-        AssertNormalized(capturedAfter, after);
+        AssertNormalizedToNfd(capturedBefore, before);
+        AssertNormalizedToNfd(capturedAfter, after);
     }
 
     [Fact]
@@ -357,7 +357,7 @@ public class WriteNormalizationTests
 
         await _normalizingApi.CreateEntry(entry);
 
-        AssertNormalized(captured, entry);
+        AssertNormalizedToNfd(captured, entry);
     }
 
     [Fact]
@@ -373,7 +373,7 @@ public class WriteNormalizationTests
 
         await _normalizingApi.CreateEntry(entry);
 
-        AssertNormalized(captured, entry);
+        AssertNormalizedToNfd(captured, entry);
     }
 
     [Fact]
@@ -500,7 +500,7 @@ public class WriteNormalizationTests
 
         await _normalizingApi.CreateComplexFormComponent(cfc);
 
-        AssertNormalized(captured, cfc);
+        AssertNormalizedToNfd(captured, cfc);
     }
 
     #endregion
@@ -520,7 +520,7 @@ public class WriteNormalizationTests
 
         await _normalizingApi.CreateSense(Guid.NewGuid(), sense);
 
-        AssertNormalized(captured, sense);
+        AssertNormalizedToNfd(captured, sense);
     }
 
     [Fact]
@@ -539,8 +539,8 @@ public class WriteNormalizationTests
 
         await _normalizingApi.UpdateSense(entryId, before, after);
 
-        AssertNormalized(capturedBefore, before);
-        AssertNormalized(capturedAfter, after);
+        AssertNormalizedToNfd(capturedBefore, before);
+        AssertNormalizedToNfd(capturedAfter, after);
     }
 
     [Fact]
@@ -556,7 +556,7 @@ public class WriteNormalizationTests
 
         await _normalizingApi.CreateSense(Guid.NewGuid(), sense);
 
-        AssertNormalized(captured, sense);
+        AssertNormalizedToNfd(captured, sense);
     }
 
     #endregion
@@ -577,7 +577,7 @@ public class WriteNormalizationTests
 
         await _normalizingApi.CreateExampleSentence(Guid.NewGuid(), Guid.NewGuid(), example);
 
-        AssertNormalized(captured, example);
+        AssertNormalizedToNfd(captured, example);
     }
 
     [Fact]
@@ -600,8 +600,8 @@ public class WriteNormalizationTests
 
         await _normalizingApi.UpdateExampleSentence(entryId, senseId, before, after);
 
-        AssertNormalized(capturedBefore, before);
-        AssertNormalized(capturedAfter, after);
+        AssertNormalizedToNfd(capturedBefore, before);
+        AssertNormalizedToNfd(capturedAfter, after);
     }
 
     [Fact]
@@ -618,7 +618,7 @@ public class WriteNormalizationTests
 
         await _normalizingApi.CreateExampleSentence(Guid.NewGuid(), Guid.NewGuid(), example);
 
-        AssertNormalized(captured, example);
+        AssertNormalizedToNfd(captured, example);
     }
 
     #endregion
@@ -639,7 +639,7 @@ public class WriteNormalizationTests
 
         await _normalizingApi.AddTranslation(Guid.NewGuid(), Guid.NewGuid(), Guid.NewGuid(), translation);
 
-        AssertNormalized(captured, translation);
+        AssertNormalizedToNfd(captured, translation);
     }
 
     #endregion

--- a/backend/FwLite/MiniLcm.Tests/WriteNormalizationTests.cs
+++ b/backend/FwLite/MiniLcm.Tests/WriteNormalizationTests.cs
@@ -651,7 +651,8 @@ public class NormalizationAssertTests
     [Fact]
     public void AllNfcFactories_ProduceDecomposableData()
     {
-        AssertAllDecomposable(NfcTestData.CreateNfcWritingSystem());
+        // WritingSystem is intentionally omitted: its string fields are not normalized
+        // (see NormalizationAssert.SkippedProperties), so AssertAllDecomposable would assert nothing.
         AssertAllDecomposable(NfcTestData.CreateNfcPartOfSpeech());
         AssertAllDecomposable(NfcTestData.CreateNfcPublication());
         AssertAllDecomposable(NfcTestData.CreateNfcSemanticDomain());
@@ -697,13 +698,17 @@ public class NormalizationAssertTests
         var entry = new Entry
         {
             Id = Guid.NewGuid(),
-            LexemeForm = [], // Empty - should fail
-            CitationForm = NfcTestData.CreateNfcMultiString()
+            LexemeForm = [], // Empty MultiString — the only expected issue
+            CitationForm = NfcTestData.CreateNfcMultiString(),
+            LiteralMeaning = NfcTestData.CreateNfcRichMultiString(),
+            Note = NfcTestData.CreateNfcRichMultiString()
         };
 
         var act = () => AssertAllDecomposable(entry);
 
-        act.Should().Throw<Xunit.Sdk.XunitException>().WithMessage("*no values*");
+        // Scope to LexemeForm so this exercises the empty-MultiString check specifically;
+        // an empty RichMultiString would also report "no values".
+        act.Should().Throw<Xunit.Sdk.XunitException>().WithMessage("*LexemeForm*no values*");
     }
 
     [Fact]

--- a/backend/FwLite/MiniLcm.Tests/WriteNormalizationTests.cs
+++ b/backend/FwLite/MiniLcm.Tests/WriteNormalizationTests.cs
@@ -661,23 +661,25 @@ public class WriteNormalizationTests
 public class NormalizationAssertTests
 {
     [Fact]
-    public void AllNfcFactories_ProduceNfcData()
+    public void AllNfcFactories_ProduceNonTriviallyNfcData()
     {
-        AssertAllNfc(NfcTestData.CreateNfcWritingSystem());
-        AssertAllNfc(NfcTestData.CreateNfcPartOfSpeech());
-        AssertAllNfc(NfcTestData.CreateNfcPublication());
-        AssertAllNfc(NfcTestData.CreateNfcSemanticDomain());
-        AssertAllNfc(NfcTestData.CreateNfcComplexFormType());
-        AssertAllNfc(NfcTestData.CreateNfcMorphType());
-        AssertAllNfc(NfcTestData.CreateNfcTranslation());
-        AssertAllNfc(NfcTestData.CreateNfcExampleSentence());
-        AssertAllNfc(NfcTestData.CreateNfcExampleSentenceWithTranslations());
-        AssertAllNfc(NfcTestData.CreateNfcSense());
-        AssertAllNfc(NfcTestData.CreateNfcSenseWithExamples());
-        AssertAllNfc(NfcTestData.CreateNfcComplexFormComponent());
-        AssertAllNfc(NfcTestData.CreateNfcEntry());
-        AssertAllNfc(NfcTestData.CreateNfcEntryWithSenses());
-        AssertAllNfc(NfcTestData.CreateNfcEntryWithComponents());
+        // requireNonTrivial: every string must differ from its NFD form. Catches ASCII-only test data,
+        // which would silently bypass the normalizer (ASCII is byte-identical in NFC and NFD).
+        AssertAllNfc(NfcTestData.CreateNfcWritingSystem(), requireNonTrivial: true);
+        AssertAllNfc(NfcTestData.CreateNfcPartOfSpeech(), requireNonTrivial: true);
+        AssertAllNfc(NfcTestData.CreateNfcPublication(), requireNonTrivial: true);
+        AssertAllNfc(NfcTestData.CreateNfcSemanticDomain(), requireNonTrivial: true);
+        AssertAllNfc(NfcTestData.CreateNfcComplexFormType(), requireNonTrivial: true);
+        AssertAllNfc(NfcTestData.CreateNfcMorphType(), requireNonTrivial: true);
+        AssertAllNfc(NfcTestData.CreateNfcTranslation(), requireNonTrivial: true);
+        AssertAllNfc(NfcTestData.CreateNfcExampleSentence(), requireNonTrivial: true);
+        AssertAllNfc(NfcTestData.CreateNfcExampleSentenceWithTranslations(), requireNonTrivial: true);
+        AssertAllNfc(NfcTestData.CreateNfcSense(), requireNonTrivial: true);
+        AssertAllNfc(NfcTestData.CreateNfcSenseWithExamples(), requireNonTrivial: true);
+        AssertAllNfc(NfcTestData.CreateNfcComplexFormComponent(), requireNonTrivial: true);
+        AssertAllNfc(NfcTestData.CreateNfcEntry(), requireNonTrivial: true);
+        AssertAllNfc(NfcTestData.CreateNfcEntryWithSenses(), requireNonTrivial: true);
+        AssertAllNfc(NfcTestData.CreateNfcEntryWithComponents(), requireNonTrivial: true);
     }
 
     [Fact]

--- a/backend/FwLite/MiniLcm/Models/Entry.cs
+++ b/backend/FwLite/MiniLcm/Models/Entry.cs
@@ -78,7 +78,7 @@ public record Entry : IObjectWithId<Entry>
             [
                 ..ComplexFormTypes.Select(cft => cft.Copy())
             ],
-            PublishIn = [ ..PublishIn.Select(p => (Publication)p.Copy())]
+            PublishIn = [ ..PublishIn.Select(p => p.Copy())]
         };
     }
 

--- a/backend/FwLite/MiniLcm/Models/Publication.cs
+++ b/backend/FwLite/MiniLcm/Models/Publication.cs
@@ -1,6 +1,6 @@
 namespace MiniLcm.Models;
 
-public class Publication : IPossibility
+public class Publication : IPossibility, IObjectWithId<Publication>
 {
     public required Guid Id { get; set; }
     public DateTimeOffset? DeletedAt { get; set; }
@@ -14,7 +14,7 @@ public class Publication : IPossibility
         return;
     }
 
-    public IObjectWithId Copy()
+    public Publication Copy()
     {
         return new Publication()
         {

--- a/backend/FwLite/MiniLcm/Normalization/MiniLcmApiWriteNormalizationWrapper.cs
+++ b/backend/FwLite/MiniLcm/Normalization/MiniLcmApiWriteNormalizationWrapper.cs
@@ -34,6 +34,9 @@ public class MiniLcmApiWriteNormalizationWrapperFactory : IMiniLcmWrapperFactory
 ///   Non-normalized data that is already persisted (before this wrapper was introduced) will be normalized by LibLcm. That's not something we want to fix here.
 /// - Properties that liblcm/FieldWorks does not NFD-normalize are passed through unchanged.
 ///   Currently only WritingSystem properties.
+/// - Each normalizer starts from the model's own Copy() (or `with` for records) and overwrites only the
+///   text-bearing fields, so non-text fields — including any added later — are preserved automatically rather
+///   than re-listed here. Copy() completeness is enforced by LcmCrdt.Tests.EntityCopyMethodTests.
 /// - JsonPatch overloads normalize string-ish values best-effort (string, RichString, MultiString, RichMultiString).
 ///   JsonElement values are only normalized when they are simple strings; complex JSON values are left as-is
 ///   to avoid guessing the target type.
@@ -99,13 +102,9 @@ public partial class MiniLcmApiWriteNormalizationWrapper(IMiniLcmApi api) : IMin
 
     private static PartOfSpeech NormalizePartOfSpeech(PartOfSpeech pos)
     {
-        return new PartOfSpeech
-        {
-            Id = pos.Id,
-            Name = StringNormalizer.Normalize(pos.Name),
-            DeletedAt = pos.DeletedAt,
-            Predefined = pos.Predefined
-        };
+        var copy = pos.Copy();
+        copy.Name = StringNormalizer.Normalize(pos.Name);
+        return copy;
     }
 
     #endregion
@@ -135,12 +134,9 @@ public partial class MiniLcmApiWriteNormalizationWrapper(IMiniLcmApi api) : IMin
 
     private static Publication NormalizePublication(Publication pub)
     {
-        return new Publication
-        {
-            Id = pub.Id,
-            Name = StringNormalizer.Normalize(pub.Name),
-            DeletedAt = pub.DeletedAt
-        };
+        var copy = pub.Copy();
+        copy.Name = StringNormalizer.Normalize(pub.Name);
+        return copy;
     }
 
     #endregion
@@ -170,14 +166,10 @@ public partial class MiniLcmApiWriteNormalizationWrapper(IMiniLcmApi api) : IMin
 
     private static SemanticDomain NormalizeSemanticDomain(SemanticDomain sd)
     {
-        return new SemanticDomain
-        {
-            Id = sd.Id,
-            Name = StringNormalizer.Normalize(sd.Name),
-            Code = StringNormalizer.Normalize(sd.Code), // yes, LibLcm normalizes this too
-            DeletedAt = sd.DeletedAt,
-            Predefined = sd.Predefined
-        };
+        var copy = sd.Copy();
+        copy.Name = StringNormalizer.Normalize(sd.Name);
+        copy.Code = StringNormalizer.Normalize(sd.Code); // yes, LibLcm normalizes this too
+        return copy;
     }
 
     #endregion
@@ -230,18 +222,13 @@ public partial class MiniLcmApiWriteNormalizationWrapper(IMiniLcmApi api) : IMin
 
     private static MorphType NormalizeMorphType(MorphType mt)
     {
-        return new MorphType
-        {
-            Id = mt.Id,
-            Kind = mt.Kind,
-            Name = StringNormalizer.Normalize(mt.Name),
-            Abbreviation = StringNormalizer.Normalize(mt.Abbreviation),
-            Description = StringNormalizer.Normalize(mt.Description),
-            Prefix = StringNormalizer.Normalize(mt.Prefix),
-            Postfix = StringNormalizer.Normalize(mt.Postfix),
-            SecondaryOrder = mt.SecondaryOrder,
-            DeletedAt = mt.DeletedAt
-        };
+        var copy = mt.Copy();
+        copy.Name = StringNormalizer.Normalize(mt.Name);
+        copy.Abbreviation = StringNormalizer.Normalize(mt.Abbreviation);
+        copy.Description = StringNormalizer.Normalize(mt.Description);
+        copy.Prefix = StringNormalizer.Normalize(mt.Prefix);
+        copy.Postfix = StringNormalizer.Normalize(mt.Postfix);
+        return copy;
     }
 
     #endregion
@@ -374,19 +361,13 @@ public partial class MiniLcmApiWriteNormalizationWrapper(IMiniLcmApi api) : IMin
 
     private static Sense NormalizeSense(Sense sense)
     {
-        return new Sense
-        {
-            Id = sense.Id,
-            Order = sense.Order,
-            DeletedAt = sense.DeletedAt,
-            EntryId = sense.EntryId,
-            Definition = StringNormalizer.Normalize(sense.Definition),
-            Gloss = StringNormalizer.Normalize(sense.Gloss),
-            PartOfSpeech = sense.PartOfSpeech is not null ? NormalizePartOfSpeech(sense.PartOfSpeech) : null,
-            PartOfSpeechId = sense.PartOfSpeechId,
-            SemanticDomains = [.. sense.SemanticDomains.Select(NormalizeSemanticDomain)],
-            ExampleSentences = [.. sense.ExampleSentences.Select(NormalizeExampleSentence)]
-        };
+        var copy = sense.Copy();
+        copy.Definition = StringNormalizer.Normalize(sense.Definition);
+        copy.Gloss = StringNormalizer.Normalize(sense.Gloss);
+        copy.PartOfSpeech = sense.PartOfSpeech is not null ? NormalizePartOfSpeech(sense.PartOfSpeech) : null;
+        copy.SemanticDomains = [.. sense.SemanticDomains.Select(NormalizeSemanticDomain)];
+        copy.ExampleSentences = [.. sense.ExampleSentences.Select(NormalizeExampleSentence)];
+        return copy;
     }
 
     #endregion
@@ -437,25 +418,18 @@ public partial class MiniLcmApiWriteNormalizationWrapper(IMiniLcmApi api) : IMin
 
     private static ExampleSentence NormalizeExampleSentence(ExampleSentence example)
     {
-        return new ExampleSentence
-        {
-            Id = example.Id,
-            Order = example.Order,
-            DeletedAt = example.DeletedAt,
-            SenseId = example.SenseId,
-            Sentence = StringNormalizer.Normalize(example.Sentence),
-            Translations = [.. example.Translations.Select(NormalizeTranslation)],
-            Reference = StringNormalizer.Normalize(example.Reference)
-        };
+        var copy = example.Copy();
+        copy.Sentence = StringNormalizer.Normalize(example.Sentence);
+        copy.Translations = [.. example.Translations.Select(NormalizeTranslation)];
+        copy.Reference = StringNormalizer.Normalize(example.Reference);
+        return copy;
     }
 
     private static Translation NormalizeTranslation(Translation translation)
     {
-        return new Translation
-        {
-            Id = translation.Id,
-            Text = StringNormalizer.Normalize(translation.Text)
-        };
+        var copy = translation.Copy();
+        copy.Text = StringNormalizer.Normalize(translation.Text);
+        return copy;
     }
 
     #endregion


### PR DESCRIPTION
Hardens the NFD write-normalization path from #2146 so a model field can't silently slip through dropped or un-normalized.

The write-normalization wrapper rebuilt each model with `new X { ... }` initializers, re-listing every field — so a field added to a model later but missed there would be reset to its default on write, uncaught unless test data also happened to set it non-default. The seven non-record normalizers now copy-then-overwrite only the text fields (records already get this from `with`), so non-text fields, including ones added in future, are preserved by each type's `Copy()` — whose completeness is already enforced by `EntityCopyMethodTests`. Behaviour is unchanged for every current field, and `Publication.Copy()` is now strongly typed, dropping two redundant casts.

On the test side: factory data uses non-default scalars and genuinely-decomposable (non-ASCII) NFC content so a dropped or no-op'd field actually fails an assertion; the empty-MultiString negative test is isolated; a vacuous `WritingSystem` assertion is removed; and `NormalizationAssert`'s per-leaf check is now a single named `StringCheck` (failure label + validator) instead of a threaded `NormalizationForm`.

Build clean for MiniLcm/LcmCrdt; WriteNormalizationTests, NormalizationAssertTests, and EntityCopyMethodTests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)