### PR TITLE
Create FwLite data directories at FwLiteWeb startup

### DIFF
--- a/backend/FwLite/FwLiteWeb/FwLiteWebServer.cs
+++ b/backend/FwLite/FwLiteWeb/FwLiteWebServer.cs
@@ -74,6 +74,7 @@ public static class FwLiteWebServer
         configure?.Invoke(builder);
         var app = builder.Build();
         app.Logger.LogInformation("FwLite FwLiteWeb startup");
+        EnsureDataDirectoriesExist(app);
 // Configure the HTTP request pipeline.
         app.UseSwagger();
         app.UseSwaggerUI(o =>
@@ -133,5 +134,24 @@ public static class FwLiteWebServer
             })
             .AddAdditionalAssemblies(typeof(FwLiteShared._Imports).Assembly);
         return app;
+    }
+
+    /// <summary>
+    /// Creates the project and auth-cache directories up front, the way the MAUI host already does
+    /// (see <c>FwLiteMauiKernel</c>). FwLiteWeb never did, which was harmless while the paths defaulted
+    /// to the working directory (always present), but a host can point <c>LcmCrdt:ProjectPath</c> /
+    /// <c>Auth:CacheFileName</c> at a per-user location that doesn't exist yet — the Platform.Bible
+    /// extension does, and it can't create the directory itself. Without this, a missing directory makes
+    /// project listing (<see cref="Directory.EnumerateFiles(string, string)"/>), project creation
+    /// (SQLite can't open a file under a missing directory), and MSAL cache init all fail.
+    /// </summary>
+    private static void EnsureDataDirectoriesExist(WebApplication app)
+    {
+        var projectPath = app.Services.GetRequiredService<IOptions<LcmCrdtConfig>>().Value.ProjectPath;
+        Directory.CreateDirectory(projectPath);
+
+        var cacheFileName = app.Services.GetRequiredService<IOptions<AuthConfig>>().Value.CacheFileName;
+        var cacheDir = Path.GetDirectoryName(cacheFileName);
+        if (!string.IsNullOrEmpty(cacheDir)) Directory.CreateDirectory(cacheDir);
     }
 }


### PR DESCRIPTION
FwLiteWeb never created its project or auth-cache directories, unlike the MAUI host (`FwLiteMauiKernel`). That was harmless while the paths defaulted to the working directory (always present), but a host can point `LcmCrdt:ProjectPath` / `Auth:CacheFileName` at a per-user location that doesn't exist yet — and can't create it itself. When the directory is missing, three things throw on a fresh install:

- **Project listing** — `CrdtProjectsService.ListProjects()` calls `Directory.EnumerateFiles(ProjectPath, "*.sqlite")` with no existence guard → `DirectoryNotFoundException`.
- **Project creation** — opens a SQLite connection under `ProjectPath`; Microsoft.Data.Sqlite won't create parent dirs → "unable to open database file".
- **Sign-in** — `MsalCacheHelper.CreateAsync` opens a lockfile in the cache dir.

This creates both directories up front in `SetupAppServer`, mirroring what the MAUI host already does. Doing it in the backend covers every host, not just the one passing the path.

Addresses **point 1** (the blocking finding) of the review on #2385: https://github.com/sillsdev/languageforge-lexbox/pull/2385#issuecomment-4878456030 — the finding this PR unblocks stems from #2385 pointing FW Lite's data at `~/.platform.bible/extensions/lexicon/` (closes #2351).

## Test plan
- [x] `dotnet build FwLiteWeb/FwLiteWeb.csproj` succeeds (no new warnings)
- [ ] With `--LcmCrdt:ProjectPath` / `--Auth:CacheFileName` pointed at a non-existent per-user dir, FwLiteWeb starts, lists/creates projects, and signs in without a `DirectoryNotFoundException`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Devin review: https://app.devin.ai/review/sillsdev/languageforge-lexbox/pull/2417