### PR TITLE
Bump Refit package to 10.2.0 (10.1.6 rerelease)

### DIFF
--- a/backend/Directory.Packages.props
+++ b/backend/Directory.Packages.props
@@ -96,10 +96,8 @@
     <PackageVersion Include="Polly.Extensions" Version="8.6.6" />
     <PackageVersion Include="Quartz.AspNetCore" Version="3.18.1" />
     <PackageVersion Include="Quartz.Serialization.SystemTextJson" Version="3.18.1" />
-    <!-- Pinned to 10.0.1: 10.1.6's author signature is revoked, failing restore (NU3012) on Linux.
-         Re-bump once https://github.com/reactiveui/refit/issues/2114 is resolved. -->
-    <PackageVersion Include="Refit" Version="10.0.1" />
-    <PackageVersion Include="Refit.HttpClientFactory" Version="10.0.1" />
+    <PackageVersion Include="Refit" Version="10.2.0" />
+    <PackageVersion Include="Refit.HttpClientFactory" Version="10.2.0" />
     <PackageVersion Include="Reinforced.Typings" Version="1.6.7" />
     <PackageVersion Include="Scalar.AspNetCore" Version="2.14.11" />
     <PackageVersion Include="SIL.Chorus.ChorusMerge" Version="6.0.0-beta0064" />


### PR DESCRIPTION
Fixes #2334.

This is #2335 reopened now that I've gotten the extraneous material out of the commit.