### PR TITLE
Fix recording waveform colour broken by OKLCH theme migration

### DIFF
--- a/frontend/viewer/src/lib/components/audio/wavesurfer/wavesurfer-utils.ts
+++ b/frontend/viewer/src/lib/components/audio/wavesurfer/wavesurfer-utils.ts
@@ -8,9 +8,9 @@ type AudioUrl = string;
 export type WaveSurferAudio = AudioUrl | Blob;
 
 function getPrimaryColor(element: HTMLElement | null = null): string {
-  return `hsl(${getComputedStyle(element ?? document.documentElement)
+  return getComputedStyle(element ?? document.documentElement)
     .getPropertyValue('--primary')
-    .trim()})`;
+    .trim();
 }
 
 function darkenColor(color: string): string {


### PR DESCRIPTION
The audio recording waveform stopped using the primary theme colour. `getPrimaryColor()` wrapped the `--primary` token in `hsl(…)`, but the shadcn/Tailwind 4 migration changed `--primary` to an `oklch(…)` value — producing the invalid string `hsl(oklch(…))`, so WaveSurfer fell back to its default colour. Use the token directly (it is already a complete colour value; `darkenColor()`s `oklch(from …)` handles it).

Before:
<img width="1142" height="578" alt="image" src="https://github.com/user-attachments/assets/34ea98dd-96e0-4c27-bbe2-e13da2b7925c" />

After:

<img width="1215" height="773" alt="image" src="https://github.com/user-attachments/assets/c9e14b46-094f-4714-a443-593a10c31d80" />


🤖 Generated with [Claude Code](https://claude.com/claude-code)