### PR TITLE
Fix issue loading tasks as starting page

### DIFF
--- a/frontend/viewer/src/lib/errors/global-errors.ts
+++ b/frontend/viewer/src/lib/errors/global-errors.ts
@@ -10,8 +10,10 @@ type UnifiedErrorEvent = {
   at?: string;
 }
 
-function unifyErrorEvent(event: ErrorEvent | PromiseRejectionEvent): UnifiedErrorEvent {
-  if ('message' in event) {
+function unifyErrorEvent(event: ErrorEvent | PromiseRejectionEvent | Error): UnifiedErrorEvent {
+  if (event instanceof Error) {
+    return { message: event.message, error: event };
+  } else if ('message' in event) {
     return { message: event.message, error: event.error, at: `${event.filename}:${event.lineno}:${event.colno}` };
   } else if (typeof event.reason === 'string') {
     return { message: event.reason, error: null };
@@ -57,7 +59,7 @@ export function setupGlobalErrorHandlers() {
   window.addEventListener('unhandledrejection', onErrorEvent);
 }
 
-function onErrorEvent(event: ErrorEvent | PromiseRejectionEvent) {
+export function onErrorEvent(event: ErrorEvent | PromiseRejectionEvent | Error) {
   const errorEvent = unifyErrorEvent(event);
   if (shouldIgnoreError(errorEvent.message)) return;
   void tryLogErrorToDotNet(errorEvent);

--- a/frontend/viewer/src/lib/layout/ViewErrorBoundary.svelte
+++ b/frontend/viewer/src/lib/layout/ViewErrorBoundary.svelte
@@ -1,0 +1,49 @@
+<script lang="ts">
+  import type {Snippet} from 'svelte';
+  import * as Alert from '$lib/components/ui/alert';
+  import {Button} from '$lib/components/ui/button';
+  import {SidebarTrigger} from '$lib/components/ui/sidebar';
+  import {Icon} from '$lib/components/ui/icon';
+  import {cn} from '$lib/utils';
+  import {t} from 'svelte-i18n-lingui';
+  import {navigate} from 'svelte-routing';
+
+  let {
+    children,
+    title,
+    class: className,
+  }: {
+    children: Snippet;
+    title?: string;
+    class?: string;
+  } = $props();
+
+  function errorMessage(error: unknown): string {
+    if (error instanceof Error) return error.message;
+    if (typeof error === 'string') return error;
+    return String(error);
+  }
+</script>
+
+<svelte:boundary>
+  <div class={cn('flex flex-col min-h-0', className)}>
+    {@render children()}
+  </div>
+  {#snippet failed(error, reset)}
+    <div class={cn('flex flex-col h-full gap-4 p-4', className)}>
+      <SidebarTrigger icon="i-mdi-menu" class="aspect-square p-0 self-start" />
+      <Alert.Root variant="destructive" class="max-w-lg">
+        <Icon icon="i-mdi-alert-circle-outline" />
+        <Alert.Title>{title ?? $t`Something went wrong`}</Alert.Title>
+        <Alert.Description>{errorMessage(error)}</Alert.Description>
+      </Alert.Root>
+      <div class="flex flex-wrap gap-2">
+        <Button variant="secondary" onclick={reset}>{$t`Try again`}</Button>
+        <Button variant="outline" class="paratext:hidden" onclick={() => navigate('/')}>
+          <Icon icon="i-mdi-close" />
+          {$t`Close Dictionary`}
+        </Button>
+      </div>
+    </div>
+  {/snippet}
+</svelte:boundary>

--- a/frontend/viewer/src/lib/layout/ViewErrorBoundary.svelte
+++ b/frontend/viewer/src/lib/layout/ViewErrorBoundary.svelte
@@ -7,6 +7,7 @@
   import {cn} from '$lib/utils';
   import {t} from 'svelte-i18n-lingui';
   import {navigate} from 'svelte-routing';
+  import {onErrorEvent} from '$lib/errors/global-errors';
 
   let {
     children,
@@ -18,14 +19,18 @@
     class?: string;
   } = $props();
 
+  function onError(error: unknown): void {
+    const errorObj = error instanceof Error ? error : new Error(String(error), { cause: error });
+    onErrorEvent(errorObj);
+  }
+
   function errorMessage(error: unknown): string {
     if (error instanceof Error) return error.message;
-    if (typeof error === 'string') return error;
     return String(error);
   }
 </script>
 
-<svelte:boundary>
+<svelte:boundary onerror={onError}>
   <div class={cn('flex flex-col min-h-0', className)}>
     {@render children()}
   </div>

--- a/frontend/viewer/src/locales/en.po
+++ b/frontend/viewer/src/locales/en.po
@@ -294,6 +294,10 @@ msgstr "blue"
 msgid "Browse"
 msgstr "Browse"
 
+#: src/project/browse/BrowseView.svelte
+msgid "Browse view failed"
+msgstr "Browse view failed"
+
 #. Button to close dialog without saving
 #. Appears in dialog footer; discards any pending edits
 #. Synonyms across UI: "Don't delete" (Delete dialog), "Close" (About dialog)
@@ -356,6 +360,7 @@ msgid "Close"
 msgstr "Close"
 
 #. Menu option to close project
+#: src/lib/layout/ViewErrorBoundary.svelte
 #: src/project/ProjectSidebar.svelte
 msgid "Close Dictionary"
 msgstr "Close Dictionary"
@@ -1731,6 +1736,10 @@ msgstr "Size:"
 msgid "Skip"
 msgstr "Skip"
 
+#: src/lib/layout/ViewErrorBoundary.svelte
+msgid "Something went wrong"
+msgstr "Something went wrong"
+
 #. Filter option
 #: src/project/browse/SearchFilter.svelte
 msgid "Specific field"
@@ -1830,6 +1839,10 @@ msgstr "Task {0}"
 msgid "Task not found: {0}"
 msgstr "Task not found: {0}"
 
+#: src/project/tasks/TasksView.svelte
+msgid "Task view failed"
+msgstr "Task view failed"
+
 #. Sidebar menu item
 #: src/project/ProjectSidebar.svelte
 msgid "Tasks"
@@ -1928,6 +1941,10 @@ msgstr "Translation {0}"
 #: src/project/ProjectSidebar.svelte
 msgid "Troubleshoot"
 msgstr "Troubleshoot"
+
+#: src/lib/layout/ViewErrorBoundary.svelte
+msgid "Try again"
+msgstr "Try again"
 
 #. Task instruction
 #: src/project/tasks/tasks-service.ts

--- a/frontend/viewer/src/locales/es.po
+++ b/frontend/viewer/src/locales/es.po
@@ -299,6 +299,10 @@ msgstr "azul"
 msgid "Browse"
 msgstr "Visite"
 
+#: src/project/browse/BrowseView.svelte
+msgid "Browse view failed"
+msgstr ""
+
 #. Button to close dialog without saving
 #. Appears in dialog footer; discards any pending edits
 #. Synonyms across UI: "Don't delete" (Delete dialog), "Close" (About dialog)
@@ -361,6 +365,7 @@ msgid "Close"
 msgstr "Cerrar"
 
 #. Menu option to close project
+#: src/lib/layout/ViewErrorBoundary.svelte
 #: src/project/ProjectSidebar.svelte
 msgid "Close Dictionary"
 msgstr "Cerrar Diccionario"
@@ -1736,6 +1741,10 @@ msgstr "Tamaño:"
 msgid "Skip"
 msgstr "Saltar"
 
+#: src/lib/layout/ViewErrorBoundary.svelte
+msgid "Something went wrong"
+msgstr ""
+
 #. Filter option
 #: src/project/browse/SearchFilter.svelte
 msgid "Specific field"
@@ -1835,6 +1844,10 @@ msgstr "Tarea {0}"
 msgid "Task not found: {0}"
 msgstr "Tarea no encontrada: {0}"
 
+#: src/project/tasks/TasksView.svelte
+msgid "Task view failed"
+msgstr ""
+
 #. Sidebar menu item
 #: src/project/ProjectSidebar.svelte
 msgid "Tasks"
@@ -1933,6 +1946,10 @@ msgstr "Traducción {0}"
 #: src/project/ProjectSidebar.svelte
 msgid "Troubleshoot"
 msgstr "Solución de problemas"
+
+#: src/lib/layout/ViewErrorBoundary.svelte
+msgid "Try again"
+msgstr ""
 
 #. Task instruction
 #: src/project/tasks/tasks-service.ts

--- a/frontend/viewer/src/locales/fr.po
+++ b/frontend/viewer/src/locales/fr.po
@@ -299,6 +299,10 @@ msgstr "bleu"
 msgid "Browse"
 msgstr "Parcourir"
 
+#: src/project/browse/BrowseView.svelte
+msgid "Browse view failed"
+msgstr ""
+
 #. Button to close dialog without saving
 #. Appears in dialog footer; discards any pending edits
 #. Synonyms across UI: "Don't delete" (Delete dialog), "Close" (About dialog)
@@ -361,6 +365,7 @@ msgid "Close"
 msgstr "Fermer"
 
 #. Menu option to close project
+#: src/lib/layout/ViewErrorBoundary.svelte
 #: src/project/ProjectSidebar.svelte
 msgid "Close Dictionary"
 msgstr "Fermer le dictionnaire"
@@ -1736,6 +1741,10 @@ msgstr "Taille :"
 msgid "Skip"
 msgstr "Ignorer"
 
+#: src/lib/layout/ViewErrorBoundary.svelte
+msgid "Something went wrong"
+msgstr ""
+
 #. Filter option
 #: src/project/browse/SearchFilter.svelte
 msgid "Specific field"
@@ -1835,6 +1844,10 @@ msgstr "Tâche {0}"
 msgid "Task not found: {0}"
 msgstr "Tâche introuvable : {0}"
 
+#: src/project/tasks/TasksView.svelte
+msgid "Task view failed"
+msgstr ""
+
 #. Sidebar menu item
 #: src/project/ProjectSidebar.svelte
 msgid "Tasks"
@@ -1933,6 +1946,10 @@ msgstr "Traduction {0}"
 #: src/project/ProjectSidebar.svelte
 msgid "Troubleshoot"
 msgstr "Dépannage"
+
+#: src/lib/layout/ViewErrorBoundary.svelte
+msgid "Try again"
+msgstr ""
 
 #. Task instruction
 #: src/project/tasks/tasks-service.ts

--- a/frontend/viewer/src/locales/id.po
+++ b/frontend/viewer/src/locales/id.po
@@ -299,6 +299,10 @@ msgstr "biru"
 msgid "Browse"
 msgstr "Jelajahi"
 
+#: src/project/browse/BrowseView.svelte
+msgid "Browse view failed"
+msgstr ""
+
 #. Button to close dialog without saving
 #. Appears in dialog footer; discards any pending edits
 #. Synonyms across UI: "Don't delete" (Delete dialog), "Close" (About dialog)
@@ -361,6 +365,7 @@ msgid "Close"
 msgstr "Tutup"
 
 #. Menu option to close project
+#: src/lib/layout/ViewErrorBoundary.svelte
 #: src/project/ProjectSidebar.svelte
 msgid "Close Dictionary"
 msgstr "Tutup Kamus"
@@ -1736,6 +1741,10 @@ msgstr "Ukuran:"
 msgid "Skip"
 msgstr "Lewati"
 
+#: src/lib/layout/ViewErrorBoundary.svelte
+msgid "Something went wrong"
+msgstr ""
+
 #. Filter option
 #: src/project/browse/SearchFilter.svelte
 msgid "Specific field"
@@ -1835,6 +1844,10 @@ msgstr "Tugas {0}"
 msgid "Task not found: {0}"
 msgstr "Tugas tidak ditemukan: {0}"
 
+#: src/project/tasks/TasksView.svelte
+msgid "Task view failed"
+msgstr ""
+
 #. Sidebar menu item
 #: src/project/ProjectSidebar.svelte
 msgid "Tasks"
@@ -1933,6 +1946,10 @@ msgstr "Terjemahan {0}"
 #: src/project/ProjectSidebar.svelte
 msgid "Troubleshoot"
 msgstr "Memecahkan masalah"
+
+#: src/lib/layout/ViewErrorBoundary.svelte
+msgid "Try again"
+msgstr ""
 
 #. Task instruction
 #: src/project/tasks/tasks-service.ts

--- a/frontend/viewer/src/locales/ko.po
+++ b/frontend/viewer/src/locales/ko.po
@@ -299,6 +299,10 @@ msgstr "파란색"
 msgid "Browse"
 msgstr "찾아보기"
 
+#: src/project/browse/BrowseView.svelte
+msgid "Browse view failed"
+msgstr ""
+
 #. Button to close dialog without saving
 #. Appears in dialog footer; discards any pending edits
 #. Synonyms across UI: "Don't delete" (Delete dialog), "Close" (About dialog)
@@ -361,6 +365,7 @@ msgid "Close"
 msgstr "닫기"
 
 #. Menu option to close project
+#: src/lib/layout/ViewErrorBoundary.svelte
 #: src/project/ProjectSidebar.svelte
 msgid "Close Dictionary"
 msgstr "사전 닫기"
@@ -1736,6 +1741,10 @@ msgstr "크기:"
 msgid "Skip"
 msgstr "건너뛰기"
 
+#: src/lib/layout/ViewErrorBoundary.svelte
+msgid "Something went wrong"
+msgstr ""
+
 #. Filter option
 #: src/project/browse/SearchFilter.svelte
 msgid "Specific field"
@@ -1835,6 +1844,10 @@ msgstr "작업 {0}"
 msgid "Task not found: {0}"
 msgstr "작업을 찾을 수 없음: {0}"
 
+#: src/project/tasks/TasksView.svelte
+msgid "Task view failed"
+msgstr ""
+
 #. Sidebar menu item
 #: src/project/ProjectSidebar.svelte
 msgid "Tasks"
@@ -1933,6 +1946,10 @@ msgstr "번역 {0}"
 #: src/project/ProjectSidebar.svelte
 msgid "Troubleshoot"
 msgstr "문제 해결"
+
+#: src/lib/layout/ViewErrorBoundary.svelte
+msgid "Try again"
+msgstr ""
 
 #. Task instruction
 #: src/project/tasks/tasks-service.ts

--- a/frontend/viewer/src/locales/ms.po
+++ b/frontend/viewer/src/locales/ms.po
@@ -299,6 +299,10 @@ msgstr "biru"
 msgid "Browse"
 msgstr "Terokai"
 
+#: src/project/browse/BrowseView.svelte
+msgid "Browse view failed"
+msgstr ""
+
 #. Button to close dialog without saving
 #. Appears in dialog footer; discards any pending edits
 #. Synonyms across UI: "Don't delete" (Delete dialog), "Close" (About dialog)
@@ -361,6 +365,7 @@ msgid "Close"
 msgstr "Tutup"
 
 #. Menu option to close project
+#: src/lib/layout/ViewErrorBoundary.svelte
 #: src/project/ProjectSidebar.svelte
 msgid "Close Dictionary"
 msgstr "Tutup Kamus"
@@ -1736,6 +1741,10 @@ msgstr "Saiz:"
 msgid "Skip"
 msgstr "Langkau"
 
+#: src/lib/layout/ViewErrorBoundary.svelte
+msgid "Something went wrong"
+msgstr ""
+
 #. Filter option
 #: src/project/browse/SearchFilter.svelte
 msgid "Specific field"
@@ -1835,6 +1844,10 @@ msgstr "Tugasan {0}"
 msgid "Task not found: {0}"
 msgstr "Tugasan tidak ditemui: {0}"
 
+#: src/project/tasks/TasksView.svelte
+msgid "Task view failed"
+msgstr ""
+
 #. Sidebar menu item
 #: src/project/ProjectSidebar.svelte
 msgid "Tasks"
@@ -1933,6 +1946,10 @@ msgstr "Terjemahan {0}"
 #: src/project/ProjectSidebar.svelte
 msgid "Troubleshoot"
 msgstr "Selesaikan masalah"
+
+#: src/lib/layout/ViewErrorBoundary.svelte
+msgid "Try again"
+msgstr ""
 
 #. Task instruction
 #: src/project/tasks/tasks-service.ts

--- a/frontend/viewer/src/locales/sw.po
+++ b/frontend/viewer/src/locales/sw.po
@@ -299,6 +299,10 @@ msgstr "buluu"
 msgid "Browse"
 msgstr "Angalia"
 
+#: src/project/browse/BrowseView.svelte
+msgid "Browse view failed"
+msgstr ""
+
 #. Button to close dialog without saving
 #. Appears in dialog footer; discards any pending edits
 #. Synonyms across UI: "Don't delete" (Delete dialog), "Close" (About dialog)
@@ -361,6 +365,7 @@ msgid "Close"
 msgstr "Funga"
 
 #. Menu option to close project
+#: src/lib/layout/ViewErrorBoundary.svelte
 #: src/project/ProjectSidebar.svelte
 msgid "Close Dictionary"
 msgstr "Funga Kamusi"
@@ -1736,6 +1741,10 @@ msgstr "Ukubwa:"
 msgid "Skip"
 msgstr "Ruka"
 
+#: src/lib/layout/ViewErrorBoundary.svelte
+msgid "Something went wrong"
+msgstr ""
+
 #. Filter option
 #: src/project/browse/SearchFilter.svelte
 msgid "Specific field"
@@ -1835,6 +1844,10 @@ msgstr "Jukumu {0}"
 msgid "Task not found: {0}"
 msgstr "Jukumu halipatikani: {0}"
 
+#: src/project/tasks/TasksView.svelte
+msgid "Task view failed"
+msgstr ""
+
 #. Sidebar menu item
 #: src/project/ProjectSidebar.svelte
 msgid "Tasks"
@@ -1933,6 +1946,10 @@ msgstr "Tafsiri {0}"
 #: src/project/ProjectSidebar.svelte
 msgid "Troubleshoot"
 msgstr "Tatanua"
+
+#: src/lib/layout/ViewErrorBoundary.svelte
+msgid "Try again"
+msgstr ""
 
 #. Task instruction
 #: src/project/tasks/tasks-service.ts

--- a/frontend/viewer/src/locales/vi.po
+++ b/frontend/viewer/src/locales/vi.po
@@ -299,6 +299,10 @@ msgstr "xanh dương"
 msgid "Browse"
 msgstr "Duyệt"
 
+#: src/project/browse/BrowseView.svelte
+msgid "Browse view failed"
+msgstr ""
+
 #. Button to close dialog without saving
 #. Appears in dialog footer; discards any pending edits
 #. Synonyms across UI: "Don't delete" (Delete dialog), "Close" (About dialog)
@@ -361,6 +365,7 @@ msgid "Close"
 msgstr "Đóng"
 
 #. Menu option to close project
+#: src/lib/layout/ViewErrorBoundary.svelte
 #: src/project/ProjectSidebar.svelte
 msgid "Close Dictionary"
 msgstr "Đóng Từ điển"
@@ -1736,6 +1741,10 @@ msgstr "Kích thước:"
 msgid "Skip"
 msgstr "Bỏ qua"
 
+#: src/lib/layout/ViewErrorBoundary.svelte
+msgid "Something went wrong"
+msgstr ""
+
 #. Filter option
 #: src/project/browse/SearchFilter.svelte
 msgid "Specific field"
@@ -1835,6 +1844,10 @@ msgstr "Nhiệm vụ {0}"
 msgid "Task not found: {0}"
 msgstr "Không tìm thấy nhiệm vụ: {0}"
 
+#: src/project/tasks/TasksView.svelte
+msgid "Task view failed"
+msgstr ""
+
 #. Sidebar menu item
 #: src/project/ProjectSidebar.svelte
 msgid "Tasks"
@@ -1933,6 +1946,10 @@ msgstr "Bản dịch {0}"
 #: src/project/ProjectSidebar.svelte
 msgid "Troubleshoot"
 msgstr "Khắc phục sự cố"
+
+#: src/lib/layout/ViewErrorBoundary.svelte
+msgid "Try again"
+msgstr ""
 
 #. Task instruction
 #: src/project/tasks/tasks-service.ts

--- a/frontend/viewer/src/project/browse/BrowseView.svelte
+++ b/frontend/viewer/src/project/browse/BrowseView.svelte
@@ -20,6 +20,7 @@
   import type {EntryListViewMode} from './EntryListViewOptions.svelte';
   import EntryListViewOptions from './EntryListViewOptions.svelte';
   import {useProjectStorage} from '$lib/storage/project-storage.svelte';
+  import ViewErrorBoundary from '$lib/layout/ViewErrorBoundary.svelte';
 
   const projectContext = useProjectContext();
   const viewService = useViewService();
@@ -70,7 +71,7 @@
     <PrimaryNewEntryButton active={!IsMobile.value && isOpen} onclick={newEntry}/>
   {/snippet}
 </SidebarPrimaryAction>
-<div class="flex flex-col h-full">
+<ViewErrorBoundary class="flex flex-col h-full" title={$t`Browse view failed`}>
   <ResizablePaneGroup direction="horizontal" class="flex-1 min-h-0 overflow-visible!">
     <IfOnce show={!IsMobile.value || !selectedEntryId.current || !entryOpen.current}>
       <ResizablePane
@@ -129,4 +130,4 @@
       </ResizablePane>
     {/if}
   </ResizablePaneGroup>
-</div>
+</ViewErrorBoundary>

--- a/frontend/viewer/src/project/tasks/TaskView.svelte
+++ b/frontend/viewer/src/project/tasks/TaskView.svelte
@@ -10,8 +10,10 @@
   import type {TaskSubject} from './subject.svelte';
   import {t} from 'svelte-i18n-lingui';
   import {cn} from '$lib/utils';
+  import {useProjectContext} from '$project/project-context.svelte';
 
   const TASK_SUBJECT_COUNT = 10;
+  const projectContext = useProjectContext();
 
   let {
     taskId,
@@ -61,22 +63,24 @@
                      disableNewEntry
                      onSelectEntry={e => entry = e} selectedEntryId={entry?.id}/>
         <Button onclick={onDone}>{$t`Done`}</Button>
-        <SubjectPopup
-          bind:entry
-          {task}
-          {progress}
-          onNextEntry={async () => {
-            const next = await entriesList?.selectNextEntry();
-            if (!next) onDone();
-          }}
-          onCompletedSubject={subject => {
-            completedSubjects.push(subject);
-            allCompletedSubjects.push(subject);
-            if (completedSubjects.length === TASK_SUBJECT_COUNT) {
-              onDone();
-            }
-          }}
-        />
+        {#if projectContext.maybeApi}
+          <SubjectPopup
+            bind:entry
+            {task}
+            {progress}
+            onNextEntry={async () => {
+              const next = await entriesList?.selectNextEntry();
+              if (!next) onDone();
+            }}
+            onCompletedSubject={subject => {
+              completedSubjects.push(subject);
+              allCompletedSubjects.push(subject);
+              if (completedSubjects.length === TASK_SUBJECT_COUNT) {
+                onDone();
+              }
+            }}
+          />
+        {/if}
       </div>
     {:else}
       <DoneView subjects={completedSubjects}

--- a/frontend/viewer/src/project/tasks/TasksView.svelte
+++ b/frontend/viewer/src/project/tasks/TasksView.svelte
@@ -6,6 +6,7 @@
   import TaskView from './TaskView.svelte';
   import {untrack} from 'svelte';
   import {SidebarTrigger} from '$lib/components/ui/sidebar';
+  import ViewErrorBoundary from '$lib/layout/ViewErrorBoundary.svelte';
 
   const selectedTaskId = useProjectStorage().selectedTaskId;
   const tasksService = useTasksService();
@@ -37,9 +38,11 @@
       </Select.Content>
     </Select.Root>
   </div>
-  {#if selectedTaskId.current}
-    <TaskView taskId={selectedTaskId.current} onClose={() => selectedTaskId.set('')}/>
-  {:else}
-    <h1 class="text-xl p-4 mx-auto">{$t`Select a new task to work on`}</h1>
-  {/if}
+  <ViewErrorBoundary class="flex-1 min-h-0 overflow-auto" title={$t`Task view failed`}>
+    {#if selectedTaskId.current}
+      <TaskView taskId={selectedTaskId.current} onClose={() => selectedTaskId.set('')}/>
+    {:else}
+      <h1 class="text-xl p-4 mx-auto">{$t`Select a new task to work on`}</h1>
+    {/if}
+  </ViewErrorBoundary>
 </div>


### PR DESCRIPTION
On my phone the tasks page is cached as the starting page and there's a JS error because the project is not ready. This caused me to be stuck on the page. I fixed the root cause and provided a failsafe.

#2316 provided one failsafe. This PR provides another using a `svelte:boundary` to catch render errors and provide a way to try again or close the project or open the sidebar.

Forcing an error to happen when rendering the tasks view looks like this:
<img width="875" height="399" alt="image" src="https://github.com/user-attachments/assets/2f64f5dd-0ff6-47c9-a775-23db1a7591a3" />

it's a little weird to have the sidebar toggle twice, but it doesn't hurt. The new error handler is also used on the Browse View, but I didn't force an error to test that version.