### PR TITLE
bring back a button to create new words from an empty search

### DIFF
--- a/frontend/viewer/src/locales/en.po
+++ b/frontend/viewer/src/locales/en.po
@@ -168,6 +168,12 @@ msgstr "Add part of"
 msgid "Add Sense"
 msgstr "Add Sense"
 
+#. Subtitle of a placeholder row shown at the end of the entry list while searching (also in the no-results state)
+#. The search text is displayed above it as a headword; clicking opens the new-entry dialog pre-filled with that text
+#: src/project/browse/EntriesList.svelte
+msgid "Add to dictionary"
+msgstr "Add to dictionary"
+
 #. Dialog title
 #: src/lib/entry-editor/NewEntryDialog.svelte
 msgid "Add Word"
@@ -453,16 +459,6 @@ msgstr "Create Entry"
 #: src/home/HomeView.svelte
 msgid "Create Example Project"
 msgstr "Create Example Project"
-
-#: src/project/browse/EntriesList.svelte
-#: src/project/browse/EntriesList.svelte
-msgid "Create new entry {0}"
-msgstr "Create new entry {0}"
-
-#: src/project/browse/EntriesList.svelte
-#: src/project/browse/EntriesList.svelte
-msgid "Create new word {0}"
-msgstr "Create new word {0}"
 
 #. Submit button in the create custom view dialog.
 #: src/lib/views/custom/CreateCustomViewDialog.svelte

--- a/frontend/viewer/src/locales/en.po
+++ b/frontend/viewer/src/locales/en.po
@@ -454,6 +454,16 @@ msgstr "Create Entry"
 msgid "Create Example Project"
 msgstr "Create Example Project"
 
+#: src/project/browse/EntriesList.svelte
+#: src/project/browse/EntriesList.svelte
+msgid "Create new entry {0}"
+msgstr "Create new entry {0}"
+
+#: src/project/browse/EntriesList.svelte
+#: src/project/browse/EntriesList.svelte
+msgid "Create new word {0}"
+msgstr "Create new word {0}"
+
 #. Submit button in the create custom view dialog.
 #: src/lib/views/custom/CreateCustomViewDialog.svelte
 msgid "Create View"
@@ -1322,6 +1332,7 @@ msgstr "No subject, unable to create a new {0}"
 #. Relevant view: Lite
 #. Classic view equivalent: "No entries found"
 #: src/lib/entry-editor/EntryOrSensePicker.svelte
+#: src/project/browse/EntriesList.svelte
 msgid "No words found"
 msgstr "No words found"
 

--- a/frontend/viewer/src/locales/es.po
+++ b/frontend/viewer/src/locales/es.po
@@ -459,6 +459,16 @@ msgstr "Crear entrada"
 msgid "Create Example Project"
 msgstr "Crear un proyecto de ejemplo"
 
+#: src/project/browse/EntriesList.svelte
+#: src/project/browse/EntriesList.svelte
+msgid "Create new entry {0}"
+msgstr ""
+
+#: src/project/browse/EntriesList.svelte
+#: src/project/browse/EntriesList.svelte
+msgid "Create new word {0}"
+msgstr ""
+
 #. Submit button in the create custom view dialog.
 #: src/lib/views/custom/CreateCustomViewDialog.svelte
 msgid "Create View"
@@ -1327,6 +1337,7 @@ msgstr "No hay tema, no se puede crear un nuevo {0}"
 #. Relevant view: Lite
 #. Classic view equivalent: "No entries found"
 #: src/lib/entry-editor/EntryOrSensePicker.svelte
+#: src/project/browse/EntriesList.svelte
 msgid "No words found"
 msgstr "No se han encontrado palabras"
 

--- a/frontend/viewer/src/locales/es.po
+++ b/frontend/viewer/src/locales/es.po
@@ -173,6 +173,12 @@ msgstr "Añadir parte de"
 msgid "Add Sense"
 msgstr "Añadir acepción"
 
+#. Subtitle of a placeholder row shown at the end of the entry list while searching (also in the no-results state)
+#. The search text is displayed above it as a headword; clicking opens the new-entry dialog pre-filled with that text
+#: src/project/browse/EntriesList.svelte
+msgid "Add to dictionary"
+msgstr ""
+
 #. Dialog title
 #: src/lib/entry-editor/NewEntryDialog.svelte
 msgid "Add Word"
@@ -458,16 +464,6 @@ msgstr "Crear entrada"
 #: src/home/HomeView.svelte
 msgid "Create Example Project"
 msgstr "Crear un proyecto de ejemplo"
