### PR TITLE
Support launching FW Lite on Linux in the lexicon extension

### DIFF
--- a/platform.bible-extension/Taskfile.yml
+++ b/platform.bible-extension/Taskfile.yml
@@ -27,6 +27,8 @@ tasks:
   build-fw-lite:
     deps: [build-viewer]
     cmds:
-      - dotnet publish ../backend/FwLite/FwLiteWeb/FwLiteWeb.csproj --configuration Release --sc --output ./public/fw-lite
+      # Publish both RIDs so one extension package runs on Windows and Linux.
+      - dotnet publish ../backend/FwLite/FwLiteWeb/FwLiteWeb.csproj --configuration Release --sc -r win-x64 --output ./public/fw-lite/win-x64
+      - dotnet publish ../backend/FwLite/FwLiteWeb/FwLiteWeb.csproj --configuration Release --sc -r linux-x64 --output ./public/fw-lite/linux-x64
   build-viewer:
     deps: [viewer:build]

--- a/platform.bible-extension/src/main.ts
+++ b/platform.bible-extension/src/main.ts
@@ -249,18 +249,25 @@ export async function deactivate(): Promise<boolean> {
  * dev-appdata directory in development, so `npm start` doesn't read/write production user data.
  *
  * Uses process.env/globalThis instead of require('os'/'path') because Platform.Bible blocks
- * non-papi requires.
+ * non-papi requires, so paths are assembled by hand with the platform-appropriate separator
+ * (backslash on Windows, forward slash on Linux/Mac, which .NET requires there).
  */
-function getFwLiteDataDir(): string {
+function getFwLiteDataDir(platform: string): string {
+  const isWindows = platform === 'win32';
+  const sep = isWindows ? '\\' : '/';
   let appDataDir: string;
   if (globalThis.isPackaged) {
-    const home = process.env.USERPROFILE;
-    if (!home) throw new Error('Cannot determine FW Lite data directory: USERPROFILE is not set');
-    appDataDir = `${home}\\.platform.bible`;
+    // Mirrors paranext-core's os.homedir()
+    const home = isWindows ? process.env.USERPROFILE : process.env.HOME;
+    if (!home) {
+      const homeVar = isWindows ? 'USERPROFILE' : 'HOME';
+      throw new Error(`Cannot determine FW Lite data directory: ${homeVar} is not set`);
+    }
+    appDataDir = `${home}${sep}.platform.bible`;
   } else {
-    appDataDir = `${globalThis.resourcesPath}\\dev-appdata`;
+    appDataDir = `${globalThis.resourcesPath}${sep}dev-appdata`;
   }
-  return `${appDataDir}\\extensions\\lexicon\\fw-lite`;
+  return `${appDataDir}${sep}extensions${sep}lexicon${sep}fw-lite`;
 }
 
 /** Returns the extension-relative path to the FW Lite binary for the given platform. */
@@ -283,11 +290,14 @@ function launchFwLite(context: ExecutionActivationContext): string {
   if (context.elevatedPrivileges.createProcess === undefined) {
     throw new Error('Requires createProcess elevated privileges to launch FW Lite');
   }
-  const binaryPath = getFwLiteBinaryPath(context.elevatedPrivileges.createProcess.osData.platform);
+  const { platform } = context.elevatedPrivileges.createProcess.osData;
+  const binaryPath = getFwLiteBinaryPath(platform);
   // TODO: Instead of hardcoding the URL and port we should run it and find them in the output.
   const baseUrl = 'http://localhost:29348';
 
-  const dataDir = getFwLiteDataDir();
+  const dataDir = getFwLiteDataDir(platform);
+  const sep = platform === 'win32' ? '\\' : '/';
+  const authCacheFile = `${dataDir}${sep}msal.json`;
   fwLiteProcess = context.elevatedPrivileges.createProcess.spawn(
     context.executionToken,
     binaryPath,
@@ -299,7 +309,7 @@ function launchFwLite(context: ExecutionActivationContext): string {
       '--FwLiteWeb:EnableFileLogging=false', // already piped to P.B (and triggers npm watch)
       '--FwLiteWeb:OpenBrowser=false',
       `--LcmCrdt:ProjectPath=${dataDir}`,
-      `--Auth:CacheFileName=${dataDir}\\msal.json`,
+      `--Auth:CacheFileName=${authCacheFile}`,
     ],
     { stdio: ['pipe', 'pipe', 'pipe'] },
   );

--- a/platform.bible-extension/src/main.ts
+++ b/platform.bible-extension/src/main.ts
@@ -270,7 +270,10 @@ function getFwLiteDataDir(platform: string): string {
   return `${appDataDir}${sep}extensions${sep}lexicon${sep}fw-lite`;
 }
 
-/** Returns the extension-relative path to the FW Lite binary for the given platform. */
+/**
+ * Returns the extension-relative path to the FW Lite binary. Forward slashes on all platforms:
+ * createProcess (Node) resolves it, so unlike getFwLiteDataDir it needs no Windows separator.
+ */
 function getFwLiteBinaryPath(platform: string): string {
   switch (platform) {
     case 'win32':

--- a/platform.bible-extension/src/main.ts
+++ b/platform.bible-extension/src/main.ts
@@ -263,15 +263,27 @@ function getFwLiteDataDir(): string {
   return `${appDataDir}\\extensions\\lexicon\\fw-lite`;
 }
 
+/** Returns the extension-relative path to the FW Lite binary for the given platform. */
+function getFwLiteBinaryPath(platform: string): string {
+  switch (platform) {
+    case 'win32':
+      return 'fw-lite/win-x64/FwLiteWeb.exe';
+    case 'linux':
+      // The extension zip doesn't preserve the Unix executable bit, but paranext-core's
+      // createProcess.spawn sets it on the command before spawning, so a plain spawn works.
+      return 'fw-lite/linux-x64/FwLiteWeb';
+    default:
+      // macOS is out of scope for now: https://github.com/sillsdev/languageforge-lexbox/issues/1603
+      throw new Error(`Cannot launch FW Lite on unsupported platform '${platform}'`);
+  }
+}
+
 /** Launches the FieldWorks Lite process and returns its URL domain. */
 function launchFwLite(context: ExecutionActivationContext): string {
-  const binaryPath = 'fw-lite/FwLiteWeb.exe';
   if (context.elevatedPrivileges.createProcess === undefined) {
     throw new Error('Requires createProcess elevated privileges to launch FW Lite');
   }
-  if (context.elevatedPrivileges.createProcess.osData.platform !== 'win32') {
-    throw new Error('Requires Windows to launch FW Lite');
-  }
+  const binaryPath = getFwLiteBinaryPath(context.elevatedPrivileges.createProcess.osData.platform);
   // TODO: Instead of hardcoding the URL and port we should run it and find them in the output.
   const baseUrl = 'http://localhost:29348';
 


### PR DESCRIPTION
The lexicon extension refused to start on anything but Windows: `launchFwLite` hardcoded `fw-lite/FwLiteWeb.exe` behind a `win32` guard, and `task build-fw-lite` published only the host RID. FW Lite already ships on Linux and Platform.Bible runs on Ubuntu, so this makes the extension's embedded FwLiteWeb backend follow.

- Select the FwLiteWeb binary per `createProcess.osData.platform` and let `linux` through the guard. macOS stays unsupported pending #1603.
- Publish self-contained win-x64 and linux-x64 builds to `public/fw-lite/<rid>/`, so one extension package bundles both platforms. This roughly doubles package size — the alternative from the issue is per-platform packages; happy to switch if that's preferred.
- No exec-bit workaround needed: paranext-core's `createProcess.spawn` chmods the command on POSIX before spawning (paranext-core PT-3250), which repairs the executable bit lost in the zip → extension-install path. Cross-publishing linux-x64 from a Windows host is fine because FwLiteWeb is plain self-contained (no NativeAOT/trimming/single-file).

Notes for reviewers:

- Devs with existing publish output directly under `public/fw-lite/` should delete that directory once; the new layout is `public/fw-lite/{win-x64,linux-x64}` and stale root-level output would still get copied into the package by webpack's CopyPlugin.
- The stable-data-dir work in #2385 is not in develop yet; once it lands, its `USERPROFILE` + backslash path handling needs the Linux treatment too (issue point 2).
- Still to verify on an actual Ubuntu machine: process launch, REST API on :29348, graceful shutdown (issue point 4).

Closes #2425

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Devin: https://app.devin.ai/review/sillsdev/languageforge-lexbox/pull/2427