### PR TITLE
Fix Playwright email tests against maildev v3

### DIFF
--- a/frontend/tests/email/maildev-mailbox.ts
+++ b/frontend/tests/email/maildev-mailbox.ts
@@ -27,8 +27,8 @@ export class MaildevMailbox extends Mailbox {
 
     for (let tries = 1; tries <= MAX_TRIES; tries++) {
       try {
-        // Maildev REST API docs: https://github.com/maildev/maildev/blob/master/docs/rest.md
-        const response = await this.api.get('http://localhost:1080/email');
+        // Maildev REST API docs: https://github.com/maildev/maildev/blob/main/docs/rest.md
+        const response = await this.api.get('http://localhost:1080/api/email');
         const emails = await response.json() as MaildevEmail[];
         return emails.filter(email => email.to.some(to => to.address === this.email));
       } catch (error) {


### PR DESCRIPTION
`maildev/maildev` is unpinned (`:latest`), so we just consumed a bump up to the first v3 RC.
I think that's probably a good thing, so I just made the tiny adaptation required to fix our 1 REST API call.