### PR TITLE
Make the MiniLcm validation wrapper validate writes by construction

### DIFF
--- a/backend/FwLite/FwLiteProjectSync.Tests/EntrySyncTests.cs
+++ b/backend/FwLite/FwLiteProjectSync.Tests/EntrySyncTests.cs
@@ -6,6 +6,7 @@ using MiniLcm;
 using MiniLcm.Exceptions;
 using MiniLcm.Models;
 using MiniLcm.SyncHelpers;
+using MiniLcm.Tests;
 using MiniLcm.Tests.AutoFakerHelpers;
 using Soenneker.Utils.AutoBogus;
 
@@ -53,7 +54,10 @@ public abstract class EntrySyncTestsBase(ExtraWritingSystemsSyncFixture fixture)
 {
     public Task InitializeAsync()
     {
-        Api = GetApi(_fixture);
+        BaseApi = GetApi(_fixture);
+        // Mirror production sync (CrdtFwdataProjectSyncService): validation only, no normalization,
+        // because the data is already normalized on both sides.
+        Api = TestMiniLcmWrappers.CreateValidationFactory().Create(BaseApi);
         return Task.CompletedTask;
     }
 
@@ -66,6 +70,7 @@ public abstract class EntrySyncTestsBase(ExtraWritingSystemsSyncFixture fixture)
 
     private readonly SyncFixture _fixture = fixture;
     protected IMiniLcmApi Api = null!;
+    protected IMiniLcmApi BaseApi = null!;
 
     private static readonly AutoFaker AutoFaker = new(AutoFakerDefault.MakeConfig(
         ExtraWritingSystemsSyncFixture.VernacularWritingSystems));
@@ -99,12 +104,10 @@ public abstract class EntrySyncTestsBase(ExtraWritingSystemsSyncFixture fixture)
     public async Task CanSyncRandomEntries(ApiType? roundTripApiType)
     {
         // arrange
-        var currentApiType = Api switch
+        var currentApiType = BaseApi switch
         {
             FwDataMiniLcmApi => ApiType.FwData,
             CrdtMiniLcmApi => ApiType.Crdt,
-            // This works now, because we're not currently wrapping Api,
-            // but if we ever do, then we want this to throw, so we know we need to detect the api differently.
             _ => throw new InvalidOperationException("Unknown API type")
         };
 

--- a/backend/FwLite/MiniLcm.Tests/MiniLcm.Tests.csproj
+++ b/backend/FwLite/MiniLcm.Tests/MiniLcm.Tests.csproj
@@ -17,6 +17,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="FluentAssertions" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
     <PackageReference Include="Soenneker.Utils.AutoBogus" />
     <PackageReference Include="System.Linq.Async" />
     <PackageReference Include="Moq" />

--- a/backend/FwLite/MiniLcm.Tests/MiniLcmTestBase.cs
+++ b/backend/FwLite/MiniLcm.Tests/MiniLcmTestBase.cs
@@ -1,6 +1,4 @@
-using MiniLcm.Normalization;
 using MiniLcm.Tests.AutoFakerHelpers;
-using MiniLcm.Wrappers;
 using Soenneker.Utils.AutoBogus;
 
 namespace MiniLcm.Tests;
@@ -17,10 +15,7 @@ public abstract class MiniLcmTestBase : IAsyncLifetime
     {
         BaseApi = await NewApi();
         BaseApi.Should().NotBeNull();
-        Api = BaseApi.WrapWith([
-            new MiniLcmApiQueryNormalizationWrapperFactory(),
-            new MiniLcmApiWriteNormalizationWrapperFactory(),
-        ], null!);
+        Api = TestMiniLcmWrappers.CreateUserFacingWrappers().Apply(BaseApi, null!);
         Api.Should().NotBeNull();
     }
 

--- a/backend/FwLite/MiniLcm.Tests/TestMiniLcmWrappers.cs
+++ b/backend/FwLite/MiniLcm.Tests/TestMiniLcmWrappers.cs
@@ -1,0 +1,37 @@
+using Microsoft.Extensions.DependencyInjection;
+using MiniLcm.Validators;
+using MiniLcm.Wrappers;
+
+namespace MiniLcm.Tests;
+
+/// <summary>
+/// Builds the production MiniLcm wrapper stack via <see cref="MiniLcmValidatorsExtensions.AddMiniLcmValidators"/>,
+/// so tests exercise the same validators and wrapper composition that real API entry points use
+/// (and pick up new registrations automatically). The resolved wrappers hold no provider-scoped state,
+/// so the throwaway provider is disposed immediately.
+/// </summary>
+public static class TestMiniLcmWrappers
+{
+    private static ServiceProvider BuildProvider() =>
+        new ServiceCollection().AddMiniLcmValidators().BuildServiceProvider();
+
+    /// <summary>
+    /// The full user-facing stack (query normalization, validation, write normalization) that real
+    /// API entry points apply via <see cref="MiniLcmApiUserFacingWrappers"/>.
+    /// </summary>
+    public static MiniLcmApiUserFacingWrappers CreateUserFacingWrappers()
+    {
+        using var provider = BuildProvider();
+        return provider.GetRequiredService<MiniLcmApiUserFacingWrappers>();
+    }
+
+    /// <summary>
+    /// The validation-only wrapper that the sync path applies (see <c>CrdtFwdataProjectSyncService</c>),
+    /// which deliberately skips normalization because both sides are already normalized.
+    /// </summary>
+    public static MiniLcmApiValidationWrapperFactory CreateValidationFactory()
+    {
+        using var provider = BuildProvider();
+        return provider.GetRequiredService<MiniLcmApiValidationWrapperFactory>();
+    }
+}

--- a/backend/FwLite/MiniLcm.Tests/UpdateEntryTestsBase.cs
+++ b/backend/FwLite/MiniLcm.Tests/UpdateEntryTestsBase.cs
@@ -84,11 +84,13 @@ public abstract class UpdateEntryTestsBase : MiniLcmTestBase
     [Fact]
     public async Task UpdateEntry_RoundTripsEmptyStrings()
     {
-        var entry = await Api.GetEntry(Entry1Id);
+        // Empty MultiString values are rejected by validation, so this exercises the raw storage layer:
+        // empty values can still reach storage (e.g. via sync) and must round-trip.
+        var entry = await BaseApi.GetEntry(Entry1Id);
         ArgumentNullException.ThrowIfNull(entry);
         var before = entry.Copy();
         entry.CitationForm["en"] = string.Empty;
-        var updatedEntry = await Api.UpdateEntry(before, entry);
+        var updatedEntry = await BaseApi.UpdateEntry(before, entry);
         updatedEntry.CitationForm["en"].Should().Be(string.Empty);
     }
 

--- a/backend/FwLite/MiniLcm.Tests/Validators/MiniLcmApiValidationWrapperTests.cs
+++ b/backend/FwLite/MiniLcm.Tests/Validators/MiniLcmApiValidationWrapperTests.cs
@@ -1,0 +1,88 @@
+using FluentValidation;
+using MiniLcm.SyncHelpers;
+using Moq;
+
+namespace MiniLcm.Tests.Validators;
+
+/// <summary>
+/// Tests the validation wrapper's wiring through the IMiniLcmApi interface - the seam that broke in
+/// #2362 - not the validator rules (those have their own unit tests). Two things are worth pinning:
+/// that methods we expect to validate actually do (so a silently-dead override like #2362's is caught),
+/// and that methods which deliberately DON'T validate despite having a validator (CreateEntry,
+/// CreatePublication, CreateMorphType) keep passing through - so a well-meaning "fix" that turns
+/// validation on, and breaks sync of empty FLEx values, trips a red test instead.
+/// </summary>
+public class MiniLcmApiValidationWrapperTests
+{
+    private readonly Mock<IMiniLcmApi> _inner = new();
+    private readonly IMiniLcmApi _api;
+
+    public MiniLcmApiValidationWrapperTests()
+    {
+        _api = TestMiniLcmWrappers.CreateValidationFactory().Create(_inner.Object);
+    }
+
+    private static Entry ValidEntry() => new() { Id = Guid.NewGuid(), LexemeForm = new() { { "en", "lexeme" } } };
+
+    // An entry the EntryValidator rejects: a MultiString that carries an empty value (NoEmptyValues).
+    // This is the shape that routinely arrives from FLEx during sync/import.
+    private static Entry EntryWithEmptyValue() => new()
+    {
+        Id = Guid.NewGuid(),
+        LexemeForm = new() { { "en", "lexeme" } },
+        CitationForm = new() { { "en", "" } },
+    };
+
+    [Fact]
+    public async Task UpdateEntry_BeforeAfter_ValidatesTheUpdatedEntry()
+    {
+        var act = () => _api.UpdateEntry(ValidEntry(), EntryWithEmptyValue());
+
+        await act.Should().ThrowAsync<ValidationException>();
+        _inner.Verify(a => a.UpdateEntry(It.IsAny<Entry>(), It.IsAny<Entry>(), It.IsAny<IMiniLcmApi?>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task CreateSense_ValidatesTheSense()
+    {
+        var sense = new Sense { Id = Guid.NewGuid(), Gloss = new() { { "en", "" } } };
+
+        var act = () => _api.CreateSense(Guid.NewGuid(), sense);
+
+        await act.Should().ThrowAsync<ValidationException>();
+        _inner.Verify(a => a.CreateSense(It.IsAny<Guid>(), It.IsAny<Sense>(), It.IsAny<BetweenPosition?>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task CreateEntry_DoesNotValidate_SoEmptyFlexValuesReachStorage()
+    {
+        var entry = EntryWithEmptyValue();
+
+        var act = () => _api.CreateEntry(entry);
+
+        await act.Should().NotThrowAsync();
+        _inner.Verify(a => a.CreateEntry(entry, It.IsAny<CreateEntryOptions?>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task CreatePublication_DoesNotValidate()
+    {
+        var publication = new Publication { Id = Guid.NewGuid(), Name = new() { { "en", "" } } };
+
+        var act = () => _api.CreatePublication(publication);
+
+        await act.Should().NotThrowAsync();
+        _inner.Verify(a => a.CreatePublication(publication), Times.Once);
+    }
+
+    [Fact]
+    public async Task CreateMorphType_DoesNotValidate()
+    {
+        var morphType = new MorphType { Id = Guid.NewGuid(), Kind = MorphTypeKind.Unknown, Name = new() { { "en", "" } } };
+
+        var act = () => _api.CreateMorphType(morphType);
+
+        await act.Should().NotThrowAsync();
+        _inner.Verify(a => a.CreateMorphType(morphType), Times.Once);
+    }
+}

--- a/backend/FwLite/MiniLcm/Validators/MiniLcmApiValidationWrapper.cs
+++ b/backend/FwLite/MiniLcm/Validators/MiniLcmApiValidationWrapper.cs
@@ -1,4 +1,5 @@
 using MiniLcm;
+using MiniLcm.Media;
 using MiniLcm.Models;
 using MiniLcm.SyncHelpers;
 using MiniLcm.Wrappers;
@@ -15,14 +16,29 @@ public class MiniLcmApiValidationWrapperFactory(MiniLcmValidators validators) : 
     }
 }
 
+/// <summary>
+/// Validates models on write before forwarding to the inner API.
+///
+/// Reads are auto-forwarded via BeaKona.AutoInterface. Writes are hand-written so that adding
+/// an IMiniLcmWriteApi method without choosing how it validates is a compile error rather than
+/// a silent unvalidated forward - which is how CreateEntry drifted out of validation (#2362).
+///
+/// CreateEntry, CreatePublication, CreateMorphType and all JsonPatch-based updates deliberately
+/// pass through unvalidated: sync/import wraps the api in this validator and writes empty
+/// MultiStrings from FLEx that those validators would reject, so validating here breaks import.
+/// </summary>
 public partial class MiniLcmApiValidationWrapper(
     IMiniLcmApi api,
     MiniLcmValidators validators) : IMiniLcmApi
 {
-    [BeaKona.AutoInterface(IncludeBaseInterfaces = true, MemberMatch = BeaKona.MemberMatchTypes.Any)]
     private readonly IMiniLcmApi _api = api;
 
-    // ********** Overrides go here **********
+    // BeaKona.AutoInterface only forwards IMiniLcmReadApi methods. IMiniLcmWriteApi methods are
+    // NOT auto-forwarded, ensuring every write method is hand-written below (see class summary).
+    [BeaKona.AutoInterface]
+    private IMiniLcmReadApi ReadApi => _api;
+
+    #region WritingSystem
 
     public async Task<WritingSystem> CreateWritingSystem(WritingSystem writingSystem, BetweenPosition<WritingSystemId?>? between = null)
     {
@@ -42,22 +58,74 @@ public partial class MiniLcmApiValidationWrapper(
         return await _api.UpdateWritingSystem(before, after, api ?? this);
     }
 
+    public Task MoveWritingSystem(WritingSystemId id, WritingSystemType type, BetweenPosition<WritingSystemId?> between)
+    {
+        return _api.MoveWritingSystem(id, type, between);
+    }
+
+    #endregion
+
+    #region PartOfSpeech
+
     public async Task<PartOfSpeech> CreatePartOfSpeech(PartOfSpeech partOfSpeech)
     {
         await validators.ValidateAndThrow(partOfSpeech);
         return await _api.CreatePartOfSpeech(partOfSpeech);
     }
 
-    public async Task<PartOfSpeech> UpdatePartOfSpeech(PartOfSpeech before, PartOfSpeech after, IMiniLcmApi? api)
+    public Task<PartOfSpeech> UpdatePartOfSpeech(Guid id, UpdateObjectInput<PartOfSpeech> update)
+    {
+        return _api.UpdatePartOfSpeech(id, update);
+    }
+
+    public async Task<PartOfSpeech> UpdatePartOfSpeech(PartOfSpeech before, PartOfSpeech after, IMiniLcmApi? api = null)
     {
         await validators.ValidateAndThrow(after);
         return await _api.UpdatePartOfSpeech(before, after, api ?? this);
     }
 
+    public Task DeletePartOfSpeech(Guid id)
+    {
+        return _api.DeletePartOfSpeech(id);
+    }
+
+    #endregion
+
+    #region Publication
+
+    public Task<Publication> CreatePublication(Publication pub)
+    {
+        return _api.CreatePublication(pub);
+    }
+
+    public Task<Publication> UpdatePublication(Guid id, UpdateObjectInput<Publication> update)
+    {
+        return _api.UpdatePublication(id, update);
+    }
+
+    public Task<Publication> UpdatePublication(Publication before, Publication after, IMiniLcmApi? api = null)
+    {
+        return _api.UpdatePublication(before, after, api);
+    }
+
+    public Task DeletePublication(Guid id)
+    {
+        return _api.DeletePublication(id);
+    }
+
+    #endregion
+
+    #region SemanticDomain
+
     public async Task<SemanticDomain> CreateSemanticDomain(SemanticDomain semanticDomain)
     {
         await validators.ValidateAndThrow(semanticDomain);
         return await _api.CreateSemanticDomain(semanticDomain);
+    }
+
+    public Task<SemanticDomain> UpdateSemanticDomain(Guid id, UpdateObjectInput<SemanticDomain> update)
+    {
+        return _api.UpdateSemanticDomain(id, update);
     }
 
     public async Task<SemanticDomain> UpdateSemanticDomain(SemanticDomain before, SemanticDomain after, IMiniLcmApi? api = null)
@@ -66,16 +134,44 @@ public partial class MiniLcmApiValidationWrapper(
         return await _api.UpdateSemanticDomain(before, after, api ?? this);
     }
 
+    public Task DeleteSemanticDomain(Guid id)
+    {
+        return _api.DeleteSemanticDomain(id);
+    }
+
+    #endregion
+
+    #region ComplexFormType
+
     public async Task<ComplexFormType> CreateComplexFormType(ComplexFormType complexFormType)
     {
         await validators.ValidateAndThrow(complexFormType);
         return await _api.CreateComplexFormType(complexFormType);
     }
 
+    public Task<ComplexFormType> UpdateComplexFormType(Guid id, UpdateObjectInput<ComplexFormType> update)
+    {
+        return _api.UpdateComplexFormType(id, update);
+    }
+
     public async Task<ComplexFormType> UpdateComplexFormType(ComplexFormType before, ComplexFormType after, IMiniLcmApi? api = null)
     {
         await validators.ValidateAndThrow(after);
         return await _api.UpdateComplexFormType(before, after, api ?? this);
+    }
+
+    public Task DeleteComplexFormType(Guid id)
+    {
+        return _api.DeleteComplexFormType(id);
+    }
+
+    #endregion
+
+    #region MorphType
+
+    public Task<MorphType> CreateMorphType(MorphType morphType)
+    {
+        return _api.CreateMorphType(morphType);
     }
 
     public async Task<MorphType> UpdateMorphType(Guid id, UpdateObjectInput<MorphType> update)
@@ -90,10 +186,18 @@ public partial class MiniLcmApiValidationWrapper(
         return await _api.UpdateMorphType(before, after, api ?? this);
     }
 
-    public async Task<Entry> CreateEntry(Entry entry)
+    #endregion
+
+    #region Entry
+
+    public Task<Entry> CreateEntry(Entry entry, CreateEntryOptions? options = null)
     {
-        await validators.ValidateAndThrow(entry);
-        return await _api.CreateEntry(entry);
+        return _api.CreateEntry(entry, options);
+    }
+
+    public Task<Entry> UpdateEntry(Guid id, UpdateObjectInput<Entry> update)
+    {
+        return _api.UpdateEntry(id, update);
     }
 
     public async Task<Entry> UpdateEntry(Entry before, Entry after, IMiniLcmApi? api = null)
@@ -102,10 +206,59 @@ public partial class MiniLcmApiValidationWrapper(
         return await _api.UpdateEntry(before, after, api ?? this);
     }
 
+    public Task DeleteEntry(Guid id)
+    {
+        return _api.DeleteEntry(id);
+    }
+
+    public Task<ComplexFormComponent> CreateComplexFormComponent(ComplexFormComponent complexFormComponent, BetweenPosition<ComplexFormComponent>? position = null)
+    {
+        return _api.CreateComplexFormComponent(complexFormComponent, position);
+    }
+
+    public Task MoveComplexFormComponent(ComplexFormComponent complexFormComponent, BetweenPosition<ComplexFormComponent> between)
+    {
+        return _api.MoveComplexFormComponent(complexFormComponent, between);
+    }
+
+    public Task DeleteComplexFormComponent(ComplexFormComponent complexFormComponent)
+    {
+        return _api.DeleteComplexFormComponent(complexFormComponent);
+    }
+
+    public Task AddComplexFormType(Guid entryId, Guid complexFormTypeId)
+    {
+        return _api.AddComplexFormType(entryId, complexFormTypeId);
+    }
+
+    public Task RemoveComplexFormType(Guid entryId, Guid complexFormTypeId)
+    {
+        return _api.RemoveComplexFormType(entryId, complexFormTypeId);
+    }
+
+    public Task AddPublication(Guid entryId, Guid publicationId)
+    {
+        return _api.AddPublication(entryId, publicationId);
+    }
+
+    public Task RemovePublication(Guid entryId, Guid publicationId)
+    {
+        return _api.RemovePublication(entryId, publicationId);
+    }
+
+    #endregion
+
+    #region Sense
+
     public async Task<Sense> CreateSense(Guid entryId, Sense sense, BetweenPosition? between = null)
     {
         await validators.ValidateAndThrow(sense);
         return await _api.CreateSense(entryId, sense, between);
+    }
+
+    public Task<Sense> UpdateSense(Guid entryId, Guid senseId, UpdateObjectInput<Sense> update)
+    {
+        return _api.UpdateSense(entryId, senseId, update);
     }
 
     public async Task<Sense> UpdateSense(Guid entryId, Sense before, Sense after, IMiniLcmApi? api = null)
@@ -114,6 +267,35 @@ public partial class MiniLcmApiValidationWrapper(
         return await _api.UpdateSense(entryId, before, after, api ?? this);
     }
 
+    public Task MoveSense(Guid entryId, Guid senseId, BetweenPosition between)
+    {
+        return _api.MoveSense(entryId, senseId, between);
+    }
+
+    public Task DeleteSense(Guid entryId, Guid senseId)
+    {
+        return _api.DeleteSense(entryId, senseId);
+    }
+
+    public Task AddSemanticDomainToSense(Guid senseId, SemanticDomain semanticDomain)
+    {
+        return _api.AddSemanticDomainToSense(senseId, semanticDomain);
+    }
+
+    public Task RemoveSemanticDomainFromSense(Guid senseId, Guid semanticDomainId)
+    {
+        return _api.RemoveSemanticDomainFromSense(senseId, semanticDomainId);
+    }
+
+    public Task SetSensePartOfSpeech(Guid senseId, Guid? partOfSpeechId)
+    {
+        return _api.SetSensePartOfSpeech(senseId, partOfSpeechId);
+    }
+
+    #endregion
+
+    #region ExampleSentence
+
     public async Task<ExampleSentence> CreateExampleSentence(Guid entryId,
         Guid senseId,
         ExampleSentence exampleSentence,
@@ -121,6 +303,14 @@ public partial class MiniLcmApiValidationWrapper(
     {
         await validators.ValidateAndThrow(exampleSentence);
         return await _api.CreateExampleSentence(entryId, senseId, exampleSentence, between);
+    }
+
+    public Task<ExampleSentence> UpdateExampleSentence(Guid entryId,
+        Guid senseId,
+        Guid exampleSentenceId,
+        UpdateObjectInput<ExampleSentence> update)
+    {
+        return _api.UpdateExampleSentence(entryId, senseId, exampleSentenceId, update);
     }
 
     public async Task<ExampleSentence> UpdateExampleSentence(Guid entryId,
@@ -132,6 +322,71 @@ public partial class MiniLcmApiValidationWrapper(
         await validators.ValidateAndThrow(after);
         return await _api.UpdateExampleSentence(entryId, senseId, before, after, api ?? this);
     }
+
+    public Task MoveExampleSentence(Guid entryId, Guid senseId, Guid exampleSentenceId, BetweenPosition between)
+    {
+        return _api.MoveExampleSentence(entryId, senseId, exampleSentenceId, between);
+    }
+
+    public Task DeleteExampleSentence(Guid entryId, Guid senseId, Guid exampleSentenceId)
+    {
+        return _api.DeleteExampleSentence(entryId, senseId, exampleSentenceId);
+    }
+
+    public Task AddTranslation(Guid entryId, Guid senseId, Guid exampleSentenceId, Translation translation)
+    {
+        return _api.AddTranslation(entryId, senseId, exampleSentenceId, translation);
+    }
+
+    public Task RemoveTranslation(Guid entryId, Guid senseId, Guid exampleSentenceId, Guid translationId)
+    {
+        return _api.RemoveTranslation(entryId, senseId, exampleSentenceId, translationId);
+    }
+
+    public Task UpdateTranslation(Guid entryId, Guid senseId, Guid exampleSentenceId, Guid translationId, UpdateObjectInput<Translation> update)
+    {
+        return _api.UpdateTranslation(entryId, senseId, exampleSentenceId, translationId, update);
+    }
+
+    #endregion
+
+    #region CustomView
+
+    public Task<CustomView> CreateCustomView(CustomView customView)
+    {
+        return _api.CreateCustomView(customView);
+    }
+
+    public Task<CustomView> UpdateCustomView(CustomView customView)
+    {
+        return _api.UpdateCustomView(customView);
+    }
+
+    public Task DeleteCustomView(Guid id)
+    {
+        return _api.DeleteCustomView(id);
+    }
+
+    #endregion
+
+    #region Bulk and Files
+
+    public Task BulkImportSemanticDomains(IAsyncEnumerable<SemanticDomain> semanticDomains)
+    {
+        return _api.BulkImportSemanticDomains(semanticDomains);
+    }
+
+    public Task BulkCreateEntries(IAsyncEnumerable<Entry> entries)
+    {
+        return _api.BulkCreateEntries(entries);
+    }
+
+    public Task<UploadFileResponse> SaveFile(Stream stream, LcmFileMetadata metadata)
+    {
+        return _api.SaveFile(stream, metadata);
+    }
+
+    #endregion
 
     void IDisposable.Dispose()
     {

--- a/backend/FwLite/MiniLcm/Validators/MiniLcmApiValidationWrapper.cs
+++ b/backend/FwLite/MiniLcm/Validators/MiniLcmApiValidationWrapper.cs
@@ -23,9 +23,10 @@ public class MiniLcmApiValidationWrapperFactory(MiniLcmValidators validators) : 
 /// an IMiniLcmWriteApi method without choosing how it validates is a compile error rather than
 /// a silent unvalidated forward - which is how CreateEntry drifted out of validation (#2362).
 ///
-/// CreateEntry, CreatePublication, CreateMorphType and all JsonPatch-based updates deliberately
-/// pass through unvalidated: sync/import wraps the api in this validator and writes empty
-/// MultiStrings from FLEx that those validators would reject, so validating here breaks import.
+/// Not every write validates. CreateEntry, CreateMorphType and all JsonPatch-based updates pass
+/// through because sync/import wraps the api here and writes empty FLEx MultiStrings the validators
+/// would reject - validating would break import. Publication writes pass through across the board
+/// (a deferred gap), so UpdatePublication is the one before/after update that doesn't validate (#2362).
 /// </summary>
 public partial class MiniLcmApiValidationWrapper(
     IMiniLcmApi api,
@@ -105,7 +106,7 @@ public partial class MiniLcmApiValidationWrapper(
 
     public Task<Publication> UpdatePublication(Publication before, Publication after, IMiniLcmApi? api = null)
     {
-        return _api.UpdatePublication(before, after, api);
+        return _api.UpdatePublication(before, after, api ?? this);
     }
 
     public Task DeletePublication(Guid id)


### PR DESCRIPTION
Fixes #2362. Companion to the open decision in #2359.

The validation wrapper let BeaKona auto-forward the whole `IMiniLcmApi`, so any write without a hand-written override forwarded straight through unvalidated. That's how `CreateEntry` quietly stopped validating — its override was `CreateEntry(Entry)` but the interface had grown a `CreateEntryOptions?` parameter, so callers bound to the generated 2-arg forwarder and skipped it.

This does what the write-normalization wrapper already does: BeaKona forwards only the *read* interface, and every *write* is hand-written — so a new or renamed write won't compile until someone decides how it validates, instead of silently slipping through. Plus wrapper tests that exercise the seam through `IMiniLcmApi` (reusing #2360's `TestMiniLcmWrappers`).

**This PR preserves current behavior** — same methods validate, same ones pass through. `CreateEntry`, `CreatePublication`, `CreateMorphType` and the JsonPatch updates stay pass-through on purpose: sync/import wraps the API here and writes empty FLEx MultiStrings the validators reject, so validating would break import. Whether we *should* change that (actually validate user-facing creates) is tracked separately in **#2359**.

Stacked on #2360, so the diff includes its commits until that merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
