### PR TITLE
Pass stable data dir to FW Lite to survive extension version updates

### DIFF
--- a/platform.bible-extension/src/main.ts
+++ b/platform.bible-extension/src/main.ts
@@ -2,6 +2,8 @@ import papi, { logger } from '@papi/backend';
 import type { ExecutionActivationContext } from '@papi/core';
 import { ChildProcessByStdio } from 'child_process';
 import type { BrowseWebViewOptions } from 'lexicon';
+import os from 'os';
+import path from 'path';
 import { Stream } from 'stream';
 import { EntryService } from './services/entry-service';
 import { WebViewType } from './types/enums';
@@ -241,6 +243,14 @@ export async function deactivate(): Promise<boolean> {
   return await shutDownFwLite();
 }
 
+/**
+ * Returns a stable per-user directory for FW Lite data (projects, auth cache).
+ * Mirrors Platform.Bible's own app:// convention so the path survives extension updates.
+ */
+function getFwLiteDataDir(): string {
+  return path.join(os.homedir(), '.platform.bible', 'extensions', 'lexicon');
+}
+
 /** Launches the FieldWorks Lite process and returns its URL domain. */
 function launchFwLite(context: ExecutionActivationContext): string {
   const binaryPath = 'fw-lite/FwLiteWeb.exe';
@@ -253,6 +263,7 @@ function launchFwLite(context: ExecutionActivationContext): string {
   // TODO: Instead of hardcoding the URL and port we should run it and find them in the output.
   const baseUrl = 'http://localhost:29348';
 
+  const dataDir = getFwLiteDataDir();
   fwLiteProcess = context.elevatedPrivileges.createProcess.spawn(
     context.executionToken,
     binaryPath,
@@ -263,6 +274,8 @@ function launchFwLite(context: ExecutionActivationContext): string {
       '--FwLiteWeb:CorsAllowAny=true',
       '--FwLiteWeb:EnableFileLogging=false', // already piped to P.B (and triggers npm watch)
       '--FwLiteWeb:OpenBrowser=false',
+      `--LcmCrdt:ProjectPath=${dataDir}`,
+      `--Auth:CacheFileName=${path.join(dataDir, 'msal.json')}`,
     ],
     { stdio: ['pipe', 'pipe', 'pipe'] },
   );

--- a/platform.bible-extension/src/main.ts
+++ b/platform.bible-extension/src/main.ts
@@ -1,6 +1,7 @@
 import papi, { logger } from '@papi/backend';
 import type { ExecutionActivationContext } from '@papi/core';
 import { ChildProcessByStdio } from 'child_process';
+import { mkdirSync } from 'fs';
 import type { BrowseWebViewOptions } from 'lexicon';
 import os from 'os';
 import path from 'path';
@@ -244,8 +245,8 @@ export async function deactivate(): Promise<boolean> {
 }
 
 /**
- * Returns a stable per-user directory for FW Lite data (projects, auth cache).
- * Mirrors Platform.Bible's own app:// convention so the path survives extension updates.
+ * Returns a stable per-user directory for FW Lite data (projects, auth cache). Mirrors
+ * Platform.Bible's own app:// convention so the path survives extension updates.
  */
 function getFwLiteDataDir(): string {
   return path.join(os.homedir(), '.platform.bible', 'extensions', 'lexicon');
@@ -264,6 +265,7 @@ function launchFwLite(context: ExecutionActivationContext): string {
   const baseUrl = 'http://localhost:29348';
 
   const dataDir = getFwLiteDataDir();
+  mkdirSync(dataDir, { recursive: true });
   fwLiteProcess = context.elevatedPrivileges.createProcess.spawn(
     context.executionToken,
     binaryPath,

--- a/platform.bible-extension/src/main.ts
+++ b/platform.bible-extension/src/main.ts
@@ -242,14 +242,25 @@ export async function deactivate(): Promise<boolean> {
 }
 
 /**
- * Returns a stable per-user directory for FW Lite data (projects, auth cache). Mirrors
- * Platform.Bible's own app:// convention so the path survives extension updates.
+ * Returns a stable per-user directory for FW Lite data (projects, auth cache), in its own
+ * subdirectory so it doesn't collide with Platform.Bible's own `papi.storage` data for this
+ * extension (`.../extensions/lexicon/user-data/`). Mirrors Platform.Bible's own `app://` scheme
+ * (paranext-core's `getAppDir()`): the real per-user location when packaged, the repo-local
+ * dev-appdata directory in development, so `npm start` doesn't read/write production user data.
  *
- * Uses process.env instead of require('os') because Platform.Bible blocks non-papi requires.
+ * Uses process.env/globalThis instead of require('os'/'path') because Platform.Bible blocks
+ * non-papi requires.
  */
 function getFwLiteDataDir(): string {
-  const home = process.env.USERPROFILE ?? process.env.HOME ?? '';
-  return `${home}\\.platform.bible\\extensions\\lexicon`;
+  let appDataDir: string;
+  if (globalThis.isPackaged) {
+    const home = process.env.USERPROFILE;
+    if (!home) throw new Error('Cannot determine FW Lite data directory: USERPROFILE is not set');
+    appDataDir = `${home}\\.platform.bible`;
+  } else {
+    appDataDir = `${globalThis.resourcesPath}\\dev-appdata`;
+  }
+  return `${appDataDir}\\extensions\\lexicon\\fw-lite`;
 }
 
 /** Launches the FieldWorks Lite process and returns its URL domain. */

--- a/platform.bible-extension/src/main.ts
+++ b/platform.bible-extension/src/main.ts
@@ -1,10 +1,7 @@
 import papi, { logger } from '@papi/backend';
 import type { ExecutionActivationContext } from '@papi/core';
 import { ChildProcessByStdio } from 'child_process';
-import { mkdirSync } from 'fs';
 import type { BrowseWebViewOptions } from 'lexicon';
-import os from 'os';
-import path from 'path';
 import { Stream } from 'stream';
 import { EntryService } from './services/entry-service';
 import { WebViewType } from './types/enums';
@@ -247,9 +244,12 @@ export async function deactivate(): Promise<boolean> {
 /**
  * Returns a stable per-user directory for FW Lite data (projects, auth cache). Mirrors
  * Platform.Bible's own app:// convention so the path survives extension updates.
+ *
+ * Uses process.env instead of require('os') because Platform.Bible blocks non-papi requires.
  */
 function getFwLiteDataDir(): string {
-  return path.join(os.homedir(), '.platform.bible', 'extensions', 'lexicon');
+  const home = process.env.USERPROFILE ?? process.env.HOME ?? '';
+  return `${home}\\.platform.bible\\extensions\\lexicon`;
 }
 
 /** Launches the FieldWorks Lite process and returns its URL domain. */
@@ -265,7 +265,6 @@ function launchFwLite(context: ExecutionActivationContext): string {
   const baseUrl = 'http://localhost:29348';
 
   const dataDir = getFwLiteDataDir();
-  mkdirSync(dataDir, { recursive: true });
   fwLiteProcess = context.elevatedPrivileges.createProcess.spawn(
     context.executionToken,
     binaryPath,
@@ -277,7 +276,7 @@ function launchFwLite(context: ExecutionActivationContext): string {
       '--FwLiteWeb:EnableFileLogging=false', // already piped to P.B (and triggers npm watch)
       '--FwLiteWeb:OpenBrowser=false',
       `--LcmCrdt:ProjectPath=${dataDir}`,
-      `--Auth:CacheFileName=${path.join(dataDir, 'msal.json')}`,
+      `--Auth:CacheFileName=${dataDir}\\msal.json`,
     ],
     { stdio: ['pipe', 'pipe', 'pipe'] },
   );

--- a/platform.bible-extension/webpack/webpack.config.base.ts
+++ b/platform.bible-extension/webpack/webpack.config.base.ts
@@ -33,6 +33,9 @@ const configBase: webpack.Configuration = {
   externals: [
     // Built-in node modules that are not blocked by Platform.Bible
     'crypto',
+    'fs',
+    'os',
+    'path',
     // Additional modules provided by Platform.Bible
     'react',
     'react/jsx-runtime',

--- a/platform.bible-extension/webpack/webpack.config.base.ts
+++ b/platform.bible-extension/webpack/webpack.config.base.ts
@@ -33,9 +33,6 @@ const configBase: webpack.Configuration = {
   externals: [
     // Built-in node modules that are not blocked by Platform.Bible
     'crypto',
-    'fs',
-    'os',
-    'path',
     // Additional modules provided by Platform.Bible
     'react',
     'react/jsx-runtime',


### PR DESCRIPTION
Platform.Bible runs each extension version from a versioned cache directory, so FW Lite's default of storing projects and auth cache relative to its binary would orphan data on every update. Pass explicit paths rooted at `~/.platform.bible/extensions/lexicon/` to keep data stable across versions.

Closes #2351

Devin: https://app.devin.ai/review/sillsdev/languageforge-lexbox/pull/2385