-
-#: src/project/browse/EntriesList.svelte
-#: src/project/browse/EntriesList.svelte
-msgid "Create new entry {0}"
-msgstr ""
-
-#: src/project/browse/EntriesList.svelte
-#: src/project/browse/EntriesList.svelte
-msgid "Create new word {0}"
-msgstr ""
 
 #. Submit button in the create custom view dialog.
 #: src/lib/views/custom/CreateCustomViewDialog.svelte

--- a/frontend/viewer/src/locales/fr.po
+++ b/frontend/viewer/src/locales/fr.po
@@ -173,6 +173,12 @@ msgstr "Ajouter une partie de"
 msgid "Add Sense"
 msgstr "Ajouter du sens"
 
+#. Subtitle of a placeholder row shown at the end of the entry list while searching (also in the no-results state)
+#. The search text is displayed above it as a headword; clicking opens the new-entry dialog pre-filled with that text
+#: src/project/browse/EntriesList.svelte
+msgid "Add to dictionary"
+msgstr ""
+
 #. Dialog title
 #: src/lib/entry-editor/NewEntryDialog.svelte
 msgid "Add Word"
@@ -458,16 +464,6 @@ msgstr "Créer une entrée"
 #: src/home/HomeView.svelte
 msgid "Create Example Project"
 msgstr "Créer un projet exemplaire"
-
-#: src/project/browse/EntriesList.svelte
-#: src/project/browse/EntriesList.svelte
-msgid "Create new entry {0}"
-msgstr ""
-
-#: src/project/browse/EntriesList.svelte
-#: src/project/browse/EntriesList.svelte
-msgid "Create new word {0}"
-msgstr ""
 
 #. Submit button in the create custom view dialog.
 #: src/lib/views/custom/CreateCustomViewDialog.svelte

--- a/frontend/viewer/src/locales/fr.po
+++ b/frontend/viewer/src/locales/fr.po
@@ -459,6 +459,16 @@ msgstr "Créer une entrée"
 msgid "Create Example Project"
 msgstr "Créer un projet exemplaire"
 
+#: src/project/browse/EntriesList.svelte
+#: src/project/browse/EntriesList.svelte
+msgid "Create new entry {0}"
+msgstr ""
+
+#: src/project/browse/EntriesList.svelte
+#: src/project/browse/EntriesList.svelte
+msgid "Create new word {0}"
+msgstr ""
+
 #. Submit button in the create custom view dialog.
 #: src/lib/views/custom/CreateCustomViewDialog.svelte
 msgid "Create View"
@@ -1327,6 +1337,7 @@ msgstr "Aucun sujet, impossible de créer un nouveau {0}"
 #. Relevant view: Lite
 #. Classic view equivalent: "No entries found"
 #: src/lib/entry-editor/EntryOrSensePicker.svelte
+#: src/project/browse/EntriesList.svelte
 msgid "No words found"
 msgstr "Aucun mot trouvé"
 

--- a/frontend/viewer/src/locales/id.po
+++ b/frontend/viewer/src/locales/id.po
@@ -173,6 +173,12 @@ msgstr "Tambahkan bagian dari"
 msgid "Add Sense"
 msgstr "Tambahkan Pengertian"
 
+#. Subtitle of a placeholder row shown at the end of the entry list while searching (also in the no-results state)
+#. The search text is displayed above it as a headword; clicking opens the new-entry dialog pre-filled with that text
+#: src/project/browse/EntriesList.svelte
+msgid "Add to dictionary"
+msgstr ""
+
 #. Dialog title
 #: src/lib/entry-editor/NewEntryDialog.svelte
 msgid "Add Word"
@@ -458,16 +464,6 @@ msgstr "Membuat Entri"
 #: src/home/HomeView.svelte
 msgid "Create Example Project"
 msgstr "Buat Proyek Contoh"
-
-#: src/project/browse/EntriesList.svelte
-#: src/project/browse/EntriesList.svelte
-msgid "Create new entry {0}"
-msgstr ""
-
-#: src/project/browse/EntriesList.svelte
-#: src/project/browse/EntriesList.svelte
-msgid "Create new word {0}"
-msgstr ""
 
 #. Submit button in the create custom view dialog.
 #: src/lib/views/custom/CreateCustomViewDialog.svelte

--- a/frontend/viewer/src/locales/id.po
+++ b/frontend/viewer/src/locales/id.po
@@ -459,6 +459,16 @@ msgstr "Membuat Entri"
 msgid "Create Example Project"
 msgstr "Buat Proyek Contoh"
 
+#: src/project/browse/EntriesList.svelte
+#: src/project/browse/EntriesList.svelte
+msgid "Create new entry {0}"
+msgstr ""
+
+#: src/project/browse/EntriesList.svelte
+#: src/project/browse/EntriesList.svelte
+msgid "Create new word {0}"
+msgstr ""
+
 #. Submit button in the create custom view dialog.
 #: src/lib/views/custom/CreateCustomViewDialog.svelte
 msgid "Create View"
