### PR TITLE
Run FwDataFactory shutdown synchronously in StopAsync

### DIFF
--- a/backend/FwLite/FwDataMiniLcmBridge/FwDataFactory.cs
+++ b/backend/FwLite/FwDataMiniLcmBridge/FwDataFactory.cs
@@ -140,6 +140,7 @@ public class FwDataFactory(
     public Task StopAsync(CancellationToken cancellationToken)
     {
         _shuttingDown = true;
-        return Task.Run(Dispose, cancellationToken);
+        Dispose();
+        return Task.CompletedTask;
     }
 }


### PR DESCRIPTION
Companion to sillsdev/libpalaso#1504, which catches the `AbandonedMutexException` itself. This PR removes a small but real abandonment-risk amplifier on the FwLite side: the unnecessary `Task.Run` inside `FwDataFactory.StopAsync()`.

### What

```diff
 public Task StopAsync(CancellationToken cancellationToken)
 {
     _shuttingDown = true;
-    return Task.Run(Dispose, cancellationToken);
+    Dispose();
+    return Task.CompletedTask;
 }
```

### Why

- `IHostedService.StopAsync` is the host's contract to do shutdown work, and the host awaits the returned `Task` before terminating the process. Offloading `Dispose()` to a threadpool task gains nothing — `StopAsync` is not on a hot path.
- The previous form passed `cancellationToken` to `Task.Run`, which only cancels the *scheduling* of `Dispose`, not an in-flight `Dispose`. If `StopAsync` was called after the host's shutdown timeout had already elapsed (cancellationToken pre-signaled), the caches would never be disposed at all — the worst possible state for any file-locks or libpalaso `GlobalMutex` holds inside them.
- Running `Dispose()` synchronously on the StopAsync caller's thread keeps shutdown deterministic. Exceptions from `Dispose()` now propagate synchronously to the host instead of being captured in a `Task` that nobody awaits the result of.
- `LcmCache.Dispose()` (via `WritingSystemManager.Save` → libpalaso `GlobalMutex.Lock`) is sensitive to the threading model — `System.Threading.Mutex` has thread affinity. Reducing the number of thread hops on shutdown reduces the surface area where a process exit can race against an in-flight Dispose.

### What this does NOT fix on its own

- The `Task.Run(lcmCache.Dispose)` in `CloseProjectAsync` is **kept** intentionally. That path is reachable from MAUI UI-thread callers (the "open in FieldWorks" handoff); removing the `Task.Run` there would freeze the UI during Dispose. The threadpool offload is correct in that location.
- The `OnLcmProjectCacheEviction` callback fires on the `MemoryCache` scanner thread and disposes the cache out from under whatever request is still using it. That's a use-after-dispose risk separate from mutex abandonment and needs a leasing/refcount scheme (the comment at lines 77–79 already flags it). Not in scope for this PR.

### Risk

- Low. Behavior change is "wait synchronously" instead of "wait via Task.Run." Callers of `StopAsync` were already awaiting the returned Task; they now observe immediate completion after `Dispose()` returns. No public API change.
- The `cancellationToken` parameter is unused after this change — same as the existing `StartAsync` above it. Kept for `IHostedService` interface compatibility.

### Tests

`FwDataMiniLcmBridge.Tests` runs 761/762 green (1 unrelated skip). No new test added: the change is a removal of a wrapper around an already-tested method.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
