### PR TITLE
LfClassicMiniLcmApi should no longer implement IMiniLcmApi

### DIFF
--- a/backend/LfClassicData/LfClassicLexboxApiProvider.cs
+++ b/backend/LfClassicData/LfClassicLexboxApiProvider.cs
@@ -5,7 +5,7 @@ namespace LfClassicData;
 
 public class LfClassicLexboxApiProvider(ProjectDbContext dbContext, SystemDbContext systemDbContext, IMemoryCache memoryCache)
 {
-    public IMiniLcmReadApi GetProjectApi(string projectCode)
+    public LfClassicMiniLcmApi GetProjectApi(string projectCode)
     {
         return new LfClassicMiniLcmApi(projectCode, dbContext, systemDbContext, memoryCache);
     }

--- a/backend/LfClassicData/LfClassicMiniLcmApi.cs
+++ b/backend/LfClassicData/LfClassicMiniLcmApi.cs
@@ -13,33 +13,11 @@ using Sense = MiniLcm.Models.Sense;
 
 namespace LfClassicData;
 
-public class LfClassicMiniLcmApi(string projectCode, ProjectDbContext dbContext, SystemDbContext systemDbContext, IMemoryCache memoryCache) : IMiniLcmReadApi
+//doesn't actually implement IMiniLcmApi, because there's not much more we're doing with this, and we don't want to have to keep adding methods that do nothing.
+public class LfClassicMiniLcmApi(string projectCode, ProjectDbContext dbContext, SystemDbContext systemDbContext, IMemoryCache memoryCache)
 {
     private IMongoCollection<Entities.Entry> Entries => dbContext.Entries(projectCode);
-    public IAsyncEnumerable<ComplexFormType> GetComplexFormTypes()
-    {
-        return AsyncEnumerable.Empty<ComplexFormType>();
-    }
 
-    public Task<ComplexFormType?> GetComplexFormType(Guid id)
-    {
-        return Task.FromResult<ComplexFormType?>(null);
-    }
-
-    public IAsyncEnumerable<MorphType> GetMorphTypes()
-    {
-        return AsyncEnumerable.Empty<MorphType>();
-    }
-
-    public Task<MorphType?> GetMorphType(Guid id)
-    {
-        return Task.FromResult<MorphType?>(null);
-    }
-
-    public Task<MorphType?> GetMorphType(MorphTypeKind kind)
-    {
-        return Task.FromResult<MorphType?>(null);
-    }
 
     private Dictionary<Guid, PartOfSpeech>? _partsOfSpeechCacheByGuid = null;
     private Dictionary<string, PartOfSpeech>? _partsOfSpeechCacheByStringKey = null;
@@ -80,17 +58,6 @@ public class LfClassicMiniLcmApi(string projectCode, ProjectDbContext dbContext,
         };
     }
 
-    public async Task<WritingSystem?> GetWritingSystem(WritingSystemId id, WritingSystemType type)
-    {
-        var ws = await GetWritingSystems();
-        return type switch
-        {
-            WritingSystemType.Vernacular => ws.Vernacular.FirstOrDefault(w => w.WsId == id),
-            WritingSystemType.Analysis => ws.Analysis.FirstOrDefault(w => w.WsId == id),
-            _ => throw new ArgumentOutOfRangeException(nameof(type), type, null)
-        };
-    }
-
     public async Task<string?> PickDefaultVernacularWritingSystem()
     {
         var cacheKey = $"LfClassic|DefaultVernacular|{projectCode}";
@@ -117,25 +84,6 @@ public class LfClassicMiniLcmApi(string projectCode, ProjectDbContext dbContext,
         }
     }
 
-    public IAsyncEnumerable<Publication> GetPublications()
-    {
-        return AsyncEnumerable.Empty<Publication>();
-    }
-
-    public async Task<PartOfSpeech?> GetPartOfSpeech(Guid id)
-    {
-        if (_partsOfSpeechCacheByGuid is null)
-        {
-            _partsOfSpeechCacheByGuid = await GetPartsOfSpeech().ToDictionaryAsync(pos => pos.Id);
-        }
-        return _partsOfSpeechCacheByGuid.GetValueOrDefault(id);
-    }
-
-    public Task<Publication?> GetPublication(Guid id)
-    {
-        return Task.FromResult<Publication?>(null);
-    }
-
     public async ValueTask<PartOfSpeech?> GetPartOfSpeech(string key)
     {
         if (_partsOfSpeechCacheByStringKey is null)
@@ -143,7 +91,7 @@ public class LfClassicMiniLcmApi(string projectCode, ProjectDbContext dbContext,
             _partsOfSpeechCacheByStringKey = await GetPartsOfSpeech().ToDictionaryAsync(pos => pos.Name["__key"]);
         }
         return _partsOfSpeechCacheByStringKey.GetValueOrDefault(key);
-    }
+    }   
 
     public async IAsyncEnumerable<SemanticDomain> GetSemanticDomains()
     {
@@ -153,11 +101,6 @@ public class LfClassicMiniLcmApi(string projectCode, ProjectDbContext dbContext,
         {
             yield return ToSemanticDomain(item);
         }
-    }
-
-    public async Task<SemanticDomain?> GetSemanticDomain(Guid id)
-    {
-        return await GetSemanticDomains().FirstOrDefaultAsync(semdom => semdom.Id == id);
     }
 
     public async Task<int> CountEntries(string? query = null, FilterQueryOptions? options = null)
@@ -432,11 +375,6 @@ public class LfClassicMiniLcmApi(string projectCode, ProjectDbContext dbContext,
         return await ToSense(entryId, sense);
     }
 
-    public Task<Sense?> GetSense(Guid id)
-    {
-        throw new NotSupportedException("Getting a sense by ID without the entry ID is not supported in LfClassicMiniLcmApi");
-    }
-
     public async Task<ExampleSentence?> GetExampleSentence(Guid entryId, Guid senseId, Guid id)
     {
         var entry = await Entries.Find(e => e.Guid == entryId).FirstOrDefaultAsync();
@@ -457,10 +395,5 @@ public class LfClassicMiniLcmApi(string projectCode, ProjectDbContext dbContext,
         var picture = sense.Pictures?.FirstOrDefault(e => e?.Guid == id);
         if (picture is null) return null;
         return ToPicture(sense.Guid, picture);
-    }
-
-    public Task<int> GetEntryIndex(Guid entryId, string? query = null, IndexQueryOptions? options = null)
-    {
-        throw new NotImplementedException();
     }
 }


### PR DESCRIPTION
This just simplifies future work, it never really conformed to the API and as it was we had compiler errors whenever we add a new API which was usually just a noop.