@@ -1327,6 +1337,7 @@ msgstr "Tidak ada subjek, tidak dapat membuat {0}baru"
 #. Relevant view: Lite
 #. Classic view equivalent: "No entries found"
 #: src/lib/entry-editor/EntryOrSensePicker.svelte
+#: src/project/browse/EntriesList.svelte
 msgid "No words found"
 msgstr "Tidak ada kata yang ditemukan"
 

--- a/frontend/viewer/src/locales/ko.po
+++ b/frontend/viewer/src/locales/ko.po
@@ -173,6 +173,12 @@ msgstr "의 일부를 추가합니다."
 msgid "Add Sense"
 msgstr "센스 추가"
 
+#. Subtitle of a placeholder row shown at the end of the entry list while searching (also in the no-results state)
+#. The search text is displayed above it as a headword; clicking opens the new-entry dialog pre-filled with that text
+#: src/project/browse/EntriesList.svelte
+msgid "Add to dictionary"
+msgstr ""
+
 #. Dialog title
 #: src/lib/entry-editor/NewEntryDialog.svelte
 msgid "Add Word"
@@ -458,16 +464,6 @@ msgstr "항목 만들기"
 #: src/home/HomeView.svelte
 msgid "Create Example Project"
 msgstr "예제 프로젝트 만들기"
-
-#: src/project/browse/EntriesList.svelte
-#: src/project/browse/EntriesList.svelte
-msgid "Create new entry {0}"
-msgstr ""
-
-#: src/project/browse/EntriesList.svelte
-#: src/project/browse/EntriesList.svelte
-msgid "Create new word {0}"
-msgstr ""
 
 #. Submit button in the create custom view dialog.
 #: src/lib/views/custom/CreateCustomViewDialog.svelte

--- a/frontend/viewer/src/locales/ko.po
+++ b/frontend/viewer/src/locales/ko.po
@@ -459,6 +459,16 @@ msgstr "항목 만들기"
 msgid "Create Example Project"
 msgstr "예제 프로젝트 만들기"
 
+#: src/project/browse/EntriesList.svelte
+#: src/project/browse/EntriesList.svelte
+msgid "Create new entry {0}"
+msgstr ""
+
+#: src/project/browse/EntriesList.svelte
+#: src/project/browse/EntriesList.svelte
+msgid "Create new word {0}"
+msgstr ""
+
 #. Submit button in the create custom view dialog.
 #: src/lib/views/custom/CreateCustomViewDialog.svelte
 msgid "Create View"
@@ -1327,6 +1337,7 @@ msgstr "제목이 없습니다, 새로 만들 수 없습니다 {0}"
 #. Relevant view: Lite
 #. Classic view equivalent: "No entries found"
 #: src/lib/entry-editor/EntryOrSensePicker.svelte
+#: src/project/browse/EntriesList.svelte
 msgid "No words found"
 msgstr "단어를 찾을 수 없습니다."
 

--- a/frontend/viewer/src/locales/ms.po
+++ b/frontend/viewer/src/locales/ms.po
@@ -459,6 +459,16 @@ msgstr "Cipta Entri"
 msgid "Create Example Project"
 msgstr "Cipta Projek Contoh"
 
+#: src/project/browse/EntriesList.svelte
+#: src/project/browse/EntriesList.svelte
+msgid "Create new entry {0}"
+msgstr ""
+
+#: src/project/browse/EntriesList.svelte
+#: src/project/browse/EntriesList.svelte
+msgid "Create new word {0}"
+msgstr ""
+
 #. Submit button in the create custom view dialog.
 #: src/lib/views/custom/CreateCustomViewDialog.svelte
 msgid "Create View"
@@ -1327,6 +1337,7 @@ msgstr "Tiada subjek, tidak dapat membuat {0} baru"
 #. Relevant view: Lite
 #. Classic view equivalent: "No entries found"
 #: src/lib/entry-editor/EntryOrSensePicker.svelte
+#: src/project/browse/EntriesList.svelte
 msgid "No words found"
 msgstr "Tiada perkataan ditemui"
 

--- a/frontend/viewer/src/locales/ms.po
+++ b/frontend/viewer/src/locales/ms.po
@@ -173,6 +173,12 @@ msgstr "Tambah sebahagian daripada"
 msgid "Add Sense"
 msgstr "Tambah Makna"
 
+#. Subtitle of a placeholder row shown at the end of the entry list while searching (also in the no-results state)
+#. The search text is displayed above it as a headword; clicking opens the new-entry dialog pre-filled with that text
+#: src/project/browse/EntriesList.svelte
+msgid "Add to dictionary"
+msgstr ""
+
 #. Dialog title
 #: src/lib/entry-editor/NewEntryDialog.svelte
 msgid "Add Word"
