### PR TITLE
Withhold premature project code error

### DIFF
--- a/frontend/src/routes/(authenticated)/project/create/+page.svelte
+++ b/frontend/src/routes/(authenticated)/project/create/+page.svelte
@@ -112,9 +112,10 @@
       if (!browser || !code || !user.canCreateProjects || code === defaultCode) return Promise.resolve(true);
       return _projectCodeAvailable(code);
     }, {initialValue: true, debounce: DEFAULT_DEBOUNCE_TIME});
+  let languageCodeIsFromUrl = $state(false);
   //don't flag as invalid until user has supplied a source (language code or custom code)
   const codeErrors = $derived(
-    $tainted?.languageCode || $form.customCode
+    $tainted?.languageCode || languageCodeIsFromUrl || $form.customCode
       ? [...new Set(concatAll($errors.code, codeIsAvailable.current ? undefined : $t('project.create.code_exists')))]
       : [],
   );
@@ -179,6 +180,7 @@
             form.code = form.languageCode = urlValues.code;
           } else {
             form.languageCode = urlValues.code.replace(new RegExp(`${standardCodeSuffix}$`), '');
+            languageCodeIsFromUrl = true;
           }
         }
         return form;

--- a/frontend/src/routes/(authenticated)/project/create/+page.svelte
+++ b/frontend/src/routes/(authenticated)/project/create/+page.svelte
@@ -112,9 +112,12 @@
       if (!browser || !code || !user.canCreateProjects || code === defaultCode) return Promise.resolve(true);
       return _projectCodeAvailable(code);
     }, {initialValue: true, debounce: DEFAULT_DEBOUNCE_TIME});
-  const codeErrors = $derived([
-    ...new Set(concatAll($errors.code, codeIsAvailable.current ? undefined : $t('project.create.code_exists'))),
-  ]);
+  //don't flag as invalid until user has supplied a source (language code or custom code)
+  const codeErrors = $derived(
+    $tainted?.languageCode || $form.customCode
+      ? [...new Set(concatAll($errors.code, codeIsAvailable.current ? undefined : $t('project.create.code_exists')))]
+      : [],
+  );
 
   let relatedProjectsInput = $derived({projectName: $form.name, langCode: $form.languageCode, orgId: $form.orgId})
   const relatedProjects = resource(() => relatedProjectsInput, async input => {


### PR DESCRIPTION
Minor ux improvement. Because the error was available before the language code had been entered, I jumped to a wrong conclusion. I entered a project name, saw the error, saw that the name wasn't incorporated in the code (which I now understand to be the correct, intended behaviour), and thought there was a bug.

Devin: https://app.devin.ai/review/sillsdev/languageforge-lexbox/pull/2437

I have not manually tested this fix.