### PR TITLE
Bump SIL.Harmony to 0.2.1-rc.211 and adopt generic remote-resource types

### DIFF
--- a/backend/Directory.Packages.props
+++ b/backend/Directory.Packages.props
@@ -109,9 +109,9 @@
     <PackageVersion Include="SIL.Chorus.LibChorus" Version="6.0.0-beta0064" />
     <PackageVersion Include="SIL.Chorus.Mercurial" Version="6.5.1.43" />
     <PackageVersion Include="SIL.ChorusPlugin.LfMergeBridge" Version="4.3.0-beta0048" />
-    <PackageVersion Include="SIL.Harmony" Version="0.2.1-rc.202" />
-    <PackageVersion Include="SIL.Harmony.Core" Version="0.2.1-rc.202" />
-    <PackageVersion Include="SIL.Harmony.Linq2db" Version="0.2.1-rc.202" />
+    <PackageVersion Include="SIL.Harmony" Version="0.2.1-rc.211" />
+    <PackageVersion Include="SIL.Harmony.Core" Version="0.2.1-rc.211" />
+    <PackageVersion Include="SIL.Harmony.Linq2db" Version="0.2.1-rc.211" />
     <PackageVersion Include="SIL.Core" Version="17.0.0" />
     <PackageVersion Include="SIL.LCModel" Version="11.0.0-beta0165" />
     <PackageVersion Include="SIL.LCModel.FixData" Version="11.0.0-beta0165" />

--- a/backend/FwLite/LcmCrdt.Tests/Changes/ChangeDeserializationRegressionData.latest.verified.txt
+++ b/backend/FwLite/LcmCrdt.Tests/Changes/ChangeDeserializationRegressionData.latest.verified.txt
@@ -943,16 +943,36 @@
   {
     "$type": "uploaded:RemoteResource",
     "RemoteId": "withdrawal",
+    "Metadata": null,
     "EntityId": "9c8b252c-d342-dfe8-c1dd-5899471ecbd1"
+  },
+  {
+    "$type": "uploaded:RemoteResource",
+    "RemoteId": "Identity",
+    "Metadata": {},
+    "EntityId": "c0fe5fa7-76ba-de0c-2a94-316fbbb84b0c"
   },
   {
     "$type": "create:remote-resource",
     "RemoteId": "Buckinghamshire",
+    "Metadata": null,
     "EntityId": "188a57e7-7d61-8742-59eb-c0bfbf959737"
   },
   {
+    "$type": "create:remote-resource",
+    "RemoteId": "back-end",
+    "Metadata": {},
+    "EntityId": "0aace990-edd6-295c-2538-7611f0622e6e"
+  },
+  {
     "$type": "create:pendingUpload",
+    "Metadata": null,
     "EntityId": "52d7432c-ad4f-430c-8304-925603b3fefa"
+  },
+  {
+    "$type": "create:pendingUpload",
+    "Metadata": {},
+    "EntityId": "f58a4713-11d6-999e-d355-0344e4fcd7b3"
   },
   {
     "$type": "delete:RemoteResource",
@@ -1293,5 +1313,10 @@
   {
     "$type": "SetMainPublicationChange",
     "EntityId": "c775e310-fc5c-6d01-5a02-146d579a88e5"
+  },
+  {
+    "$type": "set:remote-resource-metadata",
+    "Metadata": {},
+    "EntityId": "ef64afaa-972e-34b2-b57f-ae99e543b5ea"
   }
 ]

--- a/backend/FwLite/LcmCrdt.Tests/Changes/ChangeDeserializationRegressionData.legacy.verified.txt
+++ b/backend/FwLite/LcmCrdt.Tests/Changes/ChangeDeserializationRegressionData.legacy.verified.txt
@@ -625,5 +625,42 @@
       ],
       "EntityId": "f27a032b-e0f6-f389-b466-959bdb17086d"
     }
