### PR TITLE
Attribute template-import commits to a System author

### DIFF
--- a/backend/FwLite/LcmCrdt.Tests/OpenProjectTests.cs
+++ b/backend/FwLite/LcmCrdt.Tests/OpenProjectTests.cs
@@ -1,7 +1,7 @@
+using LcmCrdt.Utils;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
-using SIL.Harmony;
 using static LcmCrdt.CrdtProjectsService;
 
 namespace LcmCrdt.Tests;
@@ -76,46 +76,122 @@ public class OpenProjectTests
     public async Task CreateProjectFromTemplateAppliesRequestedIdentity()
     {
         var code = $"blank-from-template-{Guid.NewGuid():N}";
-        var sqliteFile = $"{code}.sqlite";
-        if (File.Exists(sqliteFile)) File.Delete(sqliteFile);
-        var builder = Host.CreateEmptyApplicationBuilder(null);
-        builder.Services.AddTestLcmCrdtClient();
-        using var host = builder.Build();
-        var asyncScope = host.Services.CreateAsyncScope();
-        var crdtProjectsService = asyncScope.ServiceProvider.GetRequiredService<CrdtProjectsService>();
-
-        var crdtProject = await crdtProjectsService.CreateProjectFromTemplate(new(
+        var request = new CreateProjectRequest(
             Name: "Blank From Template",
             Code: code,
             Path: "",
-            Role: UserProjectRole.Manager),
-            vernacularWs: "fr");
+            Role: UserProjectRole.Manager);
 
-        var miniLcmApi = (CrdtMiniLcmApi)await asyncScope.ServiceProvider.OpenCrdtProject(crdtProject);
-        miniLcmApi.ProjectData.Name.Should().Be("Blank From Template");
-        miniLcmApi.ProjectData.Code.Should().Be(code);
-        miniLcmApi.ProjectData.Role.Should().Be(UserProjectRole.Manager);
-        miniLcmApi.ProjectData.ClientId.Should().NotBe(Guid.Empty);
-
-        var morphTypes = await miniLcmApi.GetMorphTypes().ToArrayAsync();
-        morphTypes.Should().HaveCount(CanonicalMorphTypes.All.Count);
-
-        var writingSystems = await miniLcmApi.GetWritingSystems();
-        writingSystems.Analysis.Should().ContainSingle().Which.WsId.Should().Be((WritingSystemId)"en");
-        writingSystems.Vernacular.Should().ContainSingle().Which.WsId.Should().Be((WritingSystemId)"fr");
-
-        var entry = await miniLcmApi.CreateEntry(new Entry
+        await WithProjectFromTemplate(request, "fr", async (services, api) =>
         {
-            LexemeForm = { { "fr", "post-template" } },
-        });
-        (await miniLcmApi.GetEntry(entry.Id)).Should().NotBeNull();
+            var miniLcmApi = (CrdtMiniLcmApi)api;
+            miniLcmApi.ProjectData.Name.Should().Be("Blank From Template");
+            miniLcmApi.ProjectData.Code.Should().Be(code);
+            miniLcmApi.ProjectData.Role.Should().Be(UserProjectRole.Manager);
+            miniLcmApi.ProjectData.ClientId.Should().NotBe(Guid.Empty);
 
-        await using var dbContext = await asyncScope.ServiceProvider.GetRequiredService<IDbContextFactory<LcmCrdtDbContext>>().CreateDbContextAsync();
-        // The template is imported through the normal MiniLcm write path, so every commit — the imported
-        // system data and the post-template writes — is authored under this project's own ClientId.
-        var commitClientIds = await dbContext.Set<Commit>().AsNoTracking().Select(c => c.ClientId).Distinct().ToArrayAsync();
-        commitClientIds.Should().ContainSingle().Which.Should().Be(miniLcmApi.ProjectData.ClientId);
-        await dbContext.Database.EnsureDeletedAsync();
+            var morphTypes = await miniLcmApi.GetMorphTypes().ToArrayAsync();
+            morphTypes.Should().HaveCount(CanonicalMorphTypes.All.Count);
+
+            var writingSystems = await miniLcmApi.GetWritingSystems();
+            writingSystems.Analysis.Should().ContainSingle().Which.WsId.Should().Be((WritingSystemId)"en");
+            writingSystems.Vernacular.Should().ContainSingle().Which.WsId.Should().Be((WritingSystemId)"fr");
+
+            var entry = await miniLcmApi.CreateEntry(new Entry
+            {
+                LexemeForm = { { "fr", "post-template" } },
+            });
+            (await miniLcmApi.GetEntry(entry.Id)).Should().NotBeNull();
+
+            await using var dbContext = await services.GetRequiredService<IDbContextFactory<LcmCrdtDbContext>>().CreateDbContextAsync();
+            // The template is imported through the normal MiniLcm write path, so every commit — the imported
+            // system data and the post-template writes — is authored under this project's own ClientId.
+            var commitClientIds = await dbContext.Set<Commit>().AsNoTracking().Select(c => c.ClientId).Distinct().ToArrayAsync();
+            commitClientIds.Should().ContainSingle().Which.Should().Be(miniLcmApi.ProjectData.ClientId);
+        });
+    }
+
+    [Fact]
+    public async Task TemplateCommitsUseTheSystemAuthorAndAreStampedAsTemplateCommits()
+    {
+        // Create as a signed-in user so the template stamp has a real author to override.
+        var request = new CreateProjectRequest("Template Author", $"template-author-{Guid.NewGuid():N}",
+            AuthenticatedUser: "Test User", AuthenticatedUserId: "test-user-id", Role: UserProjectRole.Manager);
+
+        await WithProjectFromTemplate(request, "fr", async (services, api) =>
+        {
+            var historyService = services.GetRequiredService<HistoryService>();
+
+            // The imported template data is re-attributed to System and tagged, overriding the signed-in user.
+            var templateCommits = await historyService.ProjectActivity(0, 1000, new ActivityQuery()).ToArrayAsync();
+            templateCommits.Should().NotBeEmpty();
+            templateCommits.Should().AllSatisfy(activity =>
+            {
+                activity.Metadata.AuthorId.Should().Be(CommitHelpers.SystemAuthorId);
+                activity.Metadata.AuthorName.Should().BeNull("the UI owns and translates the System display name");
+                activity.Metadata[CommitHelpers.TemplateProp].Should().Be("true");
+            });
+
+            // A later edit keeps the signed-in user (not System) — the stamp is scoped to the template import.
+            await api.CreateEntry(new() { LexemeForm = { ["fr"] = "post-template" } });
+            var latest = (await historyService.ProjectActivity(0, 1, new ActivityQuery()).ToArrayAsync()).Single();
+            latest.Metadata.AuthorId.Should().Be("test-user-id");
+            latest.Metadata.AuthorName.Should().Be("Test User");
+            latest.Metadata[CommitHelpers.TemplateProp].Should().BeNull();
+        });
+    }
+
+    [Fact]
+    public async Task CommitMetadataOverrideIsScopedAndRestored()
+    {
+        var request = new CreateProjectRequest("Commit Metadata Scope", $"commit-metadata-scope-{Guid.NewGuid():N}",
+            Role: UserProjectRole.Manager);
+
+        await WithProjectFromTemplate(request, "fr", async (services, api) =>
+        {
+            var historyService = services.GetRequiredService<HistoryService>();
+            var interceptor = services.GetRequiredService<CommitMetadataInterceptor>();
+
+            // A commit made inside the interceptor scope carries the overridden author.
+            using (interceptor.Intercept(metadata => metadata.AuthorId = "override-id"))
+            {
+                await api.CreateEntry(new() { LexemeForm = { ["fr"] = "in scope" } });
+            }
+            (await LatestCommitAuthorId(historyService)).Should().Be("override-id");
+
+            // Once the scope ends the override is gone.
+            await api.CreateEntry(new() { LexemeForm = { ["fr"] = "after scope" } });
+            (await LatestCommitAuthorId(historyService)).Should().BeNull();
+        });
+    }
+
+    private static async Task<string?> LatestCommitAuthorId(HistoryService historyService)
+    {
+        var latest = await historyService.ProjectActivity(skip: 0, take: 1).ToArrayAsync();
+        return latest.Single().Metadata.AuthorId;
+    }
+
+    // Spins up a fresh CRDT host, creates a project from the template, opens it, runs the test, and deletes the db.
+    private static async Task WithProjectFromTemplate(
+        CreateProjectRequest request,
+        WritingSystemId vernacularWs,
+        Func<IServiceProvider, IMiniLcmApi, Task> test)
+    {
+        var builder = Host.CreateEmptyApplicationBuilder(null);
+        builder.Services.AddTestLcmCrdtClient();
+        using var host = builder.Build();
+        await using var scope = host.Services.CreateAsyncScope();
+        var services = scope.ServiceProvider;
+        var project = await services.GetRequiredService<CrdtProjectsService>().CreateProjectFromTemplate(request, vernacularWs);
+        try
+        {
+            await test(services, await services.OpenCrdtProject(project));
+        }
+        finally
+        {
+            await using var dbContext = await services.GetRequiredService<IDbContextFactory<LcmCrdtDbContext>>().CreateDbContextAsync();
+            await dbContext.Database.EnsureDeletedAsync();
+        }
     }
 
     [Theory]

