### PR TITLE
Tolerate objects deleted in CRDT during FwData sync

### DIFF
--- a/backend/FwLite/FwLiteProjectSync.Tests/EntrySyncTests.cs
+++ b/backend/FwLite/FwLiteProjectSync.Tests/EntrySyncTests.cs
@@ -18,6 +18,101 @@ public class CrdtEntrySyncTests(ExtraWritingSystemsSyncFixture fixture) : EntryS
     {
         return fixture.CrdtApi;
     }
+
+    // Conflict scenarios: an object is deleted in the CRDT but still present (and edited) in the diff inputs
+    // — i.e. another client deleted it while FieldWorks edited it. The CRDT deletion should win: applying the
+    // edit is a no-op, the sync must not throw, and the object stays deleted. (FwData is intentionally NOT
+    // tolerant — its writes still throw if the target is missing — so these live in the CRDT subclass only.)
+
+    [Fact]
+    public async Task SyncFull_EntryEditedButDeletedInCrdt_DoesNotThrow()
+    {
+        var entry = await Api.CreateEntry(new() { Id = Guid.NewGuid(), LexemeForm = { { "en", "victim" } } });
+        await Api.DeleteEntry(entry.Id);
+        var after = entry.Copy();
+        after.CitationForm["en"] = "edited";
+
+        await EntrySync.SyncFull(entry, after, Api);
+
+        (await Api.GetEntry(entry.Id)).Should().BeNull();
+    }
+
+    [Fact]
+    public async Task SyncFull_SenseAddedToEntryDeletedInCrdt_DoesNotThrow()
+    {
+        var entry = await Api.CreateEntry(new() { Id = Guid.NewGuid(), LexemeForm = { { "en", "victim" } } });
+        await Api.DeleteEntry(entry.Id);
+        var after = entry.Copy();
+        after.Senses.Add(new Sense { Id = Guid.NewGuid(), Gloss = { { "en", "gloss" } } });
+
+        await EntrySync.SyncFull(entry, after, Api);
+
+        (await Api.GetEntry(entry.Id)).Should().BeNull();
+    }
+
+    [Fact]
+    public async Task SyncFull_SenseEditedButDeletedInCrdt_DoesNotThrow()
+    {
+        var entry = await Api.CreateEntry(new()
+        {
+            Id = Guid.NewGuid(),
+            LexemeForm = { { "en", "victim" } },
+            Senses = [new Sense { Id = Guid.NewGuid(), Gloss = { { "en", "gloss" } } }]
+        });
+        await Api.DeleteSense(entry.Id, entry.Senses[0].Id);
+        var after = entry.Copy();
+        after.Senses[0].Gloss["en"] = "edited";
+
+        await EntrySync.SyncFull(entry, after, Api);
+
+        var actual = await Api.GetEntry(entry.Id);
+        actual.Should().NotBeNull();
+        actual.Senses.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task SyncFull_ExampleSentenceEditedButDeletedInCrdt_DoesNotThrow()
+    {
+        var entry = await Api.CreateEntry(new()
+        {
+            Id = Guid.NewGuid(),
+            LexemeForm = { { "en", "victim" } },
+            Senses =
+            [
+                new Sense
+                {
+                    Id = Guid.NewGuid(),
+                    Gloss = { { "en", "gloss" } },
+                    ExampleSentences = [new ExampleSentence { Id = Guid.NewGuid(), Sentence = { { "en", new RichString("sentence") } } }]
+                }
+            ]
+        });
+        var sense = entry.Senses[0];
+        await Api.DeleteExampleSentence(entry.Id, sense.Id, sense.ExampleSentences[0].Id);
+        var after = entry.Copy();
+        after.Senses[0].ExampleSentences[0].Sentence["en"] = new RichString("edited");
+
+        await EntrySync.SyncFull(entry, after, Api);
+
+        var actual = await Api.GetEntry(entry.Id);
+        actual.Should().NotBeNull();
+        actual.Senses[0].ExampleSentences.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task SyncFull_ComplexFormComponentReferencingEntryDeletedInCrdt_DoesNotThrow()
+    {
+        var component = await Api.CreateEntry(new() { Id = Guid.NewGuid(), LexemeForm = { { "en", "component" } } });
+        var complexForm = await Api.CreateEntry(new() { Id = Guid.NewGuid(), LexemeForm = { { "en", "complexForm" } } });
+        await Api.DeleteEntry(component.Id);
+        var after = complexForm.Copy();
+        after.Components.Add(ComplexFormComponent.FromEntries(complexForm, component));
+
+        await EntrySync.SyncFull(complexForm, after, Api);
+
+        (await Api.GetEntry(component.Id)).Should().BeNull();
+        (await Api.GetEntry(complexForm.Id))!.Components.Should().BeEmpty();
+    }
 }
 
 public class FwDataEntrySyncTests(ExtraWritingSystemsSyncFixture fixture) : EntrySyncTestsBase(fixture)

--- a/backend/FwLite/FwLiteProjectSync.Tests/EntrySyncTests.cs
+++ b/backend/FwLite/FwLiteProjectSync.Tests/EntrySyncTests.cs
@@ -19,10 +19,8 @@ public class CrdtEntrySyncTests(ExtraWritingSystemsSyncFixture fixture) : EntryS
         return fixture.CrdtApi;
     }
 
-    // Conflict scenarios: an object is deleted in the CRDT but still present (and edited) in the diff inputs
-    // — i.e. another client deleted it while FieldWorks edited it. The CRDT deletion should win: applying the
-    // edit is a no-op, the sync must not throw, and the object stays deleted. (FwData is intentionally NOT
-    // tolerant — its writes still throw if the target is missing — so these live in the CRDT subclass only.)
+    // These delete-win cases live only in the CRDT subclass: the CRDT deletion must win when an object it
+    // deleted is still edited from the other side, whereas FwData intentionally still throws on a missing target.
 
     [Fact]
     public async Task SyncFull_EntryEditedButDeletedInCrdt_DoesNotThrow()
@@ -112,6 +110,33 @@ public class CrdtEntrySyncTests(ExtraWritingSystemsSyncFixture fixture) : EntryS
 
         (await Api.GetEntry(component.Id)).Should().BeNull();
         (await Api.GetEntry(complexForm.Id))!.Components.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task SyncFull_ComplexFormComponentReorderedButEntryDeletedInCrdt_DoesNotThrow()
+    {
+        var componentA = await Api.CreateEntry(new() { Id = Guid.NewGuid(), LexemeForm = { { "en", "a" } } });
+        var componentB = await Api.CreateEntry(new() { Id = Guid.NewGuid(), LexemeForm = { { "en", "b" } } });
+        var complexForm = new Entry { Id = Guid.NewGuid(), LexemeForm = { { "en", "complexForm" } } };
+        complexForm.Components =
+        [
+            ComplexFormComponent.FromEntries(complexForm, componentA),
+            ComplexFormComponent.FromEntries(complexForm, componentB),
+        ];
+        var before = await Api.CreateEntry(complexForm);
+        await Api.DeleteEntry(before.Id);
+
+        // Id-less components (as FwData produces them) force the move to resolve the now-deleted component — the case that used to throw.
+        var after = before.Copy();
+        after.Components =
+        [
+            new ComplexFormComponent { ComplexFormEntryId = before.Id, ComponentEntryId = componentB.Id, ComponentHeadword = "b" },
+            new ComplexFormComponent { ComplexFormEntryId = before.Id, ComponentEntryId = componentA.Id, ComponentHeadword = "a" },
+        ];
+
+        await EntrySync.SyncFull(before, after, Api);
+
+        (await Api.GetEntry(before.Id)).Should().BeNull();
     }
 }
 