+  },
+  {
+    "Input": {
+      "$type": "uploaded:RemoteResource",
+      "RemoteId": "withdrawal",
+      "EntityId": "9c8b252c-d342-dfe8-c1dd-5899471ecbd1"
+    },
+    "Output": {
+      "$type": "uploaded:RemoteResource",
+      "RemoteId": "withdrawal",
+      "Metadata": null,
+      "EntityId": "9c8b252c-d342-dfe8-c1dd-5899471ecbd1"
+    }
+  },
+  {
+    "Input": {
+      "$type": "create:remote-resource",
+      "RemoteId": "Buckinghamshire",
+      "EntityId": "188a57e7-7d61-8742-59eb-c0bfbf959737"
+    },
+    "Output": {
+      "$type": "create:remote-resource",
+      "RemoteId": "Buckinghamshire",
+      "Metadata": null,
+      "EntityId": "188a57e7-7d61-8742-59eb-c0bfbf959737"
+    }
+  },
+  {
+    "Input": {
+      "$type": "create:pendingUpload",
+      "EntityId": "52d7432c-ad4f-430c-8304-925603b3fefa"
+    },
+    "Output": {
+      "$type": "create:pendingUpload",
+      "Metadata": null,
+      "EntityId": "52d7432c-ad4f-430c-8304-925603b3fefa"
+    }
   }
 ]

--- a/backend/FwLite/LcmCrdt.Tests/Changes/UseChangesTests.cs
+++ b/backend/FwLite/LcmCrdt.Tests/Changes/UseChangesTests.cs
@@ -280,11 +280,11 @@ public class UseChangesTests(MiniLcmApiFixture fixture) : IClassFixture<MiniLcmA
         var removePublicationChange = new RemovePublicationChange(entry.Id, publication2.Id);
         yield return new ChangeWithDependencies(removePublicationChange, [replacePublicationChange]);
 
-        yield return new ChangeWithDependencies(new CreateRemoteResourceChange(Guid.NewGuid(), "test-remote-id"));
-        var createRemoteResourcePendingUploadChange = new CreateRemoteResourcePendingUploadChange(Guid.NewGuid());
+        yield return new ChangeWithDependencies(new CreateRemoteResourceChange<NoMetadata>(Guid.NewGuid(), "test-remote-id"));
+        var createRemoteResourcePendingUploadChange = new CreateRemoteResourcePendingUploadChange<NoMetadata>(Guid.NewGuid());
         yield return new ChangeWithDependencies(createRemoteResourcePendingUploadChange);
         yield return new ChangeWithDependencies(
-            new RemoteResourceUploadedChange(createRemoteResourcePendingUploadChange.EntityId, "test-remote-id"),
+            new RemoteResourceUploadedChange<NoMetadata>(createRemoteResourcePendingUploadChange.EntityId, "test-remote-id"),
             [createRemoteResourcePendingUploadChange]);
 
         var customView = new CustomView

--- a/backend/FwLite/LcmCrdt.Tests/Changes/UseChangesTests.cs
+++ b/backend/FwLite/LcmCrdt.Tests/Changes/UseChangesTests.cs
@@ -280,12 +280,19 @@ public class UseChangesTests(MiniLcmApiFixture fixture) : IClassFixture<MiniLcmA
         var removePublicationChange = new RemovePublicationChange(entry.Id, publication2.Id);
         yield return new ChangeWithDependencies(removePublicationChange, [replacePublicationChange]);
 
-        yield return new ChangeWithDependencies(new CreateRemoteResourceChange<NoMetadata>(Guid.NewGuid(), "test-remote-id"));
+        var createRemoteResourceChange = new CreateRemoteResourceChange<NoMetadata>(Guid.NewGuid(), "test-remote-id");
+        yield return new ChangeWithDependencies(createRemoteResourceChange);
         var createRemoteResourcePendingUploadChange = new CreateRemoteResourcePendingUploadChange<NoMetadata>(Guid.NewGuid());
         yield return new ChangeWithDependencies(createRemoteResourcePendingUploadChange);
         yield return new ChangeWithDependencies(
             new RemoteResourceUploadedChange<NoMetadata>(createRemoteResourcePendingUploadChange.EntityId, "test-remote-id"),
             [createRemoteResourcePendingUploadChange]);
