### PR TITLE
Silence compiler warning about AddRangeAsync

### DIFF
--- a/backend/FwLite/LcmCrdt/Data/LocalCommentReadStatusService.cs
+++ b/backend/FwLite/LcmCrdt/Data/LocalCommentReadStatusService.cs
@@ -93,7 +93,10 @@ public class LocalCommentReadStatusService(IDbContextFactory<LcmCrdtDbContext> d
             .ToArray();
         if (toInsert.Length == 0) return;
 
+        // AddRangeAsync says it exists only for use in special value generators, and all other uses should call AddRange
+#pragma warning disable VSTHRD103 // Call async methods when in an async method
         dbContext.UnreadComments.AddRange(toInsert);
+#pragma warning restore VSTHRD103 // Call async methods when in an async method
         try
         {
             await dbContext.SaveChangesAsync();


### PR DESCRIPTION
The dotnet compiler warns about some code added by #2382, saying that we should use AddRangeAsync rather than AddRange because it's in an async method. But the EF Core documentation expicitly says that AddRangeAsync is only for use in special value generators, and all other uses should use AddRange. So we silence the compiler warning and still use AddRange.