--- a/backend/FwLite/LcmCrdt/CommitMetadataInterceptor.cs
+++ b/backend/FwLite/LcmCrdt/CommitMetadataInterceptor.cs
@@ -3,22 +3,24 @@ using SIL.Harmony.Core;
 namespace LcmCrdt;
 
 /// <summary>
-/// Scoped hook for shaping the <see cref="CommitMetadata"/> of commits written by
-/// <see cref="CrdtMiniLcmApi"/> for the duration of a scope — e.g. attributing template-imported
-/// system data to the System author. <see cref="CrdtMiniLcmApi"/> applies it when building metadata.
+/// Async-flow-scoped hook for shaping the <see cref="CommitMetadata"/> of commits written by
+/// <see cref="CrdtMiniLcmApi"/> for the duration of an <see cref="Intercept"/> scope — e.g. attributing
+/// template-imported system data to the System author. The override lives in an <see cref="AsyncLocal{T}"/>,
+/// so it applies only to commits made within the awaited call tree of the scope and can't leak into other
+/// operations that share the same DI scope. <see cref="CrdtMiniLcmApi"/> applies it when building metadata.
 /// </summary>
 public class CommitMetadataInterceptor
 {
-    private Action<CommitMetadata>? _interceptor;
+    private readonly AsyncLocal<Action<CommitMetadata>?> _interceptor = new();
 
     public IDisposable Intercept(Action<CommitMetadata> interceptor)
     {
-        var previous = _interceptor;
-        _interceptor = interceptor;
-        return new DisposableAction(() => _interceptor = previous);
+        var previous = _interceptor.Value;
+        _interceptor.Value = interceptor;
+        return new DisposableAction(() => _interceptor.Value = previous);
     }
 
-    public void Apply(CommitMetadata metadata) => _interceptor?.Invoke(metadata);
+    public void Apply(CommitMetadata metadata) => _interceptor.Value?.Invoke(metadata);
 
     private sealed class DisposableAction(Action onDispose) : IDisposable
     {

--- a/backend/FwLite/LcmCrdt/CommitMetadataInterceptor.cs
+++ b/backend/FwLite/LcmCrdt/CommitMetadataInterceptor.cs
@@ -1,0 +1,27 @@
+using SIL.Harmony.Core;
+
+namespace LcmCrdt;
+
+/// <summary>
+/// Scoped hook for shaping the <see cref="CommitMetadata"/> of commits written by
+/// <see cref="CrdtMiniLcmApi"/> for the duration of a scope — e.g. attributing template-imported
+/// system data to the System author. <see cref="CrdtMiniLcmApi"/> applies it when building metadata.
+/// </summary>
+public class CommitMetadataInterceptor
+{
+    private Action<CommitMetadata>? _interceptor;
+
+    public IDisposable Intercept(Action<CommitMetadata> interceptor)
+    {
+        var previous = _interceptor;
+        _interceptor = interceptor;
+        return new DisposableAction(() => _interceptor = previous);
+    }
+
+    public void Apply(CommitMetadata metadata) => _interceptor?.Invoke(metadata);
+
+    private sealed class DisposableAction(Action onDispose) : IDisposable
+    {
+        public void Dispose() => onDispose();
+    }
+}

--- a/backend/FwLite/LcmCrdt/CrdtMiniLcmApi.cs
+++ b/backend/FwLite/LcmCrdt/CrdtMiniLcmApi.cs
@@ -30,6 +30,7 @@ public class CrdtMiniLcmApi(
     IOptions<LcmCrdtConfig> config,
     ILogger<CrdtMiniLcmApi> logger,
     LcmMediaService lcmMediaService,
+    CommitMetadataInterceptor commitMetadataInterceptor,
     EntrySearchService? entrySearchService = null) : IMiniLcmApi
 {
     private Guid ClientId { get; } = projectService.ProjectData.ClientId;
@@ -45,6 +46,7 @@ public class CrdtMiniLcmApi(
             AuthorName = ProjectData.LastUserName ?? config.Value.DefaultAuthorForCommits,
             AuthorId = ProjectData.LastUserId
         };
+        commitMetadataInterceptor.Apply(metadata);
         return metadata;
     }
     private async Task<Commit> AddChange(IChange change)

--- a/backend/FwLite/LcmCrdt/CrdtProjectsService.cs
+++ b/backend/FwLite/LcmCrdt/CrdtProjectsService.cs
@@ -2,14 +2,13 @@ using System.Diagnostics;
 using System.Text;
 using System.Text.RegularExpressions;
 using LcmCrdt.MediaServer;
+using LcmCrdt.Utils;
 using SIL.Harmony;
-using MiniLcm;
 using MiniLcm.Import;
 using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
-using LcmCrdt.Objects;
 using LcmCrdt.Project;
 using Microsoft.EntityFrameworkCore;
 using MiniLcm.Project;
@@ -149,9 +148,11 @@ public partial class CrdtProjectsService(
         // Templated projects are created locally; this path has no way to associate one with a server
         // at creation time, so reject a Domain up front — the invariant holds where the project is born.
         if (request.Domain is not null)
+        {
             throw new ArgumentException(
                 "Templated projects can't be associated with a server at creation time — they're local-only.",
                 nameof(request));
+        }
 
         var callerAfterCreate = request.AfterCreate;
         return await CreateProject(request with
@@ -161,7 +162,11 @@ public partial class CrdtProjectsService(
                 var api = provider.GetRequiredService<IMiniLcmApi>();
                 var jsonOptions = provider.GetRequiredService<IOptions<CrdtConfig>>().Value.JsonSerializerOptions;
                 var snapshot = ProjectTemplate.CreateNewSnapshot(jsonOptions, vernacularWs, analysisWs);
-                await projectImporter.ImportProject(api, snapshot);
+                var commitMetadataInterceptor = provider.GetRequiredService<CommitMetadataInterceptor>();
+                using (commitMetadataInterceptor.Intercept(CommitHelpers.StampAsTemplate))
+                {
+                    await projectImporter.ImportProject(api, snapshot);
+                }
                 if (callerAfterCreate is not null) await callerAfterCreate(provider, project);
             }
         });

--- a/backend/FwLite/LcmCrdt/LcmCrdtKernel.cs
+++ b/backend/FwLite/LcmCrdt/LcmCrdtKernel.cs
@@ -69,6 +69,7 @@ public static class LcmCrdtKernel
             crdtConfig.LocalResourceCachePath = Path.Combine(lcmConfig.Value.ProjectPath, "localResourcesCache");
         });
         services.AddScoped<IMiniLcmApi, CrdtMiniLcmApi>();
