### PR TITLE
Discover Copy()-test types by reflection instead of CRDT registration

### DIFF
--- a/backend/FwLite/LcmCrdt.Tests/EntityCopyMethodTests.cs
+++ b/backend/FwLite/LcmCrdt.Tests/EntityCopyMethodTests.cs
@@ -23,7 +23,9 @@ public class EntityCopyMethodTests
 
     private static MethodInfo? CopyMethod(Type type)
     {
-        return type.GetMethod("Copy", BindingFlags.Public | BindingFlags.Instance, binder: null, Type.EmptyTypes, modifiers: null);
+        // DeclaredOnly: the type must define its own Copy(), not merely inherit one, so private
+        // RichString subclasses (e.g. the JSON-converter helper) aren't pulled in as spurious cases.
+        return type.GetMethod("Copy", BindingFlags.Public | BindingFlags.Instance | BindingFlags.DeclaredOnly, binder: null, Type.EmptyTypes, modifiers: null);
     }
 
     private void AssertDeepCopy(object copy, object original)

--- a/backend/FwLite/LcmCrdt.Tests/EntityCopyMethodTests.cs
+++ b/backend/FwLite/LcmCrdt.Tests/EntityCopyMethodTests.cs
@@ -1,7 +1,7 @@
+using System.Reflection;
 using FluentAssertions.Equivalency;
 using FluentAssertions.Execution;
 using MiniLcm.Tests.AutoFakerHelpers;
-using SIL.Harmony.Resource;
 using Soenneker.Utils.AutoBogus;
 using Soenneker.Utils.AutoBogus.Config;
 
@@ -11,13 +11,19 @@ public class EntityCopyMethodTests
 {
     private static readonly AutoFaker AutoFaker = new(AutoFakerDefault.Config);
 
+    // Discover types from the Copy() contract itself rather than the CRDT registration, so an
+    // owned type like Translation (which isn't a CRDT root) — or any model added later — can't slip
+    // through by being absent from a hand-maintained list.
     public static IEnumerable<object[]> GetEntityTypes()
     {
-        var crdtConfig = new CrdtConfig();
-        LcmCrdtKernel.ConfigureCrdt(crdtConfig);
-        return crdtConfig.ObjectTypes
-            .Except([typeof(RemoteResource)])//exclude remote resource as it's a harmony defined type, not miniLcm
+        return typeof(IObjectWithId).Assembly.GetTypes()
+            .Where(t => t is { IsClass: true, IsAbstract: false } && CopyMethod(t) is not null)
             .Select(t => new object[] { t });
+    }
+
+    private static MethodInfo? CopyMethod(Type type)
+    {
+        return type.GetMethod("Copy", BindingFlags.Public | BindingFlags.Instance, binder: null, Type.EmptyTypes, modifiers: null);
     }
 
     private void AssertDeepCopy(object copy, object original)
@@ -48,9 +54,8 @@ public class EntityCopyMethodTests
     [MemberData(nameof(GetEntityTypes))]
     public void EntityCopyMethodShouldCopyAllFields(Type type)
     {
-        type.IsAssignableTo(typeof(IObjectWithId)).Should().BeTrue();
-        var entity = (IObjectWithId) AutoFaker.Generate(type);
-        var copy = entity.Copy();
+        var entity = AutoFaker.Generate(type)!;
+        var copy = CopyMethod(type)!.Invoke(entity, null)!;
         AssertDeepCopy(copy, entity);
     }
 


### PR DESCRIPTION
`EntityCopyMethodTests` drove its theory from `crdtConfig.ObjectTypes` (the CRDT sync registration), which lists only root entities. Owned types that define their own `Copy()` — `Translation`, `ViewField`, `ViewWritingSystem`, `MultiString`, `RichMultiString`, `RichString`, `RichSpan` — were therefore only covered transitively (via their owners), and a brand-new model could be left off entirely.

This switches discovery to reflection over the MiniLcm assembly for any concrete type that **declares** a parameterless `Copy()` (`DeclaredOnly`, so inherit-only subclasses such as the private `RichStringPrimitive` JSON-converter helper are excluded). Coverage now tracks the `Copy()` contract itself rather than a registration list that can drift. The row count goes 11 → 18, with the owned types now verified as direct, named cases.

Split out of #2322, whose doc comment already points at this test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)