### PR TITLE
Add CI check for stale FwLite generated TypeScript types

### DIFF
--- a/.github/workflows/fw-lite.yaml
+++ b/.github/workflows/fw-lite.yaml
@@ -63,6 +63,9 @@ jobs:
       - name: Check for pending EF model changes
         run: task fw-lite:has-pending-model-changes -- --no-build
 
+      - name: Check for stale generated TypeScript types
+        run: task fw-lite:has-stale-generated-types -- --no-build
+
       - name: Dotnet test
         # Benchmarks run in a separate Release-mode job — see `benchmark` below.
         run: dotnet test FwLiteOnly.slnf --logger GitHubActions --no-build -p:BuildAndroid=false --filter "Category!=Benchmark"

--- a/backend/FwLite/AGENTS.md
+++ b/backend/FwLite/AGENTS.md
@@ -41,6 +41,9 @@ The frontend viewer uses TypeScript types and API interfaces generated from .NET
 ```bash
 # To manually update generated types:
 dotnet build backend/FwLite/FwLiteShared/FwLiteShared.csproj
+
+# Verify types are committed (also runs in CI):
+task fw-lite:has-stale-generated-types
 ```
 
 The configuration for this lives in `FwLiteShared/TypeGen/ReinforcedFwLiteTypingConfig.cs` and `FwLiteShared/Reinforced.Typings.settings.xml`.

--- a/backend/FwLite/Taskfile.yml
+++ b/backend/FwLite/Taskfile.yml
@@ -48,7 +48,7 @@ tasks:
   _build-fw-lite-shared-for-types:
     internal: true
     status:
-      - 'powershell -NoProfile -Command "if (''{{.CLI_ARGS}}'' -match ''--no-build'') { exit 0 } else { exit 1 }"'
+      - 'pwsh -NoProfile -Command "if (''{{.CLI_ARGS}}'' -match ''--no-build'') { exit 0 } else { exit 1 }"'
     dir: ./FwLiteShared
     cmd: dotnet build
 

--- a/backend/FwLite/Taskfile.yml
+++ b/backend/FwLite/Taskfile.yml
@@ -38,6 +38,25 @@ tasks:
     cmds:
       - dotnet ef migrations has-pending-model-changes {{.CLI_ARGS}}
 
+  has-stale-generated-types:
+    desc: 'Fail if generated TypeScript types are out of date. Pass -- --no-build after a solution build.'
+    cmds:
+      - task: _build-fw-lite-shared-for-types
+        vars: { CLI_ARGS: '{{.CLI_ARGS}}' }
+      - task: _assert-generated-types-committed
+
+  _build-fw-lite-shared-for-types:
+    internal: true
+    status:
+      - 'powershell -NoProfile -Command "if (''{{.CLI_ARGS}}'' -match ''--no-build'') { exit 0 } else { exit 1 }"'
+    dir: ./FwLiteShared
+    cmd: dotnet build
+
+  _assert-generated-types-committed:
+    internal: true
+    dir: ../..
+    cmd: pwsh -NoProfile -File backend/FwLite/scripts/assert-generated-types-committed.ps1
+
   remove-last-migration:
     desc: "This will remove the last migration, don't remove migrations that have been pushed to production, but you can remove ones you created locally."
     deps: [ tool-restore ]

--- a/backend/FwLite/scripts/assert-generated-types-committed.ps1
+++ b/backend/FwLite/scripts/assert-generated-types-committed.ps1
@@ -1,0 +1,14 @@
+param(
+    [string]$Path = 'frontend/viewer/src/lib/dotnet-types/generated-types'
+)
+
+$status = git status --porcelain -- $Path
+if ($status) {
+    Write-Host 'Generated TypeScript types are out of date.'
+    Write-Host 'Run: dotnet build backend/FwLite/FwLiteShared/FwLiteShared.csproj'
+    Write-Host "Then commit changes under $Path/"
+    Write-Host ''
+    Write-Host $status
+    git diff -- $Path
+    exit 1
+}

--- a/frontend/viewer/AGENTS.md
+++ b/frontend/viewer/AGENTS.md
@@ -22,6 +22,9 @@ This project depends on TypeScript types and API interfaces generated from .NET 
 ```bash
 # From repo root
 dotnet build backend/FwLite/FwLiteShared/FwLiteShared.csproj
+
+# Verify types are committed (also runs in CI):
+task fw-lite:has-stale-generated-types
 ```
 
 The generated files are located in `src/lib/dotnet-types/generated-types/`.

--- a/frontend/viewer/src/lib/dotnet-types/generated-types/MiniLcm/Models/IPicture.ts
+++ b/frontend/viewer/src/lib/dotnet-types/generated-types/MiniLcm/Models/IPicture.ts
@@ -11,6 +11,5 @@ export interface IPicture
 	order: number;
 	mediaUri: string;
 	caption: IRichMultiString;
-	deletedAt?: string;
 }
 /* eslint-enable */


### PR DESCRIPTION
## Summary
- Add 	ask fw-lite:has-stale-generated-types to build FwLiteShared and fail when committed viewer generated types are out of date
- Wire the check into the FieldWorks Lite PR workflow after the existing EF pending-changes step
- Document the task in FwLite and viewer AGENTS.md

## Screenshot
<img width="1114" height="474" alt="image" src="https://github.com/user-attachments/assets/770e5ac5-6476-46c4-b059-5162894b9a09" />


## Test plan
- [x] 	ask fw-lite:has-stale-generated-types -- --no-build passes on a clean tree
- [x] Temporary Entry model change causes the task to fail with a diff in IEntry.ts
- [x] Reverted test change; only CI/task wiring remains
