### PR TITLE
Refactor FwLite CI to move core tests to Linux.

### DIFF
--- a/.github/AGENTS.md
+++ b/.github/AGENTS.md
@@ -81,7 +81,7 @@ flowchart TD
 ### FwLite is Separate
 
 `fw-lite.yaml` is **independent** from the main LexBox workflows:
-- Builds on Windows (MAUI requirement)
+- Core .NET build/tests run on Linux (`FwLiteCore.slnf`); MAUI build/tests on Windows only
 - Has its own test suite
 - Publishes standalone apps, not Docker images
 - Does NOT deploy to K8s
@@ -212,7 +212,7 @@ See `integration-test-gha.yaml` for the pattern (it's complex).
 ## FwLite CI Details (`fw-lite.yaml`)
 
 This is the most complex workflow because it:
-- Builds .NET on Windows (MAUI)
+- Builds core .NET on Linux, MAUI on Windows
 - Builds viewer (Node.js)
 - Runs Playwright tests
 - Publishes for 5 platforms (Windows, Mac x64, Mac ARM, Linux x64, Linux ARM)
@@ -221,16 +221,21 @@ This is the most complex workflow because it:
 
 | Job | Runner | Purpose |
 |-----|--------|---------|
-| `build-and-test` | windows-latest | .NET build + tests |
+| `build-and-test` | ubuntu-latest | Core .NET build + tests (`FwLiteCore.slnf`) |
 | `frontend` | ubuntu-latest | Build viewer, Playwright snapshots |
 | `frontend-component-unit-tests` | ubuntu-latest | Vitest unit tests |
 | `publish-mac` | macos-latest | macOS binaries |
 | `publish-linux` | ubuntu-latest | Linux binaries |
-| `publish-windows` | windows-latest | Windows MAUI + MSIX |
+| `publish-win` | windows-latest | MAUI tests, Windows MAUI publish + MSIX |
 
-### Why Windows?
+### Solution filters
 
-.NET MAUI builds require Windows SDK. Can't build Windows target on Linux.
+- `FwLiteCore.slnf` — CI fast path (no MAUI projects)
+- `FwLiteOnly.slnf` — local full build including MAUI
+
+### Why Windows for MAUI?
+
+.NET MAUI Windows builds require the Windows SDK. Can't build Windows MAUI targets on Linux.
 
 ### Artifacts
 
@@ -320,7 +325,7 @@ Challenges:
 - Test data management is complex
 
 Current state:
-- Unit tests in `FwLiteOnly.slnf`
+- Unit tests in `FwLiteCore.slnf` (CI) / `FwLiteOnly.slnf` (local, includes MAUI)
 - Playwright snapshot tests for viewer
 - No full E2E tests in CI yet
 

--- a/.github/workflows/fw-lite.yaml
+++ b/.github/workflows/fw-lite.yaml
@@ -447,8 +447,19 @@ jobs:
         run: dotnet build backend/FwLite/FwLiteMaui.Tests/FwLiteMaui.Tests.csproj -p:BuildAndroid=false
 
       - name: Test MAUI
-        run: dotnet test backend/FwLite/FwLiteMaui.Tests/FwLiteMaui.Tests.csproj --logger GitHubActions --no-build -p:BuildAndroid=false
+        run: dotnet test backend/FwLite/FwLiteMaui.Tests/FwLiteMaui.Tests.csproj --logger GitHubActions --logger trx --results-directory "${{ github.workspace }}/TestResults" --no-build -p:BuildAndroid=false
 
+      - name: Publish MAUI test results to TestHistory
+        if: always()
+        continue-on-error: true # telemetry only
+        uses: hahn-kev/TestHistory/.github/actions/upload-results@e5fc439cd7644a145c7553bc3b0077aa643aef8d # master
+        with:
+          server-url: ${{ vars.TESTHISTORY_SERVER_URL }}
+          project-id: ${{ vars.TESTHISTORY_FWLITE_PROJECT_ID }}
+          api-token: ${{ secrets.TESTHISTORY_API_TOKEN }}
+          files: TestResults/**/*.trx
+          label: FW Lite MAUI Windows
+          on-no-files: ignore
       - name: Publish Windows MAUI portable app
         working-directory: backend/FwLite/FwLiteMaui
         run: |

--- a/.github/workflows/fw-lite.yaml
+++ b/.github/workflows/fw-lite.yaml
@@ -8,6 +8,7 @@ on:
       - 'backend/Harmony*.props'
       - 'frontend/viewer/**'
       - '.github/workflows/fw-lite.yaml'
+      - 'FwLiteCore.slnf'
       - 'FwLiteOnly.slnf'
     branches:
       - develop
@@ -19,6 +20,7 @@ on:
       - 'backend/Harmony*.props'
       - 'frontend/viewer/**'
       - '.github/workflows/fw-lite.yaml'
+      - 'FwLiteCore.slnf'
       - 'FwLiteOnly.slnf'
     branches:
       - develop
@@ -38,8 +40,8 @@ env:
 jobs:
   build-and-test:
     name: Build FW Lite and run tests
-    timeout-minutes: 40
-    runs-on: windows-latest
+    timeout-minutes: 30
+    runs-on: ubuntu-latest
     outputs:
       version: ${{ steps.setVersion.outputs.VERSION }}
       semver-version: ${{ steps.setVersion.outputs.SEMVER_VERSION }}
@@ -56,8 +58,6 @@ jobs:
           key: nuget-${{ runner.os }}-${{ hashFiles('backend/Directory.Packages.props', 'backend/Harmony*.props') }}
           restore-keys: |
             nuget-${{ runner.os }}-
-      - name: Setup Maui
-        run: dotnet workload install maui-windows
       - name: Install Task
         uses: arduino/setup-task@b91d5d2c96a56797b48ac1e0e89220bf64044611 # v2.0.0
         with:
@@ -73,8 +73,8 @@ jobs:
           echo "SEMVER_VERSION=$(date +%Y.%-m.%-d)" >> ${GITHUB_OUTPUT}
 
       - name: Dotnet build
-        # the android build is quite slow, so we disable it for builds just for testing
-        run: dotnet build FwLiteOnly.slnf -p:BuildAndroid=false
+        # FwLiteCore.slnf omits MAUI projects — those build and test on publish-win (Windows).
+        run: dotnet build FwLiteCore.slnf -p:BuildAndroid=false
 
       - name: Check for pending EF model changes
         run: task fw-lite:has-pending-model-changes -- --no-build
@@ -86,14 +86,13 @@ jobs:
         # Hosted runners default to UTC, which hides date bugs: the error equals the local UTC
         # offset, which is zero on UTC (see #2092). Eastern is non-UTC, observes DST, and has a
         # negative offset, so date round-trips run the way real users actually hit them.
-        shell: pwsh
-        run: Set-TimeZone -Id "Eastern Standard Time"
+        run: sudo timedatectl set-timezone America/New_York
 
       - name: Dotnet test
         # Benchmarks run in a separate Release-mode job — see `benchmark` below.
-        # `trx` logger writes result files for the TestHistory upload below; --results-directory
-        # collects one .trx per test project into a single folder to glob.
-        run: dotnet test FwLiteOnly.slnf --logger GitHubActions --logger trx --results-directory "${{ github.workspace }}/TestResults" --no-build -p:BuildAndroid=false --filter "Category!=Benchmark"
+        # MAUI tests run in publish-win. `trx` logger writes result files for the TestHistory
+        # upload below; --results-directory collects one .trx per test project into a single folder.
+        run: dotnet test FwLiteCore.slnf --logger GitHubActions --logger trx --results-directory "${{ github.workspace }}/TestResults" --no-build -p:BuildAndroid=false --filter "Category!=Benchmark"
 
       - name: Publish test results to TestHistory
         if: always()
@@ -443,6 +442,12 @@ jobs:
 
       - name: Setup Maui
         run: dotnet workload install maui-windows
+
+      - name: Build MAUI tests
+        run: dotnet build backend/FwLite/FwLiteMaui.Tests/FwLiteMaui.Tests.csproj -p:BuildAndroid=false
+
+      - name: Test MAUI
+        run: dotnet test backend/FwLite/FwLiteMaui.Tests/FwLiteMaui.Tests.csproj --logger GitHubActions --no-build -p:BuildAndroid=false
 
       - name: Publish Windows MAUI portable app
         working-directory: backend/FwLite/FwLiteMaui

--- a/FwLiteCore.slnf
+++ b/FwLiteCore.slnf
@@ -1,0 +1,19 @@
+{
+  "solution": {
+    "path": "LexBox.sln",
+    "projects": [
+      "backend\\FwLite\\FwDataMiniLcmBridge.Tests\\FwDataMiniLcmBridge.Tests.csproj",
+      "backend\\FwLite\\FwDataMiniLcmBridge\\FwDataMiniLcmBridge.csproj",
+      "backend\\FwLite\\FwLiteProjectSync.Tests\\FwLiteProjectSync.Tests.csproj",
+      "backend\\FwLite\\FwLiteProjectSync\\FwLiteProjectSync.csproj",
+      "backend\\FwLite\\FwLiteShared\\FwLiteShared.csproj",
+      "backend\\FwLite\\FwLiteShared.Tests\\FwLiteShared.Tests.csproj",
+      "backend\\FwLite\\FwLiteWeb\\FwLiteWeb.csproj",
+      "backend\\FwLite\\LcmCrdt.Tests\\LcmCrdt.Tests.csproj",
+      "backend\\FwLite\\LcmCrdt\\LcmCrdt.csproj",
+      "backend\\FwLite\\MiniLcm\\MiniLcm.csproj",
+      "backend\\FwLite\\MiniLcm.Tests\\MiniLcm.Tests.csproj",
+      "backend\\LfClassicData\\LfClassicData.csproj"
+    ]
+  }
+}


### PR DESCRIPTION
per our discussion today, I'm moving our MAUI tests into the publish-win job, and making our main build run on linux