### PR TITLE
Update entry search records if morph type tokens change

### DIFF
--- a/backend/FwLite/LcmCrdt.Tests/FullTextSearch/EntrySearchServiceTests.cs
+++ b/backend/FwLite/LcmCrdt.Tests/FullTextSearch/EntrySearchServiceTests.cs
@@ -209,6 +209,50 @@ public class EntrySearchServiceTests : IAsyncLifetime
     }
 
     [Fact]
+    public async Task RegeneratesSearchRecords_WhenMorphTypePostfixIsAdded()
+    {
+        var id = Guid.NewGuid();
+        await fixture.Api.CreateEntry(new Entry()
+        {
+            Id = id,
+            LexemeForm = { ["en"] = "in" },
+            MorphType = MorphTypeKind.Suffix
+        });
+        (await Headword(id)).Should().Be("-in");
+
+        var suffix = await fixture.Api.GetMorphType(MorphTypeKind.Suffix);
+        suffix.Should().NotBeNull();
+        var updated = suffix!.Copy();
+        updated.Postfix = "~";
+        await fixture.Api.UpdateMorphType(suffix, updated);
+
+        // Adding a new token must regenerate the search record's headword.
+        (await Headword(id)).Should().Be("-in~");
+    }
+
+    [Fact]
+    public async Task RegeneratesSearchRecords_WhenMorphTypePostfixIsRemoved()
+    {
+        var id = Guid.NewGuid();
+        await fixture.Api.CreateEntry(new Entry()
+        {
+            Id = id,
+            LexemeForm = { ["en"] = "in" },
+            MorphType = MorphTypeKind.Infix
+        });
+        (await Headword(id)).Should().Be("-in-");
+
+        var infix = await fixture.Api.GetMorphType(MorphTypeKind.Infix);
+        infix.Should().NotBeNull();
+        var updated = infix!.Copy();
+        updated.Postfix = "";
+        await fixture.Api.UpdateMorphType(infix, updated);
+
+        // Deleting a token must regenerate the search record's headword.
+        (await Headword(id)).Should().Be("-in");
+    }
+
+    [Fact]
     public async Task SearchTableIsUpdatedAutomaticallyOnMorphTypeChange()
     {
         var id = Guid.NewGuid();

--- a/backend/FwLite/LcmCrdt.Tests/FullTextSearch/EntrySearchServiceTests.cs
+++ b/backend/FwLite/LcmCrdt.Tests/FullTextSearch/EntrySearchServiceTests.cs
@@ -208,6 +208,29 @@ public class EntrySearchServiceTests : IAsyncLifetime
         (await Headword(id)).Should().Be("~in~");
     }
 
+    [Fact]
+    [Trait("Category", "Verified")]
+    public async Task SearchTableIsUpdatedAutomaticallyOnMorphTypeChange()
+    {
+        var id = Guid.NewGuid();
+        await fixture.Api.CreateEntry(new Entry()
+        {
+            Id = id,
+            LexemeForm = { ["en"] = "in" },
+            MorphType = MorphTypeKind.Infix
+        });
+        (await Headword(id)).Should().Be("-in-");
+
+        var entry = await _context.FindAsync<Entry>(id);
+        entry.Should().NotBeNull();
+        var updated = entry.Copy();
+        updated.MorphType = MorphTypeKind.Simulfix; // Prefix and Postfix are "="
+        await fixture.Api.UpdateEntry(entry, updated);
+
+        // Changing morph type of an entry must regenerate its search record's headword.
+        (await Headword(id)).Should().Be("=in=");
+    }
+
     private async Task<string?> Headword(Guid entryId)
     {
         // .AsNoTracking() needed here because RegenerateEntrySearchTable() has just cleared

--- a/backend/FwLite/LcmCrdt.Tests/FullTextSearch/EntrySearchServiceTests.cs
+++ b/backend/FwLite/LcmCrdt.Tests/FullTextSearch/EntrySearchServiceTests.cs
@@ -231,7 +231,7 @@ public class EntrySearchServiceTests : IAsyncLifetime
     }
 
     [Fact]
