### PR TITLE
Open project selector when a lexicon menu command has no project

### DIFF
--- a/platform.bible-extension/contributions/localizedStrings.json
+++ b/platform.bible-extension/contributions/localizedStrings.json
@@ -38,6 +38,8 @@
       "%lexicon_selectLexicon_saving%": "Saving lexicon selection",
       "%lexicon_selectLexicon_select%": "Select a lexicon",
       "%lexicon_selectLexicon_selected%": "Selected:",
+      "%lexicon_selectProject_prompt%": "Choose a project to use with the lexicon:",
+      "%lexicon_selectProject_title%": "Select a project",
       "%lexicon_webViewTitle_addWord%": "Add to lexicon",
       "%lexicon_webViewTitle_browseLexicon%": "Lexicon",
       "%lexicon_webViewTitle_findRelatedWords%": "Find related words in lexicon",

--- a/platform.bible-extension/src/main.ts
+++ b/platform.bible-extension/src/main.ts
@@ -88,7 +88,8 @@ export async function activate(context: ExecutionActivationContext): Promise<voi
     async (webViewId: string, word: string) => {
       let success = false;
 
-      const projectManager = await projectManagers.getProjectManagerFromWebViewId(webViewId);
+      const projectManager =
+        await projectManagers.getProjectManagerFromWebViewIdOrSelectProject(webViewId);
       if (!projectManager) return { success };
 
       const lexiconCode = await projectManager.getLexiconCodeOrOpenSelector();
@@ -105,7 +106,8 @@ export async function activate(context: ExecutionActivationContext): Promise<voi
     async (webViewId: string) => {
       let success = false;
 
-      const projectManager = await projectManagers.getProjectManagerFromWebViewId(webViewId);
+      const projectManager =
+        await projectManagers.getProjectManagerFromWebViewIdOrSelectProject(webViewId);
       if (!projectManager) return { success };
 
       const lexiconCode = await projectManager.getLexiconCodeOrOpenSelector();
@@ -142,7 +144,8 @@ export async function activate(context: ExecutionActivationContext): Promise<voi
     async (webViewId: string, word: string) => {
       let success = false;
 
-      const projectManager = await projectManagers.getProjectManagerFromWebViewId(webViewId);
+      const projectManager =
+        await projectManagers.getProjectManagerFromWebViewIdOrSelectProject(webViewId);
       if (!projectManager) return { success };
 
       const lexiconCode = await projectManager.getLexiconCodeOrOpenSelector();
@@ -159,7 +162,8 @@ export async function activate(context: ExecutionActivationContext): Promise<voi
     async (webViewId: string, word: string) => {
       let success = false;
 
-      const projectManager = await projectManagers.getProjectManagerFromWebViewId(webViewId);
+      const projectManager =
+        await projectManagers.getProjectManagerFromWebViewIdOrSelectProject(webViewId);
       if (!projectManager) return { success };
 
       const lexiconCode = await projectManager.getLexiconCodeOrOpenSelector();

--- a/platform.bible-extension/src/utils/project-managers.ts
+++ b/platform.bible-extension/src/utils/project-managers.ts
@@ -10,7 +10,7 @@ export class ProjectManagers {
       .getOpenWebViewDefinition(webViewId)
       .catch((e) => logger.error('Error getting WebView definition:', JSON.stringify(e)));
     if (!webViewDef?.projectId) {
-      logger.warn(`No projectId found for WebView '${webViewId}'`);
+      logger.debug(`No projectId found for WebView '${webViewId}'`);
       return;
     }
     return webViewDef.projectId;
@@ -24,8 +24,21 @@ export class ProjectManagers {
     return this.projectManagers[projectId];
   }
 
-  async getProjectManagerFromWebViewId(webViewId: string): Promise<ProjectManager | undefined> {
-    const projectId = await ProjectManagers.getProjectIdFromWebViewId(webViewId);
+  /**
+   * Resolves the project manager for the project a WebView is scoped to. When the WebView has no
+   * associated project — e.g. the Scripture Editor is open with no project selected — the user is
+   * prompted with the core project selector and their choice is used instead. Returns `undefined`
+   * only when the user dismisses the selector without choosing a project.
+   */
+  async getProjectManagerFromWebViewIdOrSelectProject(
+    webViewId: string,
+  ): Promise<ProjectManager | undefined> {
+    const projectId =
+      (await ProjectManagers.getProjectIdFromWebViewId(webViewId)) ??
+      (await papi.dialogs.selectProject({
+        prompt: '%lexicon_selectProject_prompt%',
+        title: '%lexicon_selectProject_title%',
+      }));
     if (!projectId) return;
     return this.getProjectManagerFromProjectId(projectId);
   }


### PR DESCRIPTION
The Scripture Editor can be open with no Paratext project selected. In that state the lexicon menu items (Browse lexicon, Add to lexicon, Search in lexicon, Search for related words) resolved no project manager from the WebView and silently no-op'd, leaving only a log message.

Now, when a menu command runs against a WebView that has no associated project, the extension opens Platform.Bible's core project selector (`papi.dialogs.selectProject`) and proceeds with the chosen project — matching how the Interlinearizer extension handles the same situation. Cancelling the selector leaves the command a no-op, as before.

## Changes
- Add `ProjectManagers.getProjectManagerFromWebViewIdOrSelectProject`, which falls back to the core project selector when the WebView has no project, and use it in the four Scripture-Editor menu commands (`addEntry`, `browseLexicon`, `findEntry`, `findRelatedEntries`).
- Add localized strings for the selector dialog title/prompt.
- Downgrade the "No projectId found for WebView" log from `warn` to `debug`, since a missing project is now an expected, handled path rather than an error.

## Test plan
- [x] Open the Scripture Editor with no project selected; invoke each lexicon menu item and confirm the core project selector opens.
- [x] Choose a project in the selector and confirm the corresponding lexicon WebView opens for that project (prompting for lexicon selection if none is set).
- [ ] Cancel the selector and confirm nothing opens and no error is logged.
- [x] With a project already selected in the editor, confirm the menu items behave exactly as before (no selector shown).

Fixes #2395

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Devin: https://app.devin.ai/review/sillsdev/languageforge-lexbox/pull/2438