+        yield return new ChangeWithDependencies(
+            new SetRemoteResourceMetadataChange<NoMetadata>(createRemoteResourceChange.EntityId, new NoMetadata()),
+            [createRemoteResourceChange]);
+        yield return new ChangeWithDependencies(
+            new DeleteRemoteResourceChange<NoMetadata>(createRemoteResourceChange.EntityId),
+            [createRemoteResourceChange]);
 
         var customView = new CustomView
         {

--- a/backend/FwLite/LcmCrdt.Tests/ConfigRegistrationTests.cs
+++ b/backend/FwLite/LcmCrdt.Tests/ConfigRegistrationTests.cs
@@ -16,6 +16,7 @@ public class ConfigRegistrationTests
         typeof(JsonPatchChange<ExampleSentence>), //replaced by JsonPatchExampleSentenceChange
         typeof(JsonPatchChange<CustomView>), //not supported. Use EditCustomViewChange
         typeof(DeleteChange<MorphType>), //MorphTypes cannot be deleted
+        typeof(DeleteChange<RemoteResource<NoMetadata>>), //replaced by DeleteRemoteResourceChange<NoMetadata>
     ];
 
     private readonly CrdtConfig _config;

--- a/backend/FwLite/LcmCrdt.Tests/ConfigRegistrationTests.cs
+++ b/backend/FwLite/LcmCrdt.Tests/ConfigRegistrationTests.cs
@@ -12,7 +12,7 @@ public class ConfigRegistrationTests
     private readonly HashSet<Type> _excludedChangeTypes =
     [
         typeof(JsonPatchChange<ComplexFormComponent>), //not supported
-        typeof(JsonPatchChange<RemoteResource>), //not supported
+        typeof(JsonPatchChange<RemoteResource<NoMetadata>>), //not supported
         typeof(JsonPatchChange<ExampleSentence>), //replaced by JsonPatchExampleSentenceChange
         typeof(JsonPatchChange<CustomView>), //not supported. Use EditCustomViewChange
         typeof(DeleteChange<MorphType>), //MorphTypes cannot be deleted

--- a/backend/FwLite/LcmCrdt.Tests/Data/SnapshotDeserializationRegressionData.latest.verified.txt
+++ b/backend/FwLite/LcmCrdt.Tests/Data/SnapshotDeserializationRegressionData.latest.verified.txt
@@ -3828,7 +3828,15 @@
     "$type": "RemoteResource",
     "Id": "fce4cb31-93bd-f380-fd73-3fb0d09c0fa5",
     "DeletedAt": "2025-09-17T23:53:03.6147633+02:00",
-    "RemoteId": "end-to-end"
+    "RemoteId": "end-to-end",
+    "Metadata": null
+  },
+  {
+    "$type": "RemoteResource",
+    "Id": "666023e2-5d9e-58e1-15ba-d47562be1752",
+    "DeletedAt": "2026-07-01T14:13:37.7894421+02:00",
+    "RemoteId": "4th generation",
+    "Metadata": {}
   },
   {
     "$type": "MiniLcmCrdtAdapter",

--- a/backend/FwLite/LcmCrdt.Tests/Data/SnapshotDeserializationRegressionData.legacy.verified.txt
+++ b/backend/FwLite/LcmCrdt.Tests/Data/SnapshotDeserializationRegressionData.legacy.verified.txt
@@ -3900,5 +3900,20 @@
       "Id": "853b91e6-d738-7d5d-cc98-e62904160c35",
       "DeletedAt": null
     }
+  },
+  {
+    "Input": {
+      "$type": "RemoteResource",
+      "Id": "fce4cb31-93bd-f380-fd73-3fb0d09c0fa5",
+      "DeletedAt": "2025-09-17T23:53:03.6147633+02:00",
+      "RemoteId": "end-to-end"
+    },
+    "Output": {
+      "$type": "RemoteResource",
+      "Id": "fce4cb31-93bd-f380-fd73-3fb0d09c0fa5",
+      "DeletedAt": "2025-09-17T23:53:03.6147633+02:00",
+      "RemoteId": "end-to-end",
+      "Metadata": null
+    }
   }
 ]

