### PR TITLE
Trust all networks for forwarded headers in local dev

### DIFF
--- a/deployment/local-dev/lexbox-deployment.patch.yaml
+++ b/deployment/local-dev/lexbox-deployment.patch.yaml
@@ -35,8 +35,14 @@ spec:
             name: Authentication__Jwt__Secret
           - name: LfClassicConfig__ConnectionString
             value: mongodb://host.docker.internal:27017
+          # Trust the local cluster's pod network so X-Forwarded-Proto from the
+          # ingress-nginx controller is honored — otherwise lexbox sees the request
+          # as HTTP and emits HTTP URLs in /.well-known/openid-configuration, which
+          # breaks the FwLite OAuth flow. The pod CIDR differs between Docker
+          # Desktop on Windows/Mac (10.1.0.0/16), Docker Desktop on Linux, and the
+          # kind cluster used in CI, so trust them all in non-prod environments.
           - name: ForwardedHeadersOptions__KnownNetworks__0
-            value: "10.1.0.0/16"
+            value: "0.0.0.0/0"
           - name: CloudFlare__TurnstileKey
             value: "1x0000000000000000000000000000000AA"
             valueFrom:


### PR DESCRIPTION
## Summary
Updated the local development deployment configuration to trust all networks (`0.0.0.0/0`) for forwarded headers instead of only the Docker Desktop pod CIDR (`10.1.0.0/16`).

## Changes
- Modified `ForwardedHeadersOptions__KnownNetworks__0` from `10.1.0.0/16` to `0.0.0.0/0` in the local dev deployment patch

## Details
This change ensures that the `X-Forwarded-Proto` header from the ingress-nginx controller is properly honored in all local development environments. Without this, lexbox incorrectly sees requests as HTTP and emits HTTP URLs in `/.well-known/openid-configuration`, which breaks the FwLite OAuth flow.

The pod CIDR varies across different local development setups:
- Docker Desktop on Windows/Mac: `10.1.0.0/16`
- Docker Desktop on Linux: different CIDR
- kind cluster used in CI: different CIDR

Trusting all networks (`0.0.0.0/0`) in non-production environments provides a more robust solution that works across all local development configurations.

https://claude.ai/code/session_01FdVDoZX5S2MDFnhqqmsKSv