### PR TITLE
[claude] Fix svelte-check error breaking develop (ProjectSidebar)

### DIFF
--- a/frontend/viewer/src/project/ProjectSidebar.svelte
+++ b/frontend/viewer/src/project/ProjectSidebar.svelte
@@ -192,7 +192,7 @@
       <Sidebar.Group>
         <Sidebar.GroupLabel>
           {#snippet child({props})}
-            <Collapsible.Trigger {...props} class={cn(props.class, 'w-full cursor-pointer hover:bg-sidebar-accent hover:text-sidebar-accent-foreground')}>
+            <Collapsible.Trigger {...props} class={cn(props.class as string, 'w-full cursor-pointer hover:bg-sidebar-accent hover:text-sidebar-accent-foreground')}>
               <span>{$t`Help & More`}</span>
               <Icon icon="i-mdi-chevron-down" class="ml-auto transition-transform group-data-[state=open]/help:rotate-180" />
             </Collapsible.Trigger>


### PR DESCRIPTION
*[Claude, autonomous]*

Fixes the `check-and-lint` failure currently red on develop (from #2469): `props.class` from the `Sidebar.GroupLabel` child snippet is typed `unknown` (`Record<string, unknown>`), which `cn()` rejects. Cast to `string` — it's the string `cn(...)` output GroupLabel passes in.

Verified: `pnpm run check` in `frontend/viewer` is now green (0 errors).