--- a/backend/FwLite/LcmCrdt.Tests/DataModelSnapshotTests.VerifyChangeModels.verified.txt
+++ b/backend/FwLite/LcmCrdt.Tests/DataModelSnapshotTests.VerifyChangeModels.verified.txt
@@ -1,19 +1,23 @@
 ﻿{
   DerivedTypes: [
     {
-      DerivedType: RemoteResourceUploadedChange,
+      DerivedType: RemoteResourceUploadedChange<NoMetadata>,
       TypeDiscriminator: uploaded:RemoteResource
     },
     {
-      DerivedType: CreateRemoteResourceChange,
+      DerivedType: CreateRemoteResourceChange<NoMetadata>,
       TypeDiscriminator: create:remote-resource
     },
     {
-      DerivedType: CreateRemoteResourcePendingUploadChange,
+      DerivedType: CreateRemoteResourcePendingUploadChange<NoMetadata>,
       TypeDiscriminator: create:pendingUpload
     },
     {
-      DerivedType: DeleteChange<RemoteResource>,
+      DerivedType: SetRemoteResourceMetadataChange<NoMetadata>,
+      TypeDiscriminator: set:remote-resource-metadata
+    },
+    {
+      DerivedType: DeleteRemoteResourceChange<NoMetadata>,
       TypeDiscriminator: delete:RemoteResource
     },
     {

--- a/backend/FwLite/LcmCrdt.Tests/DataModelSnapshotTests.VerifyDbModel.verified.txt
+++ b/backend/FwLite/LcmCrdt.Tests/DataModelSnapshotTests.VerifyDbModel.verified.txt
@@ -466,16 +466,19 @@
       Relational:TableName: LocalResource
       Relational:ViewName: 
       Relational:ViewSchema: 
-  EntityType: RemoteResource
+  EntityType: RemoteResource<NoMetadata>
     Properties: 
       Id (Guid) Required PK AfterSave:Throw ValueGenerated.OnAdd
       DeletedAt (DateTimeOffset?)
+      Metadata (NoMetadata)
+        Annotations: 
+          Relational:ColumnType: jsonb
       RemoteId (string)
       SnapshotId (no field, Guid?) Shadow FK Index
     Keys: 
       Id PK
     Foreign keys: 
-      RemoteResource {'SnapshotId'} -> ObjectSnapshot {'Id'} Unique SetNull
+      RemoteResource<NoMetadata> {'SnapshotId'} -> ObjectSnapshot {'Id'} Unique SetNull
     Indexes: 
       SnapshotId Unique
     Annotations: 

--- a/backend/FwLite/LcmCrdt.Tests/DataModelSnapshotTests.VerifyIObjectBaseModels.verified.txt
+++ b/backend/FwLite/LcmCrdt.Tests/DataModelSnapshotTests.VerifyIObjectBaseModels.verified.txt
@@ -5,7 +5,7 @@
       TypeDiscriminator: MiniLcmCrdtAdapter
     },
     {
-      DerivedType: RemoteResource,
+      DerivedType: RemoteResource<NoMetadata>,
       TypeDiscriminator: RemoteResource
     }
   ],

--- a/backend/FwLite/LcmCrdt.Tests/EntityCopyMethodTests.cs
+++ b/backend/FwLite/LcmCrdt.Tests/EntityCopyMethodTests.cs
@@ -16,7 +16,7 @@ public class EntityCopyMethodTests
         var crdtConfig = new CrdtConfig();
         LcmCrdtKernel.ConfigureCrdt(crdtConfig);
         return crdtConfig.ObjectTypes
-            .Except([typeof(RemoteResource)])//exclude remote resource as it's a harmony defined type, not miniLcm
+            .Except([typeof(RemoteResource<NoMetadata>)])//exclude remote resource as it's a harmony defined type, not miniLcm
             .Select(t => new object[] { t });
     }
 

--- a/backend/FwLite/LcmCrdt/LcmCrdtKernel.cs
+++ b/backend/FwLite/LcmCrdt/LcmCrdtKernel.cs
@@ -4,6 +4,7 @@ using SIL.Harmony;
 using SIL.Harmony.Linq2db;
 using SIL.Harmony.Core;
 using SIL.Harmony.Changes;