+        services.AddScoped<CommitMetadataInterceptor>();
         services.AddScoped<MiniLcmRepositoryFactory>();
         services.AddMiniLcmValidators();
         services.AddSingleton<ProjectDataCache>();

--- a/backend/FwLite/LcmCrdt/Utils/CommitHelpers.cs
+++ b/backend/FwLite/LcmCrdt/Utils/CommitHelpers.cs
@@ -5,6 +5,10 @@ namespace LcmCrdt.Utils;
 public static class CommitHelpers
 {
     public const string SyncDateProp = "SyncDate";
+    // Mirrored by SYSTEM_AUTHOR_KEY in frontend/viewer/src/lib/activity/utils.ts
+    public const string SystemAuthorId = "00000000-0000-0000-0000-000000000001";
+    public const string TemplateProp = "Template";
+
     public static DateTimeOffset? SyncDate(this CommitBase commit)
     {
         var dateAsString = commit.Metadata[SyncDateProp];
@@ -20,5 +24,12 @@ public static class CommitHelpers
     public static void SetSyncDate(this CommitBase commit, DateTimeOffset? syncDate)
     {
         commit.Metadata[SyncDateProp] = syncDate?.ToString("u");
+    }
+
+    public static void StampAsTemplate(CommitMetadata metadata)
+    {
+        metadata.AuthorId = SystemAuthorId;
+        metadata.AuthorName = null;
+        metadata[TemplateProp] = "true";
     }
 }

--- a/frontend/viewer/src/home/CreateProjectDialog.svelte
+++ b/frontend/viewer/src/home/CreateProjectDialog.svelte
@@ -37,7 +37,6 @@
     error = undefined;
     submitted = false;
     name = '';
-    code = '';
     vernacularWs = '';
     analysisWs = '';
     loading = false;

--- a/frontend/viewer/src/home/HomeView.svelte
+++ b/frontend/viewer/src/home/HomeView.svelte
@@ -219,7 +219,7 @@
                 icon="i-mdi-book-plus-outline"
                 class="mb-2 bg-transparent shadow-none hover:shadow-none border-2 border-dashed border-muted-foreground/40"
                 onclick={() => createProjectDialog?.openDialog()}>
-                <span>{$t`New Project`} ({$t`Local only`})</span>
+                <span>{$t`New Project (Local only)`}</span>
                 <span class="text-sm text-muted-foreground">{$t`Create a new FieldWorks Lite project`}</span>
               </ListItem>
             </DevContent>

--- a/frontend/viewer/src/lib/activity/ActivityFilter.svelte
+++ b/frontend/viewer/src/lib/activity/ActivityFilter.svelte
@@ -147,7 +147,7 @@
         </Select.Item>
         {#each authors.current as author (authorFilterKey(author))}
           {@const key = authorFilterKey(author)}
-          <Select.Item value={key} label={author.authorName ?? $t`Unknown`}>
+          <Select.Item value={key} label={authorKeyToLabel(key)}>
             {@render authorLabel(key)}
             <span class="text-muted-foreground ml-1">({author.commitCount})</span>
           </Select.Item>

--- a/frontend/viewer/src/lib/activity/ActivityFilter.svelte
+++ b/frontend/viewer/src/lib/activity/ActivityFilter.svelte
@@ -16,6 +16,7 @@
     ALL_AUTHORS,
     ALL_CHANGE_TYPES,
     FIELDWORKS_AUTHOR_KEY,
+    SYSTEM_AUTHOR_KEY,
     UNKNOWN_AUTHOR_KEY,
     applyMultiSelectValue,
     authorFilterKey,
@@ -23,6 +24,7 @@
     createDefaultActivityFilters,
     isAllFilterSelection,
     resolveFilterKeys,
+    wellKnownAuthorKeyToLabel,
     type ActivityFilters,
     type MultiFilterSelection,
   } from './utils';
@@ -79,7 +81,8 @@
   };
 
   function authorKeyToLabel(key: string): string {
-    if (key === UNKNOWN_AUTHOR_KEY) return $t`Unknown`;
+    const wellKnownLabel = wellKnownAuthorKeyToLabel(key);
+    if (wellKnownLabel) return wellKnownLabel;
     const author = authors.current.find(a => authorFilterKey(a) === key);
     return author?.authorName ?? key;
   }
