### PR TITLE
Improve organization selection validation in project setup

### DIFF
--- a/frontend/src/lib/i18n/locales/en.json
+++ b/frontend/src/lib/i18n/locales/en.json
@@ -419,6 +419,8 @@ so we can get this fixed!",
       "add_button": "Add Organization",
       "modal_title": "Choose organization",
       "submit_button": "Add Organization",
+      "select_org_placeholder": "Select an organization...",
+      "no_org_selected": "Please select an organization",
       "org_not_found": "Organization not found. Please refresh the page.",
       "project_not_found": "Project not found. Please refresh the page."
     },

--- a/frontend/src/routes/(authenticated)/project/[project_code]/AddOrganization.svelte
+++ b/frontend/src/routes/(authenticated)/project/[project_code]/AddOrganization.svelte
@@ -17,7 +17,7 @@
   let orgList: Org[] = $state([]);
 
   const schema = z.object({
-    orgId: z.string().trim(),
+    orgId: z.uuid({ error: $t('project_page.add_org.no_org_selected') }),
   });
 
   type Schema = typeof schema;
@@ -52,6 +52,7 @@
   {/snippet}
   {#snippet children({ errors })}
     <Select id="org" label={$t('project_page.organization.title')} bind:value={$form!.orgId} error={errors.orgId}>
+      <option value="" disabled>{$t('project_page.add_org.select_org_placeholder')}</option>
       {#each orgList as org (org.id)}
         <option value={org.id}>{org.name}</option>
       {/each}


### PR DESCRIPTION
## Summary

The point of this PR is to prevent an ugly error model if a user forgets to select an org.

Enhanced the organization selection form in the "Add Organization" modal with better validation and user guidance. The changes ensure users must explicitly select an organization and provide clearer feedback when validation fails.

## Key Changes
- Updated `orgId` validation schema to use UUID validation instead of basic string trimming, with a localized error message
- Added a disabled placeholder option ("Select an organization...") to the organization dropdown to guide users
- Added two new localization strings:
  - `select_org_placeholder`: Placeholder text for the dropdown
  - `no_org_selected`: Error message when no organization is selected

## Implementation Details
The validation now properly enforces that a valid UUID must be selected, preventing form submission with empty or invalid values. The placeholder option with `disabled` attribute ensures it cannot be submitted and serves as a visual cue that a selection is required.

https://claude.ai/code/session_013jVcoqdaKXDe17ESH61Sro