### PR TITLE
Fix FixFwData crash in fw-headless container

### DIFF
--- a/backend/.dockerignore
+++ b/backend/.dockerignore
@@ -2,6 +2,7 @@
 **/obj
 *Dockerfile
 Testing
+!Testing/test-template-repo.zip
 FwLite/FwLiteWeb
 FwLite/FwLiteMaui
 FwLite/FwLiteShared

--- a/backend/FwHeadless/Dockerfile
+++ b/backend/FwHeadless/Dockerfile
@@ -33,6 +33,16 @@ COPY --from=publish /app/publish .
 RUN chmod +x chorusmerge && chmod +x Mercurial/hg && chmod +x Mercurial/chg 2>/dev/null || true
 # Fix up mercurial.ini path to fixutf8
 RUN sed -i -e 's/fixutf8 = \/FwHeadless/fixutf8 = \/app/' Mercurial/mercurial.ini
+COPY Testing/test-template-repo.zip /tmp/test-template-repo.zip
+# Smoke-test FixFwData at image build time: FwHeadless runs under dotnet (AspNetCore shared
+# framework) but FixFwData is a standalone apphost (Core only). Web publish does not copy the
+# extra assemblies FixFwData needs (e.g. Logging.Abstractions); the csproj PublishFixFwData
+# target must publish it into the same output. Running it here catches a broken publish early.
+RUN test -f FixFwData \
+    && chmod +x FixFwData \
+    && python3 -c "import zipfile; open('/tmp/smoke.fwdata','wb').write(zipfile.ZipFile('/tmp/test-template-repo.zip').read('kevin-test-01.fwdata'))" \
+    && ./FixFwData /tmp/smoke.fwdata; ec=$?; rm -f /tmp/test-template-repo.zip /tmp/smoke.fwdata; \
+    if [ $ec -gt 1 ]; then echo "FixFwData smoke test failed with exit $ec"; exit 1; fi
 USER www-data:www-data
 ENV XDG_DATA_HOME=/var/www/.local/share
 ENTRYPOINT ["tini", "--"]

--- a/backend/FwHeadless/FwHeadless.csproj
+++ b/backend/FwHeadless/FwHeadless.csproj
@@ -17,7 +17,14 @@
     <ProjectReference Include="../FwLite/FwDataMiniLcmBridge/FwDataMiniLcmBridge.csproj" />
     <ProjectReference Include="../FwLite/LcmCrdt/LcmCrdt.csproj" />
     <ProjectReference Include="../FwLite/FwLiteProjectSync/FwLiteProjectSync.csproj" />
-    <ProjectReference Include="../FixFwData/FixFwData.csproj" />
+    <!-- FixFwData: co-publish only (no compile-time reference). ReferenceOutputAssembly=false
+         keeps the web app from linking FixFwData; PublishFixFwData (below) publishes it beside
+         FwHeadless. Without that, dotnet publish for this web project omits FixFwData's standalone
+         apphost output and framework-only dependencies (e.g. Microsoft.Extensions.Logging.Abstractions)
+         that AspNetCore publish supplies for FwHeadless but not for a Core-only tool. -->
+    <ProjectReference Include="../FixFwData/FixFwData.csproj">
+      <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
+    </ProjectReference>
     <ProjectReference Include="../LexData/LexData.csproj" />
     <ProjectReference Include="..\WebServiceDefaults\WebServiceDefaults.csproj" />
   </ItemGroup>
@@ -40,4 +47,11 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
   </ItemGroup>
+  <!-- After FwHeadless publish, publish FixFwData into the same PublishDir (see ProjectReference comment). -->
+  <Target Name="PublishFixFwData" AfterTargets="Publish">
+    <MSBuild
+      Projects="$(MSBuildThisFileDirectory)..\FixFwData\FixFwData.csproj"
+      Targets="Publish"
+      Properties="Configuration=$(Configuration);PublishDir=$(PublishDir);PublishProtocol=FileSystem" />
+  </Target>
 </Project>


### PR DESCRIPTION
## Summary

- Co-publish `FixFwData` into the FwHeadless publish output via a `PublishFixFwData` MSBuild target, so standalone-apphost dependencies (e.g. `Microsoft.Extensions.Logging.Abstractions`) are copied alongside the binary.
- Add a Dockerfile smoke test that runs `./FixFwData` against `kevin-test-01.fwdata` during image build, catching this class of publish regression before deploy.
- Allow `Testing/test-template-repo.zip` through `.dockerignore` for the smoke fixture.

## Root cause

FwHeadless runs as `dotnet FwHeadless.dll` (AspNetCore shared framework). LfMergeBridge spawns `FixFwData` as a Core-only apphost. Web publish omits assemblies that live in the AspNetCore shared framework, so FixFwData crashed at startup with `FileNotFoundException` for `Microsoft.Extensions.Logging.Abstractions`.

## Test plan

- [x] `podman build -f backend/FwHeadless/Dockerfile backend` succeeds with fix enabled
- [x] Build fails at smoke step when `PublishFixFwData` is disabled (negative test)
- [ ] CI `lexbox-fw-headless` workflow passes