### PR TITLE
Pin Refit to 10.0.1 while 10.1.6's signing cert is revoked

### DIFF
--- a/backend/Directory.Packages.props
+++ b/backend/Directory.Packages.props
@@ -96,8 +96,10 @@
     <PackageVersion Include="Polly.Extensions" Version="8.6.6" />
     <PackageVersion Include="Quartz.AspNetCore" Version="3.18.1" />
     <PackageVersion Include="Quartz.Serialization.SystemTextJson" Version="3.18.1" />
-    <PackageVersion Include="Refit" Version="10.1.6" />
-    <PackageVersion Include="Refit.HttpClientFactory" Version="10.1.6" />
+    <!-- Pinned to 10.0.1: 10.1.6's author signature is revoked, failing restore (NU3012) on Linux.
+         Re-bump once https://github.com/reactiveui/refit/issues/2114 is resolved. -->
+    <PackageVersion Include="Refit" Version="10.0.1" />
+    <PackageVersion Include="Refit.HttpClientFactory" Version="10.0.1" />
     <PackageVersion Include="Reinforced.Typings" Version="1.6.7" />
     <PackageVersion Include="Scalar.AspNetCore" Version="2.14.11" />
     <PackageVersion Include="SIL.Chorus.ChorusMerge" Version="6.0.0-beta0064" />


### PR DESCRIPTION
Refit 10.1.6's author-signing certificate was revoked upstream on 2026-06-02 (reactiveui/refit#2114), so cache-cold NuGet restores on Linux runners fail with NU3012 — currently breaking `Build API / publish-api` and `Publish FW Lite app for Linux` on any PR. 10.0.1 (published 2026-02-06) predates the revoked cert and still verifies; the repo only moved off 8.0.0 → 10.1.6 two weeks ago (#2264), so nothing depends on the 10.1.x delta. Re-bump once upstream re-signs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)