### PR TITLE
Make FwLite dev-assets viewer port configurable via FW_LITE_DEV_PORT

### DIFF
--- a/backend/FwLite/FwLiteShared/FwLiteConfig.cs
+++ b/backend/FwLite/FwLiteShared/FwLiteConfig.cs
@@ -6,7 +6,7 @@ namespace FwLiteShared;
 public class FwLiteConfig
 {
     public bool UseDevAssets { get; set; } = false;
-    //Vite dev-server port the browser pulls viewer assets from when UseDevAssets is true; override via FW_LITE_DEV_PORT so parallel worktrees can each run their own dev server.
+    //Vite dev-server port the browser pulls viewer assets from when UseDevAssets is true; override via env FwLite__DevAssetsPort so parallel worktrees can each run their own dev server.
     public int DevAssetsPort { get; set; } = 5173;
     public string AppVersion { get; set; } = "Unknown";
     public FwLitePlatform Os { get; set; } = Environment.OSVersion.Platform switch {

--- a/backend/FwLite/FwLiteShared/FwLiteConfig.cs
+++ b/backend/FwLite/FwLiteShared/FwLiteConfig.cs
@@ -6,6 +6,8 @@ namespace FwLiteShared;
 public class FwLiteConfig
 {
     public bool UseDevAssets { get; set; } = false;
+    //Vite dev-server port the browser pulls viewer assets from when UseDevAssets is true; override via FW_LITE_DEV_PORT so parallel worktrees can each run their own dev server.
+    public int DevAssetsPort { get; set; } = 5173;
     public string AppVersion { get; set; } = "Unknown";
     public FwLitePlatform Os { get; set; } = Environment.OSVersion.Platform switch {
         PlatformID.Win32NT => FwLitePlatform.Windows,

--- a/backend/FwLite/FwLiteShared/FwLiteSharedKernel.cs
+++ b/backend/FwLite/FwLiteShared/FwLiteSharedKernel.cs
@@ -53,7 +53,13 @@ public static class FwLiteSharedKernel
         services.TryAddSingleton<INetworkStatus, NetworkInterfaceNetworkStatus>();
         services.AddSingleton<UpdateService>();
         services.AddSingleton<TestingService>();
-        services.AddOptions<FwLiteConfig>().BindConfiguration("FwLite");
+        services.AddOptions<FwLiteConfig>().BindConfiguration("FwLite")
+            //env override wins over config so parallel dev worktrees can each point at their own Vite dev server
+            .PostConfigure(c =>
+            {
+                if (int.TryParse(Environment.GetEnvironmentVariable("FW_LITE_DEV_PORT"), out var devAssetsPort))
+                    c.DevAssetsPort = devAssetsPort;
+            });
         services.DecorateConstructor<IJSRuntime>((provider, runtime) =>
         {
             var crdtConfig = provider.GetRequiredService<IOptions<CrdtConfig>>().Value;

--- a/backend/FwLite/FwLiteShared/FwLiteSharedKernel.cs
+++ b/backend/FwLite/FwLiteShared/FwLiteSharedKernel.cs
@@ -53,13 +53,7 @@ public static class FwLiteSharedKernel
         services.TryAddSingleton<INetworkStatus, NetworkInterfaceNetworkStatus>();
         services.AddSingleton<UpdateService>();
         services.AddSingleton<TestingService>();
-        services.AddOptions<FwLiteConfig>().BindConfiguration("FwLite")
-            //env override wins over config so parallel dev worktrees can each point at their own Vite dev server
-            .PostConfigure(c =>
-            {
-                if (int.TryParse(Environment.GetEnvironmentVariable("FW_LITE_DEV_PORT"), out var devAssetsPort))
-                    c.DevAssetsPort = devAssetsPort;
-            });
+        services.AddOptions<FwLiteConfig>().BindConfiguration("FwLite");
         services.DecorateConstructor<IJSRuntime>((provider, runtime) =>
         {
             var crdtConfig = provider.GetRequiredService<IOptions<CrdtConfig>>().Value;

--- a/backend/FwLite/FwLiteShared/Layout/SvelteLayout.razor
+++ b/backend/FwLite/FwLiteShared/Layout/SvelteLayout.razor
@@ -12,7 +12,7 @@
 @implements IAsyncDisposable
 @if (useDevAssets)
 {
-    <script type="module" src="@DevScheme://@DevHostname:5173/@@vite/client"></script>
+    <script type="module" src="@DevScheme://@DevHostname:@DevPort/@@vite/client"></script>
 }
 else
 {
@@ -58,6 +58,7 @@ else
 
     private string DevHostname => DevUri.Host;
     private string DevScheme => DevUri.Scheme;
+    private int DevPort => Config.Value.DevAssetsPort;
 
     protected override async Task OnAfterRenderAsync(bool firstRender)
     {
@@ -75,7 +76,7 @@ else
             {
               if (useDevAssets)
               {
-                    await JS.InvokeAsync<IJSObjectReference>("import", $"{DevScheme}://{DevHostname}:5173/src/main.ts");
+                    await JS.InvokeAsync<IJSObjectReference>("import", $"{DevScheme}://{DevHostname}:{DevPort}/src/main.ts");
               }
               else
               {

--- a/frontend/viewer/src/lib/dotnet-types/generated-types/FwLiteShared/IFwLiteConfig.ts
+++ b/frontend/viewer/src/lib/dotnet-types/generated-types/FwLiteShared/IFwLiteConfig.ts
@@ -8,6 +8,7 @@ import type {FwLitePlatform} from './FwLitePlatform';
 export interface IFwLiteConfig
 {
 	useDevAssets: boolean;
+	devAssetsPort: number;
 	appVersion: string;
 	os: FwLitePlatform;
 	feedbackUrl: string;

--- a/frontend/viewer/src/project/demo/in-memory-demo-api.ts
+++ b/frontend/viewer/src/project/demo/in-memory-demo-api.ts
@@ -59,6 +59,7 @@ export const mockFwLiteConfig: IFwLiteConfig = {
   feedbackUrl: '',
   os: FwLitePlatform.Web,
   useDevAssets: true,
+  devAssetsPort: 5173,
   edition: 0,
   updateCheckCondition: 0,
   updateCheckInterval: 0,

--- a/frontend/viewer/vite.config.ts
+++ b/frontend/viewer/vite.config.ts
@@ -9,8 +9,9 @@ const ssl = false;
 
 // Override the dev-server port (and the origin it advertises) via FW_LITE_DEV_PORT so multiple
 // worktrees can each run their own viewer; the .NET host loads assets cross-origin, so origin must track the port.
-const devPortFromEnv = !!process.env.FW_LITE_DEV_PORT;
-const devPort = Number(process.env.FW_LITE_DEV_PORT) || 5173;
+const parsedDevPort = Number(process.env.FW_LITE_DEV_PORT);
+const devPortFromEnv = Number.isFinite(parsedDevPort) && parsedDevPort > 0;
+const devPort = devPortFromEnv ? parsedDevPort : 5173;
 
 // https://vitejs.dev/config/
 export default defineConfig(({command}) => ({

--- a/frontend/viewer/vite.config.ts
+++ b/frontend/viewer/vite.config.ts
@@ -7,6 +7,11 @@ import webfontDownload from 'vite-plugin-webfont-dl';
 
 const ssl = false;
 
+// Override the dev-server port (and the origin it advertises) via FW_LITE_DEV_PORT so multiple
+// worktrees can each run their own viewer; the .NET host loads assets cross-origin, so origin must track the port.
+const devPortFromEnv = !!process.env.FW_LITE_DEV_PORT;
+const devPort = Number(process.env.FW_LITE_DEV_PORT) || 5173;
+
 // https://vitejs.dev/config/
 export default defineConfig(({command}) => ({
   base: command === 'build' ? '/_content/FwLiteShared/viewer' : '/',
@@ -48,7 +53,9 @@ export default defineConfig(({command}) => ({
       ssl ? basicSsl() : null, // crypto.subtle is only available on secure connections
     ],
   server: {
-      origin: 'http://localhost:5173',
+      port: devPort,
+      strictPort: devPortFromEnv,
+      origin: `http://localhost:${devPort}`,
       host: true,
       allowedHosts: true,
       cors: true,

--- a/frontend/viewer/vite.config.ts
+++ b/frontend/viewer/vite.config.ts
@@ -7,9 +7,10 @@ import webfontDownload from 'vite-plugin-webfont-dl';
 
 const ssl = false;
 
-// Override the dev-server port (and the origin it advertises) via FW_LITE_DEV_PORT so multiple
-// worktrees can each run their own viewer; the .NET host loads assets cross-origin, so origin must track the port.
-const parsedDevPort = Number(process.env.FW_LITE_DEV_PORT);
+// Override the dev-server port (and the origin it advertises) via FwLite__DevAssetsPort so multiple
+// worktrees can each run their own viewer; the .NET host binds the same setting (FwLiteConfig.DevAssetsPort)
+// and loads assets cross-origin, so origin must track the port.
+const parsedDevPort = Number(process.env.FwLite__DevAssetsPort);
 const devPortFromEnv = Number.isFinite(parsedDevPort) && parsedDevPort > 0;
 const devPort = devPortFromEnv ? parsedDevPort : 5173;
 


### PR DESCRIPTION
Reads the viewer dev-server port from `FW_LITE_DEV_PORT` (default 5173) instead of hardcoding 5173 in the .NET host (`SvelteLayout.razor` / `FwLiteConfig`) and `vite.config.ts`, so several worktrees can run their own FwLite viewer on distinct ports at once. No behavior change when the env var is unset.