--- a/backend/FwLite/FwLiteProjectSync.Tests/SyncTests.cs
+++ b/backend/FwLite/FwLiteProjectSync.Tests/SyncTests.cs
@@ -566,9 +566,34 @@ public class SyncTests : IClassFixture<SyncFixture>, IAsyncLifetime
             ]
         });
 
-        //sync may fail because it will try to create a complex form for an entry which was deleted
+        // Regression: creating the complex-form component for the CRDT-deleted _testEntry once used to throw and wedge the sync.
         await _syncService.Sync(crdtApi, fwdataApi, projectSnapshot);
 
+        (await crdtApi.GetEntry(_testEntry.Id)).Should().BeNull();
+        (await fwdataApi.GetEntry(_testEntry.Id)).Should().BeNull();
+        var crdtComplexForm = await crdtApi.GetEntry(newEntryId);
+        crdtComplexForm.Should().NotBeNull();
+        crdtComplexForm.Components.Should().BeEmpty();
+        (await fwdataApi.GetEntry(newEntryId)).Should().NotBeNull();
+    }
+
+    [Fact]
+    [Trait("Category", "Integration")]
+    public async Task EntryEditedInFwDataButDeletedInCrdt_SyncDoesNotThrow()
+    {
+        var crdtApi = _fixture.CrdtApi;
+        var fwdataApi = _fixture.FwDataApi;
+        await _syncService.Import(crdtApi, fwdataApi);
+        var projectSnapshot = await _fixture.RegenerateAndGetSnapshot();
+
+        await fwdataApi.UpdateEntry(_testEntry.Id, new UpdateObjectInput<Entry>().Set(e => e.CitationForm["en"], "edited"));
+        await crdtApi.DeleteEntry(_testEntry.Id);
+
+        // Regression: the fwdata vs snapshot diff calls SubmitUpdateEntry on the CRDT-deleted entry, which used to throw NotFound.
+        await _syncService.Sync(crdtApi, fwdataApi, projectSnapshot);
+
+        (await crdtApi.GetEntry(_testEntry.Id)).Should().BeNull();
+        (await fwdataApi.GetEntry(_testEntry.Id)).Should().BeNull();
     }
 
     [Fact]

--- a/backend/FwLite/FwLiteProjectSync/DryRunMiniLcmApi.cs
+++ b/backend/FwLite/FwLiteProjectSync/DryRunMiniLcmApi.cs
@@ -360,6 +360,71 @@ public partial class DryRunMiniLcmApi(IMiniLcmApi api) : IMiniLcmApi
         return Task.CompletedTask;
     }
 
+    #region Submit (sync's result-less write variants)
+    // Record-only, like the rest of dry-run. Overridden explicitly (rather than inheriting the interface
+    // default, which routes to the returning Update* and re-reads the object) so a dry-run of a project with a
+    // delete-vs-edit conflict previews cleanly instead of throwing on the now-deleted object.
+    public Task SubmitUpdateEntry(Guid id, UpdateObjectInput<Entry> update)
+    {
+        DryRunRecords.Add(new DryRunRecord(nameof(SubmitUpdateEntry), $"Update entry {id}"));
+        return Task.CompletedTask;
+    }
+
+    public Task SubmitUpdateSense(Guid entryId, Guid senseId, UpdateObjectInput<Sense> update)
+    {
+        DryRunRecords.Add(new DryRunRecord(nameof(SubmitUpdateSense), $"Update sense {senseId}, changes: {update.Summarize()}"));
+        return Task.CompletedTask;
+    }
+
+    public Task SubmitUpdateExampleSentence(Guid entryId, Guid senseId, Guid exampleSentenceId, UpdateObjectInput<ExampleSentence> update)
+    {
+        DryRunRecords.Add(new DryRunRecord(nameof(SubmitUpdateExampleSentence), $"Update example sentence {exampleSentenceId}, changes: {update.Summarize()}"));
+        return Task.CompletedTask;
+    }
+
+    public Task SubmitCreateSense(Guid entryId, Sense sense, BetweenPosition? position = null)
+    {
+        DryRunRecords.Add(new DryRunRecord(nameof(SubmitCreateSense), $"Create sense {sense.Gloss}"));
+        return Task.CompletedTask;
+    }
+
+    public Task SubmitCreateExampleSentence(Guid entryId, Guid senseId, ExampleSentence exampleSentence, BetweenPosition? position = null)
+    {
+        DryRunRecords.Add(new DryRunRecord(nameof(SubmitCreateExampleSentence), $"Create example sentence {exampleSentence.Sentence}"));
+        return Task.CompletedTask;
+    }
+
+    public Task SubmitCreateComplexFormComponent(ComplexFormComponent complexFormComponent, BetweenPosition<ComplexFormComponent>? position = null)
+    {
+        DryRunRecords.Add(new DryRunRecord(nameof(SubmitCreateComplexFormComponent), $"Create complex form component {ComplexFormComponentName(complexFormComponent)}"));
+        return Task.CompletedTask;
+    }
+
+    public Task SubmitUpdatePartOfSpeech(Guid id, UpdateObjectInput<PartOfSpeech> update)
+    {
+        DryRunRecords.Add(new DryRunRecord(nameof(SubmitUpdatePartOfSpeech), $"Update part of speech {id}"));
+        return Task.CompletedTask;
+    }
+
+    public Task SubmitUpdatePublication(Guid id, UpdateObjectInput<Publication> update)
+    {
+        DryRunRecords.Add(new DryRunRecord(nameof(SubmitUpdatePublication), $"Update publication {id}"));
+        return Task.CompletedTask;
+    }
+
+    public Task SubmitUpdateSemanticDomain(Guid id, UpdateObjectInput<SemanticDomain> update)
+    {
+        DryRunRecords.Add(new DryRunRecord(nameof(SubmitUpdateSemanticDomain), $"Update semantic domain {id}"));
+        return Task.CompletedTask;
+    }
+
+    public Task SubmitUpdateComplexFormType(Guid id, UpdateObjectInput<ComplexFormType> update)
+    {
+        DryRunRecords.Add(new DryRunRecord(nameof(SubmitUpdateComplexFormType), $"Update complex form type {id}"));
+        return Task.CompletedTask;
+    }
+    #endregion
+
     private string ComplexFormComponentName(ComplexFormComponent? component)
     {
         if (component == null) return "null";

--- a/backend/FwLite/FwLiteProjectSync/DryRunMiniLcmApi.cs
+++ b/backend/FwLite/FwLiteProjectSync/DryRunMiniLcmApi.cs
@@ -361,9 +361,9 @@ public partial class DryRunMiniLcmApi(IMiniLcmApi api) : IMiniLcmApi
     }
 
     #region Submit (sync's result-less write variants)