+using SIL.Harmony.Resource;
 using LcmCrdt.Changes;
 using LcmCrdt.Changes.CustomJsonPatches;
 using LcmCrdt.Changes.Entries;
@@ -61,6 +62,10 @@ public static class LcmCrdtKernel
         services.RemoveAll<LcmCrdtDbContext>();//we don't want to be able to inject these directly as they will leak.
         services.AddOptions<LcmCrdtConfig>().BindConfiguration("LcmCrdt");
 
+        // Order matters: AddCrdtRemoteResources' Configure<CrdtConfig> delegate must run before
+        // ConfigureCrdt so the RemoteResourcesEnabled guard in ConfigureCrdt sees enabled=true and
+        // skips its own AddRemoteResourceEntity call. Configure delegates run in registration order.
+        services.AddCrdtRemoteResources<NoMetadata>();
         services.AddCrdtDataDbFactory<LcmCrdtDbContext>(
             ConfigureCrdt
         );
@@ -307,7 +312,7 @@ public static class LcmCrdtKernel
                 }).IsUnique().HasFilter($"{componentSenseId} IS NULL");
             });
 
-        config.AddRemoteResourceEntity();
+        if (!config.RemoteResourcesEnabled) config.AddRemoteResourceEntity<NoMetadata>();
 
         config.ChangeTypeListBuilder.Add<JsonPatchChange<Entry>>()
             .Add<JsonPatchChange<Sense>>()

