### PR TITLE
Tolerate objects deleted in CRDT during FwData sync

### DIFF
--- a/backend/FwLite/FwLiteProjectSync.Tests/EntrySyncTests.cs
+++ b/backend/FwLite/FwLiteProjectSync.Tests/EntrySyncTests.cs
@@ -6,6 +6,7 @@ using MiniLcm;
 using MiniLcm.Exceptions;
 using MiniLcm.Models;
 using MiniLcm.SyncHelpers;
+using MiniLcm.Tests;
 using MiniLcm.Tests.AutoFakerHelpers;
 using Soenneker.Utils.AutoBogus;
 
@@ -53,7 +54,10 @@ public abstract class EntrySyncTestsBase(ExtraWritingSystemsSyncFixture fixture)
 {
     public Task InitializeAsync()
     {
-        Api = GetApi(_fixture);
+        BaseApi = GetApi(_fixture);
+        // Mirror production sync (CrdtFwdataProjectSyncService): validation only, no normalization,
+        // because the data is already normalized on both sides.
+        Api = TestMiniLcmWrappers.CreateValidationFactory().Create(BaseApi);
         return Task.CompletedTask;
     }
 
@@ -66,6 +70,7 @@ public abstract class EntrySyncTestsBase(ExtraWritingSystemsSyncFixture fixture)
 
     private readonly SyncFixture _fixture = fixture;
     protected IMiniLcmApi Api = null!;
+    protected IMiniLcmApi BaseApi = null!;
 
     private static readonly AutoFaker AutoFaker = new(AutoFakerDefault.MakeConfig(
         ExtraWritingSystemsSyncFixture.VernacularWritingSystems));
@@ -99,12 +104,10 @@ public abstract class EntrySyncTestsBase(ExtraWritingSystemsSyncFixture fixture)
     public async Task CanSyncRandomEntries(ApiType? roundTripApiType)
     {
         // arrange
-        var currentApiType = Api switch
+        var currentApiType = BaseApi switch
         {
             FwDataMiniLcmApi => ApiType.FwData,
             CrdtMiniLcmApi => ApiType.Crdt,
-            // This works now, because we're not currently wrapping Api,
-            // but if we ever do, then we want this to throw, so we know we need to detect the api differently.
             _ => throw new InvalidOperationException("Unknown API type")
         };
 

--- a/backend/FwLite/FwLiteProjectSync.Tests/IgnoreNotFoundMiniLcmApiTests.cs
+++ b/backend/FwLite/FwLiteProjectSync.Tests/IgnoreNotFoundMiniLcmApiTests.cs
@@ -1,0 +1,81 @@
+using FwLiteProjectSync.Tests.Fixtures;
+using LcmCrdt;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging.Abstractions;
+using MiniLcm;
+using MiniLcm.Exceptions;
+using MiniLcm.Models;
+
+namespace FwLiteProjectSync.Tests;
+
+/// <summary>
+/// Lighter-weight coverage for <see cref="IgnoreNotFoundMiniLcmApi"/>: drive the CRDT API directly (no FwData,
+/// no full sync), delete a parent/reference, then assert the raw API throws <see cref="NotFoundException"/>
+/// while the wrapper tolerates it. The end-to-end behaviour through a real sync lives in
+/// <c>SyncTests.EntryEditedInFwDataButDeletedInCrdt_SyncDoesNotThrow</c>; this class is where new
+/// deleted-reference scenarios should be added.
+/// </summary>
+public class IgnoreNotFoundMiniLcmApiTests : IClassFixture<SyncFixture>, IAsyncLifetime
+{
+    private readonly SyncFixture _fixture;
+    private CrdtMiniLcmApi _crdt = null!;
+    private IgnoreNotFoundMiniLcmApi _wrapped = null!;
+
+    public IgnoreNotFoundMiniLcmApiTests(SyncFixture fixture) => _fixture = fixture;
+
+    public async Task InitializeAsync()
+    {
+        _crdt = _fixture.CrdtApi;
+        _wrapped = new IgnoreNotFoundMiniLcmApi(_crdt, NullLogger.Instance);
+        // A vernacular writing system is required to create/query entries.
+        if ((await _crdt.GetWritingSystems()).Vernacular.Length == 0)
+            await _crdt.CreateWritingSystem(new WritingSystem { Id = Guid.NewGuid(), Type = WritingSystemType.Vernacular, WsId = "en", Name = "English", Abbreviation = "en", Font = "Arial" });
+    }
+
+    public async Task DisposeAsync()
+    {
+        foreach (var entry in await _crdt.GetAllEntries().ToArrayAsync())
+            await _crdt.DeleteEntry(entry.Id);
+    }
+
+    private Task<Entry> CreateEntry(string headword) =>
+        _crdt.CreateEntry(new Entry { Id = Guid.NewGuid(), LexemeForm = { { "en", headword } } });
+
+    [Fact]
+    [Trait("Category", "Integration")]
+    public async Task UpdateEntry_OnEntryDeletedInCrdt()
+    {
+        var entry = await CreateEntry("victim");
+        await _crdt.DeleteEntry(entry.Id);
+        UpdateObjectInput<Entry> Patch() => new UpdateObjectInput<Entry>().Set(e => e.CitationForm["en"], "x");
+
+        await ((Func<Task>)(() => _crdt.UpdateEntry(entry.Id, Patch()))).Should().ThrowAsync<NotFoundException>();
+        await ((Func<Task>)(() => _wrapped.UpdateEntry(entry.Id, Patch()))).Should().NotThrowAsync();
+        _wrapped.IgnoredWriteCount.Should().Be(1);
+    }
+
+    [Fact]
+    [Trait("Category", "Integration")]
+    public async Task CreateSense_OnEntryDeletedInCrdt()
+    {
+        var entry = await CreateEntry("victim");
+        await _crdt.DeleteEntry(entry.Id);
+        Sense NewSense() => new() { Id = Guid.NewGuid(), Gloss = { { "en", "gloss" } } };
+
+        await ((Func<Task>)(() => _crdt.CreateSense(entry.Id, NewSense()))).Should().ThrowAsync<NotFoundException>();
+        await ((Func<Task>)(() => _wrapped.CreateSense(entry.Id, NewSense()))).Should().NotThrowAsync();
+    }
+
+    [Fact]
+    [Trait("Category", "Integration")]
+    public async Task CreateComplexFormComponent_ReferencingEntryDeletedInCrdt()
+    {
+        var component = await CreateEntry("component");
+        var complexForm = await CreateEntry("complexForm");
+        await _crdt.DeleteEntry(component.Id);
+        ComplexFormComponent Link() => ComplexFormComponent.FromEntries(complexForm, component);
+
+        await ((Func<Task>)(() => _crdt.CreateComplexFormComponent(Link()))).Should().ThrowAsync<NotFoundException>();
+        await ((Func<Task>)(() => _wrapped.CreateComplexFormComponent(Link()))).Should().NotThrowAsync();
+    }
+}

--- a/backend/FwLite/FwLiteProjectSync.Tests/SyncTests.cs
+++ b/backend/FwLite/FwLiteProjectSync.Tests/SyncTests.cs
@@ -580,6 +580,9 @@ public class SyncTests : IClassFixture<SyncFixture>, IAsyncLifetime
         (await fwdataApi.GetEntry(newEntryId)).Should().NotBeNull();
     }
 
+    // End-to-end proof that a delete-in-CRDT / edit-in-FwData conflict no longer crashes the sync (issue #2361).
+    // The per-write NotFound tolerance is covered more exhaustively, and without a full sync, in
+    // IgnoreNotFoundMiniLcmApiTests.
     [Fact]
     [Trait("Category", "Integration")]
     public async Task EntryEditedInFwDataButDeletedInCrdt_SyncDoesNotThrow()
@@ -593,29 +596,8 @@ public class SyncTests : IClassFixture<SyncFixture>, IAsyncLifetime
         await fwdataApi.UpdateEntry(_testEntry.Id, new UpdateObjectInput<Entry>().Set(e => e.CitationForm["en"], "edited"));
         await crdtApi.DeleteEntry(_testEntry.Id);
 
-        // The snapshot->CRDT diff treats the entry as modified and calls UpdateEntry on the CRDT,
-        // but it was deleted there. The CRDT deletion should win; the sync must not throw.
-        await _syncService.Sync(crdtApi, fwdataApi, projectSnapshot);
-
-        (await crdtApi.GetEntry(_testEntry.Id)).Should().BeNull();
-        (await fwdataApi.GetEntry(_testEntry.Id)).Should().BeNull();
-    }
-
-    [Fact]
-    [Trait("Category", "Integration")]
-    public async Task SenseAddedInFwDataButEntryDeletedInCrdt_SyncDoesNotThrow()
-    {
-        var crdtApi = _fixture.CrdtApi;
-        var fwdataApi = _fixture.FwDataApi;
-        await _syncService.Import(crdtApi, fwdataApi);
-        var projectSnapshot = await _fixture.RegenerateAndGetSnapshot();
-
-        // FwData adds a sense (a child create, not an entry-field change), CRDT deletes the entry.
-        await fwdataApi.CreateSense(_testEntry.Id, new Sense { Gloss = { { "en", "fruit" } } });
-        await crdtApi.DeleteEntry(_testEntry.Id);
-
-        // No entry field changed, so UpdateEntry isn't called — instead the new sense drives CreateSense
-        // on the deleted entry, which 404s. The wrapper must tolerate writes beyond just Update*.
+        // The snapshot->CRDT diff treats the entry as modified and calls UpdateEntry on the CRDT, but it was
+        // deleted there. The CRDT deletion should win; the sync must not throw, and the deletion propagates.
         await _syncService.Sync(crdtApi, fwdataApi, projectSnapshot);
 
         (await crdtApi.GetEntry(_testEntry.Id)).Should().BeNull();

--- a/backend/FwLite/FwLiteProjectSync.Tests/SyncTests.cs
+++ b/backend/FwLite/FwLiteProjectSync.Tests/SyncTests.cs
@@ -566,9 +566,60 @@ public class SyncTests : IClassFixture<SyncFixture>, IAsyncLifetime
             ]
         });
 
