### PR TITLE
Support 32-bit ARM Android via a separate Mono bundle

### DIFF
--- a/.github/workflows/fw-lite.yaml
+++ b/.github/workflows/fw-lite.yaml
@@ -251,20 +251,15 @@ jobs:
     needs: [ build-and-test, frontend ]
     timeout-minutes: 30
     runs-on: macos-latest
-    # Two bundles, one Play listing. .NET 10 defaults Android to CoreCLR, which ships
-    # 64-bit only; armeabi-v7a (32-bit) devices need the legacy Mono runtime. They can't
-    # be combined into one AAB (a bundle boots a single runtime), so we build both and
-    # upload both to the same Play release. The versionCode bands the runtime preference
-    # above the build number: a 64-bit device's abilist also includes armeabi-v7a, so it
-    # matches BOTH bundles — the higher-coded CoreCLR band guarantees it never resolves to
-    # Mono. 32-bit-only devices match only Mono. See create-release for the upload side.
+    # Two bundles for one Play listing: CoreCLR (64-bit) + Mono (armeabi-v7a) — they can't share an AAB
+    # (a bundle boots a single runtime). 64-bit devices' abilist also includes armeabi-v7a, so they match
+    # BOTH bundles; the versionCode bands CoreCLR above Mono so they resolve to CoreCLR and only 32-bit-only
+    # devices get Mono. See create-release for the upload side.
     strategy:
       fail-fast: false
       matrix:
         include:
-          # RIDs are NOT passed here — the csproj selects them from UseMonoRuntime (coreclr =>
-          # android-arm64;android-x64, mono => android-arm). Passing -p:RuntimeIdentifiers on the
-          # command line makes it global and breaks the per-RID fan-out (MSB1006 / MSB3030).
+          # RIDs come from the csproj, keyed on UseMonoRuntime (see FwLiteMaui.csproj).
           - variant: coreclr
             runtimeArgs: ''
             versionOffset: 100000000

--- a/.github/workflows/fw-lite.yaml
+++ b/.github/workflows/fw-lite.yaml
@@ -247,10 +247,29 @@ jobs:
           path: backend/FwLite/artifacts/publish/FwLiteWeb/*
 
   publish-android:
-    name: Publish FW Lite app for Android
+    name: Publish FW Lite app for Android (${{ matrix.variant }})
     needs: [ build-and-test, frontend ]
     timeout-minutes: 30
     runs-on: macos-latest
+    # Two bundles, one Play listing. .NET 10 defaults Android to CoreCLR, which ships
+    # 64-bit only; armeabi-v7a (32-bit) devices need the legacy Mono runtime. They can't
+    # be combined into one AAB (a bundle boots a single runtime), so we build both and
+    # upload both to the same Play release. The versionCode bands the runtime preference
+    # above the build number: a 64-bit device's abilist also includes armeabi-v7a, so it
+    # matches BOTH bundles — the higher-coded CoreCLR band guarantees it never resolves to
+    # Mono. 32-bit-only devices match only Mono. See create-release for the upload side.
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - variant: coreclr
+            rids: 'android-arm64;android-x64'
+            runtimeArgs: ''
+            versionOffset: 100000000
+          - variant: mono
+            rids: 'android-arm'
+            runtimeArgs: '-p:UseMonoRuntime=true'
+            versionOffset: 0
     steps:
       - name: Checkout
         uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
@@ -266,6 +285,10 @@ jobs:
 
       - name: Setup Maui
         run: dotnet workload install maui
+      - name: Compute Android version code
+        id: versionCode
+        shell: bash
+        run: echo "CODE=$(( ${{ matrix.versionOffset }} + ${{ github.run_number }} ))" >> ${GITHUB_OUTPUT}
       - name: Decode Android Keystore
         id: decodeKeystore
         env:
@@ -282,8 +305,9 @@ jobs:
           KEYSTORE_ALIAS: ${{ vars.FW_LITE_KEYSTORE_UPLOAD_KEY_ALIAS }}
         run: |
           dotnet publish -f net10.0-android -p:BuildApple=false --artifacts-path ../artifacts \
+            -p:RuntimeIdentifiers='${{ matrix.rids }}' ${{ matrix.runtimeArgs }} \
             -p:ApplicationDisplayVersion=${{ needs.build-and-test.outputs.semver-version }} \
-            -p:ApplicationVersion=${{ github.run_number }} \
+            -p:ApplicationVersion=${{ steps.versionCode.outputs.CODE }} \
             -p:InformationalVersion=${{ needs.build-and-test.outputs.version }} \
             -p:AndroidKeyStore=true \
             -p:AndroidSigningKeyStore=${KEYSTORE_PATH} \
@@ -295,10 +319,11 @@ jobs:
       - name: Upload FWLite App artifacts
         uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5.0.0
         with:
-          name: fw-lite-android
+          name: fw-lite-android-${{ matrix.variant }}
           if-no-files-found: error
-#          path looks like this: backend/FwLite/artifacts/publish/FwLiteMaui/release_net10.0-android/org.sil.fwlitemaui-signed.apk
-          path: backend/FwLite/artifacts/publish/FwLiteMaui/release_net10.0-android/*
+          # Single-RID (mono) publishes to release_net10.0-android_android-arm; multi-RID
+          # (coreclr) to release_net10.0-android. The trailing * tolerates both.
+          path: backend/FwLite/artifacts/publish/FwLiteMaui/release_net10.0-android*/*
 
   publish-win:
     name: Publish FW Lite app for Windows