-    // Record-only, like the rest of dry-run. Overridden explicitly (rather than inheriting the interface
-    // default, which routes to the returning Update* and re-reads the object) so a dry-run of a project with a
-    // delete-vs-edit conflict previews cleanly instead of throwing on the now-deleted object.
+    // Record-only. Overridden explicitly (not inherited from the interface default, which would route to the
+    // returning Update* and re-read the object) so a dry-run of a conflicted project doesn't throw on the
+    // now-deleted object.
     public Task SubmitUpdateEntry(Guid id, UpdateObjectInput<Entry> update)
     {
         DryRunRecords.Add(new DryRunRecord(nameof(SubmitUpdateEntry), $"Update entry {id}"));

--- a/backend/FwLite/LcmCrdt/CrdtMiniLcmApi.cs
+++ b/backend/FwLite/LcmCrdt/CrdtMiniLcmApi.cs
@@ -141,9 +141,9 @@ public class CrdtMiniLcmApi(
         return await GetPartOfSpeech(partOfSpeech.Id) ?? throw NotFoundException.ForType<PartOfSpeech>(partOfSpeech.Id);
     }
 
-    public Task SubmitUpdatePartOfSpeech(Guid id, UpdateObjectInput<PartOfSpeech> update)
+    public async Task SubmitUpdatePartOfSpeech(Guid id, UpdateObjectInput<PartOfSpeech> update)
     {
-        return AddChanges(update.Patch.ToChanges(id));
+        await AddChanges(update.Patch.ToChanges(id));
     }
 
     public async Task<PartOfSpeech> UpdatePartOfSpeech(Guid id, UpdateObjectInput<PartOfSpeech> update)
@@ -185,9 +185,9 @@ public class CrdtMiniLcmApi(
 
     }
 
-    public Task SubmitUpdatePublication(Guid id, UpdateObjectInput<Publication> update)
+    public async Task SubmitUpdatePublication(Guid id, UpdateObjectInput<Publication> update)
     {
-        return AddChanges(update.Patch.ToChanges(id));
+        await AddChanges(update.Patch.ToChanges(id));
     }
 
     public async Task<Publication> UpdatePublication(Guid id, UpdateObjectInput<Publication> update)
@@ -241,9 +241,9 @@ public class CrdtMiniLcmApi(
         return await GetSemanticDomain(semanticDomain.Id) ?? throw NotFoundException.ForType<SemanticDomain>(semanticDomain.Id);
     }
 
-    public Task SubmitUpdateSemanticDomain(Guid id, UpdateObjectInput<SemanticDomain> update)
+    public async Task SubmitUpdateSemanticDomain(Guid id, UpdateObjectInput<SemanticDomain> update)
     {
-        return AddChanges(update.Patch.ToChanges(id));
+        await AddChanges(update.Patch.ToChanges(id));
     }
 
     public async Task<SemanticDomain> UpdateSemanticDomain(Guid id, UpdateObjectInput<SemanticDomain> update)
@@ -291,9 +291,9 @@ public class CrdtMiniLcmApi(
         return await repo.ComplexFormTypes.SingleAsync(c => c.Id == complexFormType.Id);
     }
 
-    public Task SubmitUpdateComplexFormType(Guid id, UpdateObjectInput<ComplexFormType> update)
+    public async Task SubmitUpdateComplexFormType(Guid id, UpdateObjectInput<ComplexFormType> update)
     {
-        return AddChange(new JsonPatchChange<ComplexFormType>(id, update.Patch));
+        await AddChange(new JsonPatchChange<ComplexFormType>(id, update.Patch));
     }
 
     public async Task<ComplexFormType> UpdateComplexFormType(Guid id, UpdateObjectInput<ComplexFormType> update)
@@ -324,7 +324,6 @@ public class CrdtMiniLcmApi(
             // This aligns with FwData (which ignores the ID entirely) and prevents
             // Harmony duplicate-ID pitfalls during sync.
             complexFormComponent.Id = Guid.NewGuid();
-            // AddEntryComponentChange creates the component already-deleted if a referenced entry is gone.
             var addEntryComponentChange = await repo.CreateComplexFormComponentChange(complexFormComponent, betweenIds);
             await AddChange(addEntryComponentChange);
             return;
@@ -347,13 +346,27 @@ public class CrdtMiniLcmApi(
 
     public async Task MoveComplexFormComponent(ComplexFormComponent component, BetweenPosition<ComplexFormComponent> between)
     {
+        await MoveComplexFormComponent(component, between, tolerateMissing: false);
+    }
+
+    public async Task SubmitMoveComplexFormComponent(ComplexFormComponent component, BetweenPosition<ComplexFormComponent> between)
+    {
+        await MoveComplexFormComponent(component, between, tolerateMissing: true);
+    }
+
+    private async Task MoveComplexFormComponent(ComplexFormComponent component, BetweenPosition<ComplexFormComponent> between, bool tolerateMissing)
+    {
         await using var repo = await repoFactory.CreateRepoAsync();
+        // FwData components carry no stable Id, so the move target is resolved by its references rather than MaybeId.
+        var id = component.MaybeId ?? (await repo.FindComplexFormComponent(component))?.Id;
+        if (id is null)
+        {
+            if (tolerateMissing) return; // we can't submit the change, because we don't have an ID to refer to
+            throw NotFoundException.ForType<ComplexFormComponent>("missing ID");
+        }
         var betweenIds = await between.MapAsync(async c => (await repo.FindComplexFormComponent(c))?.Id);
         var order = await OrderPicker.PickOrder(repo.ComplexFormComponents.Where(s => s.ComplexFormEntryId == component.ComplexFormEntryId), betweenIds);
-        var id = component.MaybeId ??
-                 (await repo.FindComplexFormComponent(component))?.Id
-                 ?? throw NotFoundException.ForType<ComplexFormComponent>("missing ID");
-        await AddChange(new Changes.SetOrderChange<ComplexFormComponent>(id, order));
+        await AddChange(new Changes.SetOrderChange<ComplexFormComponent>(id.Value, order));
     }
 
     public async Task DeleteComplexFormComponent(ComplexFormComponent complexFormComponent)
@@ -652,9 +665,9 @@ public class CrdtMiniLcmApi(
         return !await repo.Entries.AnyAsyncEF(e => e.Id == id);
     }
 
-    public Task SubmitUpdateEntry(Guid id, UpdateObjectInput<Entry> update)
+    public async Task SubmitUpdateEntry(Guid id, UpdateObjectInput<Entry> update)
     {
-        return AddChanges(update.Patch.ToChanges(id));
+        await AddChanges(update.Patch.ToChanges(id));
     }
 
     public async Task<Entry> UpdateEntry(Guid id,
@@ -716,7 +729,6 @@ public class CrdtMiniLcmApi(
 
     public async Task SubmitCreateSense(Guid entryId, Sense sense, BetweenPosition? between = null)
     {
-        // No PartOfSpeech check here (the returning CreateSense validates instead; CreateSenseChange drops a missing one).
         await using var repo = await repoFactory.CreateRepoAsync();
         sense.Order = await OrderPicker.PickOrder(repo.Senses.Where(s => s.EntryId == entryId), between);
         await AddChanges(await CreateSenseChanges(entryId, sense, repo.SemanticDomains).ToArrayAsync());
@@ -734,9 +746,9 @@ public class CrdtMiniLcmApi(
         return createdSense;
     }
 
-    public Task SubmitUpdateSense(Guid entryId, Guid senseId, UpdateObjectInput<Sense> update)
+    public async Task SubmitUpdateSense(Guid entryId, Guid senseId, UpdateObjectInput<Sense> update)
     {
-        return AddChanges(update.Patch.ToChanges(senseId));
+        await AddChanges(update.Patch.ToChanges(senseId));
     }
 
     public async Task<Sense> UpdateSense(Guid entryId,
@@ -818,12 +830,12 @@ public class CrdtMiniLcmApi(
         return await repo.GetExampleSentence(entryId, senseId, id);
     }
 
-    public Task SubmitUpdateExampleSentence(Guid entryId,
+    public async Task SubmitUpdateExampleSentence(Guid entryId,
         Guid senseId,
         Guid exampleSentenceId,
         UpdateObjectInput<ExampleSentence> update)
     {
-        return AddChange(new JsonPatchExampleSentenceChange(exampleSentenceId, update.Patch));
+        await AddChange(new JsonPatchExampleSentenceChange(exampleSentenceId, update.Patch));
     }
 
     public async Task<ExampleSentence> UpdateExampleSentence(Guid entryId,

--- a/backend/FwLite/LcmCrdt/CrdtMiniLcmApi.cs
+++ b/backend/FwLite/LcmCrdt/CrdtMiniLcmApi.cs
@@ -141,11 +141,14 @@ public class CrdtMiniLcmApi(
         return await GetPartOfSpeech(partOfSpeech.Id) ?? throw NotFoundException.ForType<PartOfSpeech>(partOfSpeech.Id);
     }
 
+    public Task SubmitUpdatePartOfSpeech(Guid id, UpdateObjectInput<PartOfSpeech> update)
+    {
+        return AddChanges(update.Patch.ToChanges(id));
+    }
+
     public async Task<PartOfSpeech> UpdatePartOfSpeech(Guid id, UpdateObjectInput<PartOfSpeech> update)
     {
-        var pos = await GetPartOfSpeech(id) ?? throw NotFoundException.ForType<PartOfSpeech>(id);
-
-        await AddChanges(update.Patch.ToChanges(pos.Id));
+        await SubmitUpdatePartOfSpeech(id, update);
         return await GetPartOfSpeech(id) ?? throw NotFoundException.ForType<PartOfSpeech>(id);
     }
 
@@ -182,11 +185,15 @@ public class CrdtMiniLcmApi(
 
     }
 
+    public Task SubmitUpdatePublication(Guid id, UpdateObjectInput<Publication> update)
+    {
+        return AddChanges(update.Patch.ToChanges(id));
+    }
+
     public async Task<Publication> UpdatePublication(Guid id, UpdateObjectInput<Publication> update)
     {
+        await SubmitUpdatePublication(id, update);
         await using var repo = await repoFactory.CreateRepoAsync();
-        var pub = await repo.GetPublication(id) ?? throw NotFoundException.ForType<Publication>(id);
-        await AddChanges(update.Patch.ToChanges(pub.Id));
         return await repo.GetPublication(id) ?? throw NotFoundException.ForType<Publication>($"{id} (invalid patching to a new id?)");
     }
 
@@ -234,10 +241,14 @@ public class CrdtMiniLcmApi(
         return await GetSemanticDomain(semanticDomain.Id) ?? throw NotFoundException.ForType<SemanticDomain>(semanticDomain.Id);
     }
 
+    public Task SubmitUpdateSemanticDomain(Guid id, UpdateObjectInput<SemanticDomain> update)
+    {
+        return AddChanges(update.Patch.ToChanges(id));
+    }
+
     public async Task<SemanticDomain> UpdateSemanticDomain(Guid id, UpdateObjectInput<SemanticDomain> update)
     {
-        var semDom = await GetSemanticDomain(id) ?? throw NotFoundException.ForType<SemanticDomain>(id);
-        await AddChanges(update.Patch.ToChanges(semDom.Id));
+        await SubmitUpdateSemanticDomain(id, update);
         return await GetSemanticDomain(id) ?? throw NotFoundException.ForType<SemanticDomain>(id);
     }
 
@@ -280,9 +291,14 @@ public class CrdtMiniLcmApi(
         return await repo.ComplexFormTypes.SingleAsync(c => c.Id == complexFormType.Id);
     }
 
+    public Task SubmitUpdateComplexFormType(Guid id, UpdateObjectInput<ComplexFormType> update)
+    {
+        return AddChange(new JsonPatchChange<ComplexFormType>(id, update.Patch));
+    }
+
     public async Task<ComplexFormType> UpdateComplexFormType(Guid id, UpdateObjectInput<ComplexFormType> update)
     {
-        await AddChange(new JsonPatchChange<ComplexFormType>(id, update.Patch));
+        await SubmitUpdateComplexFormType(id, update);
         return await GetComplexFormType(id) ?? throw NotFoundException.ForType<ComplexFormType>(id);
     }
 

--- a/backend/FwLite/LcmCrdt/CrdtMiniLcmApi.cs
+++ b/backend/FwLite/LcmCrdt/CrdtMiniLcmApi.cs
@@ -324,9 +324,8 @@ public class CrdtMiniLcmApi(
             // This aligns with FwData (which ignores the ID entirely) and prevents
             // Harmony duplicate-ID pitfalls during sync.
             complexFormComponent.Id = Guid.NewGuid();
+            // AddEntryComponentChange creates the component already-deleted if a referenced entry is gone.
             var addEntryComponentChange = await repo.CreateComplexFormComponentChange(complexFormComponent, betweenIds);
-            // No re-fetch: if a referenced entry was deleted the component is created already-deleted, which the
-            // sync must tolerate. AddEntryComponentChange itself handles the missing reference.
             await AddChange(addEntryComponentChange);
             return;
         }
@@ -655,7 +654,6 @@ public class CrdtMiniLcmApi(
 
     public Task SubmitUpdateEntry(Guid id, UpdateObjectInput<Entry> update)
     {
-        // No existence check: applying the patch to a deleted entry leaves it deleted (delete wins); the sync relies on this.
         return AddChanges(update.Patch.ToChanges(id));
     }
 
@@ -718,8 +716,7 @@ public class CrdtMiniLcmApi(
 
     public async Task SubmitCreateSense(Guid entryId, Sense sense, BetweenPosition? between = null)
     {
-        // No PartOfSpeech existence check and no re-fetch: CreateSenseChange already drops a missing/deleted
-        // PartOfSpeech, and a sense created under a deleted entry is born deleted (delete wins); the sync relies on this.
+        // No PartOfSpeech check here (the returning CreateSense validates instead; CreateSenseChange drops a missing one).
         await using var repo = await repoFactory.CreateRepoAsync();
         sense.Order = await OrderPicker.PickOrder(repo.Senses.Where(s => s.EntryId == entryId), between);
         await AddChanges(await CreateSenseChanges(entryId, sense, repo.SemanticDomains).ToArrayAsync());

--- a/backend/FwLite/LcmCrdt/CrdtMiniLcmApi.cs
+++ b/backend/FwLite/LcmCrdt/CrdtMiniLcmApi.cs
@@ -297,7 +297,7 @@ public class CrdtMiniLcmApi(
         await AddChange(new DeleteChange<ComplexFormType>(id));
     }
 
-    public async Task<ComplexFormComponent> CreateComplexFormComponent(ComplexFormComponent complexFormComponent, BetweenPosition<ComplexFormComponent>? between = null)
+    public async Task SubmitCreateComplexFormComponent(ComplexFormComponent complexFormComponent, BetweenPosition<ComplexFormComponent>? between = null)
     {
         await using var repo = await repoFactory.CreateRepoAsync();
         var existing = await repo.FindComplexFormComponent(complexFormComponent);
@@ -306,11 +306,13 @@ public class CrdtMiniLcmApi(
             var betweenIds = between is null ? null : await between.MapAsync(async c => (await repo.FindComplexFormComponent(c))?.Id);
             // Always generate a new entity ID — the caller's ID is never used.
             // This aligns with FwData (which ignores the ID entirely) and prevents
-            // Harmony duplicate-ID pitfalls during sync (see EntrySync.ComplexFormsDiffApi.Add).
+            // Harmony duplicate-ID pitfalls during sync.
             complexFormComponent.Id = Guid.NewGuid();
             var addEntryComponentChange = await repo.CreateComplexFormComponentChange(complexFormComponent, betweenIds);
+            // No re-fetch: if a referenced entry was deleted the component is created already-deleted, which the
+            // sync must tolerate. AddEntryComponentChange itself handles the missing reference.
             await AddChange(addEntryComponentChange);
-            return await repo.FindComplexFormComponent(addEntryComponentChange.EntityId);
+            return;
         }
 
         // The orderable diff sends (null, null) for singletons; skip the move so
@@ -319,7 +321,13 @@ public class CrdtMiniLcmApi(
         {
             await MoveComplexFormComponent(existing, between);
         }
-        return existing;
+    }
+
+    public async Task<ComplexFormComponent> CreateComplexFormComponent(ComplexFormComponent complexFormComponent, BetweenPosition<ComplexFormComponent>? between = null)
+    {
+        await SubmitCreateComplexFormComponent(complexFormComponent, between);
+        await using var repo = await repoFactory.CreateRepoAsync();
+        return await repo.FindComplexFormComponent(complexFormComponent) ?? throw NotFoundException.ForType<ComplexFormComponent>(complexFormComponent.ComplexFormEntryId);
     }
 
     public async Task MoveComplexFormComponent(ComplexFormComponent component, BetweenPosition<ComplexFormComponent> between)
@@ -629,14 +637,18 @@ public class CrdtMiniLcmApi(
         return !await repo.Entries.AnyAsyncEF(e => e.Id == id);
     }
 
+    public Task SubmitUpdateEntry(Guid id, UpdateObjectInput<Entry> update)
+    {
+        // No existence check: applying the patch to a deleted entry leaves it deleted (delete wins); the sync relies on this.
+        return AddChanges(update.Patch.ToChanges(id));
+    }
+
     public async Task<Entry> UpdateEntry(Guid id,
         UpdateObjectInput<Entry> update)
     {
+        await SubmitUpdateEntry(id, update);
         await using var repo = await repoFactory.CreateRepoAsync();
-        var entry = await repo.GetEntry(id) ?? throw NotFoundException.ForType<Entry>(id);
-        await AddChanges(update.Patch.ToChanges(entry.Id));
-        var updatedEntry = await repo.GetEntry(id) ?? throw NotFoundException.ForType<Entry>(id);
-        return updatedEntry;
+        return await repo.GetEntry(id) ?? throw NotFoundException.ForType<Entry>(id);
     }
 
     public async Task<Entry> UpdateEntry(Entry before, Entry after, IMiniLcmApi? api = null)
@@ -688,27 +700,38 @@ public class CrdtMiniLcmApi(
         if (sense.EntryId != entryId) throw new NotFoundException($"Sense {sense.Id} does not belong to the expected entry, expected Id {entryId}, actual Id {sense.EntryId}", nameof(Sense));
     }
 
+    public async Task SubmitCreateSense(Guid entryId, Sense sense, BetweenPosition? between = null)
+    {
+        // No PartOfSpeech existence check and no re-fetch: CreateSenseChange already drops a missing/deleted
+        // PartOfSpeech, and a sense created under a deleted entry is born deleted (delete wins); the sync relies on this.
+        await using var repo = await repoFactory.CreateRepoAsync();
+        sense.Order = await OrderPicker.PickOrder(repo.Senses.Where(s => s.EntryId == entryId), between);
+        await AddChanges(await CreateSenseChanges(entryId, sense, repo.SemanticDomains).ToArrayAsync());
+    }
+
     public async Task<Sense> CreateSense(Guid entryId, Sense sense, BetweenPosition? between = null)
     {
-        await using var repo = await repoFactory.CreateRepoAsync();
         if (sense.PartOfSpeechId.HasValue && await GetPartOfSpeech(sense.PartOfSpeechId.Value) is null)
             throw new InvalidOperationException($"Part of speech must exist when creating a sense (could not find GUID {sense.PartOfSpeechId.Value})");
 
-        sense.Order = await OrderPicker.PickOrder(repo.Senses.Where(s => s.EntryId == entryId), between);
-        await AddChanges(await CreateSenseChanges(entryId, sense, repo.SemanticDomains).ToArrayAsync());
+        await SubmitCreateSense(entryId, sense, between);
+        await using var repo = await repoFactory.CreateRepoAsync();
         var createdSense = await repo.GetSense(sense.Id) ?? throw NotFoundException.ForType<Sense>(sense.Id);
         VerifySenseBelongsToEntry(entryId, createdSense);
         return createdSense;
+    }
+
+    public Task SubmitUpdateSense(Guid entryId, Guid senseId, UpdateObjectInput<Sense> update)
+    {
+        return AddChanges(update.Patch.ToChanges(senseId));
     }
 
     public async Task<Sense> UpdateSense(Guid entryId,
         Guid senseId,
         UpdateObjectInput<Sense> update)
     {
+        await SubmitUpdateSense(entryId, senseId, update);
         await using var repo = await repoFactory.CreateRepoAsync();
-        var sense = await repo.GetSense(senseId) ?? throw NotFoundException.ForType<Sense>(senseId);
-        VerifySenseBelongsToEntry(entryId, sense);
-        await AddChanges(update.Patch.ToChanges(sense.Id));
         var updatedSense = await repo.GetSense(senseId) ?? throw NotFoundException.ForType<Sense>(senseId);
         VerifySenseBelongsToEntry(entryId, updatedSense);
         return updatedSense;
@@ -757,7 +780,7 @@ public class CrdtMiniLcmApi(
         await AddChange(new SetPartOfSpeechChange(senseId, partOfSpeechId));
     }
 
-    public async Task<ExampleSentence> CreateExampleSentence(Guid entryId,
+    public async Task SubmitCreateExampleSentence(Guid entryId,
         Guid senseId,
         ExampleSentence exampleSentence,
         BetweenPosition? between = null)
@@ -765,7 +788,15 @@ public class CrdtMiniLcmApi(
         await using var repo = await repoFactory.CreateRepoAsync();
         exampleSentence.Order = await OrderPicker.PickOrder(repo.ExampleSentences.Where(s => s.SenseId == senseId), between);
         await AddChange(new CreateExampleSentenceChange(exampleSentence, senseId));
-        return await repo.GetExampleSentence(entryId, senseId, exampleSentence.Id) ?? throw NotFoundException.ForType<ExampleSentence>(exampleSentence.Id);
+    }
+
+    public async Task<ExampleSentence> CreateExampleSentence(Guid entryId,
+        Guid senseId,
+        ExampleSentence exampleSentence,
+        BetweenPosition? between = null)
+    {
+        await SubmitCreateExampleSentence(entryId, senseId, exampleSentence, between);
+        return await GetExampleSentence(entryId, senseId, exampleSentence.Id) ?? throw NotFoundException.ForType<ExampleSentence>(exampleSentence.Id);
     }
 
     public async Task<ExampleSentence?> GetExampleSentence(Guid entryId, Guid senseId, Guid id)
@@ -774,14 +805,20 @@ public class CrdtMiniLcmApi(
         return await repo.GetExampleSentence(entryId, senseId, id);
     }
 
+    public Task SubmitUpdateExampleSentence(Guid entryId,
+        Guid senseId,
+        Guid exampleSentenceId,
+        UpdateObjectInput<ExampleSentence> update)
+    {
+        return AddChange(new JsonPatchExampleSentenceChange(exampleSentenceId, update.Patch));
+    }
+
     public async Task<ExampleSentence> UpdateExampleSentence(Guid entryId,
         Guid senseId,
         Guid exampleSentenceId,
         UpdateObjectInput<ExampleSentence> update)
     {
-        var jsonPatch = update.Patch;
-        var patchChange = new JsonPatchExampleSentenceChange(exampleSentenceId, jsonPatch);
-        await AddChange(patchChange);
+        await SubmitUpdateExampleSentence(entryId, senseId, exampleSentenceId, update);
         return await GetExampleSentence(entryId, senseId, exampleSentenceId) ?? throw NotFoundException.ForType<ExampleSentence>(exampleSentenceId);
     }
 

--- a/backend/FwLite/MiniLcm/IMiniLcmWriteApi.cs
+++ b/backend/FwLite/MiniLcm/IMiniLcmWriteApi.cs
@@ -125,6 +125,14 @@ public interface IMiniLcmWriteApi
     Task SubmitUpdateSense(Guid entryId, Guid senseId, UpdateObjectInput<Sense> update) => UpdateSense(entryId, senseId, update);
     Task SubmitCreateExampleSentence(Guid entryId, Guid senseId, ExampleSentence exampleSentence, BetweenPosition? position = null) => CreateExampleSentence(entryId, senseId, exampleSentence, position);
     Task SubmitUpdateExampleSentence(Guid entryId, Guid senseId, Guid exampleSentenceId, UpdateObjectInput<ExampleSentence> update) => UpdateExampleSentence(entryId, senseId, exampleSentenceId, update);
+    // Dependency types (synced before entries). These run outside EntrySync's try/catch, so a deleted-in-CRDT
+    // one that's still edited in FwData would otherwise crash the whole sync the same way (issue #2361).
+    // WritingSystem is omitted (its update needs to resolve the entity id, so it can't be a blind submit, and
+    // deleting a writing system is a deliberate, cascading operation); MorphType is omitted (not deletable).
+    Task SubmitUpdatePartOfSpeech(Guid id, UpdateObjectInput<PartOfSpeech> update) => UpdatePartOfSpeech(id, update);
+    Task SubmitUpdatePublication(Guid id, UpdateObjectInput<Publication> update) => UpdatePublication(id, update);
+    Task SubmitUpdateSemanticDomain(Guid id, UpdateObjectInput<SemanticDomain> update) => UpdateSemanticDomain(id, update);
+    Task SubmitUpdateComplexFormType(Guid id, UpdateObjectInput<ComplexFormType> update) => UpdateComplexFormType(id, update);
     #endregion
 
     #region CustomView

--- a/backend/FwLite/MiniLcm/IMiniLcmWriteApi.cs
+++ b/backend/FwLite/MiniLcm/IMiniLcmWriteApi.cs
@@ -118,6 +118,7 @@ public interface IMiniLcmWriteApi
     // method (correct for FwData, which still surfaces a genuinely-missing object).
     Task SubmitUpdateEntry(Guid id, UpdateObjectInput<Entry> update) => UpdateEntry(id, update);
     Task SubmitCreateComplexFormComponent(ComplexFormComponent complexFormComponent, BetweenPosition<ComplexFormComponent>? position = null) => CreateComplexFormComponent(complexFormComponent, position);
+    Task SubmitMoveComplexFormComponent(ComplexFormComponent complexFormComponent, BetweenPosition<ComplexFormComponent> between) => MoveComplexFormComponent(complexFormComponent, between);
     Task SubmitCreateSense(Guid entryId, Sense sense, BetweenPosition? position = null) => CreateSense(entryId, sense, position);
     Task SubmitUpdateSense(Guid entryId, Guid senseId, UpdateObjectInput<Sense> update) => UpdateSense(entryId, senseId, update);
     Task SubmitCreateExampleSentence(Guid entryId, Guid senseId, ExampleSentence exampleSentence, BetweenPosition? position = null) => CreateExampleSentence(entryId, senseId, exampleSentence, position);

--- a/backend/FwLite/MiniLcm/IMiniLcmWriteApi.cs
+++ b/backend/FwLite/MiniLcm/IMiniLcmWriteApi.cs
@@ -112,23 +112,18 @@ public interface IMiniLcmWriteApi
     #endregion
 
     #region Submit (fire-and-forget write variants for sync)
-    // The Update/Create methods above fetch and return the written object, which forces them to assume it
-    // currently exists. During sync an object can be deleted on one side while still referenced by the other,
-    // so the sync uses these result-less variants instead. The CRDT implementation overrides them to just
-    // submit the Harmony change (which leaves a deleted object deleted — delete wins), so they don't throw.
-    // The default implementations call the returning method and discard the result, which is the right
-    // behaviour for everything except the CRDT (FwData still throws if the object is genuinely missing — that
-    // shouldn't happen during sync, and if it does we want to hear about it).
+    // Result-less write variants the sync uses instead of the returning Update/Create methods above. The CRDT
+    // overrides them to submit the change without fetching the result, so applying to an object the other side
+    // deleted leaves it deleted (delete wins) rather than throwing. The defaults forward to the returning
+    // method (correct for FwData, which still surfaces a genuinely-missing object).
     Task SubmitUpdateEntry(Guid id, UpdateObjectInput<Entry> update) => UpdateEntry(id, update);
     Task SubmitCreateComplexFormComponent(ComplexFormComponent complexFormComponent, BetweenPosition<ComplexFormComponent>? position = null) => CreateComplexFormComponent(complexFormComponent, position);
     Task SubmitCreateSense(Guid entryId, Sense sense, BetweenPosition? position = null) => CreateSense(entryId, sense, position);
     Task SubmitUpdateSense(Guid entryId, Guid senseId, UpdateObjectInput<Sense> update) => UpdateSense(entryId, senseId, update);
     Task SubmitCreateExampleSentence(Guid entryId, Guid senseId, ExampleSentence exampleSentence, BetweenPosition? position = null) => CreateExampleSentence(entryId, senseId, exampleSentence, position);
     Task SubmitUpdateExampleSentence(Guid entryId, Guid senseId, Guid exampleSentenceId, UpdateObjectInput<ExampleSentence> update) => UpdateExampleSentence(entryId, senseId, exampleSentenceId, update);
-    // Dependency types (synced before entries). These run outside EntrySync's try/catch, so a deleted-in-CRDT
-    // one that's still edited in FwData would otherwise crash the whole sync the same way (issue #2361).
-    // WritingSystem is omitted (its update needs to resolve the entity id, so it can't be a blind submit, and
-    // deleting a writing system is a deliberate, cascading operation); MorphType is omitted (not deletable).
+    // Dependency types too (they sync before entries, outside EntrySync's try/catch). WritingSystem is omitted
+    // (its update resolves the entity id, so it can't be a blind submit); MorphType is omitted (not deletable).
     Task SubmitUpdatePartOfSpeech(Guid id, UpdateObjectInput<PartOfSpeech> update) => UpdatePartOfSpeech(id, update);
     Task SubmitUpdatePublication(Guid id, UpdateObjectInput<Publication> update) => UpdatePublication(id, update);
     Task SubmitUpdateSemanticDomain(Guid id, UpdateObjectInput<SemanticDomain> update) => UpdateSemanticDomain(id, update);

--- a/backend/FwLite/MiniLcm/IMiniLcmWriteApi.cs
+++ b/backend/FwLite/MiniLcm/IMiniLcmWriteApi.cs
@@ -111,6 +111,22 @@ public interface IMiniLcmWriteApi
     Task UpdateTranslation(Guid entryId, Guid senseId, Guid exampleSentenceId, Guid translationId, UpdateObjectInput<Translation> update);
     #endregion
 
+    #region Submit (fire-and-forget write variants for sync)
+    // The Update/Create methods above fetch and return the written object, which forces them to assume it
+    // currently exists. During sync an object can be deleted on one side while still referenced by the other,
+    // so the sync uses these result-less variants instead. The CRDT implementation overrides them to just
+    // submit the Harmony change (which leaves a deleted object deleted — delete wins), so they don't throw.
+    // The default implementations call the returning method and discard the result, which is the right
+    // behaviour for everything except the CRDT (FwData still throws if the object is genuinely missing — that
+    // shouldn't happen during sync, and if it does we want to hear about it).
+    Task SubmitUpdateEntry(Guid id, UpdateObjectInput<Entry> update) => UpdateEntry(id, update);
+    Task SubmitCreateComplexFormComponent(ComplexFormComponent complexFormComponent, BetweenPosition<ComplexFormComponent>? position = null) => CreateComplexFormComponent(complexFormComponent, position);
+    Task SubmitCreateSense(Guid entryId, Sense sense, BetweenPosition? position = null) => CreateSense(entryId, sense, position);
+    Task SubmitUpdateSense(Guid entryId, Guid senseId, UpdateObjectInput<Sense> update) => UpdateSense(entryId, senseId, update);
+    Task SubmitCreateExampleSentence(Guid entryId, Guid senseId, ExampleSentence exampleSentence, BetweenPosition? position = null) => CreateExampleSentence(entryId, senseId, exampleSentence, position);
+    Task SubmitUpdateExampleSentence(Guid entryId, Guid senseId, Guid exampleSentenceId, UpdateObjectInput<ExampleSentence> update) => UpdateExampleSentence(entryId, senseId, exampleSentenceId, update);
+    #endregion
+
     #region CustomView
     Task<CustomView> CreateCustomView(CustomView customView)
     {

--- a/backend/FwLite/MiniLcm/SyncHelpers/ComplexFormTypeSync.cs
+++ b/backend/FwLite/MiniLcm/SyncHelpers/ComplexFormTypeSync.cs
@@ -20,7 +20,7 @@ public static class ComplexFormTypeSync
         IMiniLcmApi api)
     {
         var updateObjectInput = ComplexFormTypeDiffToUpdate(before, after);
-        if (updateObjectInput is not null) await api.UpdateComplexFormType(after.Id, updateObjectInput);
+        if (updateObjectInput is not null) await api.SubmitUpdateComplexFormType(after.Id, updateObjectInput);
         return updateObjectInput is null ? 0 : 1;
     }
 

--- a/backend/FwLite/MiniLcm/SyncHelpers/EntrySync.cs
+++ b/backend/FwLite/MiniLcm/SyncHelpers/EntrySync.cs
@@ -51,7 +51,7 @@ public static class EntrySync
         try
         {
             var updateObjectInput = EntryDiffToUpdate(beforeEntry, afterEntry);
-            if (updateObjectInput is not null) await api.UpdateEntry(afterEntry.Id, updateObjectInput);
+            if (updateObjectInput is not null) await api.SubmitUpdateEntry(afterEntry.Id, updateObjectInput);
             var changes = await SensesSync(afterEntry.Id, beforeEntry.Senses, afterEntry.Senses, api, allBeforeSenses, allAfterSenses);
             changes += await Sync(afterEntry.Id, beforeEntry.ComplexFormTypes, afterEntry.ComplexFormTypes, api);
             changes += await SyncPublications(afterEntry.Id, beforeEntry.PublishIn, afterEntry.PublishIn, api);
@@ -226,14 +226,8 @@ public static class EntrySync
 
         public override async Task<int> Add(ComplexFormComponent after)
         {
-            try
-            {
-                await api.CreateComplexFormComponent(after);
-            }
-            catch (NotFoundException)
-            {
-                //this can happen if the entry was deleted, so we can just ignore it
-            }
+            // Submit* tolerates a deleted referenced entry (no NotFound), so no try/catch here.
+            await api.SubmitCreateComplexFormComponent(after);
             return 1;
         }
 
@@ -265,14 +259,7 @@ public static class EntrySync
 
         public async Task<int> Add(ComplexFormComponent after, BetweenPosition<ComplexFormComponent> between)
         {
-            try
-            {
-                await api.CreateComplexFormComponent(after, between);
-            }
-            catch (NotFoundException)
-            {
-                //this can happen if the entry was deleted, so we can just ignore it
-            }
+            await api.SubmitCreateComplexFormComponent(after, between);
             return 1;
         }
 
@@ -321,7 +308,7 @@ public static class EntrySync
                 await api.MoveSense(entryId, sense.Id, new BetweenPosition(between.Previous?.Id, between.Next?.Id));
                 return 1 + await SenseSync.Sync(entryId, existing, sense, api);
             }
-            await api.CreateSense(entryId, sense, new BetweenPosition(between.Previous?.Id, between.Next?.Id));
+            await api.SubmitCreateSense(entryId, sense, new BetweenPosition(between.Previous?.Id, between.Next?.Id));
             return 1;
         }
 

--- a/backend/FwLite/MiniLcm/SyncHelpers/EntrySync.cs
+++ b/backend/FwLite/MiniLcm/SyncHelpers/EntrySync.cs
@@ -226,7 +226,6 @@ public static class EntrySync
 
         public override async Task<int> Add(ComplexFormComponent after)
         {
-            // Submit* tolerates a deleted referenced entry (no NotFound), so no try/catch here.
             await api.SubmitCreateComplexFormComponent(after);
             return 1;
         }
@@ -265,7 +264,7 @@ public static class EntrySync
 
         public async Task<int> Move(ComplexFormComponent component, BetweenPosition<ComplexFormComponent> between)
         {
-            await api.MoveComplexFormComponent(component, between);
+            await api.SubmitMoveComplexFormComponent(component, between);
             return 1;
         }
 

--- a/backend/FwLite/MiniLcm/SyncHelpers/ExampleSentenceSync.cs
+++ b/backend/FwLite/MiniLcm/SyncHelpers/ExampleSentenceSync.cs
@@ -25,7 +25,7 @@ public static class ExampleSentenceSync
     {
         var updateObjectInput = DiffToUpdate(beforeExampleSentence, afterExampleSentence);
         if (updateObjectInput is not null)
-            await api.UpdateExampleSentence(entryId, senseId, beforeExampleSentence.Id, updateObjectInput);
+            await api.SubmitUpdateExampleSentence(entryId, senseId, beforeExampleSentence.Id, updateObjectInput);
         var translationChanges = await DiffCollection.Diff(beforeExampleSentence.Translations,
             afterExampleSentence.Translations,
             new TranslationDiffApi(api, entryId, senseId, beforeExampleSentence.Id));
@@ -97,7 +97,7 @@ public static class ExampleSentenceSync
 
         public async Task<int> Add(ExampleSentence afterExampleSentence, BetweenPosition<ExampleSentence> between)
         {
-            await api.CreateExampleSentence(entryId, senseId, afterExampleSentence, new BetweenPosition(between.Previous?.Id, between.Next?.Id));
+            await api.SubmitCreateExampleSentence(entryId, senseId, afterExampleSentence, new BetweenPosition(between.Previous?.Id, between.Next?.Id));
             return 1;
         }
 

--- a/backend/FwLite/MiniLcm/SyncHelpers/PartOfSpeechSync.cs
+++ b/backend/FwLite/MiniLcm/SyncHelpers/PartOfSpeechSync.cs
@@ -20,7 +20,7 @@ public static class PartOfSpeechSync
         IMiniLcmApi api)
     {
         var updateObjectInput = PartOfSpeechDiffToUpdate(before, after);
-        if (updateObjectInput is not null) await api.UpdatePartOfSpeech(after.Id, updateObjectInput);
+        if (updateObjectInput is not null) await api.SubmitUpdatePartOfSpeech(after.Id, updateObjectInput);
         return updateObjectInput is null ? 0 : 1;
     }
 

--- a/backend/FwLite/MiniLcm/SyncHelpers/PublicationSync.cs
+++ b/backend/FwLite/MiniLcm/SyncHelpers/PublicationSync.cs
@@ -22,7 +22,7 @@ public static class PublicationSync
     {
         var updateObjectInput = DiffToUpdate(beforePublication, afterPublication);
         if (updateObjectInput is null) return 0;
-        await api.UpdatePublication(beforePublication.Id, updateObjectInput);
+        await api.SubmitUpdatePublication(beforePublication.Id, updateObjectInput);
         return 1;
     }
 

--- a/backend/FwLite/MiniLcm/SyncHelpers/SemanticDomainSync.cs
+++ b/backend/FwLite/MiniLcm/SyncHelpers/SemanticDomainSync.cs
@@ -20,7 +20,7 @@ public static class SemanticDomainSync
         IMiniLcmApi api)
     {
         var updateObjectInput = SemanticDomainDiffToUpdate(before, after);
-        if (updateObjectInput is not null) await api.UpdateSemanticDomain(after.Id, updateObjectInput);
+        if (updateObjectInput is not null) await api.SubmitUpdateSemanticDomain(after.Id, updateObjectInput);
         return updateObjectInput is null ? 0 : 1;
     }
 

--- a/backend/FwLite/MiniLcm/SyncHelpers/SenseSync.cs
+++ b/backend/FwLite/MiniLcm/SyncHelpers/SenseSync.cs
@@ -11,7 +11,7 @@ public static class SenseSync
         IMiniLcmApi api)
     {
         var updateObjectInput = SenseDiffToUpdate(beforeSense, afterSense);
-        if (updateObjectInput is not null) await api.UpdateSense(entryId, beforeSense.Id, updateObjectInput);
+        if (updateObjectInput is not null) await api.SubmitUpdateSense(entryId, beforeSense.Id, updateObjectInput);
         if (beforeSense.PartOfSpeechId != afterSense.PartOfSpeechId)
         {
             await api.SetSensePartOfSpeech(beforeSense.Id, afterSense.PartOfSpeechId);


### PR DESCRIPTION
When an object is deleted in the CRDT but still edited or referenced from FwData between syncs, the diff calls an Update/Create on it; the CRDT method's `GetX`-or-throw then throws `NotFoundException` and the whole sync crashes (issue #2361). Homograph-number churn — which touches every entry — made this common in production.

Instead of fetching-and-returning the written object (which forces assuming it still exists), the sync now uses new result-less `Submit*` variants on `IMiniLcmWriteApi`. The CRDT overrides them to just submit the Harmony change with no existence check or re-fetch, so applying to a deleted object leaves it deleted (delete wins) rather than throwing. The returning `Update`/`Create` methods delegate to the `Submit` variant then fetch/return as before, so the editor's behaviour is unchanged.

A few decisions a reviewer might wonder about:
- Only `CrdtMiniLcmApi` needs an explicit `Submit` override; FwData and the wrappers inherit the interface default (BeaKona forwards even default-impl members — verified via generated sources). FwData's default still throws if an object is genuinely missing, which shouldn't happen in sync (FwData is never the deleted side), and we'd want to know if it does.
- `Submit` variants cover the returning writes the sync calls, including the dependency types (parts of speech, publications, semantic domains, complex-form types) that sync before entries and would otherwise crash the same way. WritingSystem is omitted (its update resolves the entity id, so it can't be a blind submit; WS deletion is deliberate/cascading) and MorphType (not deletable).
- `DryRunMiniLcmApi` overrides the `Submit` variants record-only, so a dry-run of a conflicted project previews cleanly instead of throwing on the now-deleted object.
- A never-existed (vs deleted) id now surfaces `NotSupportedException` from Harmony on the returning methods instead of `NotFound` — an error path, acceptable.

New sync-class tests in `CrdtEntrySyncTests` cover the entry/sense/example/complex-form-component conflict cases (confirmed red before the fix). Verified against the production project that hit this (`blj-flex`): sync went from crashing to completing.

Supersedes #2364 (which fixed the same bug via an exception-swallowing wrapper).

Resolves #2361

🤖 Generated with [Claude Code](https://claude.com/claude-code)