@@ -109,6 +112,9 @@
     {/if}
     {#if key === FIELDWORKS_AUTHOR_KEY}
       <Icon class="size-5" src={flexLogo} alt={$t`FieldWorks logo`} />
+    {/if}
+    {#if key === SYSTEM_AUTHOR_KEY}
+      <Icon icon="i-mdi-cog" class="size-5" />
     {/if}
   </span>
 {/snippet}

--- a/frontend/viewer/src/lib/activity/ActivityFilter.svelte
+++ b/frontend/viewer/src/lib/activity/ActivityFilter.svelte
@@ -111,7 +111,7 @@
           {$t`No authors`}
         {:else if filters.authorFilterKeys.length === 1}
           {@const selectedAuthor = authors.current.find(a => authorFilterKey(a) === filters.authorFilterKeys[0])}
-          <AuthorLabel authorId={selectedAuthor?.authorId} authorName={selectedAuthor?.authorName} />
+          <AuthorLabel authorId={selectedAuthor?.authorId} authorName={selectedAuthor?.authorName} iconClass="size-5" />
         {:else}
           {$t`${filters.authorFilterKeys.length} authors`}
         {/if}
@@ -129,7 +129,7 @@
         {#each authors.current as author (authorFilterKey(author))}
           {@const key = authorFilterKey(author)}
           <Select.Item value={key} label={authorKeyToLabel(key)}>
-            <AuthorLabel authorId={author.authorId} authorName={author.authorName} />
+            <AuthorLabel authorId={author.authorId} authorName={author.authorName} iconClass="size-5" />
             <span class="text-muted-foreground ml-1">({author.commitCount})</span>
           </Select.Item>
         {/each}

--- a/frontend/viewer/src/lib/activity/ActivityFilter.svelte
+++ b/frontend/viewer/src/lib/activity/ActivityFilter.svelte
@@ -111,7 +111,7 @@
           {$t`No authors`}
         {:else if filters.authorFilterKeys.length === 1}
           {@const selectedAuthor = authors.current.find(a => authorFilterKey(a) === filters.authorFilterKeys[0])}
-          <AuthorLabel authorId={selectedAuthor?.authorId} authorName={selectedAuthor?.authorName} iconClass="size-5" />
+          <AuthorLabel authorId={selectedAuthor?.authorId} authorName={selectedAuthor?.authorName} />
         {:else}
           {$t`${filters.authorFilterKeys.length} authors`}
         {/if}
@@ -129,7 +129,7 @@
         {#each authors.current as author (authorFilterKey(author))}
           {@const key = authorFilterKey(author)}
           <Select.Item value={key} label={authorKeyToLabel(key)}>
-            <AuthorLabel authorId={author.authorId} authorName={author.authorName} iconClass="size-5" />
+            <AuthorLabel authorId={author.authorId} authorName={author.authorName} />
             <span class="text-muted-foreground ml-1">({author.commitCount})</span>
           </Select.Item>
         {/each}

--- a/frontend/viewer/src/lib/activity/ActivityFilter.svelte
+++ b/frontend/viewer/src/lib/activity/ActivityFilter.svelte
@@ -1,5 +1,4 @@
 <script lang="ts">
-  import flexLogo from '$lib/assets/flex-logo.png';
   import {useHistoryService} from '$lib/services/history-service';
   import {t} from 'svelte-i18n-lingui';
   import {resource} from 'runed';
@@ -15,9 +14,6 @@
   import {
     ALL_AUTHORS,
     ALL_CHANGE_TYPES,
-    FIELDWORKS_AUTHOR_KEY,
-    SYSTEM_AUTHOR_KEY,
-    UNKNOWN_AUTHOR_KEY,
     applyMultiSelectValue,
     authorFilterKey,
     compareActivityAuthors,
@@ -28,6 +24,7 @@
     type ActivityFilters,
     type MultiFilterSelection,
   } from './utils';
+  import AuthorLabel from './AuthorLabel.svelte';
 
   type Props = {
     filters?: ActivityFilters;
@@ -102,23 +99,6 @@
   }
 </script>
 
-{#snippet authorLabel(key: string)}
-  {@const label = authorKeyToLabel(key)}
-  <span class="inline-flex items-center gap-1">
-    {#if key === UNKNOWN_AUTHOR_KEY}
-      <span class="italic">{$t`Unknown`}</span>
-    {:else}
-      {label}
-    {/if}
-    {#if key === FIELDWORKS_AUTHOR_KEY}
-      <Icon class="size-5" src={flexLogo} alt={$t`FieldWorks logo`} />
-    {/if}
-    {#if key === SYSTEM_AUTHOR_KEY}
-      <Icon icon="i-mdi-cog" class="size-5" />
-    {/if}
-  </span>
-{/snippet}
-
 <div class="flex flex-col gap-2 mb-1">
   <div class="flex flex-wrap gap-2">
     <SidebarTrigger icon="i-mdi-menu" class="aspect-square p-0 shrink-0" />
@@ -130,7 +110,8 @@
         {:else if filters.authorFilterKeys.length === 0}
           {$t`No authors`}
         {:else if filters.authorFilterKeys.length === 1}
-          {@render authorLabel(filters.authorFilterKeys[0])}
+          {@const selectedAuthor = authors.current.find(a => authorFilterKey(a) === filters.authorFilterKeys[0])}
+          <AuthorLabel authorId={selectedAuthor?.authorId} authorName={selectedAuthor?.authorName} />
         {:else}
           {$t`${filters.authorFilterKeys.length} authors`}
         {/if}
@@ -148,7 +129,7 @@
         {#each authors.current as author (authorFilterKey(author))}
           {@const key = authorFilterKey(author)}
           <Select.Item value={key} label={authorKeyToLabel(key)}>
-            {@render authorLabel(key)}
+            <AuthorLabel authorId={author.authorId} authorName={author.authorName} />
             <span class="text-muted-foreground ml-1">({author.commitCount})</span>
           </Select.Item>
         {/each}

--- a/frontend/viewer/src/lib/activity/ActivityItem.svelte
+++ b/frontend/viewer/src/lib/activity/ActivityItem.svelte
@@ -25,7 +25,7 @@
   import {T, t} from 'svelte-i18n-lingui';
   import {VList} from 'virtua/svelte';
   import ActivityItemChangePreview from './ActivityItemChangePreview.svelte';
-  import {formatJsonForUi} from './utils';
+  import {formatJsonForUi, wellKnownAuthorKeyToLabel} from './utils';
   import type {HTMLAttributes} from 'svelte/elements';
   import {cn} from '$lib/utils';
   import * as Popover from '$lib/components/ui/popover';
@@ -51,6 +51,8 @@
   const changes = $derived(!historyService.loaded ? undefined : activity.changes.map(change => {
     return new ChangeWithLazyContext(change, activity, () => historyService.loadChangeContext(activity.commitId, change.index));
   }));
+
+  const authorLabel = $derived(wellKnownAuthorKeyToLabel(activity.metadata.authorId) ?? activity.metadata.authorName);
 </script>
 
 <div {...restProps} class={cn(className, 'grid gap-2 grid-rows-[auto_1fr] h-full')}>
@@ -59,8 +61,8 @@
       <span>
         <span>
           {$t`Author:`}
-          {#if activity.metadata.authorName}
-            <span class="font-semibold">{activity.metadata.authorName}</span>
+          {#if authorLabel}
+            <span class="font-semibold">{authorLabel}</span>
           {:else}
             <span class="opacity-75 italic">{$t`Unknown`}</span>
           {/if}

--- a/frontend/viewer/src/lib/activity/ActivityItem.svelte
+++ b/frontend/viewer/src/lib/activity/ActivityItem.svelte
@@ -25,7 +25,8 @@
   import {T, t} from 'svelte-i18n-lingui';
   import {VList} from 'virtua/svelte';
   import ActivityItemChangePreview from './ActivityItemChangePreview.svelte';
-  import {formatJsonForUi, wellKnownAuthorKeyToLabel} from './utils';
+  import {formatJsonForUi} from './utils';
+  import AuthorLabel from './AuthorLabel.svelte';
   import type {HTMLAttributes} from 'svelte/elements';
   import {cn} from '$lib/utils';
   import * as Popover from '$lib/components/ui/popover';
@@ -51,8 +52,6 @@
   const changes = $derived(!historyService.loaded ? undefined : activity.changes.map(change => {
     return new ChangeWithLazyContext(change, activity, () => historyService.loadChangeContext(activity.commitId, change.index));
   }));
-
-  const authorLabel = $derived(wellKnownAuthorKeyToLabel(activity.metadata.authorId) ?? activity.metadata.authorName);
 </script>
 
 <div {...restProps} class={cn(className, 'grid gap-2 grid-rows-[auto_1fr] h-full')}>
@@ -61,11 +60,7 @@
       <span>
         <span>
           {$t`Author:`}
-          {#if authorLabel}
-            <span class="font-semibold">{authorLabel}</span>
-          {:else}
-            <span class="opacity-75 italic">{$t`Unknown`}</span>
-          {/if}
+          <AuthorLabel class="font-semibold" authorId={activity.metadata.authorId} authorName={activity.metadata.authorName} />
         </span>
         {#if activity.changes.length > 1}
           <span>{$t`– (${activity.changes.length} changes)`}</span>

--- a/frontend/viewer/src/lib/activity/ActivityView.svelte
+++ b/frontend/viewer/src/lib/activity/ActivityView.svelte
@@ -18,6 +18,7 @@
     MIN_VISIBLE_FILTERED,
     serverQueryKey,
     toServerQuery,
+    wellKnownAuthorKeyToLabel,
     type ActivityFilters,
     type ActivityLoad,
   } from './utils';
@@ -164,7 +165,7 @@
                         actualDateOptions={{ dateStyle: 'medium', timeStyle: 'short' }}/>
               </span>
               <span>
-                {row.metadata.authorName ?? $t`Unknown`}
+                {wellKnownAuthorKeyToLabel(row.metadata.authorId) ?? row.metadata.authorName ?? $t`Unknown`}
               </span>
             </div>
           </ListItem>

--- a/frontend/viewer/src/lib/activity/ActivityView.svelte
+++ b/frontend/viewer/src/lib/activity/ActivityView.svelte
@@ -164,7 +164,7 @@
                 <FormatRelativeDate date={row.timestamp}
                         actualDateOptions={{ dateStyle: 'medium', timeStyle: 'short' }}/>
               </span>
-              <AuthorLabel authorId={row.metadata.authorId} authorName={row.metadata.authorName} iconClass="size-4" />
+              <AuthorLabel authorId={row.metadata.authorId} authorName={row.metadata.authorName} />
             </div>
           </ListItem>
         {/snippet}

--- a/frontend/viewer/src/lib/activity/ActivityView.svelte
+++ b/frontend/viewer/src/lib/activity/ActivityView.svelte
@@ -18,10 +18,10 @@
     MIN_VISIBLE_FILTERED,
     serverQueryKey,
     toServerQuery,
-    wellKnownAuthorKeyToLabel,
     type ActivityFilters,
     type ActivityLoad,
   } from './utils';
+  import AuthorLabel from './AuthorLabel.svelte';
 
   const historyService = useHistoryService();
 
@@ -164,9 +164,7 @@
                 <FormatRelativeDate date={row.timestamp}
                         actualDateOptions={{ dateStyle: 'medium', timeStyle: 'short' }}/>
               </span>
-              <span>
-                {wellKnownAuthorKeyToLabel(row.metadata.authorId) ?? row.metadata.authorName ?? $t`Unknown`}
-              </span>
+              <AuthorLabel authorId={row.metadata.authorId} authorName={row.metadata.authorName} iconClass="size-4" />
             </div>
           </ListItem>
         {/snippet}

--- a/frontend/viewer/src/lib/activity/AuthorLabel.svelte
+++ b/frontend/viewer/src/lib/activity/AuthorLabel.svelte
@@ -1,0 +1,31 @@
+<script lang="ts">
+  import {t} from 'svelte-i18n-lingui';
+  import {Icon} from '$lib/components/ui/icon';
+  import {cn} from '$lib/utils';
+  import flexLogo from '$lib/assets/flex-logo.png';
+  import {FIELDWORKS_AUTHOR_KEY, SYSTEM_AUTHOR_KEY, UNKNOWN_AUTHOR_KEY, authorFilterKey, wellKnownAuthorKeyToLabel} from './utils';
+
+  let {authorId, authorName, iconClass = 'size-5', class: className}: {
+    authorId?: string;
+    authorName?: string;
+    iconClass?: string;
+    class?: string;
+  } = $props();
+
+  const key = $derived(authorFilterKey({authorId, authorName}));
+  // Well-known authors (System) get a translated label; FieldWorks and people fall back to their stored name.
+  const label = $derived(wellKnownAuthorKeyToLabel(key) ?? authorName);
+</script>
+
+<span class={cn('inline-flex items-center gap-1', className)}>
+  {#if key === UNKNOWN_AUTHOR_KEY}
+    <span class="italic opacity-75">{$t`Unknown`}</span>
+  {:else}
+    {label}
+  {/if}
+  {#if key === FIELDWORKS_AUTHOR_KEY}
+    <Icon class={iconClass} src={flexLogo} alt={$t`FieldWorks logo`} />
+  {:else if key === SYSTEM_AUTHOR_KEY}
+    <Icon icon="i-mdi-cog" class={iconClass} />
+  {/if}
+</span>

--- a/frontend/viewer/src/lib/activity/AuthorLabel.svelte
+++ b/frontend/viewer/src/lib/activity/AuthorLabel.svelte
@@ -5,7 +5,7 @@
   import flexLogo from '$lib/assets/flex-logo.png';
   import {FIELDWORKS_AUTHOR_KEY, SYSTEM_AUTHOR_KEY, UNKNOWN_AUTHOR_KEY, authorFilterKey, wellKnownAuthorKeyToLabel} from './utils';
 
-  let {authorId, authorName, iconClass = 'size-5', class: className}: {
+  let {authorId, authorName, iconClass = 'size-4', class: className}: {
     authorId?: string;
     authorName?: string;
     iconClass?: string;

--- a/frontend/viewer/src/lib/activity/AuthorLabel.svelte
+++ b/frontend/viewer/src/lib/activity/AuthorLabel.svelte
@@ -5,10 +5,9 @@
   import flexLogo from '$lib/assets/flex-logo.png';
   import {FIELDWORKS_AUTHOR_KEY, SYSTEM_AUTHOR_KEY, UNKNOWN_AUTHOR_KEY, authorFilterKey, wellKnownAuthorKeyToLabel} from './utils';
 
-  let {authorId, authorName, iconClass = 'size-4', class: className}: {
+  let {authorId, authorName, class: className}: {
     authorId?: string;
     authorName?: string;
-    iconClass?: string;
     class?: string;
   } = $props();
 
@@ -24,8 +23,8 @@
     {label}
   {/if}
   {#if key === FIELDWORKS_AUTHOR_KEY}
-    <Icon class={iconClass} src={flexLogo} alt={$t`FieldWorks logo`} />
+    <Icon class="size-5" src={flexLogo} alt={$t`FieldWorks logo`} />
   {:else if key === SYSTEM_AUTHOR_KEY}
-    <Icon icon="i-mdi-cog" class={iconClass} />
+    <Icon icon="i-mdi-cog" class="size-4" />
   {/if}
 </span>

--- a/frontend/viewer/src/lib/activity/utils.ts
+++ b/frontend/viewer/src/lib/activity/utils.ts
@@ -1,8 +1,11 @@
 import {ActivitySort, type IActivityAuthor, type IActivityQuery, type IProjectActivity} from '$lib/dotnet-types';
+import {gt} from 'svelte-i18n-lingui';
 
 export const ALL_AUTHORS = '__all__';
 export const UNKNOWN_AUTHOR_KEY = '__unknown__';
 export const FIELDWORKS_AUTHOR_KEY = authorFilterKey({authorName: 'FieldWorks'});
+// Mirrors SystemAuthorId in backend/FwLite/LcmCrdt/Utils/CommitHelpers.cs
+export const SYSTEM_AUTHOR_KEY = '00000000-0000-0000-0000-000000000001';
 export const ALL_CHANGE_TYPES = '__all__';
 export const MIN_VISIBLE_FILTERED = 20;
 
@@ -68,17 +71,24 @@ export function authorFilterKey(author: Omit<IActivityAuthor, 'commitCount'>): s
   return `name:${author.authorName}`;
 }
 
+export function wellKnownAuthorKeyToLabel(key: string | undefined): string | undefined {
+  if (key === UNKNOWN_AUTHOR_KEY) return gt`Unknown`;
+  if (key === SYSTEM_AUTHOR_KEY) return gt`System`;
+  return undefined;
+}
+
 function authorSortRank(author: IActivityAuthor): number {
-  const key = authorFilterKey(author);
-  if (key === UNKNOWN_AUTHOR_KEY) return 0; // 1st
-  if (key === FIELDWORKS_AUTHOR_KEY) return 1; // 2nd
-  return 2;
+  // Unknown is pinned to the top (it's the catch-all, not a real author); FieldWorks, System
+  // and people all sort alphabetically together.
+  return authorFilterKey(author) === UNKNOWN_AUTHOR_KEY ? 0 : 1;
 }
 
 export function compareActivityAuthors(a: IActivityAuthor, b: IActivityAuthor): number {
   const rankDiff = authorSortRank(a) - authorSortRank(b);
   if (rankDiff !== 0) return rankDiff;
-  return (a.authorName || '').localeCompare(b.authorName || '');
+  const aName = wellKnownAuthorKeyToLabel(a.authorId) || a.authorName || a.authorId || '';
+  const bName = wellKnownAuthorKeyToLabel(b.authorId) || b.authorName || b.authorId || '';
+  return aName.localeCompare(bName);
 }
 
 export function applyMultiSelectValue(

--- a/frontend/viewer/src/locales/en.po
+++ b/frontend/viewer/src/locales/en.po
@@ -1174,7 +1174,6 @@ msgstr "Local"
 
 #. Subtitle shown on a project card when the project has no server configured (no sync partner).
 #: src/home/HomeView.svelte
-#: src/home/HomeView.svelte
 msgid "Local only"
 msgstr "Local only"
 
@@ -1328,9 +1327,12 @@ msgid "New Entry"
 msgstr "New Entry"
 
 #: src/home/CreateProjectDialog.svelte
-#: src/home/HomeView.svelte
 msgid "New Project"
 msgstr "New Project"
+
+#: src/home/HomeView.svelte
+msgid "New Project (Local only)"
+msgstr "New Project (Local only)"
 
 #. Relevant view: Lite
 #. Classic view equivalent: "New Entry"
@@ -1940,6 +1942,7 @@ msgid "Syncing..."
 msgstr "Syncing..."
 
 #. Theme option
+#: src/lib/activity/utils.ts
 #: src/lib/components/ThemePicker.svelte
 msgid "System"
 msgstr "System"
@@ -2090,9 +2093,9 @@ msgstr "Unable to open in FieldWorks"
 #. Fallback value shown when author name or last-change date is unavailable (e.g., in activity history or the sync panel).
 #: src/lib/activity/ActivityFilter.svelte
 #: src/lib/activity/ActivityFilter.svelte
-#: src/lib/activity/ActivityFilter.svelte
 #: src/lib/activity/ActivityItem.svelte
 #: src/lib/activity/ActivityView.svelte
+#: src/lib/activity/utils.ts
 #: src/project/sync/FwLiteToFwMergeDetails.svelte
 #: src/project/sync/FwLiteToFwMergeDetails.svelte
 msgid "Unknown"

--- a/frontend/viewer/src/locales/es.po
+++ b/frontend/viewer/src/locales/es.po
@@ -1179,7 +1179,6 @@ msgstr "Local"
 
 #. Subtitle shown on a project card when the project has no server configured (no sync partner).
 #: src/home/HomeView.svelte
-#: src/home/HomeView.svelte
 msgid "Local only"
 msgstr "Sólo local"
 
@@ -1333,8 +1332,11 @@ msgid "New Entry"
 msgstr "Nueva entrada"
 
 #: src/home/CreateProjectDialog.svelte
-#: src/home/HomeView.svelte
 msgid "New Project"
+msgstr ""
+
+#: src/home/HomeView.svelte
+msgid "New Project (Local only)"
 msgstr ""
 
 #. Relevant view: Lite
@@ -1945,6 +1947,7 @@ msgid "Syncing..."
 msgstr "Sincronizando..."
 
 #. Theme option
+#: src/lib/activity/utils.ts
 #: src/lib/components/ThemePicker.svelte
 msgid "System"
 msgstr "Sistema"
@@ -2095,9 +2098,9 @@ msgstr "No se puede abrir en FieldWorks"
 #. Fallback value shown when author name or last-change date is unavailable (e.g., in activity history or the sync panel).
 #: src/lib/activity/ActivityFilter.svelte
 #: src/lib/activity/ActivityFilter.svelte
-#: src/lib/activity/ActivityFilter.svelte
 #: src/lib/activity/ActivityItem.svelte
 #: src/lib/activity/ActivityView.svelte
+#: src/lib/activity/utils.ts
 #: src/project/sync/FwLiteToFwMergeDetails.svelte
 #: src/project/sync/FwLiteToFwMergeDetails.svelte
 msgid "Unknown"

--- a/frontend/viewer/src/locales/fr.po
+++ b/frontend/viewer/src/locales/fr.po
@@ -1179,7 +1179,6 @@ msgstr "Local"
 
 #. Subtitle shown on a project card when the project has no server configured (no sync partner).
 #: src/home/HomeView.svelte
-#: src/home/HomeView.svelte
 msgid "Local only"
 msgstr "Uniquement au niveau local"
 
@@ -1333,8 +1332,11 @@ msgid "New Entry"
 msgstr "Nouvelle entrée"
 
 #: src/home/CreateProjectDialog.svelte
-#: src/home/HomeView.svelte
 msgid "New Project"
+msgstr ""
+
+#: src/home/HomeView.svelte
+msgid "New Project (Local only)"
 msgstr ""
 
 #. Relevant view: Lite
@@ -1945,6 +1947,7 @@ msgid "Syncing..."
 msgstr "Synchronisation en cours..."
 
 #. Theme option
+#: src/lib/activity/utils.ts
 #: src/lib/components/ThemePicker.svelte
 msgid "System"
 msgstr "Système"
@@ -2095,9 +2098,9 @@ msgstr "Impossible d'ouvrir FieldWorks"
 #. Fallback value shown when author name or last-change date is unavailable (e.g., in activity history or the sync panel).
 #: src/lib/activity/ActivityFilter.svelte
 #: src/lib/activity/ActivityFilter.svelte
-#: src/lib/activity/ActivityFilter.svelte
 #: src/lib/activity/ActivityItem.svelte
 #: src/lib/activity/ActivityView.svelte
+#: src/lib/activity/utils.ts
 #: src/project/sync/FwLiteToFwMergeDetails.svelte
 #: src/project/sync/FwLiteToFwMergeDetails.svelte
 msgid "Unknown"

--- a/frontend/viewer/src/locales/id.po
+++ b/frontend/viewer/src/locales/id.po
@@ -1179,7 +1179,6 @@ msgstr "Lokal"
 
 #. Subtitle shown on a project card when the project has no server configured (no sync partner).
 #: src/home/HomeView.svelte
-#: src/home/HomeView.svelte
 msgid "Local only"
 msgstr "Hanya lokal"
 
@@ -1333,8 +1332,11 @@ msgid "New Entry"
 msgstr "Entri Baru"
 
 #: src/home/CreateProjectDialog.svelte
-#: src/home/HomeView.svelte
 msgid "New Project"
+msgstr ""
+
+#: src/home/HomeView.svelte
+msgid "New Project (Local only)"
 msgstr ""
 
 #. Relevant view: Lite
@@ -1945,6 +1947,7 @@ msgid "Syncing..."
 msgstr "Menyinkronkan..."
 
 #. Theme option
+#: src/lib/activity/utils.ts
 #: src/lib/components/ThemePicker.svelte
 msgid "System"
 msgstr "Sistem"
@@ -2095,9 +2098,9 @@ msgstr "Tidak dapat dibuka di FieldWorks"
 #. Fallback value shown when author name or last-change date is unavailable (e.g., in activity history or the sync panel).
 #: src/lib/activity/ActivityFilter.svelte
 #: src/lib/activity/ActivityFilter.svelte
-#: src/lib/activity/ActivityFilter.svelte
 #: src/lib/activity/ActivityItem.svelte
 #: src/lib/activity/ActivityView.svelte
+#: src/lib/activity/utils.ts
 #: src/project/sync/FwLiteToFwMergeDetails.svelte
 #: src/project/sync/FwLiteToFwMergeDetails.svelte
 msgid "Unknown"

--- a/frontend/viewer/src/locales/ko.po
+++ b/frontend/viewer/src/locales/ko.po
@@ -1179,7 +1179,6 @@ msgstr "로컬"
 
 #. Subtitle shown on a project card when the project has no server configured (no sync partner).
 #: src/home/HomeView.svelte
-#: src/home/HomeView.svelte
 msgid "Local only"
 msgstr "로컬 전용"
 
@@ -1333,8 +1332,11 @@ msgid "New Entry"
 msgstr "새 항목"
 
 #: src/home/CreateProjectDialog.svelte
-#: src/home/HomeView.svelte
 msgid "New Project"
+msgstr ""
+
+#: src/home/HomeView.svelte
+msgid "New Project (Local only)"
 msgstr ""
 
 #. Relevant view: Lite
@@ -1945,6 +1947,7 @@ msgid "Syncing..."
 msgstr "동기화..."
 
 #. Theme option
+#: src/lib/activity/utils.ts
 #: src/lib/components/ThemePicker.svelte
 msgid "System"
 msgstr "시스템"
@@ -2095,9 +2098,9 @@ msgstr "FieldWorks에서 열 수 없음"
 #. Fallback value shown when author name or last-change date is unavailable (e.g., in activity history or the sync panel).
 #: src/lib/activity/ActivityFilter.svelte
 #: src/lib/activity/ActivityFilter.svelte
-#: src/lib/activity/ActivityFilter.svelte
 #: src/lib/activity/ActivityItem.svelte
 #: src/lib/activity/ActivityView.svelte
+#: src/lib/activity/utils.ts
 #: src/project/sync/FwLiteToFwMergeDetails.svelte
 #: src/project/sync/FwLiteToFwMergeDetails.svelte
 msgid "Unknown"

--- a/frontend/viewer/src/locales/ms.po
+++ b/frontend/viewer/src/locales/ms.po
@@ -1179,7 +1179,6 @@ msgstr "Tempatan"
 
 #. Subtitle shown on a project card when the project has no server configured (no sync partner).
 #: src/home/HomeView.svelte
-#: src/home/HomeView.svelte
 msgid "Local only"
 msgstr "Tempatan sahaja"
 
@@ -1333,8 +1332,11 @@ msgid "New Entry"
 msgstr "Entri Baru"
 
 #: src/home/CreateProjectDialog.svelte
-#: src/home/HomeView.svelte
 msgid "New Project"
+msgstr ""
+
+#: src/home/HomeView.svelte
+msgid "New Project (Local only)"
 msgstr ""
 
 #. Relevant view: Lite
@@ -1945,6 +1947,7 @@ msgid "Syncing..."
 msgstr "Sedang disegerakkan..."
 
 #. Theme option
+#: src/lib/activity/utils.ts
 #: src/lib/components/ThemePicker.svelte
 msgid "System"
 msgstr "Sistem"
@@ -2095,9 +2098,9 @@ msgstr "Tidak dapat membuka dalam FieldWorks"
 #. Fallback value shown when author name or last-change date is unavailable (e.g., in activity history or the sync panel).
 #: src/lib/activity/ActivityFilter.svelte
 #: src/lib/activity/ActivityFilter.svelte
-#: src/lib/activity/ActivityFilter.svelte
 #: src/lib/activity/ActivityItem.svelte
 #: src/lib/activity/ActivityView.svelte
+#: src/lib/activity/utils.ts
 #: src/project/sync/FwLiteToFwMergeDetails.svelte
 #: src/project/sync/FwLiteToFwMergeDetails.svelte
 msgid "Unknown"

--- a/frontend/viewer/src/locales/sw.po
+++ b/frontend/viewer/src/locales/sw.po
@@ -1179,7 +1179,6 @@ msgstr "Mitaa"
 
 #. Subtitle shown on a project card when the project has no server configured (no sync partner).
 #: src/home/HomeView.svelte
-#: src/home/HomeView.svelte
 msgid "Local only"
 msgstr "Mitaa tu"
 
@@ -1333,8 +1332,11 @@ msgid "New Entry"
 msgstr "Ingizo Mpya"
 
 #: src/home/CreateProjectDialog.svelte
-#: src/home/HomeView.svelte
 msgid "New Project"
+msgstr ""
+
+#: src/home/HomeView.svelte
+msgid "New Project (Local only)"
 msgstr ""
 
 #. Relevant view: Lite
@@ -1945,6 +1947,7 @@ msgid "Syncing..."
 msgstr "Inaoanisha..."
 
 #. Theme option
+#: src/lib/activity/utils.ts
 #: src/lib/components/ThemePicker.svelte
 msgid "System"
 msgstr "Mfumo"
@@ -2095,9 +2098,9 @@ msgstr "Haiwezi kufungua katika FieldWorks"
 #. Fallback value shown when author name or last-change date is unavailable (e.g., in activity history or the sync panel).
 #: src/lib/activity/ActivityFilter.svelte
 #: src/lib/activity/ActivityFilter.svelte
-#: src/lib/activity/ActivityFilter.svelte
 #: src/lib/activity/ActivityItem.svelte
 #: src/lib/activity/ActivityView.svelte
+#: src/lib/activity/utils.ts
 #: src/project/sync/FwLiteToFwMergeDetails.svelte
 #: src/project/sync/FwLiteToFwMergeDetails.svelte
 msgid "Unknown"

--- a/frontend/viewer/src/locales/vi.po
+++ b/frontend/viewer/src/locales/vi.po
@@ -1179,7 +1179,6 @@ msgstr "Cục bộ"
 
 #. Subtitle shown on a project card when the project has no server configured (no sync partner).
 #: src/home/HomeView.svelte
-#: src/home/HomeView.svelte
 msgid "Local only"
 msgstr "Chỉ cục bộ"
 
@@ -1333,8 +1332,11 @@ msgid "New Entry"
 msgstr "Mục mới"
 
 #: src/home/CreateProjectDialog.svelte
-#: src/home/HomeView.svelte
 msgid "New Project"
+msgstr ""
+
+#: src/home/HomeView.svelte
+msgid "New Project (Local only)"
 msgstr ""
 
 #. Relevant view: Lite
@@ -1945,6 +1947,7 @@ msgid "Syncing..."
 msgstr "Đang đồng bộ..."
 
 #. Theme option
+#: src/lib/activity/utils.ts
 #: src/lib/components/ThemePicker.svelte
 msgid "System"
 msgstr "Hệ thống"
@@ -2095,9 +2098,9 @@ msgstr "Không thể mở trong FieldWorks"
 #. Fallback value shown when author name or last-change date is unavailable (e.g., in activity history or the sync panel).
 #: src/lib/activity/ActivityFilter.svelte
 #: src/lib/activity/ActivityFilter.svelte
-#: src/lib/activity/ActivityFilter.svelte
 #: src/lib/activity/ActivityItem.svelte
 #: src/lib/activity/ActivityView.svelte
+#: src/lib/activity/utils.ts
 #: src/project/sync/FwLiteToFwMergeDetails.svelte
 #: src/project/sync/FwLiteToFwMergeDetails.svelte
 msgid "Unknown"


### PR DESCRIPTION
Builds on #2281 (template-based project creation, already merged). A scoped `CommitMetadataInterceptor` stamps **only** the template-import commits as a well-known System author (and flags them `Template`); later user edits keep their real author. The activity view shows "System" and stops pinning special authors.

Drive-by fixes found while polishing #2281:
- Fold the runtime-composed `New Project` + `(Local only)` label into one translatable msgid (re-extracted catalogs).
- Drop the stray assignment to the derived `code` in `CreateProjectDialog.openDialog`.

**Test plan**
- [x] `LcmCrdt.Tests` `OpenProjectTests` — 17 pass, incl. System-author stamping, interceptor scope/restore, and template identity.
- [x] `pnpm --filter viewer run check` — 0 errors.

<img width="803" height="728" alt="image" src="https://github.com/user-attachments/assets/29140cbb-3566-4552-8f18-1d3971003003" />