### PR TITLE
Tolerate complex form parent already deleted during FwData sync

### DIFF
--- a/backend/FwLite/FwDataMiniLcmBridge/Api/FwDataMiniLcmApi.cs
+++ b/backend/FwLite/FwDataMiniLcmBridge/Api/FwDataMiniLcmApi.cs
@@ -1088,13 +1088,15 @@ public class FwDataMiniLcmApi(
 
     public Task DeleteComplexFormComponent(ComplexFormComponent complexFormComponent)
     {
+        //complex form entry has been deleted, so this component relationship is gone already
+        if (!EntriesRepository.TryGetObject(complexFormComponent.ComplexFormEntryId, out var lexEntry))
+            return Task.CompletedTask;
+
         UndoableUnitOfWorkHelper.DoUsingNewOrCurrentUOW("Delete Complex Form Component",
             "Add Complex Form Component",
             Cache.ServiceLocator.ActionHandler,
             () =>
             {
-                //complex form entry has been deleted, so this component relationship is gone already
-                if (!EntriesRepository.TryGetObject(complexFormComponent.ComplexFormEntryId, out var lexEntry)) return;
                 RemoveComplexFormComponent(lexEntry, complexFormComponent);
             });
         return Task.CompletedTask;

--- a/backend/FwLite/FwDataMiniLcmBridge/Api/FwDataMiniLcmApi.cs
+++ b/backend/FwLite/FwDataMiniLcmBridge/Api/FwDataMiniLcmApi.cs
@@ -1093,7 +1093,8 @@ public class FwDataMiniLcmApi(
             Cache.ServiceLocator.ActionHandler,
             () =>
             {
-                var lexEntry = EntriesRepository.GetObject(complexFormComponent.ComplexFormEntryId);
+                //complex form entry has been deleted, so this component relationship is gone already
+                if (!EntriesRepository.TryGetObject(complexFormComponent.ComplexFormEntryId, out var lexEntry)) return;
                 RemoveComplexFormComponent(lexEntry, complexFormComponent);
             });
         return Task.CompletedTask;

--- a/backend/FwLite/FwLiteProjectSync.Tests/EntrySyncTests.cs
+++ b/backend/FwLite/FwLiteProjectSync.Tests/EntrySyncTests.cs
@@ -168,6 +168,27 @@ public class FwDataEntrySyncTests(ExtraWritingSystemsSyncFixture fixture) : Entr
         actual.Should().NotBeNull();
         actual.MorphType.Should().Be(MorphTypeKind.BoundStem);
     }
+
+    [Fact]
+    public async Task SyncFull_RemovingComplexFormWhoseParentWasDeleted_DoesNotThrow()
+    {
+        var component = await Api.CreateEntry(new() { Id = Guid.NewGuid(), LexemeForm = { { "en", "component" } } });
+        var complexForm = new Entry { Id = Guid.NewGuid(), LexemeForm = { { "en", "complexForm" } } };
+        complexForm.Components = [ComplexFormComponent.FromEntries(complexForm, component)];
+        await Api.CreateEntry(complexForm);
+
+        var before = await Api.GetEntry(component.Id);
+        before!.ComplexForms.Should().ContainSingle();
+
+        // Deleting the parent already drops the relationship; the sync then redundantly removes it from the surviving component, which used to throw because the parent was gone.
+        await Api.DeleteEntry(complexForm.Id);
+        var after = before.Copy();
+        after.ComplexForms.Clear();
+
+        await EntrySync.SyncFull(before, after, Api);
+
+        (await Api.GetEntry(component.Id)).Should().NotBeNull();
+    }
 }
 
 public abstract class EntrySyncTestsBase(ExtraWritingSystemsSyncFixture fixture) : IClassFixture<ExtraWritingSystemsSyncFixture>, IAsyncLifetime


### PR DESCRIPTION
Resolves #2373

Just ran into this when trying to sync the rmunn thai-food project in prod.

This bug/exception could also be fixed by re-reading all the FwData entries before diffing/syncing complex forms and components. I.e. make the diff reflect any cascaded deletes before moving to a new phase.

Funny that we just dealt with this sort of thing in CRDT-land. But this is different, here in fwdata-land.