-        //sync may fail because it will try to create a complex form for an entry which was deleted
+        // Sync tries to create a complex-form component referencing the entry that was deleted in the CRDT.
+        // The IgnoreNotFoundMiniLcmApi wrapper tolerates the resulting NotFound instead of failing the sync.
         await _syncService.Sync(crdtApi, fwdataApi, projectSnapshot);
 
+        // The CRDT deletion wins: the deleted entry stays gone (and propagates to FwData), while the new
+        // complex form syncs in without the dangling component to the deleted entry.
+        (await crdtApi.GetEntry(_testEntry.Id)).Should().BeNull();
+        (await fwdataApi.GetEntry(_testEntry.Id)).Should().BeNull();
+        var crdtComplexForm = await crdtApi.GetEntry(newEntryId);
+        crdtComplexForm.Should().NotBeNull();
+        crdtComplexForm.Components.Should().BeEmpty();
+        (await fwdataApi.GetEntry(newEntryId)).Should().NotBeNull();
+    }
+
+    [Fact]
+    [Trait("Category", "Integration")]
+    public async Task EntryEditedInFwDataButDeletedInCrdt_SyncDoesNotThrow()
+    {
+        var crdtApi = _fixture.CrdtApi;
+        var fwdataApi = _fixture.FwDataApi;
+        await _syncService.Import(crdtApi, fwdataApi);
+        var projectSnapshot = await _fixture.RegenerateAndGetSnapshot();
+
+        // FwData edits the entry (so snapshot != fwdata), CRDT deletes the same entry.
+        await fwdataApi.UpdateEntry(_testEntry.Id, new UpdateObjectInput<Entry>().Set(e => e.CitationForm["en"], "edited"));
+        await crdtApi.DeleteEntry(_testEntry.Id);
+
+        // The snapshot->CRDT diff treats the entry as modified and calls UpdateEntry on the CRDT,
+        // but it was deleted there. The CRDT deletion should win; the sync must not throw.
+        await _syncService.Sync(crdtApi, fwdataApi, projectSnapshot);
+
+        (await crdtApi.GetEntry(_testEntry.Id)).Should().BeNull();
+        (await fwdataApi.GetEntry(_testEntry.Id)).Should().BeNull();
+    }
+
+    [Fact]
+    [Trait("Category", "Integration")]
+    public async Task SenseAddedInFwDataButEntryDeletedInCrdt_SyncDoesNotThrow()
+    {
+        var crdtApi = _fixture.CrdtApi;
+        var fwdataApi = _fixture.FwDataApi;
+        await _syncService.Import(crdtApi, fwdataApi);
+        var projectSnapshot = await _fixture.RegenerateAndGetSnapshot();
+
+        // FwData adds a sense (a child create, not an entry-field change), CRDT deletes the entry.
+        await fwdataApi.CreateSense(_testEntry.Id, new Sense { Gloss = { { "en", "fruit" } } });
+        await crdtApi.DeleteEntry(_testEntry.Id);
+
+        // No entry field changed, so UpdateEntry isn't called — instead the new sense drives CreateSense
+        // on the deleted entry, which 404s. The wrapper must tolerate writes beyond just Update*.
+        await _syncService.Sync(crdtApi, fwdataApi, projectSnapshot);
+
+        (await crdtApi.GetEntry(_testEntry.Id)).Should().BeNull();
+        (await fwdataApi.GetEntry(_testEntry.Id)).Should().BeNull();
     }
 
     [Fact]

