### PR TITLE
use android custom tabs for login

### DIFF
--- a/backend/FwLite/FwLiteMaui/Platforms/Android/AndroidManifest.xml
+++ b/backend/FwLite/FwLiteMaui/Platforms/Android/AndroidManifest.xml
@@ -6,4 +6,9 @@
 	<uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.RECORD_AUDIO"/>
     <uses-permission android:name="android.permission.MODIFY_AUDIO_SETTINGS"/>
+    <queries>
+        <intent>
+            <action android:name="android.support.customtabs.action.CustomTabsService" />
+        </intent>
+    </queries>
 </manifest>


### PR DESCRIPTION
closes #2266

It turns out that MSIL was trying to use custom tabs this whole time! However it was trying to be smart and check for support before using them and falling back to just launching the browser if there wasn't support. However it's check for support requires a declaration in the manifest (thanks [chrome docs](https://developer.chrome.com/docs/android/custom-tabs/howto-custom-tab-check#android_11_package_visibility_changes)). So after a simple tweak login now happens in a custom tab:
<img width="1080" height="2400" alt="image" src="https://github.com/user-attachments/assets/0d720331-736d-46c2-a9fa-4656a0eca09d" />

this should improve the situation for low memory devices, because this tab is opened in the app then the app shouldn't get killed in the background. It also solves a weird issue I see on my phone where the post auth page would stay open in my phone browser, sometimes triggering the FW Lite app to open unexpectedly.