-    public async Task SearchTableIsUpdatedAutomaticallyWhenManyChangesHappenAtOnce()
+    public async Task SearchTableIsUpdatedAutomaticallyWhenManyChangesHappenOneAfterAnother()
     {
         var id = Guid.NewGuid();
         await fixture.Api.CreateEntry(new Entry()
@@ -253,8 +253,68 @@ public class EntrySearchServiceTests : IAsyncLifetime
         entry.Should().NotBeNull();
         var updated = entry.Copy();
         updated.LexemeForm = new() { ["en"] = "out" };
-        updated.MorphType = MorphTypeKind.Simulfix; // Prefix and Postfix are "="
+        updated.MorphType = MorphTypeKind.Simulfix;
         await fixture.Api.UpdateEntry(entry, updated);
+
+        // Changing morph type of an entry must regenerate its search record's headword.
+        (await Headword(id)).Should().Be("~out~");
+    }
+
+    [Fact]
+    public async Task SearchTableIsUpdatedAutomaticallyWhenManyChangesHappenAtOnce_MorphTypeFirstThenEntry()
+    {
+        var id = Guid.NewGuid();
+        await fixture.Api.CreateEntry(new Entry()
+        {
+            Id = id,
+            LexemeForm = { ["en"] = "in" },
+            MorphType = MorphTypeKind.Infix
+        });
+        (await Headword(id)).Should().Be("-in-");
+
+        // Here we make changes directly in the DbContext, then call SaveChanges once at the end
+        var simulfix = await _context.Set<MorphType>().FirstOrDefaultAsync(mt => mt.Kind == MorphTypeKind.Simulfix);
+        simulfix.Should().NotBeNull();
+        simulfix.Prefix = "~";
+        simulfix.Postfix = "~";
+        _context.Update(simulfix);
+
+        var entry = await _context.FindAsync<Entry>(id);
+        entry.Should().NotBeNull();
+        entry.LexemeForm = new() { ["en"] = "out" };
+        entry.MorphType = MorphTypeKind.Simulfix;
+        _context.Update(entry);
+        await _context.SaveChangesAsync();
+
+        // Changing morph type of an entry must regenerate its search record's headword.
+        (await Headword(id)).Should().Be("~out~");
+    }
+
+    [Fact]
+    public async Task SearchTableIsUpdatedAutomaticallyWhenManyChangesHappenAtOnce_EntryFirstThenMorphType()
+    {
+        var id = Guid.NewGuid();
+        await fixture.Api.CreateEntry(new Entry()
+        {
+            Id = id,
+            LexemeForm = { ["en"] = "in" },
+            MorphType = MorphTypeKind.Infix
+        });
+        (await Headword(id)).Should().Be("-in-");
+
+        // Here we make changes directly in the DbContext, then call SaveChanges once at the end
+        var entry = await _context.FindAsync<Entry>(id);
+        entry.Should().NotBeNull();
+        entry.LexemeForm = new() { ["en"] = "out" };
+        entry.MorphType = MorphTypeKind.Simulfix;
+        _context.Update(entry);
+
+        var simulfix = await _context.Set<MorphType>().FirstOrDefaultAsync(mt => mt.Kind == MorphTypeKind.Simulfix);
+        simulfix.Should().NotBeNull();
+        simulfix.Prefix = "~";
+        simulfix.Postfix = "~";
+        _context.Update(simulfix);
+        await _context.SaveChangesAsync();
 
         // Changing morph type of an entry must regenerate its search record's headword.
         (await Headword(id)).Should().Be("~out~");

--- a/backend/FwLite/LcmCrdt.Tests/FullTextSearch/EntrySearchServiceTests.cs
+++ b/backend/FwLite/LcmCrdt.Tests/FullTextSearch/EntrySearchServiceTests.cs
@@ -209,7 +209,6 @@ public class EntrySearchServiceTests : IAsyncLifetime
     }
 
     [Fact]
-    [Trait("Category", "Verified")]
     public async Task SearchTableIsUpdatedAutomaticallyOnMorphTypeChange()
     {
         var id = Guid.NewGuid();

--- a/backend/FwLite/LcmCrdt.Tests/FullTextSearch/EntrySearchServiceTests.cs
+++ b/backend/FwLite/LcmCrdt.Tests/FullTextSearch/EntrySearchServiceTests.cs
@@ -139,6 +139,87 @@ public class EntrySearchServiceTests : IAsyncLifetime
     }
 
     [Fact]
+    public async Task RegeneratesSearchRecords_WhenMorphTypePrefixChanges()
+    {
+        // Suffix morph type has Prefix="-" by default, so a lexeme-only entry's headword is "-cat".
+        var id = Guid.NewGuid();
+        await fixture.Api.CreateEntry(new Entry()
+        {
+            Id = id,
+            LexemeForm = { ["en"] = "cat" },
+            MorphType = MorphTypeKind.Suffix
+        });
+        (await Headword(id)).Should().Be("-cat");
+
+        var suffix = await fixture.Api.GetMorphType(MorphTypeKind.Suffix);
+        suffix.Should().NotBeNull();
+        var updated = suffix!.Copy();
+        updated.Prefix = "~";
+        await fixture.Api.UpdateMorphType(suffix, updated);
+
+        // Changing the prefix token must regenerate the search record's headword.
+        (await Headword(id)).Should().Be("~cat");
+    }
+
+    [Fact]
+    public async Task RegeneratesSearchRecords_WhenMorphTypePostfixChanges()
+    {
+        // Prefix morph type has Postfix="-" by default, so a lexeme-only entry's headword is "un-".
+        var id = Guid.NewGuid();
+        await fixture.Api.CreateEntry(new Entry()
+        {
+            Id = id,
+            LexemeForm = { ["en"] = "un" },
+            MorphType = MorphTypeKind.Prefix
+        });
+        (await Headword(id)).Should().Be("un-");
+
+        var prefix = await fixture.Api.GetMorphType(MorphTypeKind.Prefix);
+        prefix.Should().NotBeNull();
+        var updated = prefix!.Copy();
+        updated.Postfix = "~";
+        await fixture.Api.UpdateMorphType(prefix, updated);
+
+        // Changing the postfix token must regenerate the search record's headword.
+        (await Headword(id)).Should().Be("un~");
+    }
+
+    [Fact]
+    public async Task RegeneratesSearchRecords_WhenMorphTypePrefixAndPostfixChange()
+    {
+        // Infix morph type has Prefix="-" and Postfix="-" by default, so the headword is "-in-".
+        var id = Guid.NewGuid();
+        await fixture.Api.CreateEntry(new Entry()
+        {
+            Id = id,
+            LexemeForm = { ["en"] = "in" },
+            MorphType = MorphTypeKind.Infix
+        });
+        (await Headword(id)).Should().Be("-in-");
+
+        var infix = await fixture.Api.GetMorphType(MorphTypeKind.Infix);
+        infix.Should().NotBeNull();
+        var updated = infix!.Copy();
+        updated.Prefix = "~";
+        updated.Postfix = "~";
+        await fixture.Api.UpdateMorphType(infix, updated);
+
+        // Changing both tokens in a single update must regenerate the search record's headword.
+        (await Headword(id)).Should().Be("~in~");
+    }
+
+    private async Task<string?> Headword(Guid entryId)
+    {
+        // .AsNoTracking() needed here because RegenerateEntrySearchTable() has just cleared
+        // and recreated the table using Linq2DB, but EF Core doesn't know that yet and so it
+        // will serve us the cached copy of the table. So .AsNoTracking() ensures that EF Core
+        // will hit the database and retrieve a fresh copy of the headword.
+        var record = await _service.EntrySearchRecords.AsNoTracking().SingleOrDefaultAsync(e => e.Id == entryId);
+        record.Should().NotBeNull();
+        return record!.Headword;
+    }
+
+    [Fact]
     public async Task CanRegenerateTheSearchTable()
     {
         var id = Guid.NewGuid();

--- a/backend/FwLite/LcmCrdt.Tests/FullTextSearch/EntrySearchServiceTests.cs
+++ b/backend/FwLite/LcmCrdt.Tests/FullTextSearch/EntrySearchServiceTests.cs
@@ -230,6 +230,36 @@ public class EntrySearchServiceTests : IAsyncLifetime
         (await Headword(id)).Should().Be("=in=");
     }
 
+    [Fact]
+    public async Task SearchTableIsUpdatedAutomaticallyWhenManyChangesHappenAtOnce()
+    {
+        var id = Guid.NewGuid();
+        await fixture.Api.CreateEntry(new Entry()
+        {
+            Id = id,
+            LexemeForm = { ["en"] = "in" },
+            MorphType = MorphTypeKind.Infix
+        });
+        (await Headword(id)).Should().Be("-in-");
+
+        var simulfix = await fixture.Api.GetMorphType(MorphTypeKind.Simulfix);
+        simulfix.Should().NotBeNull();
+        var updatedMorphType = simulfix!.Copy();
+        updatedMorphType.Prefix = "~";
+        updatedMorphType.Postfix = "~";
+        await fixture.Api.UpdateMorphType(simulfix, updatedMorphType);
+
+        var entry = await _context.FindAsync<Entry>(id);
+        entry.Should().NotBeNull();
+        var updated = entry.Copy();
+        updated.LexemeForm = new() { ["en"] = "out" };
+        updated.MorphType = MorphTypeKind.Simulfix; // Prefix and Postfix are "="
+        await fixture.Api.UpdateEntry(entry, updated);
+
+        // Changing morph type of an entry must regenerate its search record's headword.
+        (await Headword(id)).Should().Be("~out~");
+    }
+
     private async Task<string?> Headword(Guid entryId)
     {
         // .AsNoTracking() needed here because RegenerateEntrySearchTable() has just cleared

--- a/backend/FwLite/LcmCrdt/FullTextSearch/EntrySearchService.cs
+++ b/backend/FwLite/LcmCrdt/FullTextSearch/EntrySearchService.cs
@@ -283,7 +283,8 @@ public class EntrySearchService(LcmCrdtDbContext dbContext, ILogger<EntrySearchS
 
     public static async Task RegenerateEntrySearchTable(LcmCrdtDbContext dbContext)
     {
-        await using var transaction = await dbContext.Database.BeginTransactionAsync();
+        // SQLite doesn't allow nested transactions, so check if we're already in one before opening a new transaction
+        await using var transaction = dbContext.Database.CurrentTransaction is null ? await dbContext.Database.BeginTransactionAsync() : null;
         var entrySearchRecordsTable = dbContext.GetTable<EntrySearchRecord>();
         await entrySearchRecordsTable.TruncateAsync();
 
@@ -297,7 +298,7 @@ public class EntrySearchService(LcmCrdtDbContext dbContext, ILogger<EntrySearchS
                 .AsQueryable()
                 .Select(entry => ToEntrySearchRecord(entry, writingSystems, morphTypeLookup))
                 .AsAsyncEnumerable());
-        await transaction.CommitAsync();
+        if (transaction is not null) await transaction.CommitAsync();
     }
 
     public async Task RegenerateIfMissing()

--- a/backend/FwLite/LcmCrdt/FullTextSearch/EntrySearchService.cs
+++ b/backend/FwLite/LcmCrdt/FullTextSearch/EntrySearchService.cs
@@ -276,14 +276,22 @@ public class EntrySearchService(LcmCrdtDbContext dbContext, ILogger<EntrySearchS
             .DeleteAsync();
     }
 
-    public async Task RegenerateEntrySearchTable()
+    public Task RegenerateEntrySearchTable()
+    {
+        return RegenerateEntrySearchTable(dbContext);
+    }
+
+    public static async Task RegenerateEntrySearchTable(LcmCrdtDbContext dbContext)
     {
         await using var transaction = await dbContext.Database.BeginTransactionAsync();
-        await EntrySearchRecordsTable.TruncateAsync();
+        var entrySearchRecordsTable = dbContext.GetTable<EntrySearchRecord>();
+        await entrySearchRecordsTable.TruncateAsync();
 
         var writingSystems = await dbContext.WritingSystemsOrdered.ToArrayAsync();
+        // TODO: Double check that dbContext.MorphTypes will be returning the changed morph type tokens (it's using .AsNoTracking() which could interfere with that)
+        // Alternately, just ensure that this runs after the EF Core changes have been committed, and then we'll get the correct tokens anyway
         var morphTypeLookup = await dbContext.MorphTypes.ToDictionaryAsync(m => m.Kind);
-        await EntrySearchRecordsTable
+        await entrySearchRecordsTable
             .BulkCopyAsync(dbContext.Set<Entry>()
                 .LoadWith(e => e.Senses)
                 .AsQueryable()

--- a/backend/FwLite/LcmCrdt/FullTextSearch/EntrySearchService.cs
+++ b/backend/FwLite/LcmCrdt/FullTextSearch/EntrySearchService.cs
@@ -289,8 +289,6 @@ public class EntrySearchService(LcmCrdtDbContext dbContext, ILogger<EntrySearchS
         await entrySearchRecordsTable.TruncateAsync();
 
         var writingSystems = await dbContext.WritingSystemsOrdered.ToArrayAsync();
-        // TODO: Double check that dbContext.MorphTypes will be returning the changed morph type tokens (it's using .AsNoTracking() which could interfere with that)
-        // Alternately, just ensure that this runs after the EF Core changes have been committed, and then we'll get the correct tokens anyway
         var morphTypeLookup = await dbContext.MorphTypes.ToDictionaryAsync(m => m.Kind);
         await entrySearchRecordsTable
             .BulkCopyAsync(dbContext.Set<Entry>()

--- a/backend/FwLite/LcmCrdt/FullTextSearch/UpdateEntrySearchTableInterceptor.cs
+++ b/backend/FwLite/LcmCrdt/FullTextSearch/UpdateEntrySearchTableInterceptor.cs
@@ -84,6 +84,15 @@ public class UpdateEntrySearchTableInterceptor : ISaveChangesInterceptor
         await EntrySearchService.RegenerateEntrySearchTable(dbContext);
     }
 
+    // If saving changes fails, then the MorphType changes didn't make it into the DB and headwords don't need to be regenerated after all
+    public void SaveChangesFailed(DbContextErrorEventData eventData) => EntryTableNeedsRegeneration = false;
+
+    public Task SaveChangesFailedAsync(DbContextErrorEventData eventData, CancellationToken cancellationToken = default)
+    {
+        EntryTableNeedsRegeneration = false;
+        return Task.CompletedTask;
+    }
+
     private async Task<(Entry? updatedEntry, Guid? removed)> ForUpdate(IEnumerable<EntityEntry> group, Guid entryId, DbContext dbContext)
     {
         var entities = group.ToArray();

--- a/backend/FwLite/LcmCrdt/FullTextSearch/UpdateEntrySearchTableInterceptor.cs
+++ b/backend/FwLite/LcmCrdt/FullTextSearch/UpdateEntrySearchTableInterceptor.cs
@@ -37,6 +37,18 @@ public class UpdateEntrySearchTableInterceptor : ISaveChangesInterceptor
     private async Task UpdateSearchTableOnSave(DbContext? maybeDbContext)
     {
         if (maybeDbContext is not LcmCrdtDbContext dbContext) return;
+        // Morph types with changes to prefix or postfix tokens will require updated entry search records
+        // (Note that morph types can't be added or deleted, so we only need to catch changes, which will be rare)
+        var changedMorphTypes = dbContext.ChangeTracker.Entries<MorphType>()
+            .Where(e => e.State == EntityState.Modified && (e.Property(m => m.Prefix).IsModified || e.Property(m => m.Postfix).IsModified))
+            .Select(e => e.Entity).ToList();
+        if (changedMorphTypes is not [])
+        {
+            // The actual table regeneration will happen in the SavedChangesAsync handler; here we just flag that it will be needed
+            EntryTableNeedsRegeneration = true;
+            // Any change to morph-type tokens will invalidate the whole entry search table, so no need to check for individual entries
+            return;
+        }
         List<Entry> toUpdate = [];
         List<Guid> toRemove = [];
         var newWritingSystems = dbContext.ChangeTracker.Entries<WritingSystem>()
@@ -59,22 +71,8 @@ public class UpdateEntrySearchTableInterceptor : ISaveChangesInterceptor
             if (updatedEntry is not null) toUpdate.Add(updatedEntry);
             if (removed is not null) toRemove.Add(removed.Value);
         }
-
-        // Morph types with changes to prefix or postfix tokens will also require updated entry search records
-        // (Note that morph types can't be added or deleted, so we only need to catch changes, which will be rare)
-        var changedMorphTypes = dbContext.ChangeTracker.Entries<MorphType>()
-            .Where(e => e.State == EntityState.Modified && (e.Property(m => m.Prefix).IsModified || e.Property(m => m.Postfix).IsModified))
-            .Select(e => e.Entity).ToList();
-        if (toUpdate is [] && toRemove is [] && changedMorphTypes is []) return;
-        if (changedMorphTypes is [])
-        {
-            await EntrySearchService.UpdateEntrySearchTable(toUpdate, toRemove, newWritingSystems, dbContext);
-        }
-        else
-        {
-            // Skip updating the entry search table for individual records, because we're going to regenerate the whole thing later
-            EntryTableNeedsRegeneration = true;
-        }
+        if (toUpdate is [] && toRemove is []) return;
+        await EntrySearchService.UpdateEntrySearchTable(toUpdate, toRemove, newWritingSystems, dbContext);
     }
 
     private async Task RegenerateSearchTableAfterSave(DbContext? maybeDbContext)

--- a/backend/FwLite/LcmCrdt/FullTextSearch/UpdateEntrySearchTableInterceptor.cs
+++ b/backend/FwLite/LcmCrdt/FullTextSearch/UpdateEntrySearchTableInterceptor.cs
@@ -40,9 +40,8 @@ public class UpdateEntrySearchTableInterceptor : ISaveChangesInterceptor
         // Morph types with changes to prefix or postfix tokens will require updated entry search records
         // (Note that morph types can't be added or deleted, so we only need to catch changes, which will be rare)
         var changedMorphTypes = dbContext.ChangeTracker.Entries<MorphType>()
-            .Where(e => e.State == EntityState.Modified && (e.Property(m => m.Prefix).IsModified || e.Property(m => m.Postfix).IsModified))
-            .Select(e => e.Entity).ToList();
-        if (changedMorphTypes is not [])
+            .Any(e => e.State == EntityState.Modified && (e.Property(m => m.Prefix).IsModified || e.Property(m => m.Postfix).IsModified));
+        if (changedMorphTypes)
         {
             // The actual table regeneration will happen in the SavedChangesAsync handler; here we just flag that it will be needed
             EntryTableNeedsRegeneration = true;

--- a/backend/FwLite/LcmCrdt/FullTextSearch/UpdateEntrySearchTableInterceptor.cs
+++ b/backend/FwLite/LcmCrdt/FullTextSearch/UpdateEntrySearchTableInterceptor.cs
@@ -25,14 +25,14 @@ public class UpdateEntrySearchTableInterceptor : ISaveChangesInterceptor
         return result;
     }
 
-    private async Task UpdateSearchTableOnSave(DbContext? dbContext)
+    private async Task UpdateSearchTableOnSave(DbContext? maybeDbContext)
     {
-        if (dbContext is null) return;
+        if (maybeDbContext is not LcmCrdtDbContext dbContext) return;
         List<Entry> toUpdate = [];
         List<Guid> toRemove = [];
-        var newWritingSystems = dbContext.ChangeTracker.Entries()
-            .Where(e => e.Entity is WritingSystem && e.State == EntityState.Added)
-            .Select(e => (WritingSystem)e.Entity).ToList();
+        var newWritingSystems = dbContext.ChangeTracker.Entries<WritingSystem>()
+            .Where(e => e.State == EntityState.Added)
+            .Select(e => e.Entity).ToList();
         foreach (var group in dbContext.ChangeTracker.Entries()
                      .Where(e => e is { State: EntityState.Added or EntityState.Modified or EntityState.Deleted, Entity: Entry or Sense })
                      .GroupBy(e =>
@@ -50,8 +50,22 @@ public class UpdateEntrySearchTableInterceptor : ISaveChangesInterceptor
             if (updatedEntry is not null) toUpdate.Add(updatedEntry);
             if (removed is not null) toRemove.Add(removed.Value);
         }
-        if (toUpdate is [] && toRemove is []) return;
-        await EntrySearchService.UpdateEntrySearchTable(toUpdate, toRemove, newWritingSystems, (LcmCrdtDbContext)dbContext);
+
+        // Morph types with changes to prefix or postfix tokens will also require updated entry search records
+        // (Note that morph types can't be added or deleted, so we only need to catch changes, which will be rare)
+        var changedMorphTypes = dbContext.ChangeTracker.Entries<MorphType>()
+            .Where(e => e.State == EntityState.Modified && (e.Property(m => m.Prefix).IsModified || e.Property(m => m.Postfix).IsModified))
+            .Select(e => e.Entity).ToList();
+        if (toUpdate is [] && toRemove is [] && changedMorphTypes is []) return;
+        if (changedMorphTypes is [])
+        {
+            await EntrySearchService.UpdateEntrySearchTable(toUpdate, toRemove, newWritingSystems, dbContext);
+        }
+        else
+        {
+            // TODO: Cue this up to run *after* the EF Core commit is done, so we don't have to regenerate the search table multiple times
+            await EntrySearchService.RegenerateEntrySearchTable(dbContext);
+        }
     }
 
     private async Task<(Entry? updatedEntry, Guid? removed)> ForUpdate(IEnumerable<EntityEntry> group, Guid entryId, DbContext dbContext)

--- a/backend/FwLite/LcmCrdt/FullTextSearch/UpdateEntrySearchTableInterceptor.cs
+++ b/backend/FwLite/LcmCrdt/FullTextSearch/UpdateEntrySearchTableInterceptor.cs
@@ -31,7 +31,6 @@ public class UpdateEntrySearchTableInterceptor : ISaveChangesInterceptor
         CancellationToken cancellationToken = new CancellationToken())
     {
         if (EntryTableNeedsRegeneration) await RegenerateSearchTableAfterSave(eventData.Context);
-        // await UpdateSearchTableOnSave(eventData.Context);
         return result;
     }
 

--- a/backend/FwLite/LcmCrdt/FullTextSearch/UpdateEntrySearchTableInterceptor.cs
+++ b/backend/FwLite/LcmCrdt/FullTextSearch/UpdateEntrySearchTableInterceptor.cs
@@ -7,6 +7,7 @@ namespace LcmCrdt.FullTextSearch;
 
 public class UpdateEntrySearchTableInterceptor : ISaveChangesInterceptor
 {
+    private bool EntryTableNeedsRegeneration { get; set; } = false;
     public InterceptionResult<int> SavingChanges(DbContextEventData eventData, InterceptionResult<int> result)
     {
         throw new NotImplementedException(
@@ -22,6 +23,15 @@ public class UpdateEntrySearchTableInterceptor : ISaveChangesInterceptor
         CancellationToken cancellationToken = new CancellationToken())
     {
         await UpdateSearchTableOnSave(eventData.Context);
+        return result;
+    }
+
+    public async ValueTask<int> SavedChangesAsync(SaveChangesCompletedEventData eventData,
+        int result,
+        CancellationToken cancellationToken = new CancellationToken())
+    {
+        if (EntryTableNeedsRegeneration) await RegenerateSearchTableAfterSave(eventData.Context);
+        // await UpdateSearchTableOnSave(eventData.Context);
         return result;
     }
 
@@ -63,9 +73,16 @@ public class UpdateEntrySearchTableInterceptor : ISaveChangesInterceptor
         }
         else
         {
-            // TODO: Cue this up to run *after* the EF Core commit is done, so we don't have to regenerate the search table multiple times
-            await EntrySearchService.RegenerateEntrySearchTable(dbContext);
+            // Skip updating the entry search table for individual records, because we're going to regenerate the whole thing later
+            EntryTableNeedsRegeneration = true;
         }
+    }
+
+    private async Task RegenerateSearchTableAfterSave(DbContext? maybeDbContext)
+    {
+        EntryTableNeedsRegeneration = false;
+        if (maybeDbContext is not LcmCrdtDbContext dbContext) return;
+        await EntrySearchService.RegenerateEntrySearchTable(dbContext);
     }
 
     private async Task<(Entry? updatedEntry, Guid? removed)> ForUpdate(IEnumerable<EntityEntry> group, Guid entryId, DbContext dbContext)


### PR DESCRIPTION
Fixes #2213.

I chose to hook into the existing interceptor rather than creating a new one. That way if entries and morph types change in the same "transaction" (or the EF equivalent of a transaction), we can avoid duplicating the search record updates for entries that changed (and we can use the changed entries, rather than their original values, when calculating the updated headwords with the new morph types — if we used a separate interceptor then we wouldn't be able to guarantee that these two steps ran in the desired order).

P.S. This is #2246 recreated on top of current `develop`.