### PR TITLE
Enhance Android app actions, deep linking, and SvelteNavigate integration

### DIFF
--- a/backend/FwLite/FwLiteMaui/App.xaml.cs
+++ b/backend/FwLite/FwLiteMaui/App.xaml.cs
@@ -1,13 +1,12 @@
-using FwLiteShared.Services;
-using Microsoft.AspNetCore.Components;
 
 namespace FwLiteMaui;
 
 public partial class App : Application
 {
     private readonly MainPage _mainPage;
+    public static string? OverrideStartupUrl { get; set; }
 
-    public App(MainPage mainPage, IPreferencesService preferences)
+    public App(MainPage mainPage)
     {
         _mainPage = mainPage;
         InitializeComponent();
@@ -16,7 +15,6 @@ public partial class App : Application
     internal void LoadAppUrl(string url)
     {
         _mainPage.LoadAppUrl(url);
-
     }
 
     protected override Window CreateWindow(IActivationState? activationState)

--- a/backend/FwLite/FwLiteMaui/App.xaml.cs
+++ b/backend/FwLite/FwLiteMaui/App.xaml.cs
@@ -1,4 +1,5 @@
 using FwLiteShared.Services;
+using Microsoft.AspNetCore.Components;
 
 namespace FwLiteMaui;
 
@@ -9,12 +10,13 @@ public partial class App : Application
     public App(MainPage mainPage, IPreferencesService preferences)
     {
         _mainPage = mainPage;
-        var lastUrl = preferences.Get(nameof(PreferenceKey.AppLastUrl));
-        if (lastUrl?.StartsWith('/') == true)
-        {
-            mainPage.StartPath = lastUrl;
-        }
         InitializeComponent();
+    }
+
+    internal void LoadAppUrl(string url)
+    {
+        _mainPage.LoadAppUrl(url);
+
     }
 
     protected override Window CreateWindow(IActivationState? activationState)

--- a/backend/FwLite/FwLiteMaui/App.xaml.cs
+++ b/backend/FwLite/FwLiteMaui/App.xaml.cs
@@ -3,11 +3,13 @@ namespace FwLiteMaui;
 
 public partial class App : Application
 {
+    public IServiceProvider ServiceProvider { get; }
     private readonly MainPage _mainPage;
     public static string? OverrideStartupUrl { get; set; }
 
-    public App(MainPage mainPage)
+    public App(MainPage mainPage, IServiceProvider serviceProvider)
     {
+        ServiceProvider = serviceProvider;
         _mainPage = mainPage;
         InitializeComponent();
     }

--- a/backend/FwLite/FwLiteMaui/MainPage.xaml.cs
+++ b/backend/FwLite/FwLiteMaui/MainPage.xaml.cs
@@ -1,3 +1,5 @@
+using FwLiteShared.Services;
+using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.WebView;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
@@ -7,20 +9,44 @@ namespace FwLiteMaui;
 
 public partial class MainPage : ContentPage
 {
-    public MainPage()
+    public MainPage(IPreferencesService preferences)
     {
         InitializeComponent();
         blazorWebView.BlazorWebViewInitializing += BlazorWebViewInitializing;
         blazorWebView.BlazorWebViewInitialized += BlazorWebViewInitialized;
         blazorWebView.UrlLoading += BlazorWebViewOnUrlLoading;
+
+        var lastUrl = preferences.Get(nameof(PreferenceKey.AppLastUrl));
+        #if ANDROID
+        var intent = Platform.CurrentActivity?.Intent;
+        if (intent is not null && intent.Action == "ACTION_XE_APP_ACTION")
+        {
+            var actionId = intent.GetStringExtra("EXTRA_XE_APP_ACTION_ID");
+            if (actionId is "home") lastUrl = "/home";
+        }
+        #endif
+        if (lastUrl?.StartsWith('/') == true)
+        {
+            StartPath = lastUrl;
+        }
     }
-
-
 
     internal string StartPath
     {
         get => blazorWebView.StartPath;
         set => blazorWebView.StartPath = value;
+    }
+
+    internal void LoadAppUrl(string url)
+    {
+        blazorWebView.StartPath = url;
+        _ = blazorWebView.TryDispatchAsync(services =>
+        {
+            var navigationManager = services.GetRequiredService<NavigationManager>();
+            navigationManager.NavigateTo(url);
+            //the svelte-routing library doesn't notice the url change via NavigateTo, so just reload the page
+            navigationManager.Refresh();
+        });
     }
 
 #if ANDROID || WINDOWS

--- a/backend/FwLite/FwLiteMaui/MainPage.xaml.cs
+++ b/backend/FwLite/FwLiteMaui/MainPage.xaml.cs
@@ -1,9 +1,6 @@
+using System.Text.Json;
 using FwLiteShared.Services;
-using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.WebView;
-using Microsoft.Extensions.Hosting;
-using Microsoft.Extensions.Logging;
-using Microsoft.Extensions.Options;
 using Microsoft.JSInterop;
 
 namespace FwLiteMaui;
@@ -23,6 +20,7 @@ public partial class MainPage : ContentPage
             //only change it if it's still the default, might have been changed already, for example when opening a new window
             if (blazorWebView.StartPath == "/")
                 blazorWebView.StartPath = initial;
+            App.OverrideStartupUrl = null;
         };
         blazorWebView.UrlLoading += BlazorWebViewOnUrlLoading;
     }
@@ -43,7 +41,7 @@ public partial class MainPage : ContentPage
             {
                 var js = $$"""
                     if (window.lexbox.SvelteNavigate) {
-                        window.lexbox.SvelteNavigate('{{url}}', { replace: true });
+                        window.lexbox.SvelteNavigate({{JsonSerializer.Serialize(url)}}, { replace: true });
                     }
                 """;
                 _ = jsRuntime.InvokeVoidAsync("eval", js);

--- a/backend/FwLite/FwLiteMaui/MainPage.xaml.cs
+++ b/backend/FwLite/FwLiteMaui/MainPage.xaml.cs
@@ -4,6 +4,7 @@ using Microsoft.AspNetCore.Components.WebView;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
+using Microsoft.JSInterop;
 
 namespace FwLiteMaui;
 
@@ -12,23 +13,18 @@ public partial class MainPage : ContentPage
     public MainPage(IPreferencesService preferences)
     {
         InitializeComponent();
+        var lastUrlFromPrefs = preferences.Get(nameof(PreferenceKey.AppLastUrl));
         blazorWebView.BlazorWebViewInitializing += BlazorWebViewInitializing;
         blazorWebView.BlazorWebViewInitialized += BlazorWebViewInitialized;
+        blazorWebView.BlazorWebViewInitialized += (s, e) =>
+        {
+            // Decide initial StartPath here (after Android intent is processed) to avoid cold-start race
+            var initial = App.OverrideStartupUrl ?? lastUrlFromPrefs ?? "/";
+            //only change it if it's still the default, might have been changed already, for example when opening a new window
+            if (blazorWebView.StartPath == "/")
+                blazorWebView.StartPath = initial;
+        };
         blazorWebView.UrlLoading += BlazorWebViewOnUrlLoading;
-
-        var lastUrl = preferences.Get(nameof(PreferenceKey.AppLastUrl));
-        #if ANDROID
-        var intent = Platform.CurrentActivity?.Intent;
-        if (intent is not null && intent.Action == "ACTION_XE_APP_ACTION")
-        {
-            var actionId = intent.GetStringExtra("EXTRA_XE_APP_ACTION_ID");
-            if (actionId is "home") lastUrl = "/home";
-        }
-        #endif
-        if (lastUrl?.StartsWith('/') == true)
-        {
-            StartPath = lastUrl;
-        }
     }
 
     internal string StartPath
@@ -42,10 +38,16 @@ public partial class MainPage : ContentPage
         blazorWebView.StartPath = url;
         _ = blazorWebView.TryDispatchAsync(services =>
         {
-            var navigationManager = services.GetRequiredService<NavigationManager>();
-            navigationManager.NavigateTo(url);
-            //the svelte-routing library doesn't notice the url change via NavigateTo, so just reload the page
-            navigationManager.Refresh();
+            var jsRuntime = services.GetService<IJSRuntime>();
+            if (jsRuntime != null)
+            {
+                var js = $$"""
+                    if (window.lexbox.SvelteNavigate) {
+                        window.lexbox.SvelteNavigate('{{url}}', { replace: true });
+                    }
+                """;
+                _ = jsRuntime.InvokeVoidAsync("eval", js);
+            }
         });
     }
 

--- a/backend/FwLite/FwLiteMaui/MainPage.xaml.cs
+++ b/backend/FwLite/FwLiteMaui/MainPage.xaml.cs
@@ -1,14 +1,17 @@
-using System.Text.Json;
 using FwLiteShared.Services;
 using Microsoft.AspNetCore.Components.WebView;
+using Microsoft.Extensions.Logging;
 using Microsoft.JSInterop;
 
 namespace FwLiteMaui;
 
 public partial class MainPage : ContentPage
 {
-    public MainPage(IPreferencesService preferences)
+    private readonly ILogger<MainPage> _logger;
+
+    public MainPage(IPreferencesService preferences, ILogger<MainPage> logger)
     {
+        _logger = logger;
         InitializeComponent();
         var lastUrlFromPrefs = preferences.Get(nameof(PreferenceKey.AppLastUrl));
         blazorWebView.BlazorWebViewInitializing += BlazorWebViewInitializing;
@@ -38,15 +41,20 @@ public partial class MainPage : ContentPage
         {
             var jsRuntime = services.GetService<IJSRuntime>();
             if (jsRuntime != null)
-            {
-                var js = $$"""
-                    if (window.lexbox.SvelteNavigate) {
-                        window.lexbox.SvelteNavigate({{JsonSerializer.Serialize(url)}}, { replace: true });
-                    }
-                """;
-                _ = jsRuntime.InvokeVoidAsync("eval", js);
-            }
+                _ = NavigateAsync(jsRuntime, url);
         });
+    }
+
+    private async Task NavigateAsync(IJSRuntime jsRuntime, string url)
+    {
+        try
+        {
+            await jsRuntime.InvokeVoidAsync("lexbox.SvelteNavigate", url, new { replace = true });
+        }
+        catch (Exception e)
+        {
+            _logger.LogError(e, "Failed to navigate to {Url} via SvelteNavigate", url);
+        }
     }
 
 #if ANDROID || WINDOWS

--- a/backend/FwLite/FwLiteMaui/MauiProgram.cs
+++ b/backend/FwLite/FwLiteMaui/MauiProgram.cs
@@ -52,6 +52,18 @@ public static class MauiProgram
         builder.ConfigureEssentials(essentialsBuilder =>
         {
             essentialsBuilder.UseVersionTracking();
+
+            essentialsBuilder.AddAppAction("home", "Home")
+                .OnAppAction(action =>
+                {
+                    if (action.Id == "home")
+                    {
+                        App.Current!.Dispatcher.Dispatch(() =>
+                        {
+                            ((App?)App.Current)!.LoadAppUrl("/home");
+                        });
+                    }
+                });
         });
         builder.Services.AddFwLiteMauiServices(builder.Configuration, builder.Logging);
 

--- a/backend/FwLite/FwLiteMaui/MauiProgram.cs
+++ b/backend/FwLite/FwLiteMaui/MauiProgram.cs
@@ -1,3 +1,4 @@
+using FwLiteShared.Services;
 using Microsoft.Extensions.Logging;
 using Microsoft.Maui.LifecycleEvents;
 
@@ -61,11 +62,21 @@ public static class MauiProgram
 
             essentialsBuilder.OnAppAction(action =>
             {
+                var app = (App?)Application.Current;
+                if (app is null) return;
                 if (Shortcuts.TryGetUrl(action.Id, out var url))
                 {
-                    Application.Current!.Dispatcher.Dispatch(() =>
+                    app.Dispatcher.Dispatch(() =>
                     {
-                        ((App?)Application.Current)?.LoadAppUrl(url);
+                        app.LoadAppUrl(url);
+                    });  
+                }
+                else if (action.Id == Shortcuts.ShareLogOut)
+                {
+                    app.Dispatcher.Dispatch(() =>
+                    {
+                        _ = app.ServiceProvider.GetRequiredService<ITroubleshootingService>()
+                            .ShareLogFile();
                     });
                 }
             });

--- a/backend/FwLite/FwLiteMaui/MauiProgram.cs
+++ b/backend/FwLite/FwLiteMaui/MauiProgram.cs
@@ -53,17 +53,22 @@ public static class MauiProgram
         {
             essentialsBuilder.UseVersionTracking();
 
-            essentialsBuilder.AddAppAction("home", "Home")
-                .OnAppAction(action =>
+            // Register all shortcuts from a single central place
+            foreach (var action in Shortcuts.Declarations)
+            {
+                essentialsBuilder.AddAppAction(action);
+            }
+
+            essentialsBuilder.OnAppAction(action =>
+            {
+                if (Shortcuts.TryGetUrl(action.Id, out var url))
                 {
-                    if (action.Id == "home")
+                    Application.Current!.Dispatcher.Dispatch(() =>
                     {
-                        App.Current!.Dispatcher.Dispatch(() =>
-                        {
-                            ((App?)App.Current)!.LoadAppUrl("/home");
-                        });
-                    }
-                });
+                        ((App?)Application.Current)?.LoadAppUrl(url);
+                    });
+                }
+            });
         });
         builder.Services.AddFwLiteMauiServices(builder.Configuration, builder.Logging);
 