@@ -399,17 +424,29 @@ jobs:
           path: fw-lite-web-linux
       - uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5.0.0
         with:
-          name: fw-lite-android
-          path: fw-lite-android
+          name: fw-lite-android-coreclr
+          path: fw-lite-android-coreclr
+      - uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5.0.0
+        with:
+          name: fw-lite-android-mono
+          path: fw-lite-android-mono
 
       - name: Zip artifacts
         run: |
           zip -r fw-lite-portable.zip fw-lite-portable
           chmod +x fw-lite-web-linux/*/FwLiteWeb fw-lite-web-linux/*/*.sh
           zip -r fw-lite-web-linux.zip fw-lite-web-linux
-      - name: Rename Installer
+      - name: Rename Installer and stage Android bundles
         run: |
           mv fw-lite-msix/FwLiteMaui.msixbundle fw-lite-msix/FieldWorksLiteInstaller.msixbundle
+          # Both variants share the org.sil.FwLiteMaui basename, so rename per arch before
+          # attaching (release asset names must be unique). Upload BOTH .aab to one Play release.
+          mkdir -p fw-lite-android
+          for v in coreclr mono; do
+            case $v in coreclr) arch=64bit ;; mono) arch=arm32 ;; esac
+            cp fw-lite-android-$v/*.aab fw-lite-android/FieldWorksLite-$arch.aab
+            cp fw-lite-android-$v/*.apk fw-lite-android/FieldWorksLite-$arch.apk 2>/dev/null || true
+          done
 
       - name: Create Release
         uses: softprops/action-gh-release@c95fe1489396fe8a9eb87c0abf8aa5b2ef267fda #v2.2.1

--- a/.github/workflows/fw-lite.yaml
+++ b/.github/workflows/fw-lite.yaml
@@ -262,12 +262,13 @@ jobs:
       fail-fast: false
       matrix:
         include:
+          # RIDs are NOT passed here — the csproj selects them from UseMonoRuntime (coreclr =>
+          # android-arm64;android-x64, mono => android-arm). Passing -p:RuntimeIdentifiers on the
+          # command line makes it global and breaks the per-RID fan-out (MSB1006 / MSB3030).
           - variant: coreclr
-            rids: 'android-arm64;android-x64'
             runtimeArgs: ''
             versionOffset: 100000000
           - variant: mono
-            rids: 'android-arm'
             runtimeArgs: '-p:UseMonoRuntime=true'
             versionOffset: 0
     steps:
@@ -304,8 +305,7 @@ jobs:
           KEYSTORE_PASS: ${{ secrets.FW_LITE_KEYSTORE_PASS }}
           KEYSTORE_ALIAS: ${{ vars.FW_LITE_KEYSTORE_UPLOAD_KEY_ALIAS }}
         run: |
-          dotnet publish -f net10.0-android -p:BuildApple=false --artifacts-path ../artifacts \
-            -p:RuntimeIdentifiers='${{ matrix.rids }}' ${{ matrix.runtimeArgs }} \
+          dotnet publish -f net10.0-android -p:BuildApple=false --artifacts-path ../artifacts ${{ matrix.runtimeArgs }} \
             -p:ApplicationDisplayVersion=${{ needs.build-and-test.outputs.semver-version }} \
             -p:ApplicationVersion=${{ steps.versionCode.outputs.CODE }} \
             -p:InformationalVersion=${{ needs.build-and-test.outputs.version }} \

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -152,3 +152,8 @@ tasks:
     aliases: [android-release-dev]
     desc: Build a Release "Dev" APK and adb-install it on the connected USB device
     deps: [fw-lite:install-maui-android-release-dev]
+
+  fw-lite-android-release-arm32:
+    aliases: [android-release-arm32]
+    desc: Build & install a Release Mono arm32 (armeabi-v7a) APK on the connected USB device
+    deps: [fw-lite:install-maui-android-release-arm32]

--- a/backend/FwLite/FwLiteMaui/FwLiteMaui.csproj
+++ b/backend/FwLite/FwLiteMaui/FwLiteMaui.csproj
@@ -12,7 +12,10 @@
 		The Mac App Store will NOT accept apps with ONLY maccatalyst-arm64 indicated;
 		either BOTH runtimes must be indicated or ONLY macatalyst-x64. -->
     <!-- For example: <RuntimeIdentifiers>maccatalyst-x64;maccatalyst-arm64</RuntimeIdentifiers> -->
-    <RuntimeIdentifiers Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'android'">android-arm;android-arm64;android-x86;android-x64</RuntimeIdentifiers>
+    <!-- CoreCLR (the .NET 10 default Android runtime) only ships 64-bit packs, so the default build is 64-bit.
+         The 32-bit armeabi-v7a bundle is built separately with -p:UseMonoRuntime=true -p:RuntimeIdentifiers=android-arm
+         (see the publish-android matrix in .github/workflows/fw-lite.yaml and the install-maui-android-release-arm32 task). -->
+    <RuntimeIdentifiers Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'android'">android-arm64;android-x64</RuntimeIdentifiers>
     <OutputType>Exe</OutputType>
     <RootNamespace>FwLiteMaui</RootNamespace>
     <UseMaui>true</UseMaui>

--- a/backend/FwLite/FwLiteMaui/FwLiteMaui.csproj
+++ b/backend/FwLite/FwLiteMaui/FwLiteMaui.csproj
@@ -12,11 +12,9 @@
 		The Mac App Store will NOT accept apps with ONLY maccatalyst-arm64 indicated;
 		either BOTH runtimes must be indicated or ONLY macatalyst-x64. -->
     <!-- For example: <RuntimeIdentifiers>maccatalyst-x64;maccatalyst-arm64</RuntimeIdentifiers> -->
-    <!-- CoreCLR (the .NET 10 default Android runtime) only ships 64-bit packs, so the default build is 64-bit.
-         Setting UseMonoRuntime=true builds the 32-bit armeabi-v7a bundle (the legacy runtime still ships an
-         android-arm pack). Keep the RID list HERE rather than passing -p:RuntimeIdentifiers on the command line:
-         a global -p: value breaks the SDK's per-RID fan-out (the ';' is read as a property separator -> MSB1006,
-         and dependency projects don't get the singular RuntimeIdentifier -> MSB3030 missing per-RID output). -->
+    <!-- CoreCLR (the .NET 10 default Android runtime) is 64-bit only; UseMonoRuntime=true builds the 32-bit
+         armeabi-v7a bundle. Keep RIDs here, not on the command line — a global -p:RuntimeIdentifiers breaks
+         the SDK's per-RID fan-out (dependency projects don't get the singular RID). -->
     <RuntimeIdentifiers Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'android' And '$(UseMonoRuntime)' != 'true'">android-arm64;android-x64</RuntimeIdentifiers>
     <RuntimeIdentifiers Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'android' And '$(UseMonoRuntime)' == 'true'">android-arm</RuntimeIdentifiers>
     <OutputType>Exe</OutputType>

--- a/backend/FwLite/FwLiteMaui/FwLiteMaui.csproj
+++ b/backend/FwLite/FwLiteMaui/FwLiteMaui.csproj
@@ -13,9 +13,12 @@
 		either BOTH runtimes must be indicated or ONLY macatalyst-x64. -->
     <!-- For example: <RuntimeIdentifiers>maccatalyst-x64;maccatalyst-arm64</RuntimeIdentifiers> -->
     <!-- CoreCLR (the .NET 10 default Android runtime) only ships 64-bit packs, so the default build is 64-bit.
-         The 32-bit armeabi-v7a bundle is built separately with -p:UseMonoRuntime=true -p:RuntimeIdentifiers=android-arm
-         (see the publish-android matrix in .github/workflows/fw-lite.yaml and the install-maui-android-release-arm32 task). -->
-    <RuntimeIdentifiers Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'android'">android-arm64;android-x64</RuntimeIdentifiers>
+         Setting UseMonoRuntime=true builds the 32-bit armeabi-v7a bundle (the legacy runtime still ships an
+         android-arm pack). Keep the RID list HERE rather than passing -p:RuntimeIdentifiers on the command line:
+         a global -p: value breaks the SDK's per-RID fan-out (the ';' is read as a property separator -> MSB1006,
+         and dependency projects don't get the singular RuntimeIdentifier -> MSB3030 missing per-RID output). -->
+    <RuntimeIdentifiers Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'android' And '$(UseMonoRuntime)' != 'true'">android-arm64;android-x64</RuntimeIdentifiers>
+    <RuntimeIdentifiers Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'android' And '$(UseMonoRuntime)' == 'true'">android-arm</RuntimeIdentifiers>
     <OutputType>Exe</OutputType>
     <RootNamespace>FwLiteMaui</RootNamespace>
     <UseMaui>true</UseMaui>

--- a/backend/FwLite/FwLiteMaui/Services/MauiTroubleshootingService.cs
+++ b/backend/FwLite/FwLiteMaui/Services/MauiTroubleshootingService.cs
@@ -23,6 +23,9 @@ public class MauiTroubleshootingService(
     public Task<bool> GetCanShare() => Task.FromResult(true);
 
     [JSInvokable]
+    public Task<string> GetProcessArchitecture() => Task.FromResult(RuntimeInfoHelper.ProcessArchitecture());
+
+    [JSInvokable]
     public async Task<bool> TryOpenDataDirectory()
     {
         try

--- a/backend/FwLite/FwLiteMaui/build/Linq2DbCctorPatcher/Program.cs
+++ b/backend/FwLite/FwLiteMaui/build/Linq2DbCctorPatcher/Program.cs
@@ -49,37 +49,26 @@ using (var asm = AssemblyDefinition.ReadAssembly(dllPath, new ReaderParameters {
     if (nested is null)
         return Fail("SqlTransparentExpression nested type not found inside EFCoreMetadataReader.");
 
-    // The _ctor field is what makes Quote() dangerous, so its continued existence
-    // is the real invariant — guard it directly rather than inferring it from the cctor.
-    if (!nested.Fields.Any(f => f.Name == "_ctor"))
-        return Fail("SqlTransparentExpression no longer declares the _ctor field; IL shape changed.");
-
     var cctor = nested.Methods.FirstOrDefault(m => m.IsConstructor && m.IsStatic);
     if (cctor is null || !cctor.HasBody)
         return Fail("SqlTransparentExpression .cctor not found (or has no body).");
 
-    // The cctor must be in one of two recognised shapes:
-    //  - the original reflection-based init, which assigns _ctor via stsfld (we neutralise it below), or
-    //  - an effective no-op (just `ret`), which the size-optimising trimmer produces by dropping the
-    //    now-unused field init — and which is also what our own stub leaves behind on a re-run.
-    // Any other shape (real instructions but no stsfld _ctor) is an unrecognised restructure: fail loud.
+    // Sanity-check the cctor shape: at least one stsfld targeting the _ctor field.
+    // If upstream renames _ctor or restructures the field init, we want to know.
     var storesCtorField = cctor.Body.Instructions.Any(ins =>
         ins.OpCode == OpCodes.Stsfld
         && ins.Operand is FieldReference fr
         && fr.Name == "_ctor"
         && fr.DeclaringType.FullName == nested.FullName);
-    var isNoOp = cctor.Body.Instructions.All(ins => ins.OpCode == OpCodes.Nop || ins.OpCode == OpCodes.Ret);
-    if (!storesCtorField && !isNoOp)
-        return Fail("SqlTransparentExpression .cctor has an unrecognised shape (no stsfld for _ctor and not a no-op); IL shape changed.");
+    if (!storesCtorField)
+        return Fail("SqlTransparentExpression .cctor no longer contains a stsfld for the _ctor field; IL shape changed.");
 
     var quote = nested.Methods.FirstOrDefault(m => m.Name == "Quote" && m.Parameters.Count == 0);
     if (quote is null || !quote.HasBody)
         return Fail("SqlTransparentExpression.Quote() not found (or has no body).");
 
     ReplaceBodyWith(cctor, Instruction.Create(OpCodes.Ret));
-    Console.WriteLine(storesCtorField
-        ? "Stubbed SqlTransparentExpression .cctor to no-op ret"
-        : "SqlTransparentExpression .cctor already a no-op (trimmer-neutralised); ensured ret");
+    Console.WriteLine("Stubbed SqlTransparentExpression .cctor to no-op ret");
 
     // Replace Quote() with `throw new NotImplementedException();` so anything that
     // somehow reaches it fails loud rather than NRE'ing on the now-null _ctor field.

--- a/backend/FwLite/FwLiteMaui/build/Linq2DbCctorPatcher/Program.cs
+++ b/backend/FwLite/FwLiteMaui/build/Linq2DbCctorPatcher/Program.cs
@@ -49,26 +49,37 @@ using (var asm = AssemblyDefinition.ReadAssembly(dllPath, new ReaderParameters {
     if (nested is null)
         return Fail("SqlTransparentExpression nested type not found inside EFCoreMetadataReader.");
 
+    // The _ctor field is what makes Quote() dangerous, so its continued existence
+    // is the real invariant — guard it directly rather than inferring it from the cctor.
+    if (!nested.Fields.Any(f => f.Name == "_ctor"))
+        return Fail("SqlTransparentExpression no longer declares the _ctor field; IL shape changed.");
+
     var cctor = nested.Methods.FirstOrDefault(m => m.IsConstructor && m.IsStatic);
     if (cctor is null || !cctor.HasBody)
         return Fail("SqlTransparentExpression .cctor not found (or has no body).");
 
-    // Sanity-check the cctor shape: at least one stsfld targeting the _ctor field.
-    // If upstream renames _ctor or restructures the field init, we want to know.
+    // The cctor must be in one of two recognised shapes:
+    //  - the original reflection-based init, which assigns _ctor via stsfld (we neutralise it below), or
+    //  - an effective no-op (just `ret`), which the size-optimising trimmer produces by dropping the
+    //    now-unused field init — and which is also what our own stub leaves behind on a re-run.
+    // Any other shape (real instructions but no stsfld _ctor) is an unrecognised restructure: fail loud.
     var storesCtorField = cctor.Body.Instructions.Any(ins =>
         ins.OpCode == OpCodes.Stsfld
         && ins.Operand is FieldReference fr
         && fr.Name == "_ctor"
         && fr.DeclaringType.FullName == nested.FullName);
-    if (!storesCtorField)
-        return Fail("SqlTransparentExpression .cctor no longer contains a stsfld for the _ctor field; IL shape changed.");
+    var isNoOp = cctor.Body.Instructions.All(ins => ins.OpCode == OpCodes.Nop || ins.OpCode == OpCodes.Ret);
+    if (!storesCtorField && !isNoOp)
+        return Fail("SqlTransparentExpression .cctor has an unrecognised shape (no stsfld for _ctor and not a no-op); IL shape changed.");
 
     var quote = nested.Methods.FirstOrDefault(m => m.Name == "Quote" && m.Parameters.Count == 0);
     if (quote is null || !quote.HasBody)
         return Fail("SqlTransparentExpression.Quote() not found (or has no body).");
 
     ReplaceBodyWith(cctor, Instruction.Create(OpCodes.Ret));
-    Console.WriteLine("Stubbed SqlTransparentExpression .cctor to no-op ret");
+    Console.WriteLine(storesCtorField
+        ? "Stubbed SqlTransparentExpression .cctor to no-op ret"
+        : "SqlTransparentExpression .cctor already a no-op (trimmer-neutralised); ensured ret");
 
     // Replace Quote() with `throw new NotImplementedException();` so anything that
     // somehow reaches it fails loud rather than NRE'ing on the now-null _ctor field.

--- a/backend/FwLite/FwLiteShared/Services/ITroubleshootingService.cs
+++ b/backend/FwLite/FwLiteShared/Services/ITroubleshootingService.cs
@@ -3,6 +3,7 @@ namespace FwLiteShared.Services;
 public interface ITroubleshootingService
 {
     Task<bool> GetCanShare();
+    Task<string> GetProcessArchitecture();
     Task<bool> TryOpenDataDirectory();
     Task<string> GetDataDirectory();
     Task OpenLogFile();

--- a/backend/FwLite/FwLiteShared/Services/RuntimeInfoHelper.cs
+++ b/backend/FwLite/FwLiteShared/Services/RuntimeInfoHelper.cs
@@ -4,8 +4,7 @@ namespace FwLiteShared.Services;
 
 public static class RuntimeInfoHelper
 {
-    // Android ships a separate bundle per ABI (CoreCLR/64-bit vs Mono/armeabi-v7a), so the
-    // process architecture is a ground-truth fingerprint of which bundle a device installed.
+    // On Android the process architecture reveals which bundle a device installed (Mono/arm32 vs CoreCLR/64-bit).
     public static string ProcessArchitecture()
     {
         var bits = Environment.Is64BitProcess ? "64-bit" : "32-bit";

--- a/backend/FwLite/FwLiteShared/Services/RuntimeInfoHelper.cs
+++ b/backend/FwLite/FwLiteShared/Services/RuntimeInfoHelper.cs
@@ -1,0 +1,14 @@
+using System.Runtime.InteropServices;
+
+namespace FwLiteShared.Services;
+
+public static class RuntimeInfoHelper
+{
+    // Android ships a separate bundle per ABI (CoreCLR/64-bit vs Mono/armeabi-v7a), so the
+    // process architecture is a ground-truth fingerprint of which bundle a device installed.
+    public static string ProcessArchitecture()
+    {
+        var bits = Environment.Is64BitProcess ? "64-bit" : "32-bit";
+        return $"{RuntimeInformation.ProcessArchitecture} ({bits})";
+    }
+}

--- a/backend/FwLite/FwLiteWeb/Services/WebTroubleshootingService.cs
+++ b/backend/FwLite/FwLiteWeb/Services/WebTroubleshootingService.cs
@@ -14,6 +14,9 @@ public class WebTroubleshootingService(
     public Task<bool> GetCanShare() => Task.FromResult(false);
 
     [JSInvokable]
+    public Task<string> GetProcessArchitecture() => Task.FromResult(RuntimeInfoHelper.ProcessArchitecture());
+
+    [JSInvokable]
     public Task<string> GetDataDirectory()
     {
         return Task.FromResult(crdtConfig.Value.ProjectPath);

--- a/backend/FwLite/Taskfile.yml
+++ b/backend/FwLite/Taskfile.yml
@@ -121,6 +121,16 @@ tasks:
         vars: { FLAVOR: 'Dev' }
       - adb -d install -r bin/Release/net10.0-android/org.sil.FwLiteMaui.dev-Signed.apk
 
+  install-maui-android-release-arm32:
+    # Production CoreCLR builds are 64-bit only; this builds the separate Mono/armeabi-v7a bundle
+    # for testing the 32-bit app on real hardware. Output lands under the android-arm RID subfolder.
+    desc: Build a Release Mono arm32 (armeabi-v7a) "Dev" APK and adb-install it on the connected USB device
+    dir: ./FwLiteMaui
+    deps: [ ui:build-viewer ]
+    cmds:
+      - dotnet build -f net10.0-android -c Release -t:SignAndroidPackage -p:FwLiteFlavor=Dev -p:UseMonoRuntime=true -p:RuntimeIdentifiers=android-arm -p:RuntimeIdentifier=android-arm -p:AndroidPackageFormat=apk
+      - adb -d install -r bin/Release/net10.0-android/android-arm/org.sil.FwLiteMaui.dev-Signed.apk
+
   build-mini-lcm-sdk:
     desc: Builds the sdk, a zip with the FwLiteWeb server with a project and config to run locally
     dir: ./FwLiteWeb

--- a/backend/FwLite/Taskfile.yml
+++ b/backend/FwLite/Taskfile.yml
@@ -122,14 +122,13 @@ tasks:
       - adb -d install -r bin/Release/net10.0-android/org.sil.FwLiteMaui.dev-Signed.apk
 
   install-maui-android-release-arm32:
-    # Production CoreCLR builds are 64-bit only; this builds the separate Mono/armeabi-v7a bundle
-    # for testing the 32-bit app on real hardware. Output lands under the android-arm RID subfolder.
-    desc: Build a Release Mono arm32 (armeabi-v7a) "Dev" APK and adb-install it on the connected USB device
+    # Production CoreCLR builds are 64-bit only; this builds & runs the separate Mono/armeabi-v7a
+    # bundle for testing the 32-bit app on real hardware. -t:Run drives the full
+    # build -> install -> launch graph and targets the connected USB device (AdbTarget=-d).
+    desc: Build, install & run a Release Mono arm32 (armeabi-v7a) "Dev" APK on the connected USB device
     dir: ./FwLiteMaui
     deps: [ ui:build-viewer ]
-    cmds:
-      - dotnet build -f net10.0-android -c Release -t:SignAndroidPackage -p:FwLiteFlavor=Dev -p:UseMonoRuntime=true -p:RuntimeIdentifiers=android-arm -p:RuntimeIdentifier=android-arm -p:AndroidPackageFormat=apk
-      - adb -d install -r bin/Release/net10.0-android/android-arm/org.sil.FwLiteMaui.dev-Signed.apk
+    cmd: dotnet build -f net10.0-android -c Release -t:Run -p:FwLiteFlavor=Dev -p:UseMonoRuntime=true -p:RuntimeIdentifiers=android-arm -p:RuntimeIdentifier=android-arm -p:AndroidPackageFormat=apk -p:AdbTarget=-d
 
   build-mini-lcm-sdk:
     desc: Builds the sdk, a zip with the FwLiteWeb server with a project and config to run locally

--- a/backend/FwLite/Taskfile.yml
+++ b/backend/FwLite/Taskfile.yml
@@ -122,9 +122,8 @@ tasks:
       - adb -d install -r bin/Release/net10.0-android/org.sil.FwLiteMaui.dev-Signed.apk
 
   install-maui-android-release-arm32:
-    # Production CoreCLR builds are 64-bit only; this builds & runs the separate Mono/armeabi-v7a
-    # bundle for testing the 32-bit app on real hardware. -t:Run drives the full
-    # build -> install -> launch graph and targets the connected USB device (AdbTarget=-d).
+    # Production builds are 64-bit (CoreCLR); this builds & runs the Mono/armeabi-v7a bundle to test
+    # the 32-bit app on a connected USB device.
     desc: Build, install & run a Release Mono arm32 (armeabi-v7a) "Dev" APK on the connected USB device
     dir: ./FwLiteMaui
     deps: [ ui:build-viewer ]

--- a/frontend/viewer/src/lib/dotnet-types/generated-types/FwLiteShared/Services/ITroubleshootingService.ts
+++ b/frontend/viewer/src/lib/dotnet-types/generated-types/FwLiteShared/Services/ITroubleshootingService.ts
@@ -6,6 +6,7 @@
 export interface ITroubleshootingService
 {
 	getCanShare() : Promise<boolean>;
+	getProcessArchitecture() : Promise<string>;
 	tryOpenDataDirectory() : Promise<boolean>;
 	getDataDirectory() : Promise<string>;
 	openLogFile() : Promise<void>;

--- a/frontend/viewer/src/lib/troubleshoot/TroubleshootDialog.svelte
+++ b/frontend/viewer/src/lib/troubleshoot/TroubleshootDialog.svelte
@@ -46,7 +46,7 @@
 
 <ResponsiveDialog bind:open={openQueryParam.current} title={$t`Troubleshoot`} disableBackHandler>
   <div class="flex flex-col gap-4 items-start">
-    <div>
+    <div class="flex flex-col gap-1">
       <p class="flex items-baseline gap-1">
         {$t`FieldWorks Lite version`}:
         <span class="font-semibold border-b">

--- a/frontend/viewer/src/lib/troubleshoot/TroubleshootDialog.svelte
+++ b/frontend/viewer/src/lib/troubleshoot/TroubleshootDialog.svelte
@@ -27,6 +27,7 @@
   const config = useFwLiteConfig();
   let projectCode = $state<string>();
   let canShare = resource(() => service, async (s) => await s?.getCanShare());
+  let architecture = resource(() => service, async (s) => await s?.getProcessArchitecture());
   // Mobile platforms keep app data in private storage that no file manager can open.
   const canOpenDataDirectory = $derived(config.os !== FwLitePlatform.Android && config.os !== FwLitePlatform.iOS);
 
@@ -56,13 +57,19 @@
           size="icon-xs"
           iconProps={{class: 'size-4'}}
           title={$t`Copy version`}
-          text={`FieldWorks Lite ${config.appVersion} on ${config.os}`}
+          text={`FieldWorks Lite ${config.appVersion} on ${config.os}${architecture.current ? ` (${architecture.current})` : ''}`}
         />
       </p>
       <p class="flex items-baseline gap-1">
         {$t`Platform`}:
         <span class="font-semibold">{config.os}</span>
       </p>
+      {#if architecture.current}
+        <p class="flex items-baseline gap-1">
+          {$t`Architecture`}:
+          <span class="font-semibold">{architecture.current}</span>
+        </p>
+      {/if}
     </div>
     {#if service && (canOpenDataDirectory || $isDev)}
       <div class="w-full flex flex-col gap-1.5">

--- a/frontend/viewer/src/lib/troubleshoot/TroubleshootDialog.svelte
+++ b/frontend/viewer/src/lib/troubleshoot/TroubleshootDialog.svelte
@@ -55,6 +55,7 @@
         <CopyButton
           variant="ghost"
           size="icon-xs"
+          class="-my-2 self-center"
           iconProps={{class: 'size-4'}}
           title={$t`Copy version`}
           text={`FieldWorks Lite ${config.appVersion} on ${config.os}${architecture.current ? ` (${architecture.current})` : ''}`}

--- a/frontend/viewer/src/locales/en.po
+++ b/frontend/viewer/src/locales/en.po
@@ -227,6 +227,10 @@ msgstr "Any semantic domain"
 msgid "Any Ws"
 msgstr "Any Ws"
 
+#: src/lib/troubleshoot/TroubleshootDialog.svelte
+msgid "Architecture"
+msgstr "Architecture"
+
 #. Confirmation prompt
 #: src/lib/entry-editor/DeleteDialog.svelte
 msgid "Are you sure you want to delete {0}?"

--- a/frontend/viewer/src/locales/es.po
+++ b/frontend/viewer/src/locales/es.po
@@ -232,6 +232,10 @@ msgstr "Cualquier dominio semántico"
 msgid "Any Ws"
 msgstr "Cualquier W"
 
+#: src/lib/troubleshoot/TroubleshootDialog.svelte
+msgid "Architecture"
+msgstr ""
+
 #. Confirmation prompt
 #: src/lib/entry-editor/DeleteDialog.svelte
 msgid "Are you sure you want to delete {0}?"

--- a/frontend/viewer/src/locales/fr.po
+++ b/frontend/viewer/src/locales/fr.po
@@ -232,6 +232,10 @@ msgstr "N'importe quel domaine sémantique"
 msgid "Any Ws"
 msgstr "Tous les Systèmes d'Ecriture"
 
+#: src/lib/troubleshoot/TroubleshootDialog.svelte
+msgid "Architecture"
+msgstr ""
+
 #. Confirmation prompt
 #: src/lib/entry-editor/DeleteDialog.svelte
 msgid "Are you sure you want to delete {0}?"

--- a/frontend/viewer/src/locales/id.po
+++ b/frontend/viewer/src/locales/id.po
@@ -232,6 +232,10 @@ msgstr "Domain semantik apa pun"
 msgid "Any Ws"
 msgstr "Setiap Ws"
 
+#: src/lib/troubleshoot/TroubleshootDialog.svelte
+msgid "Architecture"
+msgstr ""
+
 #. Confirmation prompt
 #: src/lib/entry-editor/DeleteDialog.svelte
 msgid "Are you sure you want to delete {0}?"

--- a/frontend/viewer/src/locales/ko.po
+++ b/frontend/viewer/src/locales/ko.po
@@ -232,6 +232,10 @@ msgstr "모든 시맨틱 도메인"
 msgid "Any Ws"
 msgstr "모든 W"
 
+#: src/lib/troubleshoot/TroubleshootDialog.svelte
+msgid "Architecture"
+msgstr ""
+
 #. Confirmation prompt
 #: src/lib/entry-editor/DeleteDialog.svelte
 msgid "Are you sure you want to delete {0}?"

--- a/frontend/viewer/src/locales/ms.po
+++ b/frontend/viewer/src/locales/ms.po
@@ -232,6 +232,10 @@ msgstr "Mana-mana domain semantik"
 msgid "Any Ws"
 msgstr "Mana-mana Ws"
 
+#: src/lib/troubleshoot/TroubleshootDialog.svelte
+msgid "Architecture"
+msgstr ""
+
 #. Confirmation prompt
 #: src/lib/entry-editor/DeleteDialog.svelte
 msgid "Are you sure you want to delete {0}?"

--- a/frontend/viewer/src/locales/sw.po
+++ b/frontend/viewer/src/locales/sw.po
@@ -232,6 +232,10 @@ msgstr "Kikoa chochote cha kumkutania"
 msgid "Any Ws"
 msgstr "Ws yoyote"
 
+#: src/lib/troubleshoot/TroubleshootDialog.svelte
+msgid "Architecture"
+msgstr ""
+
 #. Confirmation prompt
 #: src/lib/entry-editor/DeleteDialog.svelte
 msgid "Are you sure you want to delete {0}?"

--- a/frontend/viewer/src/locales/vi.po
+++ b/frontend/viewer/src/locales/vi.po
@@ -232,6 +232,10 @@ msgstr "Bất kỳ miền ngữ nghĩa nào"
 msgid "Any Ws"
 msgstr "Bất kỳ hệ chữ nào"
 
+#: src/lib/troubleshoot/TroubleshootDialog.svelte
+msgid "Architecture"
+msgstr ""
+
 #. Confirmation prompt
 #: src/lib/entry-editor/DeleteDialog.svelte
 msgid "Are you sure you want to delete {0}?"


### PR DESCRIPTION
## Summary

.NET 10 defaults Android to CoreCLR, whose runtime packs are 64-bit-only, so the published AAB dropped `armeabi-v7a` and 32-bit devices show up as "incompatible". This change builds a **second Mono / `armeabi-v7a` bundle** alongside the CoreCLR 64-bit one and ships **both** to a single Play listing. The two bundles are **version-code-banded** (CoreCLR above Mono) so 64-bit devices resolve to the CoreCLR bundle and only 32-bit-only devices fall through to Mono. A process-architecture readout is added to the Troubleshoot dialog.

## Caveats reviewers must know

1. ⚠️ **Play multi-AAB ABI routing is UNVERIFIED.** Before relying on this, validate on a closed/internal track that the Play Console device catalog / App Bundle Explorer routes a 64-bit device to the CoreCLR bundle and a 32-bit-only device to the Mono bundle. This is a lightly-documented path; the fallback is an all-Mono single bundle or a sideloaded arm32 APK.
2. **arm32 / Mono is a time-boxed target.** The MAUI team is "still reviewing whether to support Android arm32" in .NET 11 ([source](https://devblogs.microsoft.com/dotnet/dotnet-maui-moves-to-coreclr-in-dotnet-11/))
3. **Operational:** both AABs must be uploaded together every release (CoreCLR `versionCode` banded above Mono). The Troubleshoot dialog now shows Arm / Arm64 so you can confirm in the field which bundle a device actually installed.