@@ -458,16 +464,6 @@ msgstr "Cipta Entri"
 #: src/home/HomeView.svelte
 msgid "Create Example Project"
 msgstr "Cipta Projek Contoh"
-
-#: src/project/browse/EntriesList.svelte
-#: src/project/browse/EntriesList.svelte
-msgid "Create new entry {0}"
-msgstr ""
-
-#: src/project/browse/EntriesList.svelte
-#: src/project/browse/EntriesList.svelte
-msgid "Create new word {0}"
-msgstr ""
 
 #. Submit button in the create custom view dialog.
 #: src/lib/views/custom/CreateCustomViewDialog.svelte

--- a/frontend/viewer/src/locales/sw.po
+++ b/frontend/viewer/src/locales/sw.po
@@ -173,6 +173,12 @@ msgstr "Ongeza sehemu ya"
 msgid "Add Sense"
 msgstr "Ongeza Maana"
 
+#. Subtitle of a placeholder row shown at the end of the entry list while searching (also in the no-results state)
+#. The search text is displayed above it as a headword; clicking opens the new-entry dialog pre-filled with that text
+#: src/project/browse/EntriesList.svelte
+msgid "Add to dictionary"
+msgstr ""
+
 #. Dialog title
 #: src/lib/entry-editor/NewEntryDialog.svelte
 msgid "Add Word"
@@ -458,16 +464,6 @@ msgstr "Tengeneza Ingizo"
 #: src/home/HomeView.svelte
 msgid "Create Example Project"
 msgstr "Tengeneza Mradi wa Mfano"
-
-#: src/project/browse/EntriesList.svelte
-#: src/project/browse/EntriesList.svelte
-msgid "Create new entry {0}"
-msgstr ""
-
-#: src/project/browse/EntriesList.svelte
-#: src/project/browse/EntriesList.svelte
-msgid "Create new word {0}"
-msgstr ""
 
 #. Submit button in the create custom view dialog.
 #: src/lib/views/custom/CreateCustomViewDialog.svelte

--- a/frontend/viewer/src/locales/sw.po
+++ b/frontend/viewer/src/locales/sw.po
@@ -459,6 +459,16 @@ msgstr "Tengeneza Ingizo"
 msgid "Create Example Project"
 msgstr "Tengeneza Mradi wa Mfano"
 
+#: src/project/browse/EntriesList.svelte
+#: src/project/browse/EntriesList.svelte
+msgid "Create new entry {0}"
+msgstr ""
+
+#: src/project/browse/EntriesList.svelte
+#: src/project/browse/EntriesList.svelte
+msgid "Create new word {0}"
+msgstr ""
+
 #. Submit button in the create custom view dialog.
 #: src/lib/views/custom/CreateCustomViewDialog.svelte
 msgid "Create View"
@@ -1327,6 +1337,7 @@ msgstr "Hakuna kigezo, haiwezi kutengeneza {0} mpya"
 #. Relevant view: Lite
 #. Classic view equivalent: "No entries found"
 #: src/lib/entry-editor/EntryOrSensePicker.svelte
+#: src/project/browse/EntriesList.svelte
 msgid "No words found"
 msgstr "Hakuna neno liliyopatikana"
 

--- a/frontend/viewer/src/locales/vi.po
+++ b/frontend/viewer/src/locales/vi.po
@@ -459,6 +459,16 @@ msgstr "Tạo mục"
 msgid "Create Example Project"
 msgstr "Tạo Dự án ví dụ"
 
+#: src/project/browse/EntriesList.svelte
+#: src/project/browse/EntriesList.svelte
+msgid "Create new entry {0}"
+msgstr ""
+
+#: src/project/browse/EntriesList.svelte
+#: src/project/browse/EntriesList.svelte
+msgid "Create new word {0}"
+msgstr ""
+
 #. Submit button in the create custom view dialog.
 #: src/lib/views/custom/CreateCustomViewDialog.svelte
 msgid "Create View"
@@ -1327,6 +1337,7 @@ msgstr "Không có chủ đề, không thể tạo mới {0}"
 #. Relevant view: Lite
 #. Classic view equivalent: "No entries found"
 #: src/lib/entry-editor/EntryOrSensePicker.svelte
+#: src/project/browse/EntriesList.svelte
 msgid "No words found"
 msgstr "Không tìm thấy từ nào"
 

--- a/frontend/viewer/src/locales/vi.po
+++ b/frontend/viewer/src/locales/vi.po
@@ -173,6 +173,12 @@ msgstr "Thêm phần của"
 msgid "Add Sense"
 msgstr "Thêm Ý nghĩa (sense)"
 
