### PR TITLE
Stop drawer scrolling above the keyboard on mobile

### DIFF
--- a/frontend/viewer/src/app.css
+++ b/frontend/viewer/src/app.css
@@ -78,6 +78,16 @@
   scroll-margin-bottom: 3.5rem;
 }
 
+/* Stops the drawer scrolling up above the keyboard on mobile. */
+[data-vaul-drawer] [class*="overflow-auto"],
+[data-vaul-drawer] [class*="overflow-y-auto"],
+[data-vaul-drawer] [class*="overflow-x-auto"],
+[data-vaul-drawer] [class*="overflow-scroll"],
+[data-vaul-drawer] [class*="overflow-y-scroll"],
+[data-vaul-drawer] [class*="overflow-x-scroll"] {
+  overscroll-behavior: contain;
+}
+
 .x-ellipsis {
   max-width: 100%;
   overflow: hidden;


### PR DESCRIPTION
Overscrolling a scroll container inside a drawer chained to the page, jostling vaul's on-screen-keyboard tracking and pushing the drawer up above the keyboard. Contain overscroll on drawer scroll containers to close that path.

Both I and AI think that this generic global handling is probably safe.
Nested scrolling containers would maybe not behave well, but that's a weird edge case and we don't have any of those.