### PR TITLE
Exclude audio writing systems from entry text search

### DIFF
--- a/backend/FwLite/FwDataMiniLcmBridge.Tests/MediaFileTests.cs
+++ b/backend/FwLite/FwDataMiniLcmBridge.Tests/MediaFileTests.cs
@@ -199,6 +199,21 @@ public class MediaFileTests : IAsyncLifetime
     }
 
     [Fact]
+    public async Task SearchEntries_DoesNotMatchAudioWritingSystemValues()
+    {
+        // The audio writing system's value is a media-file reference, not searchable text.
+        _audioWs.IsAudio.Should().BeTrue("the whole test is vacuous unless this is an audio writing system");
+        var fileName = "audioonlysearchtoken.wav";
+        var entryId = await AddFileDirectly(fileName, "test");
+
+        // guard against a vacuous test: the entry is findable via its real (non-audio) lexeme form
+        (await _api.SearchEntries("test").ToArrayAsync()).Should().Contain(e => e.Id == entryId);
+
+        // the token only appears in the audio media reference, so it must not match a text search
+        (await _api.SearchEntries("audioonlysearchtoken").ToArrayAsync()).Should().NotContain(e => e.Id == entryId);
+    }
+
+    [Fact]
     public async Task GetStreamForNotFoundIsNull()
     {
         var fileStream = await _api.GetFileStream(MediaUri.NotFound);

--- a/backend/FwLite/FwDataMiniLcmBridge/Api/FwDataMiniLcmApi.cs
+++ b/backend/FwLite/FwDataMiniLcmBridge/Api/FwDataMiniLcmApi.cs
@@ -1000,8 +1000,8 @@ public class FwDataMiniLcmApi(
     {
         if (string.IsNullOrEmpty(query)) return null;
         return entry => entry.SearchHeadWord(query) || // CitationForm.SearchValue would be redundant
-                        entry.LexemeFormOA?.Form.SearchValue(query) is true ||
-                        entry.AllSenses.Any(s => s.Gloss.SearchValue(query));
+                        entry.LexemeFormOA?.Form.SearchValue(entry.Cache, query) is true ||
+                        entry.AllSenses.Any(s => s.Gloss.SearchValue(entry.Cache, query));
     }
 
     public Task<Entry?> GetEntry(Guid id)

--- a/backend/FwLite/FwDataMiniLcmBridge/Api/LcmHelpers.cs
+++ b/backend/FwLite/FwDataMiniLcmBridge/Api/LcmHelpers.cs
@@ -45,6 +45,8 @@ internal static class LcmHelpers
     {
         foreach (var ws in entry.Cache.ServiceLocator.WritingSystems.VernacularWritingSystems)
         {
+            //audio writing systems hold a media-file reference, not searchable text
+            if (entry.Cache.GetWritingSystemId(ws.Handle).IsAudio) continue;
             var headword = entry.HeadWordForWs(ws.Handle);
             if (headword is null) continue;
             var text = headword.Text;
@@ -54,11 +56,12 @@ internal static class LcmHelpers
         return false;
     }
 
-    internal static bool SearchValue(this ITsMultiString multiString, string value)
+    internal static bool SearchValue(this ITsMultiString multiString, LcmCache cache, string value)
     {
         for (var i = 0; i < multiString.StringCount; i++)
         {
-            var tsString = multiString.GetStringFromIndex(i, out var _);
+            var tsString = multiString.GetStringFromIndex(i, out var ws);
+            if (cache.GetWritingSystemId(ws).IsAudio) continue;
             if (string.IsNullOrEmpty(tsString.Text)) continue;
             if (tsString.Text.ContainsDiacriticMatch(value))
             {

--- a/backend/FwLite/LcmCrdt.Tests/MiniLcmTests/QueryEntryTests.cs
+++ b/backend/FwLite/LcmCrdt.Tests/MiniLcmTests/QueryEntryTests.cs
@@ -79,6 +79,38 @@ public class QueryEntryTests(ITestOutputHelper outputHelper) : QueryEntryTestsBa
         timePerEntry.TotalMicroseconds.Should().BeLessThan(0.5);
     }
 
+    [Fact]
+    public async Task SearchEntries_DoesNotMatchAudioWritingSystemValues()
+    {
+        const string audioWs = "en-Zxxx-x-audio";
+        new WritingSystemId(audioWs).IsAudio.Should().BeTrue("the whole test is vacuous unless this is an audio writing system");
+        await Api.CreateWritingSystem(new WritingSystem
+        {
+            Id = Guid.NewGuid(),
+            Type = WritingSystemType.Vernacular,
+            WsId = audioWs,
+            Name = "English Audio",
+            Abbreviation = "en-a",
+            Font = "Arial"
+        });
+        var id = Guid.NewGuid();
+        await Api.CreateEntry(new Entry
+        {
+            Id = id,
+            // the audio value is a media URI whose only text ("-", "lexbox", ...) is not real dictionary content
+            LexemeForm = { ["en"] = "cool entry", [audioWs] = "sil-media://lexbox.org/2354c80a-ac85-46af-8873-66916a3417a0" },
+        });
+
+        // guard against a vacuous test: the entry is findable via its real (non-audio) content
+        (await Api.SearchEntries("cool").ToArrayAsync()).Should().Contain(e => e.Id == id);
+
+        // non-FTS path (< 3 chars): "-" only appears in the audio media URI
+        (await Api.SearchEntries("-").ToArrayAsync()).Should().NotContain(e => e.Id == id);
+
+        // FTS path (>= 3 chars): "lexbox" only appears in the audio media URI
+        (await Api.SearchEntries("lexbox").ToArrayAsync()).Should().NotContain(e => e.Id == id);
+    }
+
     public override async Task DisposeAsync()
     {
         await base.DisposeAsync();

--- a/backend/FwLite/LcmCrdt/Data/EntryQueryHelpers.cs
+++ b/backend/FwLite/LcmCrdt/Data/EntryQueryHelpers.cs
@@ -95,6 +95,7 @@ public static class EntryQueryHelpers
     {
         return e.CitationForm.SearchValue(query)
             || e.LexemeForm.Values.Any(kvp =>
+                !kvp.Key.IsAudio &&
                 string.IsNullOrEmpty(e.CitationForm[kvp.Key]?.Trim()) &&
                 SqlHelpers.ContainsIgnoreCaseAccents((leading ?? "") + (kvp.Value?.Trim() ?? "") + (trailing ?? ""), query));
     }
@@ -102,9 +103,10 @@ public static class EntryQueryHelpers
     private static Expression<Func<Entry, string?, string?, string, bool>> SearchHeadwords()
     {
         return (e, leading, trailing, query) =>
-            Json.QueryValues(e.CitationForm).Any(
-                v => SqlHelpers.ContainsIgnoreCaseAccents(v, query)) ||
+            Json.QueryEntries(e.CitationForm).Any(
+                kv => !SqlHelpers.IsAudioWs(kv.Key) && SqlHelpers.ContainsIgnoreCaseAccents(kv.Value, query)) ||
             Json.QueryEntries(e.LexemeForm).Any(kv =>
+                !SqlHelpers.IsAudioWs(kv.Key) &&
                 string.IsNullOrEmpty((Json.At(e.CitationForm, kv.Key) ?? "").Trim()) &&
                 SqlHelpers.ContainsIgnoreCaseAccents((leading ?? "") + (kv.Value ?? "").Trim() + (trailing ?? ""), query));
     }

--- a/backend/FwLite/LcmCrdt/FullTextSearch/EntrySearchService.cs
+++ b/backend/FwLite/LcmCrdt/FullTextSearch/EntrySearchService.cs
@@ -155,7 +155,7 @@ public class EntrySearchService(LcmCrdtDbContext dbContext, ILogger<EntrySearchS
     public static string LexemeForm(WritingSystem[] wss, Entry entry)
     {
         return string.Join(" ",
-            wss.Where(ws => ws.Type == WritingSystemType.Vernacular)
+            wss.Where(ws => ws.Type == WritingSystemType.Vernacular && !ws.IsAudio)
                 .Select(ws => entry.LexemeForm[ws.WsId])
                 .Where(h => !string.IsNullOrEmpty(h)));
     }
@@ -163,7 +163,7 @@ public class EntrySearchService(LcmCrdtDbContext dbContext, ILogger<EntrySearchS
     public static string CitationForm(WritingSystem[] wss, Entry entry)
     {
         return string.Join(" ",
-            wss.Where(ws => ws.Type == WritingSystemType.Vernacular)
+            wss.Where(ws => ws.Type == WritingSystemType.Vernacular && !ws.IsAudio)
                 .Select(ws => entry.CitationForm[ws.WsId])
                 .Where(h => !string.IsNullOrEmpty(h)));
     }
@@ -185,7 +185,7 @@ public class EntrySearchService(LcmCrdtDbContext dbContext, ILogger<EntrySearchS
 
     private static IEnumerable<string> JoinAll(MultiString ms, WritingSystem[] wss, WritingSystemType type)
     {
-        return wss.Where(ws => ws.Type == type)
+        return wss.Where(ws => ws.Type == type && !ws.IsAudio)
             .Select(ws => ms.Values.TryGetValue(ws.WsId, out var value) ? value : null)
             .OfType<string>()
             .Where(v => v.Length > 0);
@@ -193,7 +193,7 @@ public class EntrySearchService(LcmCrdtDbContext dbContext, ILogger<EntrySearchS
 
     private static IEnumerable<RichString> JoinAll(RichMultiString ms, WritingSystem[] wss, WritingSystemType type)
     {
-        return wss.Where(ws => ws.Type == type)
+        return wss.Where(ws => ws.Type == type && !ws.IsAudio)
             .Select(ws => ms.TryGetValue(ws.WsId, out var value) ? value : null)
             .OfType<RichString>();
     }
@@ -321,7 +321,7 @@ public class EntrySearchService(LcmCrdtDbContext dbContext, ILogger<EntrySearchS
         // This ensures FTS matches across all WS, including morph-token-decorated forms.
         var headwords = EntryQueryHelpers.ComputeHeadwords(entry, morphTypeLookup);
         var headword = string.Join(" ",
-            writingSystems.Where(ws => ws.Type == WritingSystemType.Vernacular)
+            writingSystems.Where(ws => ws.Type == WritingSystemType.Vernacular && !ws.IsAudio)
                 .Select(ws => headwords[ws.WsId])
                 .Where(h => !string.IsNullOrEmpty(h)));
 

--- a/backend/FwLite/LcmCrdt/SqlHelpers.cs
+++ b/backend/FwLite/LcmCrdt/SqlHelpers.cs
@@ -34,9 +34,11 @@ public static class SqlHelpers
     /// <summary>
     /// An audio writing system's IETF tag uses the Zxxx ("unwritten") script with an "audio"
     /// private-use variant (see <see cref="WritingSystemId.IsAudio"/>). Its stored value is a
-    /// media-file reference, so it must be excluded from text searches.
+    /// media-file reference, so it must be excluded from text searches. The LIKE patterns match
+    /// "audio" as a whole hyphen-delimited subtag (not a substring like "audiophile"), so this
+    /// stays in step with the exact-segment match <see cref="WritingSystemId.IsAudio"/> performs.
     /// </summary>
-    [Sql.Expression("({0} LIKE '%-zxxx-%' AND {0} LIKE '%-audio%')", ServerSideOnly = true, IsPredicate = true)]
+    [Sql.Expression("({0} LIKE '%-zxxx-%' AND ({0} LIKE '%-audio' OR {0} LIKE '%-audio-%'))", ServerSideOnly = true, IsPredicate = true)]
     public static bool IsAudioWs(string wsCode) => new WritingSystemId(wsCode).IsAudio;
 
     [Sql.Expression(CustomSqliteFunctionInterceptor.ContainsFunction + "({0}, {1})")]

--- a/backend/FwLite/LcmCrdt/SqlHelpers.cs
+++ b/backend/FwLite/LcmCrdt/SqlHelpers.cs
@@ -23,13 +23,21 @@ public static class SqlHelpers
     [ExpressionMethod(nameof(SearchValueExpression))]
     public static bool SearchValue(this MultiString ms, string search)
     {
-        return ms.Values.Any(pair => pair.Value.ContainsDiacriticMatch(search));
+        return ms.Values.Any(pair => !pair.Key.IsAudio && pair.Value.ContainsDiacriticMatch(search));
     }
 
     private static Expression<Func<MultiString, string, bool>> SearchValueExpression()
     {
-        return (ms, search) => Json.QueryValues(ms).Any(s => ContainsIgnoreCaseAccents(s, search));
+        return (ms, search) => Json.QueryEntries(ms).Any(kv => !IsAudioWs(kv.Key) && ContainsIgnoreCaseAccents(kv.Value, search));
     }
+
+    /// <summary>
+    /// An audio writing system's IETF tag uses the Zxxx ("unwritten") script with an "audio"
+    /// private-use variant (see <see cref="WritingSystemId.IsAudio"/>). Its stored value is a
+    /// media-file reference, so it must be excluded from text searches.
+    /// </summary>
+    [Sql.Expression("({0} LIKE '%-zxxx-%' AND {0} LIKE '%-audio%')", ServerSideOnly = true, IsPredicate = true)]
+    public static bool IsAudioWs(string wsCode) => new WritingSystemId(wsCode).IsAudio;
 
     [Sql.Expression(CustomSqliteFunctionInterceptor.ContainsFunction + "({0}, {1})")]
     public static bool ContainsIgnoreCaseAccents(string s, string search) => s.ContainsDiacriticMatch(search);


### PR DESCRIPTION
Free-text entry search matched entries on their audio writing system, because search iterated *every* WS value and an audio WS holds a media reference (`sil-media://…-…`). Searching `-` matched those hyphens; longer queries could match tokens inside the URI too.

Skips audio WSs in both `IMiniLcmApi` implementations:
- CRDT: `SqlHelpers.SearchValue` / `EntryQueryHelpers.SearchHeadwords` (new server-side `IsAudioWs` predicate for the `json_each` path), and keeps audio out of the FTS index (`EntrySearchService`).
- FwData: `LcmHelpers.SearchHeadWord` / `SearchValue`.

Existing CRDT projects need no reindex — the `SearchValue` guard filters stale audio content out of FTS results regardless.

Tests: added a failing-then-passing regression test per backend (`QueryEntryTests`, `MediaFileTests`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)