+#. Subtitle of a placeholder row shown at the end of the entry list while searching (also in the no-results state)
+#. The search text is displayed above it as a headword; clicking opens the new-entry dialog pre-filled with that text
+#: src/project/browse/EntriesList.svelte
+msgid "Add to dictionary"
+msgstr ""
+
 #. Dialog title
 #: src/lib/entry-editor/NewEntryDialog.svelte
 msgid "Add Word"
@@ -458,16 +464,6 @@ msgstr "Tạo mục"
 #: src/home/HomeView.svelte
 msgid "Create Example Project"
 msgstr "Tạo Dự án ví dụ"
-
-#: src/project/browse/EntriesList.svelte
-#: src/project/browse/EntriesList.svelte
-msgid "Create new entry {0}"
-msgstr ""
-
-#: src/project/browse/EntriesList.svelte
-#: src/project/browse/EntriesList.svelte
-msgid "Create new word {0}"
-msgstr ""
 
 #. Submit button in the create custom view dialog.
 #: src/lib/views/custom/CreateCustomViewDialog.svelte

--- a/frontend/viewer/src/project/browse/EntriesList.svelte
+++ b/frontend/viewer/src/project/browse/EntriesList.svelte
@@ -19,6 +19,8 @@
   import Delayed from '$lib/components/Delayed.svelte';
   import {EntryLoaderService} from '$lib/services/entry-loader-service.svelte';
   import {onDestroy, untrack} from 'svelte';
