### PR TITLE
[claude] Bump SIL.Harmony to rc.228 and fix config-time freeze

### DIFF
--- a/backend/Directory.Packages.props
+++ b/backend/Directory.Packages.props
@@ -109,9 +109,9 @@
     <PackageVersion Include="SIL.Chorus.LibChorus" Version="6.0.0-beta0064" />
     <PackageVersion Include="SIL.Chorus.Mercurial" Version="6.5.1.43" />
     <PackageVersion Include="SIL.ChorusPlugin.LfMergeBridge" Version="4.3.0-beta0048" />
-    <PackageVersion Include="SIL.Harmony" Version="0.2.1-rc.211" />
-    <PackageVersion Include="SIL.Harmony.Core" Version="0.2.1-rc.211" />
-    <PackageVersion Include="SIL.Harmony.Linq2db" Version="0.2.1-rc.211" />
+    <PackageVersion Include="SIL.Harmony" Version="0.2.1-rc.228" />
+    <PackageVersion Include="SIL.Harmony.Core" Version="0.2.1-rc.228" />
+    <PackageVersion Include="SIL.Harmony.Linq2db" Version="0.2.1-rc.228" />
     <PackageVersion Include="SIL.Core" Version="17.0.0" />
     <PackageVersion Include="SIL.LCModel" Version="11.0.0-beta0165" />
     <PackageVersion Include="SIL.LCModel.FixData" Version="11.0.0-beta0165" />

--- a/backend/FwLite/LcmCrdt.Tests/DataModelSnapshotTests.cs
+++ b/backend/FwLite/LcmCrdt.Tests/DataModelSnapshotTests.cs
@@ -1,3 +1,4 @@
+using System.Runtime.CompilerServices;
 using System.Text.Json;
 using System.Text.Json.Serialization.Metadata;
 using FluentAssertions.Execution;
@@ -74,7 +75,24 @@ public class DataModelSnapshotTests : IAsyncLifetime
     [Trait("Category", "Verified")]
     public async Task VerifyChangeModels()
     {
-        await Verify(GetPolymorphicTypesFor(typeof(IChange)));
+        await Verify(GetChangePolymorphicTypes());
+    }
+
+    // IChange polymorphism is no longer expressed through PolymorphismOptions; each concrete change
+    // type instead carries a synthetic "$type" property (read by Harmony's change converter), so read
+    // the discriminator from there to snapshot the registered change set.
+    private IEnumerable<JsonDerivedType> GetChangePolymorphicTypes()
+    {
+        return LcmCrdtKernel.AllChangeTypes()
+            .Select(changeType =>
+            {
+                var discriminatorProperty = _jsonSerializerOptions.GetTypeInfo(changeType).Properties
+                    .SingleOrDefault(p => p.Name == CrdtConstants.ChangeDiscriminatorProperty);
+                discriminatorProperty.Should().NotBeNull("change type {0} should declare a $type discriminator", changeType);
+                var discriminator = discriminatorProperty!.Get!(RuntimeHelpers.GetUninitializedObject(changeType));
+                return new JsonDerivedType(changeType, (string)discriminator!);
+            })
+            .OrderBy(t => t.DerivedType.FullName);
     }
 
     [Fact]

--- a/backend/FwLite/LcmCrdt.Tests/TestJsonOptions.cs
+++ b/backend/FwLite/LcmCrdt.Tests/TestJsonOptions.cs
@@ -18,6 +18,7 @@ public static class TestJsonOptions
     {
         var config = new CrdtConfig();
         LcmCrdtKernel.ConfigureCrdt(config);
+        LcmCrdtKernel.FinalizeJsonSerializerOptions(config);
         return config.JsonSerializerOptions;
     }
 }

--- a/backend/FwLite/LcmCrdt/LcmCrdtKernel.cs
+++ b/backend/FwLite/LcmCrdt/LcmCrdtKernel.cs
@@ -66,6 +66,9 @@ public static class LcmCrdtKernel
             config => ConfigureCrdt(config, false)//don't add remote resources because they are added in AddCrdtRemoteResources
         );
         services.AddCrdtRemoteResources<LcmFileMetadata>();
+        // AddCrdtRemoteResources registers its change types in a Configure callback, so finalize the
+        // JSON options in a PostConfigure (which runs after every Configure) — see FinalizeJsonSerializerOptions.
+        services.AddOptions<CrdtConfig>().PostConfigure(FinalizeJsonSerializerOptions);
         services.AddOptions<CrdtConfig>().PostConfigure((CrdtConfig crdtConfig, IOptions<LcmCrdtConfig> lcmConfig) =>
         {
             crdtConfig.LocalResourceCachePath = Path.Combine(lcmConfig.Value.ProjectPath, "localResourcesCache");
@@ -395,12 +398,21 @@ public static class LcmCrdtKernel
             // you must add an instance of it to UseChangesTests.GetAllChanges()
             ;
 
+        if (addRemoteResourceEntity)
+            config.AddRemoteResourceEntity<LcmFileMetadata>();
+    }
+
+    // Adds the legacy ExampleSentence.Translation modifier to Harmony's JSON options. Reading
+    // config.JsonSerializerOptions builds the lazily-created options and freezes ChangeTypeListBuilder,
+    // so this must run only once every change type is registered. It's therefore kept out of
+    // ConfigureCrdt and run once the config is complete (a PostConfigure in DI, see AddLcmCrdtClientCore;
+    // right before reading the options for standalone callers, see TestJsonOptions.Harmony).
+    // Call once per config: it wraps the existing resolver, so a second call double-adds the modifier.
+    internal static void FinalizeJsonSerializerOptions(CrdtConfig config)
+    {
         config.JsonSerializerOptions.TypeInfoResolver =
             (config.JsonSerializerOptions.TypeInfoResolver ?? new DefaultJsonTypeInfoResolver())
             .WithAddedModifier(Json.ExampleSentenceTranslationModifier);
-
-        if (addRemoteResourceEntity)
-            config.AddRemoteResourceEntity<LcmFileMetadata>();
     }
 
     public static IEnumerable<Type> AllChangeTypes()


### PR DESCRIPTION
*[Claude, autonomous]*

Bumps SIL.Harmony 0.2.1-rc.211 → rc.228.

rc.228 makes `CrdtConfig.JsonSerializerOptions` a lazy that freezes `ChangeTypeListBuilder` when built, so reading it inside `ConfigureCrdt` (before remote-resource change types are registered) threw `ChangeTypeListBuilder is frozen`. Moved the JSON-options finalization into a single `PostConfigure` that runs after every `Configure`; `ConfigureCrdt` is now pure type registration.

`DataModelSnapshotTests.VerifyChangeModels` now reads change discriminators from the synthetic `$type` property (rc.228 dropped built-in `IChange` `PolymorphismOptions` for a converter). Verified snapshot is byte-identical, so the registered change set and discriminators are unchanged — on-disk/wire format stays compatible.

harmony-sentinel reviewed: no data-loss or format-compat risk (commit hash chain doesn't depend on change payload; `$type` name/value/position unchanged).