--- a/backend/FwLite/LcmCrdt/MediaServer/LcmMediaService.cs
+++ b/backend/FwLite/LcmCrdt/MediaServer/LcmMediaService.cs
@@ -11,15 +11,15 @@ using MiniLcm.Media;
 namespace LcmCrdt.MediaServer;
 
 public class LcmMediaService(
-    ResourceService resourceService,
+    ResourceService<NoMetadata> resourceService,
     CurrentProjectService currentProjectService,
     IOptions<CrdtConfig> options,
     IRefitHttpServiceFactory refitFactory,
     IServerHttpClientProvider httpClientProvider,
     ILogger<LcmMediaService> logger
-) : IRemoteResourceService
+) : IRemoteResourceService<NoMetadata>
 {
-    public async Task<HarmonyResource[]> AllResources()
+    public async Task<HarmonyResource<NoMetadata>[]> AllResources()
     {
         return await resourceService.AllResources();
     }
@@ -87,7 +87,7 @@ public class LcmMediaService(
         return mediaClient;
     }
 
-    async Task<DownloadResult> IRemoteResourceService.DownloadResource(string remoteId, string localResourceCachePath)
+    async Task<DownloadResult> IRemoteResourceService<NoMetadata>.DownloadResource(string remoteId, string localResourceCachePath)
     {
         var projectResourceCachePath = ProjectResourceCachePath;
         Directory.CreateDirectory(projectResourceCachePath);
@@ -112,7 +112,7 @@ public class LcmMediaService(
     }
 
 
-    async Task<UploadResult> IRemoteResourceService.UploadResource(Guid resourceId, string localPath)
+    async Task<UploadResult<NoMetadata>> IRemoteResourceService<NoMetadata>.UploadResource(Guid resourceId, string localPath, NoMetadata? metadata)
     {
         var mediaClient = await MediaServerClient();
         var fileName = Path.GetFileName(localPath);
@@ -121,10 +121,10 @@ public class LcmMediaService(
             projectId: currentProjectService.ProjectData.Id,
             fileId: resourceId.ToString("D"),
             filename: fileName);
-        return new UploadResult(resourceId.ToString("N"));
+        return new UploadResult<NoMetadata>(resourceId.ToString("N"));
     }
 
-    public async Task<(HarmonyResource resource, bool newResource)> SaveFile(Stream stream, LcmFileMetadata metadata)
+    public async Task<(HarmonyResource<NoMetadata> resource, bool newResource)> SaveFile(Stream stream, LcmFileMetadata metadata)
     {
         var projectResourceCachePath = ProjectResourceCachePath;
         Directory.CreateDirectory(projectResourceCachePath);
@@ -138,7 +138,7 @@ public class LcmMediaService(
 
         try
         {
-            IRemoteResourceService? remoteResourceService = null;
+            IRemoteResourceService<NoMetadata>? remoteResourceService = null;
             if (await httpClientProvider.ConnectionStatus() == ConnectionStatus.Online) remoteResourceService = this;
             return (await resourceService.AddLocalResource(
                 localPath,

--- a/backend/FwLite/LcmCrdt/Migrations/20260701154631_AddRemoteResourceMetadata.Designer.cs
+++ b/backend/FwLite/LcmCrdt/Migrations/20260701154631_AddRemoteResourceMetadata.Designer.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using LcmCrdt;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace LcmCrdt.Migrations
 {
     [DbContext(typeof(LcmCrdtDbContext))]
-    partial class LcmCrdtDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260701154631_AddRemoteResourceMetadata")]
+    partial class AddRemoteResourceMetadata
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder.HasAnnotation("ProductVersion", "10.0.8");

--- a/backend/FwLite/LcmCrdt/Migrations/20260701154631_AddRemoteResourceMetadata.cs
+++ b/backend/FwLite/LcmCrdt/Migrations/20260701154631_AddRemoteResourceMetadata.cs
@@ -1,0 +1,28 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace LcmCrdt.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddRemoteResourceMetadata : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "Metadata",
+                table: "RemoteResource",
+                type: "jsonb",
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "Metadata",
+                table: "RemoteResource");
+        }
+    }
+}

--- a/frontend/viewer/src/lib/dotnet-types/generated-types/SIL/Harmony/Resource/IRemoteResource.ts
+++ b/frontend/viewer/src/lib/dotnet-types/generated-types/SIL/Harmony/Resource/IRemoteResource.ts
@@ -8,5 +8,6 @@ export interface IRemoteResource
 	id: string;
 	deletedAt?: string;
 	remoteId?: string;
+	metadata?: unknown;
 }
 /* eslint-enable */


### PR DESCRIPTION
Harmony PR [sillsdev/harmony#75](https://github.com/sillsdev/harmony/pull/75) made `RemoteResource`, `ResourceService`, `IRemoteResourceService`, and the resource change classes generic on `TMetadata`. We pick `NoMetadata` — lexbox media has no synced metadata today. EF migration adds a nullable `Metadata` jsonb column; existing rows get `NULL`. Wire discriminators are preserved (`delete:RemoteResource` etc.); legacy payloads round-trip with `Metadata: null`.

`AddRemoteResourceEntity<NoMetadata>()` stays in `ConfigureCrdt` (behind a `RemoteResourcesEnabled` guard) so bare-`CrdtConfig` callers — TypeGen, `HistoryService.AllChangeTypes`, `LcmDebugger` — still see the resource entity + change types. DI order matters: `AddCrdtRemoteResources` is registered first so its Configure delegate flips the guard before `ConfigureCrdt` runs.

Follow-up (separate PR, on top of #2393): plumb `CommitMetadata` into the `ResourceService` calls so media commits get author attribution the same way `CrdtMiniLcmApi` does.

Notes:
- `0.2.1-rc.211` is an untagged `main`-branch prerelease from sillsdev/harmony, consistent with how we pinned `rc.202`.
- Any future move off `NoMetadata` becomes wire-breaking for older clients — not this PR's concern, but this bump opens that door.

## Test plan
- [x] `LcmCrdt.Tests` verified snapshots (12 pass) — includes `DataModelSnapshotTests`, `ChangeSerializationTests.RegressionDataUpToDate`, `MigrationTests`, `SnapshotDeserializationTests`
- [x] `FwLiteProjectSync.Tests` verified snapshots (2 pass)
- [x] `dotnet build backend/FwLite/FwLiteShared/FwLiteShared.csproj` — no generated-TS drift
- [x] Full build across LcmCrdt.Tests, FwLiteProjectSync.Tests, LcmDebugger, FwHeadless, FwLiteMaui, LexBoxApi — all green