### PR TITLE
disable gh comments for unit tests

### DIFF
--- a/.github/workflows/fw-lite.yaml
+++ b/.github/workflows/fw-lite.yaml
@@ -162,6 +162,7 @@ jobs:
           check_name: UI unit Tests
           files: ./frontend/viewer/test-results/*.xml
           action_fail_on_inconclusive: true
+          comment_mode: off
 
   publish-mac:
     name: Publish FW Lite app for Mac

--- a/.github/workflows/integration-test.yaml
+++ b/.github/workflows/integration-test.yaml
@@ -119,6 +119,7 @@ jobs:
         with:
           check_name: Integration Tests ${{ inputs.runs-on }} for Mercurial ${{ inputs.hg-version }}
           files: ./test-results/*.trx
+          comment_mode: off
 
 #  playwright-test:
 #    if: ${{ inputs.run-playwright }}

--- a/.github/workflows/lexbox-api.yaml
+++ b/.github/workflows/lexbox-api.yaml
@@ -67,6 +67,7 @@ jobs:
         with:
           check_name: C# Unit Tests
           files: ./test-results/*.xml
+          comment_mode: off
       - name: Upload test results
         if: always()
         uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5.0.0

--- a/.github/workflows/lexbox-fw-headless.yaml
+++ b/.github/workflows/lexbox-fw-headless.yaml
@@ -58,6 +58,7 @@ jobs:
         with:
           check_name: C# FwHeadless Unit Tests
           files: ./test-results/*.xml
+          comment_mode: off
       - name: Upload test results
         if: always()
         uses: actions/upload-artifact@v4

--- a/.github/workflows/lexbox-ui.yaml
+++ b/.github/workflows/lexbox-ui.yaml
@@ -47,6 +47,7 @@ jobs:
           check_name: UI unit Tests
           files: ./frontend/test-results/*.xml
           action_fail_on_inconclusive: true
+          comment_mode: off
 
       - name: Docker meta
         id: meta


### PR DESCRIPTION
per our discussion last week I'm opening this up to disable comments from `EnricoMi/publish-unit-test-result-action`