### PR TITLE
Use the validation wrapper in MiniLcm API tests

### DIFF
--- a/backend/FwLite/FwLiteProjectSync.Tests/EntrySyncTests.cs
+++ b/backend/FwLite/FwLiteProjectSync.Tests/EntrySyncTests.cs
@@ -6,6 +6,7 @@ using MiniLcm;
 using MiniLcm.Exceptions;
 using MiniLcm.Models;
 using MiniLcm.SyncHelpers;
+using MiniLcm.Tests;
 using MiniLcm.Tests.AutoFakerHelpers;
 using Soenneker.Utils.AutoBogus;
 
@@ -53,7 +54,10 @@ public abstract class EntrySyncTestsBase(ExtraWritingSystemsSyncFixture fixture)
 {
     public Task InitializeAsync()
     {
-        Api = GetApi(_fixture);
+        BaseApi = GetApi(_fixture);
+        // Mirror production sync (CrdtFwdataProjectSyncService): validation only, no normalization,
+        // because the data is already normalized on both sides.
+        Api = TestMiniLcmWrappers.CreateValidationFactory().Create(BaseApi);
         return Task.CompletedTask;
     }
 
@@ -66,6 +70,7 @@ public abstract class EntrySyncTestsBase(ExtraWritingSystemsSyncFixture fixture)
 
     private readonly SyncFixture _fixture = fixture;
     protected IMiniLcmApi Api = null!;
+    protected IMiniLcmApi BaseApi = null!;
 
     private static readonly AutoFaker AutoFaker = new(AutoFakerDefault.MakeConfig(
         ExtraWritingSystemsSyncFixture.VernacularWritingSystems));
@@ -99,12 +104,10 @@ public abstract class EntrySyncTestsBase(ExtraWritingSystemsSyncFixture fixture)
     public async Task CanSyncRandomEntries(ApiType? roundTripApiType)
     {
         // arrange
-        var currentApiType = Api switch
+        var currentApiType = BaseApi switch
         {
             FwDataMiniLcmApi => ApiType.FwData,
             CrdtMiniLcmApi => ApiType.Crdt,
-            // This works now, because we're not currently wrapping Api,
-            // but if we ever do, then we want this to throw, so we know we need to detect the api differently.
             _ => throw new InvalidOperationException("Unknown API type")
         };
 

--- a/backend/FwLite/MiniLcm.Tests/MiniLcm.Tests.csproj
+++ b/backend/FwLite/MiniLcm.Tests/MiniLcm.Tests.csproj
@@ -17,6 +17,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="FluentAssertions" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
     <PackageReference Include="Soenneker.Utils.AutoBogus" />
     <PackageReference Include="System.Linq.Async" />
     <PackageReference Include="Moq" />

--- a/backend/FwLite/MiniLcm.Tests/MiniLcmTestBase.cs
+++ b/backend/FwLite/MiniLcm.Tests/MiniLcmTestBase.cs
@@ -1,6 +1,4 @@
-using MiniLcm.Normalization;
 using MiniLcm.Tests.AutoFakerHelpers;
-using MiniLcm.Wrappers;
 using Soenneker.Utils.AutoBogus;
 
 namespace MiniLcm.Tests;
@@ -17,10 +15,7 @@ public abstract class MiniLcmTestBase : IAsyncLifetime
     {
         BaseApi = await NewApi();
         BaseApi.Should().NotBeNull();
-        Api = BaseApi.WrapWith([
-            new MiniLcmApiQueryNormalizationWrapperFactory(),
-            new MiniLcmApiWriteNormalizationWrapperFactory(),
-        ], null!);
+        Api = TestMiniLcmWrappers.CreateUserFacingWrappers().Apply(BaseApi, null!);
         Api.Should().NotBeNull();
     }
 

--- a/backend/FwLite/MiniLcm.Tests/TestMiniLcmWrappers.cs
+++ b/backend/FwLite/MiniLcm.Tests/TestMiniLcmWrappers.cs
@@ -1,0 +1,37 @@
+using Microsoft.Extensions.DependencyInjection;
+using MiniLcm.Validators;
+using MiniLcm.Wrappers;
+
+namespace MiniLcm.Tests;
+
+/// <summary>
+/// Builds the production MiniLcm wrapper stack via <see cref="MiniLcmValidatorsExtensions.AddMiniLcmValidators"/>,
+/// so tests exercise the same validators and wrapper composition that real API entry points use
+/// (and pick up new registrations automatically). The resolved wrappers hold no provider-scoped state,
+/// so the throwaway provider is disposed immediately.
+/// </summary>
+public static class TestMiniLcmWrappers
+{
+    private static ServiceProvider BuildProvider() =>
+        new ServiceCollection().AddMiniLcmValidators().BuildServiceProvider();
+
+    /// <summary>
+    /// The full user-facing stack (query normalization, validation, write normalization) that real
+    /// API entry points apply via <see cref="MiniLcmApiUserFacingWrappers"/>.
+    /// </summary>
+    public static MiniLcmApiUserFacingWrappers CreateUserFacingWrappers()
+    {
+        using var provider = BuildProvider();
+        return provider.GetRequiredService<MiniLcmApiUserFacingWrappers>();
+    }
+
+    /// <summary>
+    /// The validation-only wrapper that the sync path applies (see <c>CrdtFwdataProjectSyncService</c>),
+    /// which deliberately skips normalization because both sides are already normalized.
+    /// </summary>
+    public static MiniLcmApiValidationWrapperFactory CreateValidationFactory()
+    {
+        using var provider = BuildProvider();
+        return provider.GetRequiredService<MiniLcmApiValidationWrapperFactory>();
+    }
+}

--- a/backend/FwLite/MiniLcm.Tests/UpdateEntryTestsBase.cs
+++ b/backend/FwLite/MiniLcm.Tests/UpdateEntryTestsBase.cs
@@ -84,11 +84,13 @@ public abstract class UpdateEntryTestsBase : MiniLcmTestBase
     [Fact]
     public async Task UpdateEntry_RoundTripsEmptyStrings()
     {
-        var entry = await Api.GetEntry(Entry1Id);
+        // Empty MultiString values are rejected by validation, so this exercises the raw storage layer:
+        // empty values can still reach storage (e.g. via sync) and must round-trip.
+        var entry = await BaseApi.GetEntry(Entry1Id);
         ArgumentNullException.ThrowIfNull(entry);
         var before = entry.Copy();
         entry.CitationForm["en"] = string.Empty;
-        var updatedEntry = await Api.UpdateEntry(before, entry);
+        var updatedEntry = await BaseApi.UpdateEntry(before, entry);
         updatedEntry.CitationForm["en"].Should().Be(string.Empty);
     }
 


### PR DESCRIPTION
Adds the validation wrapper to a bunch of tests. Most notably everything inheriting from `MiniLcmTestBase.cs`.

Not having the validation-wrapper in the stack made testing cases that involved validation (e.g. the new `IsMain` publication stuff) awkward, dissatisfying and messy.

Also, this validation is essentially **part of** our API it's just in a wrapper, so that we can easily apply it to multiple implementations.

And then it just makes sense to have an API stack that more closely resembles prod code.