--- a/backend/FwLite/FwLiteProjectSync/CrdtFwdataProjectSyncService.cs
+++ b/backend/FwLite/FwLiteProjectSync/CrdtFwdataProjectSyncService.cs
@@ -69,9 +69,15 @@ public class CrdtFwdataProjectSyncService(MiniLcmImport miniLcmImport,
 
         // An object deleted in the CRDT but still edited/referenced from FwData (since the last sync) makes
         // the diff try to write to an object that no longer exists in the CRDT. Tolerate the resulting
-        // NotFound; the reverse diff then propagates the deletion to FwData. Scoped to the CRDT side: that's
-        // the direction issue #2361 reported, and the symmetric FwData-deleted case is far rarer.
-        crdtApi = ignoreNotFoundWrapperFactory.Create(crdtApi);
+        // NotFound; the reverse diff then propagates the deletion to FwData. Scoped to the CRDT side (that's
+        // the direction issue #2361 reported), and to sync only: a fresh import has no deletion races, so a
+        // NotFound there is a real bug that must surface, not be swallowed.
+        IgnoreNotFoundMiniLcmApi? ignoreNotFound = null;
+        if (projectSnapshot is not null)
+        {
+            ignoreNotFound = ignoreNotFoundWrapperFactory.Create(crdtApi);
+            crdtApi = ignoreNotFound;
+        }
 
         if (dryRun)
         {
@@ -100,6 +106,9 @@ public class CrdtFwdataProjectSyncService(MiniLcmImport miniLcmImport,
         var syncResult = projectSnapshot is null
             ? await ImportInternal(crdtApi, fwdataApi, fwdata.EntryCount)
             : await SyncInternal(crdtApi, fwdataApi, projectSnapshot);
+
+        if (ignoreNotFound is { IgnoredWriteCount: > 0 })
+            logger.LogInformation("Sync ignored {Count} write(s) to objects deleted in the CRDT", ignoreNotFound.IgnoredWriteCount);
 
         if (!dryRun)
         {

--- a/backend/FwLite/FwLiteProjectSync/CrdtFwdataProjectSyncService.cs
+++ b/backend/FwLite/FwLiteProjectSync/CrdtFwdataProjectSyncService.cs
@@ -11,7 +11,8 @@ namespace FwLiteProjectSync;
 
 public class CrdtFwdataProjectSyncService(MiniLcmImport miniLcmImport,
     ILogger<CrdtFwdataProjectSyncService> logger,
-    MiniLcmApiValidationWrapperFactory validationWrapperFactory)
+    MiniLcmApiValidationWrapperFactory validationWrapperFactory,
+    IgnoreNotFoundMiniLcmApiFactory ignoreNotFoundWrapperFactory)
 {
     public record DryRunSyncResult(
         int CrdtChanges,
@@ -65,6 +66,12 @@ public class CrdtFwdataProjectSyncService(MiniLcmImport miniLcmImport,
         // No query normalization: The sync doesn't do any querying.
         crdtApi = validationWrapperFactory.Create(crdtApi);
         fwdataApi = validationWrapperFactory.Create(fwdataApi);
+
+        // An object deleted in the CRDT but still edited/referenced from FwData (since the last sync) makes
+        // the diff try to write to an object that no longer exists in the CRDT. Tolerate the resulting
+        // NotFound; the reverse diff then propagates the deletion to FwData. Scoped to the CRDT side: that's
+        // the direction issue #2361 reported, and the symmetric FwData-deleted case is far rarer.
+        crdtApi = ignoreNotFoundWrapperFactory.Create(crdtApi);
 
         if (dryRun)
         {

--- a/backend/FwLite/FwLiteProjectSync/FwLiteProjectSyncKernel.cs
+++ b/backend/FwLite/FwLiteProjectSync/FwLiteProjectSyncKernel.cs
@@ -8,6 +8,7 @@ public static class FwLiteProjectSyncKernel
     public static IServiceCollection AddFwLiteProjectSync(this IServiceCollection services)
     {
         services.AddScoped<CrdtFwdataProjectSyncService>();
+        services.AddSingleton<IgnoreNotFoundMiniLcmApiFactory>();
         services.AddScoped<ProjectSnapshotService>();
         services.AddScoped<MiniLcmImport>();
         services.AddScoped<IProjectImport>(s => s.GetRequiredService<MiniLcmImport>());

--- a/backend/FwLite/FwLiteProjectSync/IgnoreNotFoundMiniLcmApi.cs
+++ b/backend/FwLite/FwLiteProjectSync/IgnoreNotFoundMiniLcmApi.cs
@@ -10,7 +10,7 @@ namespace FwLiteProjectSync;
 
 public class IgnoreNotFoundMiniLcmApiFactory(ILogger<IgnoreNotFoundMiniLcmApi> logger)
 {
-    public IMiniLcmApi Create(IMiniLcmApi api) => new IgnoreNotFoundMiniLcmApi(api, logger);
+    public IgnoreNotFoundMiniLcmApi Create(IMiniLcmApi api) => new(api, logger);
 }
 
 /// <summary>
@@ -42,6 +42,9 @@ public partial class IgnoreNotFoundMiniLcmApi(IMiniLcmApi api, ILogger logger) :
     [BeaKona.AutoInterface]
     private IMiniLcmReadApi ReadApi => _api;
 
+    /// <summary>How many writes were skipped because their target/reference was already deleted. The sync logs a summary of this.</summary>
+    public int IgnoredWriteCount { get; private set; }
+
     private async Task<T> IgnoreNotFound<T>(Func<Task<T>> operation, [CallerMemberName] string method = "")
     {
         try
@@ -50,6 +53,7 @@ public partial class IgnoreNotFoundMiniLcmApi(IMiniLcmApi api, ILogger logger) :
         }
         catch (NotFoundException e)
         {
+            IgnoredWriteCount++;
             logger.LogInformation(e, "Ignoring {Method} during sync because the object was deleted on this side", method);
             return default!;
         }
@@ -63,6 +67,7 @@ public partial class IgnoreNotFoundMiniLcmApi(IMiniLcmApi api, ILogger logger) :
         }
         catch (NotFoundException e)
         {
+            IgnoredWriteCount++;
             logger.LogInformation(e, "Ignoring {Method} during sync because the object was deleted on this side", method);
         }
     }

--- a/backend/FwLite/FwLiteProjectSync/IgnoreNotFoundMiniLcmApi.cs
+++ b/backend/FwLite/FwLiteProjectSync/IgnoreNotFoundMiniLcmApi.cs
@@ -1,0 +1,164 @@
+using System.Runtime.CompilerServices;
+using Microsoft.Extensions.Logging;
+using MiniLcm;
+using MiniLcm.Exceptions;
+using MiniLcm.Media;
+using MiniLcm.Models;
+using MiniLcm.SyncHelpers;
+
+namespace FwLiteProjectSync;
+
+public class IgnoreNotFoundMiniLcmApiFactory(ILogger<IgnoreNotFoundMiniLcmApi> logger)
+{
+    public IMiniLcmApi Create(IMiniLcmApi api) => new IgnoreNotFoundMiniLcmApi(api, logger);
+}
+
+/// <summary>
+/// During sync an object can be deleted on this side while it's still referenced by edits coming from the
+/// other side. The diff then tries to update an object that's gone, create a child on a deleted parent, or
+/// attach a relationship to a deleted object, and the API throws <see cref="NotFoundException"/>. Every write
+/// here swallows that (and logs it): the object is gone, so there's nothing to write, and the reverse-direction
+/// diff propagates the deletion to the other side.
+///
+/// Because a NotFound can come from almost any write (any one that touches a parent/referenced object), every
+/// write is wrapped rather than a hand-picked subset — that way a newly added write can't silently skip the
+/// handling. The one exception is CreateEntry (see below). Read operations are forwarded automatically via
+/// BeaKona.AutoInterface.
+///
+/// The swallowed result (null) is never observed: the sync diff discards the return of every wrapped write
+/// (child creates, relationship adds, updates). CreateEntry is the only write whose return the diff consumes,
+/// so it's left unwrapped — and it creates a root object that can't 404, so it needs no tolerance anyway.
+///
+/// Note: a couple of "referenced object was deleted" cases throw InvalidOperationException instead of
+/// NotFoundException (e.g. CreateSense with a deleted PartOfSpeech, AddComplexFormType with a deleted type)
+/// and are deliberately NOT handled here — catching InvalidOperationException broadly would mask real bugs.
+///
+/// Only meant to wrap the CRDT API during sync (see <see cref="CrdtFwdataProjectSyncService"/>).
+/// </summary>
+public partial class IgnoreNotFoundMiniLcmApi(IMiniLcmApi api, ILogger logger) : IMiniLcmApi
+{
+    private readonly IMiniLcmApi _api = api;
+
+    [BeaKona.AutoInterface]
+    private IMiniLcmReadApi ReadApi => _api;
+
+    private async Task<T> IgnoreNotFound<T>(Func<Task<T>> operation, [CallerMemberName] string method = "")
+    {
+        try
+        {
+            return await operation();
+        }
+        catch (NotFoundException e)
+        {
+            logger.LogInformation(e, "Ignoring {Method} during sync because the object was deleted on this side", method);
+            return default!;
+        }
+    }
+
+    private async Task IgnoreNotFound(Func<Task> operation, [CallerMemberName] string method = "")
+    {
+        try
+        {
+            await operation();
+        }
+        catch (NotFoundException e)
+        {
+            logger.LogInformation(e, "Ignoring {Method} during sync because the object was deleted on this side", method);
+        }
+    }
+
+    #region WritingSystem
+    public Task<WritingSystem> CreateWritingSystem(WritingSystem writingSystem, BetweenPosition<WritingSystemId?>? between = null) => IgnoreNotFound(() => _api.CreateWritingSystem(writingSystem, between));
+    public Task<WritingSystem> UpdateWritingSystem(WritingSystemId id, WritingSystemType type, UpdateObjectInput<WritingSystem> update) => IgnoreNotFound(() => _api.UpdateWritingSystem(id, type, update));
+    public Task<WritingSystem> UpdateWritingSystem(WritingSystem before, WritingSystem after, IMiniLcmApi? api = null) => IgnoreNotFound(() => _api.UpdateWritingSystem(before, after, api ?? this));
+    public Task MoveWritingSystem(WritingSystemId id, WritingSystemType type, BetweenPosition<WritingSystemId?> between) => IgnoreNotFound(() => _api.MoveWritingSystem(id, type, between));
+    #endregion
+
+    #region PartOfSpeech
+    public Task<PartOfSpeech> CreatePartOfSpeech(PartOfSpeech partOfSpeech) => IgnoreNotFound(() => _api.CreatePartOfSpeech(partOfSpeech));
+    public Task<PartOfSpeech> UpdatePartOfSpeech(Guid id, UpdateObjectInput<PartOfSpeech> update) => IgnoreNotFound(() => _api.UpdatePartOfSpeech(id, update));
+    public Task<PartOfSpeech> UpdatePartOfSpeech(PartOfSpeech before, PartOfSpeech after, IMiniLcmApi? api = null) => IgnoreNotFound(() => _api.UpdatePartOfSpeech(before, after, api ?? this));
+    public Task DeletePartOfSpeech(Guid id) => IgnoreNotFound(() => _api.DeletePartOfSpeech(id));
+    #endregion
+
+    #region Publication
+    public Task<Publication> CreatePublication(Publication pub) => IgnoreNotFound(() => _api.CreatePublication(pub));
+    public Task<Publication> UpdatePublication(Guid id, UpdateObjectInput<Publication> update) => IgnoreNotFound(() => _api.UpdatePublication(id, update));
+    public Task<Publication> UpdatePublication(Publication before, Publication after, IMiniLcmApi? api = null) => IgnoreNotFound(() => _api.UpdatePublication(before, after, api ?? this));
+    public Task DeletePublication(Guid id) => IgnoreNotFound(() => _api.DeletePublication(id));
+    #endregion
+
+    #region SemanticDomain
+    public Task<SemanticDomain> CreateSemanticDomain(SemanticDomain semanticDomain) => IgnoreNotFound(() => _api.CreateSemanticDomain(semanticDomain));
+    public Task<SemanticDomain> UpdateSemanticDomain(Guid id, UpdateObjectInput<SemanticDomain> update) => IgnoreNotFound(() => _api.UpdateSemanticDomain(id, update));
+    public Task<SemanticDomain> UpdateSemanticDomain(SemanticDomain before, SemanticDomain after, IMiniLcmApi? api = null) => IgnoreNotFound(() => _api.UpdateSemanticDomain(before, after, api ?? this));
+    public Task DeleteSemanticDomain(Guid id) => IgnoreNotFound(() => _api.DeleteSemanticDomain(id));
+    #endregion
+
+    #region ComplexFormType
+    public Task<ComplexFormType> CreateComplexFormType(ComplexFormType complexFormType) => IgnoreNotFound(() => _api.CreateComplexFormType(complexFormType));
+    public Task<ComplexFormType> UpdateComplexFormType(Guid id, UpdateObjectInput<ComplexFormType> update) => IgnoreNotFound(() => _api.UpdateComplexFormType(id, update));
+    public Task<ComplexFormType> UpdateComplexFormType(ComplexFormType before, ComplexFormType after, IMiniLcmApi? api = null) => IgnoreNotFound(() => _api.UpdateComplexFormType(before, after, api ?? this));
+    public Task DeleteComplexFormType(Guid id) => IgnoreNotFound(() => _api.DeleteComplexFormType(id));
+    #endregion
+
+    #region MorphType
+    public Task<MorphType> CreateMorphType(MorphType morphType) => IgnoreNotFound(() => _api.CreateMorphType(morphType));
+    public Task<MorphType> UpdateMorphType(Guid id, UpdateObjectInput<MorphType> update) => IgnoreNotFound(() => _api.UpdateMorphType(id, update));
+    public Task<MorphType> UpdateMorphType(MorphType before, MorphType after, IMiniLcmApi? api = null) => IgnoreNotFound(() => _api.UpdateMorphType(before, after, api ?? this));
+    #endregion
+
+    #region Entry
+    // Not wrapped: the diff consumes the returned entry, and a root-object create can't 404, so wrapping would
+    // add no safety while risking a null fed into the diff.
+    public Task<Entry> CreateEntry(Entry entry, CreateEntryOptions? options = null) => _api.CreateEntry(entry, options);
+    public Task<Entry> UpdateEntry(Guid id, UpdateObjectInput<Entry> update) => IgnoreNotFound(() => _api.UpdateEntry(id, update));
+    public Task<Entry> UpdateEntry(Entry before, Entry after, IMiniLcmApi? api = null) => IgnoreNotFound(() => _api.UpdateEntry(before, after, api ?? this));
+    public Task DeleteEntry(Guid id) => IgnoreNotFound(() => _api.DeleteEntry(id));
+    public Task<ComplexFormComponent> CreateComplexFormComponent(ComplexFormComponent complexFormComponent, BetweenPosition<ComplexFormComponent>? position = null) => IgnoreNotFound(() => _api.CreateComplexFormComponent(complexFormComponent, position));
+    public Task MoveComplexFormComponent(ComplexFormComponent complexFormComponent, BetweenPosition<ComplexFormComponent> between) => IgnoreNotFound(() => _api.MoveComplexFormComponent(complexFormComponent, between));
+    public Task DeleteComplexFormComponent(ComplexFormComponent complexFormComponent) => IgnoreNotFound(() => _api.DeleteComplexFormComponent(complexFormComponent));
+    public Task AddComplexFormType(Guid entryId, Guid complexFormTypeId) => IgnoreNotFound(() => _api.AddComplexFormType(entryId, complexFormTypeId));
+    public Task RemoveComplexFormType(Guid entryId, Guid complexFormTypeId) => IgnoreNotFound(() => _api.RemoveComplexFormType(entryId, complexFormTypeId));
+    public Task AddPublication(Guid entryId, Guid publicationId) => IgnoreNotFound(() => _api.AddPublication(entryId, publicationId));
+    public Task RemovePublication(Guid entryId, Guid publicationId) => IgnoreNotFound(() => _api.RemovePublication(entryId, publicationId));
+    #endregion
+
+    #region Sense
+    public Task<Sense> CreateSense(Guid entryId, Sense sense, BetweenPosition? position = null) => IgnoreNotFound(() => _api.CreateSense(entryId, sense, position));
+    public Task<Sense> UpdateSense(Guid entryId, Guid senseId, UpdateObjectInput<Sense> update) => IgnoreNotFound(() => _api.UpdateSense(entryId, senseId, update));
+    public Task<Sense> UpdateSense(Guid entryId, Sense before, Sense after, IMiniLcmApi? api = null) => IgnoreNotFound(() => _api.UpdateSense(entryId, before, after, api ?? this));
+    public Task MoveSense(Guid entryId, Guid senseId, BetweenPosition position) => IgnoreNotFound(() => _api.MoveSense(entryId, senseId, position));
+    public Task DeleteSense(Guid entryId, Guid senseId) => IgnoreNotFound(() => _api.DeleteSense(entryId, senseId));
+    public Task AddSemanticDomainToSense(Guid senseId, SemanticDomain semanticDomain) => IgnoreNotFound(() => _api.AddSemanticDomainToSense(senseId, semanticDomain));
+    public Task RemoveSemanticDomainFromSense(Guid senseId, Guid semanticDomainId) => IgnoreNotFound(() => _api.RemoveSemanticDomainFromSense(senseId, semanticDomainId));
+    public Task SetSensePartOfSpeech(Guid senseId, Guid? partOfSpeechId) => IgnoreNotFound(() => _api.SetSensePartOfSpeech(senseId, partOfSpeechId));
+    #endregion
+
+    #region ExampleSentence
+    public Task<ExampleSentence> CreateExampleSentence(Guid entryId, Guid senseId, ExampleSentence exampleSentence, BetweenPosition? position = null) => IgnoreNotFound(() => _api.CreateExampleSentence(entryId, senseId, exampleSentence, position));
+    public Task<ExampleSentence> UpdateExampleSentence(Guid entryId, Guid senseId, Guid exampleSentenceId, UpdateObjectInput<ExampleSentence> update) => IgnoreNotFound(() => _api.UpdateExampleSentence(entryId, senseId, exampleSentenceId, update));
+    public Task<ExampleSentence> UpdateExampleSentence(Guid entryId, Guid senseId, ExampleSentence before, ExampleSentence after, IMiniLcmApi? api = null) => IgnoreNotFound(() => _api.UpdateExampleSentence(entryId, senseId, before, after, api ?? this));
+    public Task MoveExampleSentence(Guid entryId, Guid senseId, Guid exampleSentenceId, BetweenPosition position) => IgnoreNotFound(() => _api.MoveExampleSentence(entryId, senseId, exampleSentenceId, position));
+    public Task DeleteExampleSentence(Guid entryId, Guid senseId, Guid exampleSentenceId) => IgnoreNotFound(() => _api.DeleteExampleSentence(entryId, senseId, exampleSentenceId));
+    public Task AddTranslation(Guid entryId, Guid senseId, Guid exampleSentenceId, Translation translation) => IgnoreNotFound(() => _api.AddTranslation(entryId, senseId, exampleSentenceId, translation));
+    public Task RemoveTranslation(Guid entryId, Guid senseId, Guid exampleSentenceId, Guid translationId) => IgnoreNotFound(() => _api.RemoveTranslation(entryId, senseId, exampleSentenceId, translationId));
+    public Task UpdateTranslation(Guid entryId, Guid senseId, Guid exampleSentenceId, Guid translationId, UpdateObjectInput<Translation> update) => IgnoreNotFound(() => _api.UpdateTranslation(entryId, senseId, exampleSentenceId, translationId, update));
+    #endregion
+
+    #region CustomView
+    public Task<CustomView> CreateCustomView(CustomView customView) => IgnoreNotFound(() => _api.CreateCustomView(customView));
+    public Task<CustomView> UpdateCustomView(CustomView customView) => IgnoreNotFound(() => _api.UpdateCustomView(customView));
+    public Task DeleteCustomView(Guid id) => IgnoreNotFound(() => _api.DeleteCustomView(id));
+    #endregion
+
+    #region Bulk / Files
+    public Task BulkImportSemanticDomains(IAsyncEnumerable<SemanticDomain> semanticDomains) => IgnoreNotFound(() => _api.BulkImportSemanticDomains(semanticDomains));
+    public Task BulkCreateEntries(IAsyncEnumerable<Entry> entries) => IgnoreNotFound(() => _api.BulkCreateEntries(entries));
+    public Task<UploadFileResponse> SaveFile(Stream stream, LcmFileMetadata metadata) => IgnoreNotFound(() => _api.SaveFile(stream, metadata));
+    #endregion
+
+    void IDisposable.Dispose()
+    {
+    }
+}

--- a/backend/FwLite/MiniLcm.Tests/MiniLcm.Tests.csproj
+++ b/backend/FwLite/MiniLcm.Tests/MiniLcm.Tests.csproj
@@ -17,6 +17,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="FluentAssertions" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
     <PackageReference Include="Soenneker.Utils.AutoBogus" />
     <PackageReference Include="System.Linq.Async" />
     <PackageReference Include="Moq" />

--- a/backend/FwLite/MiniLcm.Tests/MiniLcmTestBase.cs
+++ b/backend/FwLite/MiniLcm.Tests/MiniLcmTestBase.cs
@@ -1,6 +1,4 @@
-using MiniLcm.Normalization;
 using MiniLcm.Tests.AutoFakerHelpers;
-using MiniLcm.Wrappers;
 using Soenneker.Utils.AutoBogus;
 
 namespace MiniLcm.Tests;
@@ -17,10 +15,7 @@ public abstract class MiniLcmTestBase : IAsyncLifetime
     {
         BaseApi = await NewApi();
         BaseApi.Should().NotBeNull();
-        Api = BaseApi.WrapWith([
-            new MiniLcmApiQueryNormalizationWrapperFactory(),
-            new MiniLcmApiWriteNormalizationWrapperFactory(),
-        ], null!);
+        Api = TestMiniLcmWrappers.CreateUserFacingWrappers().Apply(BaseApi, null!);
         Api.Should().NotBeNull();
     }
 

--- a/backend/FwLite/MiniLcm.Tests/TestMiniLcmWrappers.cs
+++ b/backend/FwLite/MiniLcm.Tests/TestMiniLcmWrappers.cs
@@ -1,0 +1,37 @@
+using Microsoft.Extensions.DependencyInjection;
+using MiniLcm.Validators;
+using MiniLcm.Wrappers;
+
+namespace MiniLcm.Tests;
+
+/// <summary>
+/// Builds the production MiniLcm wrapper stack via <see cref="MiniLcmValidatorsExtensions.AddMiniLcmValidators"/>,
+/// so tests exercise the same validators and wrapper composition that real API entry points use
+/// (and pick up new registrations automatically). The resolved wrappers hold no provider-scoped state,
+/// so the throwaway provider is disposed immediately.
+/// </summary>
+public static class TestMiniLcmWrappers
+{
+    private static ServiceProvider BuildProvider() =>
+        new ServiceCollection().AddMiniLcmValidators().BuildServiceProvider();
+
+    /// <summary>
+    /// The full user-facing stack (query normalization, validation, write normalization) that real
+    /// API entry points apply via <see cref="MiniLcmApiUserFacingWrappers"/>.
+    /// </summary>
+    public static MiniLcmApiUserFacingWrappers CreateUserFacingWrappers()
+    {
+        using var provider = BuildProvider();
+        return provider.GetRequiredService<MiniLcmApiUserFacingWrappers>();
+    }
+
+    /// <summary>
+    /// The validation-only wrapper that the sync path applies (see <c>CrdtFwdataProjectSyncService</c>),
+    /// which deliberately skips normalization because both sides are already normalized.
+    /// </summary>
+    public static MiniLcmApiValidationWrapperFactory CreateValidationFactory()
+    {
+        using var provider = BuildProvider();
+        return provider.GetRequiredService<MiniLcmApiValidationWrapperFactory>();
+    }
+}

--- a/backend/FwLite/MiniLcm.Tests/UpdateEntryTestsBase.cs
+++ b/backend/FwLite/MiniLcm.Tests/UpdateEntryTestsBase.cs
@@ -84,11 +84,13 @@ public abstract class UpdateEntryTestsBase : MiniLcmTestBase
     [Fact]
     public async Task UpdateEntry_RoundTripsEmptyStrings()
     {
-        var entry = await Api.GetEntry(Entry1Id);
+        // Empty MultiString values are rejected by validation, so this exercises the raw storage layer:
+        // empty values can still reach storage (e.g. via sync) and must round-trip.
+        var entry = await BaseApi.GetEntry(Entry1Id);
         ArgumentNullException.ThrowIfNull(entry);
         var before = entry.Copy();
         entry.CitationForm["en"] = string.Empty;
-        var updatedEntry = await Api.UpdateEntry(before, entry);
+        var updatedEntry = await BaseApi.UpdateEntry(before, entry);
         updatedEntry.CitationForm["en"].Should().Be(string.Empty);
     }
 

--- a/backend/FwLite/MiniLcm/SyncHelpers/EntrySync.cs
+++ b/backend/FwLite/MiniLcm/SyncHelpers/EntrySync.cs
@@ -226,14 +226,7 @@ public static class EntrySync
 
         public override async Task<int> Add(ComplexFormComponent after)
         {
-            try
-            {
-                await api.CreateComplexFormComponent(after);
-            }
-            catch (NotFoundException)
-            {
-                //this can happen if the entry was deleted, so we can just ignore it
-            }
+            await api.CreateComplexFormComponent(after);
             return 1;
         }
 
@@ -265,14 +258,7 @@ public static class EntrySync
 
         public async Task<int> Add(ComplexFormComponent after, BetweenPosition<ComplexFormComponent> between)
         {
-            try
-            {
-                await api.CreateComplexFormComponent(after, between);
-            }
-            catch (NotFoundException)
-            {
-                //this can happen if the entry was deleted, so we can just ignore it
-            }
+            await api.CreateComplexFormComponent(after, between);
             return 1;
         }
 

--- a/backend/Testing/FwHeadless/Services/SyncWorkerTestHarness.cs
+++ b/backend/Testing/FwHeadless/Services/SyncWorkerTestHarness.cs
@@ -252,6 +252,7 @@ internal sealed class SyncWorkerTestHarness : IDisposable
             MockBehavior.Strict,
             null!,
             NullLogger<CrdtFwdataProjectSyncService>.Instance,
+            null!,
             null!);
 
         syncService


### PR DESCRIPTION
When an object is deleted in the CRDT but still edited or referenced from FwData between syncs, the diff tries to write to an object that no longer exists and the whole sync crashes with `NotFoundException` — wedging the project's sync indefinitely (the snapshot never advances, so every later sync repeats the crash). Homograph-number churn, which touches every entry, made this common in production.

The fix is a new `IgnoreNotFoundMiniLcmApi` decorator that wraps the CRDT API during sync and swallows (and logs) `NotFoundException` on every write. The deletion wins — applying a change to a deleted CRDT object is already a no-op — and the reverse-direction diff then propagates the deletion to FwData. The two ad-hoc complex-form `catch (NotFoundException)` blocks in `EntrySync` are folded into the wrapper.

A few decisions a reviewer might wonder about:
- **Every write is wrapped, not a hand-picked subset** (except `CreateEntry`, which can't 404 and whose return the diff consumes) — so a newly added write can't silently skip the handling.
- **CRDT side only.** That's the direction this bug was reported in; the symmetric FwData-deleted case is far rarer.
- **FwLite interactive editing isn't covered** — it reuses the same `EntrySync` diff but not this wrapper, so it keeps its pre-existing behavior of throwing on a concurrent-delete race. Editing races are far rarer than sync; comprehensive editor delete-tolerance is a follow-up.
- **Two "deleted reference" cases throw `InvalidOperationException`, not `NotFound`** (a sense referencing a deleted PartOfSpeech; `AddComplexFormType` with a deleted type) and are deliberately not caught — broadly catching `InvalidOperationException` would mask real bugs. Follow-up.

Verified against the production project that hit this (`blj-flex`): the sync went from crashing to completing.

Note: this branch is based on #2360 (not yet merged), so its commits appear in the diff until that lands.

Resolves #2361

🤖 Generated with [Claude Code](https://claude.com/claude-code)