### PR TITLE
Fix missing search bar in find-word and find-related-words webviews

### DIFF
--- a/platform.bible-extension/src/web-views/find-related-words.web-view.tsx
+++ b/platform.bible-extension/src/web-views/find-related-words.web-view.tsx
@@ -143,8 +143,9 @@ globalThis.webViewComponent = function LexiconFindRelatedWords({
       elementHeader={
         <div className="tw:flex tw:flex-col tw:gap-2">
           <div className="tw:flex tw:gap-2">
-            <div className="tw:max-w-lg">
+            <div className="tw:w-full tw:max-w-lg">
               <SearchBar
+                isFullWidth
                 onSearch={onSearch}
                 placeholder={localizedStrings['%lexicon_findRelatedWord_textField%']}
                 value={searchTerm}

--- a/platform.bible-extension/src/web-views/find-word.web-view.tsx
+++ b/platform.bible-extension/src/web-views/find-word.web-view.tsx
@@ -95,8 +95,9 @@ globalThis.webViewComponent = function LexiconFindWord({
     <EntryListWrapper
       elementHeader={
         <div className="tw:flex tw:gap-2">
-          <div className="tw:max-w-72">
+          <div className="tw:w-full tw:max-w-72">
             <SearchBar
+              isFullWidth
               onSearch={onSearch}
               placeholder={localizedStrings['%lexicon_findWord_textField%']}
               value={searchTerm}


### PR DESCRIPTION
Fixing a regression from the Tailwind update in #2333

## Summary

- `SearchBar`'s `tw:@container/search` wrapper sets `container-type: inline-size`, which collapses to zero width in a flex context without an explicit width — making the `<input>` invisible
- Add `tw:w-full` to the wrapper `div` and `isFullWidth` to `SearchBar` in both affected webviews
- Mirrors the fix applied to the `paranext-core` dictionary component in [`c63af4e205`](https://github.com/paranext/paranext-core/commit/c63af4e205cb32082fce7c4f31a27489079685d6)

## Test plan

- [x] Open "Search in lexicon" webview — search text field is visible
- [x] Open "Find related words in lexicon" webview — search text field is visible
- [x] Search still functions correctly in both webviews

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Devin: https://app.devin.ai/review/sillsdev/languageforge-lexbox/pull/2387