--- a/backend/FwLite/FwLiteMaui/MauiProgram.cs
+++ b/backend/FwLite/FwLiteMaui/MauiProgram.cs
@@ -69,14 +69,22 @@ public static class MauiProgram
                     app.Dispatcher.Dispatch(() =>
                     {
                         app.LoadAppUrl(url);
-                    });  
+                    });
                 }
                 else if (action.Id == Shortcuts.ShareLogOut)
                 {
-                    app.Dispatcher.Dispatch(() =>
+                    _ = app.Dispatcher.DispatchAsync(async () =>
                     {
-                        _ = app.ServiceProvider.GetRequiredService<ITroubleshootingService>()
-                            .ShareLogFile();
+                        try
+                        {
+                            await app.ServiceProvider.GetRequiredService<ITroubleshootingService>()
+                                .ShareLogFile();
+                        }
+                        catch (Exception e)
+                        {
+                            app.ServiceProvider.GetService<ILogger<App>>()?
+                                .LogError(e, "Failed to share log file from app action");
+                        }
                     });
                 }
             });

--- a/backend/FwLite/FwLiteMaui/Platforms/Android/MainActivity.cs
+++ b/backend/FwLite/FwLiteMaui/Platforms/Android/MainActivity.cs
@@ -14,6 +14,8 @@ namespace FwLiteMaui;
     LaunchMode = LaunchMode.SingleTop,
     ConfigurationChanges = ConfigChanges.ScreenSize | ConfigChanges.Orientation | ConfigChanges.UiMode |
                            ConfigChanges.ScreenLayout | ConfigChanges.SmallestScreenSize | ConfigChanges.Density)]