+  import {useViewService} from '$lib/views/view-service.svelte';
+  import { pt } from '$lib/views/view-text';
 
   let {
     search = '',
@@ -49,6 +51,7 @@
   const miniLcmApi = $derived(projectContext.maybeApi);
   const dialogsService = useDialogsService();
   const projectEventBus = useProjectEventBus();
+  const viewService = useViewService();
 
   // The closures maybe need to be created OUTSIDE untrack so they maintain reactivity
   const deps = {
@@ -104,12 +107,12 @@
   // to avoid a "white phase" between initial load and list initialization.
   const indexArray = $derived(
     entryLoader?.totalCount !== undefined
-      ? Array.from({ length: entryLoader.totalCount }, (_, i) => i)
+      ? Array.from({ length: entryLoader.totalCount + 1 }, (_, i) => i)
       : Array.from({ length: skeletonRowCount }, (_, i) => i)
   );
 
-  async function handleNewEntry() {
-    const entry = await dialogsService.createNewEntry(undefined, {
+  async function handleNewEntry(headword: string | undefined = undefined) {
+    const entry = await dialogsService.createNewEntry(headword, {
       publishIn: publication ? [publication] : [],
     }, {
       semanticDomains: semanticDomain ? [semanticDomain] : [],
@@ -184,7 +187,7 @@
     />
   </DevContent>
   {#if !disableNewEntry}
-    <PrimaryNewEntryButton onclick={handleNewEntry} shortForm />
+    <PrimaryNewEntryButton onclick={() => handleNewEntry()} shortForm />
   {/if}
 </FabContainer>
 
@@ -197,8 +200,14 @@
   {:else}
     <div class="h-full">
       {#if entryLoader?.totalCount === 0}
-        <div class="flex items-center justify-center h-full text-muted-foreground">
-          <p>{$t`No entries found`}</p>
+        <div class="flex flex-col items-center justify-center h-full text-muted-foreground gap-2">
+          <p>{pt($t`No entries found`, $t`No words found`, viewService.currentView)}</p>
+
+          {#if search}
+            <Button icon="i-mdi-plus" class="" onclick={() => handleNewEntry(search)}>
+              {pt($t`Create new entry ${search}`, $t`Create new word ${search}`, viewService.currentView)}
+            </Button>
+          {/if}
         </div>
       {/if}
 
@@ -208,30 +217,39 @@
             getKey={(index: number) => `${entryLoader?.generation ?? EntryLoaderService.DEFAULT_GENERATION}-${index}`}
             bufferSize={450}>
         {#snippet children(index: number)}
-          {#key entryLoader?.generation ?? EntryLoaderService.DEFAULT_GENERATION}
-            <Delayed
-              getCached={() => entryLoader?.getCachedEntryByIndex(index)}
-              load={() => entryLoader?.getOrLoadEntryByIndex(index)}
-              delay={250}
-            >
-              {#snippet children(state)}
-                {#if state.loading || !state.current}
-                  <!-- we want the initial loading state and the first loading entries
-                  to share the same skeletons, so there's no flicker -->
-                  <EntryRow class="mb-2" skeleton={true} />
-                {:else}
-                  {@const entry = state.current}
-                  <EntryMenu {entry} contextMenu>
-                    <EntryRow {entry}
-                              class="mb-2"
-                              selected={selectedEntryId === entry.id}
-                              onclick={() => onSelectEntry(entry)}
-                              {previewDictionary}/>
-                  </EntryMenu>
-                {/if}
-              {/snippet}
-            </Delayed>
-          {/key}
+          <!--the last item is a button to create a new entry based on the search query-->
+          {#if index !== entryLoader?.totalCount}
+            {#key entryLoader?.generation ?? EntryLoaderService.DEFAULT_GENERATION}
+              <Delayed
+                getCached={() => entryLoader?.getCachedEntryByIndex(index)}
+                load={() => entryLoader?.getOrLoadEntryByIndex(index)}
+                delay={250}
+              >
+                {#snippet children(state)}
+                  {#if state.loading || !state.current}
+                    <!-- we want the initial loading state and the first loading entries
+                    to share the same skeletons, so there's no flicker -->
+                    <EntryRow class="mb-2" skeleton={true}/>
+                  {:else}
+                    {@const entry = state.current}
+                    <EntryMenu {entry} contextMenu>
+                      <EntryRow {entry}
+                                class="mb-2"
+                                selected={selectedEntryId === entry.id}
+                                onclick={() => onSelectEntry(entry)}
+                                {previewDictionary}/>
+                    </EntryMenu>
+                  {/if}
+                {/snippet}
+              </Delayed>
+            {/key}
+          {:else}
+            {#if search && entryLoader?.totalCount !== 0}
+              <Button icon="i-mdi-plus" onclick={() => handleNewEntry(search)}>
+                {pt($t`Create new entry ${search}`, $t`Create new word ${search}`, viewService.currentView)}
+              </Button>
+            {/if}
+          {/if}
         {/snippet}
       </VList>
     </div>

--- a/frontend/viewer/src/project/browse/EntriesList.svelte
+++ b/frontend/viewer/src/project/browse/EntriesList.svelte
@@ -3,6 +3,7 @@
   import {Debounced, watch} from 'runed';
   import EntryRow from './EntryRow.svelte';
   import Button from '$lib/components/ui/button/button.svelte';
+  import ListItem from '$lib/components/ListItem.svelte';
   import {cn} from '$lib/utils';
   import {t} from 'svelte-i18n-lingui';
   import DevContent from '$lib/layout/DevContent.svelte';
@@ -20,7 +21,7 @@
   import {EntryLoaderService} from '$lib/services/entry-loader-service.svelte';
   import {onDestroy, untrack} from 'svelte';
   import {useViewService} from '$lib/views/view-service.svelte';
-  import { pt } from '$lib/views/view-text';
+  import {pt} from '$lib/views/view-text';
 
   let {
     search = '',
@@ -61,6 +62,7 @@
   };
 
   let entryLoader = $derived(!miniLcmApi ? undefined : untrack(() => new EntryLoaderService(miniLcmApi, deps)));
+  const displayedEntryCount = $derived(entryLoader?.totalCount ?? 0);
 
   // Destroy the previous entryLoader when a new one is created
   watch(
@@ -102,14 +104,21 @@
   // Generate a random number of skeleton rows
   const skeletonRowCount = Math.ceil(Math.random() * 3) + 3;
 
-  // Generate index array for virtual list.
-  // We use a small number of skeletons if the total count is not yet known
-  // to avoid a "white phase" between initial load and list initialization.
-  const indexArray = $derived(
-    entryLoader?.totalCount !== undefined
-      ? Array.from({ length: entryLoader.totalCount + 1 }, (_, i) => i)
-      : Array.from({ length: skeletonRowCount }, (_, i) => i)
-  );
+  const canCreateFromSearch = $derived(search?.trim() && !disableNewEntry);
+  const showTerminalCreateRow = $derived(canCreateFromSearch && displayedEntryCount > 0);
+
+  type ListRow = {key: string, index: number, create?: boolean};
+  const rows: ListRow[] = $derived.by(() => {
+    if (entryLoader?.totalCount === undefined) {
+      return Array.from({length: skeletonRowCount}, (_, i) => ({key: `skeleton-${i}`, index: i}));
+    }
+    const generation = entryLoader.generation;
+    const entryRows: ListRow[] = Array.from({length: displayedEntryCount}, (_, i) => ({key: `${generation}-${i}`, index: i}));
+    if (showTerminalCreateRow) {
+      entryRows.push({key: `${generation}-create`, index: displayedEntryCount, create: true});
+    }
+    return entryRows;
+  });
 
   async function handleNewEntry(headword: string | undefined = undefined) {
     const entry = await dialogsService.createNewEntry(headword, {
@@ -176,6 +185,18 @@
 
 </script>
 
+{#snippet newEntryFromSearchRow(className: string = '')}
+  <ListItem
+    class={cn('bg-transparent shadow-none hover:shadow-none border-2 border-dashed border-muted-foreground/40', className)}
+    onclick={() => handleNewEntry(search)}>
+    {#snippet icon()}
+      <Icon icon="i-mdi-plus-thick" class="size-6 text-primary/60" />
+    {/snippet}
+    <span class="font-medium text-2xl">{search}</span>
+    <span class="text-sm text-muted-foreground">{$t`Add to dictionary`}</span>
+  </ListItem>
+{/snippet}
+
 <FabContainer>
   <DevContent>
     <Button
@@ -200,54 +221,45 @@
   {:else}
     <div class="h-full">
       {#if entryLoader?.totalCount === 0}
-        <div class="flex flex-col items-center justify-center h-full text-muted-foreground gap-2">
-          <p>{pt($t`No entries found`, $t`No words found`, viewService.currentView)}</p>
+        <div class="flex flex-col items-center justify-center h-full gap-4 px-4">
+          <p class="text-muted-foreground">{pt($t`No entries found`, $t`No words found`, viewService.currentView)}</p>
 
-          {#if search}
-            <Button icon="i-mdi-plus" class="" onclick={() => handleNewEntry(search)}>
-              {pt($t`Create new entry ${search}`, $t`Create new word ${search}`, viewService.currentView)}
-            </Button>
+          {#if canCreateFromSearch}
+            {@render newEntryFromSearchRow('max-w-md')}
           {/if}
         </div>
       {/if}
 
       <VList bind:this={vList}
-            data={indexArray}
+            data={rows}
             class="h-full p-0.5 md:pr-3 after:h-12 after:block"
-            getKey={(index: number) => `${entryLoader?.generation ?? EntryLoaderService.DEFAULT_GENERATION}-${index}`}
+            getKey={(row: ListRow) => row.key}
             bufferSize={450}>
-        {#snippet children(index: number)}
-          {#key entryLoader?.generation ?? EntryLoaderService.DEFAULT_GENERATION}
-            <!--the last item is a button to create a new entry based on the search query-->
-            {#if index !== entryLoader?.totalCount}
-              <Delayed
-                getCached={() => entryLoader?.getCachedEntryByIndex(index)}
-                load={() => entryLoader?.getOrLoadEntryByIndex(index)}
-                delay={250}
-              >
-                {#snippet children(state)}
-                  {#if state.loading || !state.current}
-                    <!-- we want the initial loading state and the first loading entries
-                    to share the same skeletons, so there's no flicker -->
-                    <EntryRow class="mb-2" skeleton={true}/>
-                  {:else}
-                    {@const entry = state.current}
-                    <EntryMenu {entry} contextMenu>
-                      <EntryRow {entry}
-                                class="mb-2"
-                                selected={selectedEntryId === entry.id}
-                                onclick={() => onSelectEntry(entry)}
-                                {previewDictionary}/>
-                    </EntryMenu>
-                  {/if}
-                {/snippet}
-              </Delayed>
-            {:else if search && entryLoader?.totalCount !== 0}
-                <Button icon="i-mdi-plus" onclick={() => handleNewEntry(search)}>
-                  {pt($t`Create new entry ${search}`, $t`Create new word ${search}`, viewService.currentView)}
-                </Button>
-            {/if}
-          {/key}
+        {#snippet children(row: ListRow)}
+          {#if row.create}
+            {@render newEntryFromSearchRow()}
+          {:else}
+            <Delayed
+              getCached={() => entryLoader?.getCachedEntryByIndex(row.index)}
+              load={() => entryLoader?.getOrLoadEntryByIndex(row.index)}
+              delay={250}
+            >
+              {#snippet children(state)}
+                {#if state.loading || !state.current}
+                  <EntryRow class="mb-2" skeleton={true}/>
+                {:else}
+                  {@const entry = state.current}
+                  <EntryMenu {entry} contextMenu>
+                    <EntryRow {entry}
+                              class="mb-2"
+                              selected={selectedEntryId === entry.id}
+                              onclick={() => onSelectEntry(entry)}
+                              {previewDictionary}/>
+                  </EntryMenu>
+                {/if}
+              {/snippet}
+            </Delayed>
+          {/if}
         {/snippet}
       </VList>
     </div>

--- a/frontend/viewer/src/project/browse/EntriesList.svelte
+++ b/frontend/viewer/src/project/browse/EntriesList.svelte
@@ -217,9 +217,9 @@
             getKey={(index: number) => `${entryLoader?.generation ?? EntryLoaderService.DEFAULT_GENERATION}-${index}`}
             bufferSize={450}>
         {#snippet children(index: number)}
-          <!--the last item is a button to create a new entry based on the search query-->
-          {#if index !== entryLoader?.totalCount}
-            {#key entryLoader?.generation ?? EntryLoaderService.DEFAULT_GENERATION}
+          {#key entryLoader?.generation ?? EntryLoaderService.DEFAULT_GENERATION}
+            <!--the last item is a button to create a new entry based on the search query-->
+            {#if index !== entryLoader?.totalCount}
               <Delayed
                 getCached={() => entryLoader?.getCachedEntryByIndex(index)}
                 load={() => entryLoader?.getOrLoadEntryByIndex(index)}
@@ -242,14 +242,12 @@
                   {/if}
                 {/snippet}
               </Delayed>
-            {/key}
-          {:else}
-            {#if search && entryLoader?.totalCount !== 0}
-              <Button icon="i-mdi-plus" onclick={() => handleNewEntry(search)}>
-                {pt($t`Create new entry ${search}`, $t`Create new word ${search}`, viewService.currentView)}
-              </Button>
+            {:else if search && entryLoader?.totalCount !== 0}
+                <Button icon="i-mdi-plus" onclick={() => handleNewEntry(search)}>
+                  {pt($t`Create new entry ${search}`, $t`Create new word ${search}`, viewService.currentView)}
+                </Button>
             {/if}
-          {/if}
+          {/key}
         {/snippet}
       </VList>
     </div>

--- a/frontend/viewer/tests/entries-list-component.ts
+++ b/frontend/viewer/tests/entries-list-component.ts
@@ -25,6 +25,8 @@ export class EntriesListComponent {
   async goto(waitForTestUtils = false): Promise<void> {
     await this.page.goto('/testing/project-view');
     await waitForProjectViewReady(this.page, waitForTestUtils);
+    const renderedRowCount = await this.entryRows.count();
+    expect(renderedRowCount).toBeGreaterThan(0);
   }
 
   async waitForSkeletonsToResolve(): Promise<void> {

--- a/frontend/viewer/tests/entries-list.test.ts
+++ b/frontend/viewer/tests/entries-list.test.ts
@@ -1,4 +1,5 @@
 import {expect, test} from '@playwright/test';
+
 import {EntriesListComponent} from './entries-list-component';
 import {EntryApiHelper} from './entry-api-helper';
 
@@ -131,6 +132,24 @@ test.describe('EntriesList', () => {
 
       await expect(entriesList.selectedEntry).toBeVisible({timeout: 10000});
       await expect(entriesList.selectedEntry).toContainText(headword);
+    });
+
+    test('searching an existing entry after load shows it', async () => {
+      const {headword} = await api.getEntryWithEnglishGloss();
+      expect(headword.length).toBeGreaterThan(0);
+
+      await entriesList.searchInput.fill(headword);
+      await expect(entriesList.skeletons).toHaveCount(0);
+
+      const entryRow = entriesList.entryRows
+        .filter({hasText: headword})
+        .filter({hasNotText: 'Add to dictionary'});
+      const createFromSearchRow = entriesList.entryRows
+        .filter({hasText: 'Add to dictionary'});
+
+      await expect(entriesList.entryRows).toHaveCount(2);
+      await expect(entryRow).toBeVisible();
+      await expect(createFromSearchRow).toBeVisible();
     });
   });
 

--- a/frontend/viewer/tests/test-utils.ts
+++ b/frontend/viewer/tests/test-utils.ts
@@ -3,6 +3,7 @@ import {type Page, expect} from '@playwright/test';
 export async function waitForProjectViewReady(page: Page, waitForTestUtils = false) {
   await expect(page.locator('.i-mdi-loading')).toHaveCount(0, {timeout: 10000});
   await page.waitForFunction(() => document.fonts.ready);
+  await expect(page.locator('[role="table"]')).toBeVisible({timeout: 10000});
   await expect(page.locator('[data-skeleton]')).toHaveCount(0, {timeout: 10000});
   // Wait for test utilities to be available if requested
   if (waitForTestUtils) {


### PR DESCRIPTION
I was looking throught some feedback and someone mentioned wanting to create missing entries from search. We had that feature before we adopted shadcn, so I brought it back.

Search with no results:
<img width="916" height="919" alt="Screenshot 2026-06-10 at 12-09-49 " src="https://github.com/user-attachments/assets/920053fa-2830-480f-a1d8-274613be41f6" />

Search with results:
<img width="916" height="919" alt="Screenshot 2026-06-10 at 12-10-49 " src="https://github.com/user-attachments/assets/10a73e06-42c1-49bf-8100-a5c79364e638" />

the create button is included inline so when the list scrolls it'll be at the bottom.

After I implemented this however, it did feel a bit redundant to have both the add button, and the create button for the search. We could just make the add button use the search for the headword, but I don't think that would be very obvious that this is what would happen.