### PR TITLE
Stop debounced entry resets surfacing "Cancelled" error toast

### DIFF
--- a/frontend/viewer/src/lib/services/entry-loader-service.svelte.test.ts
+++ b/frontend/viewer/src/lib/services/entry-loader-service.svelte.test.ts
@@ -189,15 +189,8 @@ describe('EntryLoaderService', () => {
       await service.getOrLoadEntryByIndex(0);
       const countBefore = api.countEntries.mock.calls.length;
 
-      // Multiple rapid calls
-      const p1 = service.quietReset();
-      const p2 = service.quietReset();
-      const p3 = service.quietReset();
-
-      expect(p1).toBe(p2);
-      expect(p2).toBe(p3);
-
-      await p3;
+      // Multiple rapid calls collapse into a single reset after the debounce delay
+      await Promise.all([service.quietReset(), service.quietReset(), service.quietReset()]);
 
       // Should only have called the API once (after the debounce delay)
       expect(api.countEntries.mock.calls.length).toBe(countBefore + 1);

--- a/frontend/viewer/src/lib/services/entry-loader-service.svelte.test.ts
+++ b/frontend/viewer/src/lib/services/entry-loader-service.svelte.test.ts
@@ -1,6 +1,6 @@
 import {afterEach, describe, expect, it, vi} from 'vitest';
 
-import {EntryLoaderService} from '$lib/services/entry-loader-service.svelte';
+import {EntryLoaderService, ignoreDebounceCancelled} from '$lib/services/entry-loader-service.svelte';
 import type {IEntry} from '$lib/dotnet-types';
 import type {IMiniLcmJsInvokable} from '$lib/dotnet-types/generated-types/FwLiteShared/Services/IMiniLcmJsInvokable';
 import {defaultEntry} from '$lib/utils';
@@ -201,6 +201,18 @@ describe('EntryLoaderService', () => {
 
       // Should only have called the API once (after the debounce delay)
       expect(api.countEntries.mock.calls.length).toBe(countBefore + 1);
+    });
+  });
+
+  describe('ignoreDebounceCancelled', () => {
+    it('swallows the "Cancelled" rejection useDebounce.cancel() produces', () => {
+      expect(ignoreDebounceCancelled('Cancelled')).toBeUndefined();
+    });
+
+    it('rethrows any other rejection so genuine errors still surface', () => {
+      const failure = new Error('boom');
+      expect(() => ignoreDebounceCancelled(failure)).toThrow(failure);
+      expect(() => ignoreDebounceCancelled('other')).toThrow('other');
     });
   });
 

--- a/frontend/viewer/src/lib/services/entry-loader-service.svelte.ts
+++ b/frontend/viewer/src/lib/services/entry-loader-service.svelte.ts
@@ -27,6 +27,14 @@ const EVENT_DEBOUNCE_MS = 600;
 // void (not Promise<void>) to get the correct runtime return type.
 type DebouncedVoidFn = ReturnType<typeof useDebounce<[], void>>;
 
+// useDebounce rejects a pending promise with the string "Cancelled" when its
+// cancel() supersedes it (a newer reset took over). That's expected control flow,
+// not an error; anything else is rethrown so real failures still surface.
+function ignoreDebounceCancelled(reason: unknown): void {
+  if (reason === 'Cancelled') return;
+  throw reason;
+}
+
 export class EntryLoaderService {
   static readonly DEFAULT_GENERATION = 0;
 
@@ -122,7 +130,7 @@ export class EntryLoaderService {
     // Filter resets take precedence; any entry events that arrive mid-reset are
     // replayed afterward via the eventPendingAfterFilterReset flag to ensure all updates are
     // eventually applied to the shown data.
-    const filterResetPromise = this.#debouncedFilterReset();
+    const filterResetPromise = this.#debouncedFilterReset().catch(ignoreDebounceCancelled);
     this.#filterResetInFlight = filterResetPromise;
     await this.#filterResetInFlight;
     if (this.#filterResetInFlight === filterResetPromise) {
@@ -135,7 +143,7 @@ export class EntryLoaderService {
   }
 
   #scheduleEventReset(): Promise<void> {
-    return this.#debouncedEventReset();
+    return this.#debouncedEventReset().catch(ignoreDebounceCancelled);
   }
 
   async #executeReset(isQuiet: boolean): Promise<void> {

--- a/frontend/viewer/src/lib/services/entry-loader-service.svelte.ts
+++ b/frontend/viewer/src/lib/services/entry-loader-service.svelte.ts
@@ -30,7 +30,7 @@ type DebouncedVoidFn = ReturnType<typeof useDebounce<[], void>>;
 // useDebounce rejects a pending promise with the string "Cancelled" when its
 // cancel() supersedes it (a newer reset took over). That's expected control flow,
 // not an error; anything else is rethrown so real failures still surface.
-function ignoreDebounceCancelled(reason: unknown): void {
+export function ignoreDebounceCancelled(reason: unknown): void {
   if (reason === 'Cancelled') return;
   throw reason;
 }


### PR DESCRIPTION
Rapid filter typing / entry switching in the viewer could pop a red "Cancelled" error toast. `runed`'s `useDebounce` rejects pending promises with the string `"Cancelled"` when `cancel()` supersedes them; in `EntryLoaderService` those rejections went unhandled (notably the fire-and-forget `void this.#scheduleFilterReset()` in the `watch`), so the global error handler surfaced them.

Fix swallows only the `"Cancelled"` string rejection at the two debounced call sites (`#scheduleFilterReset`, `#scheduleEventReset`), rethrowing anything else so genuine load errors still surface. Scoped to the service rather than the global handler to keep the suppression narrow.

Reproduced on `/testing/project-view` by typing a filter and immediately clicking an entry. `svelte-check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