+[IntentFilter([Platform.Intent.ActionAppAction],
+    Categories = [Intent.CategoryDefault])]
 public class MainActivity : MauiAppCompatActivity
 {
     protected override void OnCreate(Bundle? savedInstanceState)
@@ -22,6 +24,18 @@ public class MainActivity : MauiAppCompatActivity
         ApplyBrandedSystemBars();
     }
 
+    protected override void OnResume()
+    {
+        base.OnResume();
+
+        Platform.OnResume(this);
+    }
+
+    protected override void OnNewIntent(Intent? intent)
+    {
+        base.OnNewIntent(intent);
+        Platform.OnNewIntent(intent);
+    }
     public override void OnConfigurationChanged(Configuration newConfig)
     {
         base.OnConfigurationChanged(newConfig);

--- a/backend/FwLite/FwLiteMaui/Platforms/Android/MainActivity.cs
+++ b/backend/FwLite/FwLiteMaui/Platforms/Android/MainActivity.cs
@@ -25,6 +25,7 @@ public class MainActivity : MauiAppCompatActivity
 
         if (Intent?.Action == Platform.Intent.ActionAppAction)
         {
+            //name comes from internal maui code: https://github.com/dotnet/maui/blob/271d2505eb436600bb84002c8941670abb0ae23b/src/Essentials/src/AppActions/AppActions.android.cs#L83
             var actionId = Intent.GetStringExtra("EXTRA_XE_APP_ACTION_ID");
             if (Shortcuts.TryGetUrl(actionId, out var url))
             {

--- a/backend/FwLite/FwLiteMaui/Platforms/Android/MainActivity.cs
+++ b/backend/FwLite/FwLiteMaui/Platforms/Android/MainActivity.cs
@@ -21,13 +21,22 @@ public class MainActivity : MauiAppCompatActivity
     protected override void OnCreate(Bundle? savedInstanceState)
     {
         base.OnCreate(savedInstanceState);
+
+        if (Intent?.Action == Platform.Intent.ActionAppAction)
+        {
+            var actionId = Intent.GetStringExtra("EXTRA_XE_APP_ACTION_ID");
+            if (Shortcuts.TryGetUrl(actionId, out var url))
+            {
+                App.OverrideStartupUrl = url;
+            }
+        }
+
         ApplyBrandedSystemBars();
     }
 
     protected override void OnResume()
     {
         base.OnResume();
-
         Platform.OnResume(this);
     }
 

--- a/backend/FwLite/FwLiteMaui/Platforms/Android/MainActivity.cs
+++ b/backend/FwLite/FwLiteMaui/Platforms/Android/MainActivity.cs
@@ -12,6 +12,7 @@ namespace FwLiteMaui;
 [Activity(Theme = "@style/Maui.SplashTheme",
     MainLauncher = true,
     LaunchMode = LaunchMode.SingleTop,
+    ResizeableActivity = true,
     ConfigurationChanges = ConfigChanges.ScreenSize | ConfigChanges.Orientation | ConfigChanges.UiMode |
                            ConfigChanges.ScreenLayout | ConfigChanges.SmallestScreenSize | ConfigChanges.Density)]
 [IntentFilter([Platform.Intent.ActionAppAction],

--- a/backend/FwLite/FwLiteMaui/Shortcuts.cs
+++ b/backend/FwLite/FwLiteMaui/Shortcuts.cs
@@ -1,14 +1,10 @@
-using System.Collections.ObjectModel;
-
 namespace FwLiteMaui;
 
 public static class Shortcuts
 {
-    // Define shortcut IDs here
     public const string Home = "home";
     public const string ShareLogOut = "share-log-out";
 
-    // Map IDs to URL paths
     private static readonly IReadOnlyDictionary<string, string> IdToUrl = new Dictionary<string, string>
     {
         [Home] = "/",

--- a/backend/FwLite/FwLiteMaui/Shortcuts.cs
+++ b/backend/FwLite/FwLiteMaui/Shortcuts.cs
@@ -6,6 +6,7 @@ public static class Shortcuts
 {
     // Define shortcut IDs here
     public const string Home = "home";
+    public const string ShareLogOut = "share-log-out";
 
     // Map IDs to URL paths
     private static readonly IReadOnlyDictionary<string, string> IdToUrl = new Dictionary<string, string>
@@ -16,7 +17,8 @@ public static class Shortcuts
     // Titles/subtitles shown in the system UI (if supported)
     public static readonly IReadOnlyList<AppAction> Declarations =
     [
-        new(Home, "Home")
+        new(Home, "Home"),
+        new(ShareLogOut, "Share Debug Log"),
     ];
 
     public static bool TryGetUrl(string? id, out string url)

--- a/backend/FwLite/FwLiteMaui/Shortcuts.cs
+++ b/backend/FwLite/FwLiteMaui/Shortcuts.cs
@@ -1,0 +1,37 @@
+using System.Collections.ObjectModel;
+
+namespace FwLiteMaui;
+
+public static class Shortcuts
+{
+    // Define shortcut IDs here
+    public const string Home = "home";
+
+    // Map IDs to URL paths
+    private static readonly IReadOnlyDictionary<string, string> IdToUrl = new Dictionary<string, string>
+    {
+        [Home] = "/",
+    };
+
+    // Titles/subtitles shown in the system UI (if supported)
+    public static readonly IReadOnlyList<AppAction> Declarations =
+    [
+        new(Home, "Home")
+    ];
+
+    public static bool TryGetUrl(string? id, out string url)
+    {
+        if (id is null)
+        {
+            url = string.Empty;
+            return false;
+        }
+        if (IdToUrl.TryGetValue(id, out var found))
+        {
+            url = found;
+            return true;
+        }
+        url = string.Empty;
+        return false;
+    }
+}

--- a/backend/FwLite/FwLiteMaui/build/Linq2DbCctorPatcher/Program.cs
+++ b/backend/FwLite/FwLiteMaui/build/Linq2DbCctorPatcher/Program.cs
@@ -53,6 +53,13 @@ using (var asm = AssemblyDefinition.ReadAssembly(dllPath, new ReaderParameters {
     if (cctor is null || !cctor.HasBody)
         return Fail("SqlTransparentExpression .cctor not found (or has no body).");
 
+    if (cctor.Body.Instructions.Count == 1 && cctor.Body.Instructions[0].OpCode == OpCodes.Ret)
+    {
+        Console.WriteLine($"Already patched (inferred from IL): {dllPath}");
+        File.WriteAllText(markerPath, DateTime.UtcNow.ToString("O"));
+        return 0;
+    }
+
     // Sanity-check the cctor shape: at least one stsfld targeting the _ctor field.
     // If upstream renames _ctor or restructures the field init, we want to know.
     var storesCtorField = cctor.Body.Instructions.Any(ins =>

--- a/frontend/viewer/src/lib/services/service-declaration.ts
+++ b/frontend/viewer/src/lib/services/service-declaration.ts
@@ -11,7 +11,7 @@ declare global {
     Search: { openSearch: (search: string) => void };
     IsDotnetHosted?: boolean;
     // Expose svelte-routing navigate for native hosts (MAUI) and other integrations
-    SvelteNavigate?: (url: string, options?: { replace?: boolean; state?: unknown }) => void;
+    SvelteNavigate?: (url: string, options?: { replace?: boolean }) => void;
     /* eslint-enable @typescript-eslint/naming-convention */
   }
 

--- a/frontend/viewer/src/lib/services/service-declaration.ts
+++ b/frontend/viewer/src/lib/services/service-declaration.ts
@@ -10,6 +10,8 @@ declare global {
     ServiceProvider: LexboxServiceProvider;
     Search: { openSearch: (search: string) => void };
     IsDotnetHosted?: boolean;
+    // Expose svelte-routing navigate for native hosts (MAUI) and other integrations
+    SvelteNavigate?: (url: string, options?: { replace?: boolean; state?: unknown }) => void;
     /* eslint-enable @typescript-eslint/naming-convention */
   }
 

--- a/frontend/viewer/src/main.ts
+++ b/frontend/viewer/src/main.ts
@@ -22,7 +22,7 @@ if (!window.lexbox.IsDotnetHosted) {
 useEventBus();
 
 // Wire up globally-accessible helpers for hosts (e.g., MAUI)
-window.lexbox.SvelteNavigate = (url: string, options?: { replace?: boolean }) =>  navigate(url, options);
+window.lexbox.SvelteNavigate = (url: string, options?: { replace?: boolean }) => navigate(url, options);
 
 //don't mount the app until after we've loaded the local
 void setLanguage('default')

--- a/frontend/viewer/src/main.ts
+++ b/frontend/viewer/src/main.ts
@@ -7,6 +7,7 @@ import '@formatjs/intl-durationformat/polyfill';
 
 import App from './App.svelte';
 import {mount} from 'svelte';
+import {navigate} from 'svelte-routing';
 import {setupDotnetServiceProvider} from './lib/services/service-provider-dotnet';
 import {setupServiceProvider} from '$lib/services/service-provider';
 import {setupBrowserAppServices} from '$lib/services/browser-app-services';
@@ -19,6 +20,9 @@ if (!window.lexbox.IsDotnetHosted) {
   setupBrowserAppServices();
 }
 useEventBus();
+
+// Wire up globally-accessible helpers for hosts (e.g., MAUI)
+window.lexbox.SvelteNavigate = (url: string, options?: { replace?: boolean }) =>  navigate(url, options);
 
 //don't mount the app until after we've loaded the local
 void setLanguage('default')


### PR DESCRIPTION
This adds an android app shortcut to launch the home page. Test different race conditions between starting the app fresh, vs when the app is already running.

<img width="231" height="317" alt="image" src="https://github.com/user-attachments/assets/e072adca-561e-40a4-aaa3-bebb7d589062" />

Share debug log will trigger sharing the logs, this should bypass any bugs with the UI of the app.