### PR TITLE
Activity redesign part 2: render writing-system codes as monospace chips

### DIFF
--- a/frontend/viewer/src/lib/components/dictionary/DictionaryEntry.svelte
+++ b/frontend/viewer/src/lib/components/dictionary/DictionaryEntry.svelte
@@ -3,6 +3,7 @@
   import {usePartsOfSpeech, asString, useWritingSystemService} from '$project/data';
   import type {HTMLAttributes} from 'svelte/elements';
   import {Icon} from '$lib/components/ui/icon';
+  import WsCode from '$lib/components/writing-system/WsCode.svelte';
   import {cn} from '$lib/utils';
   import type {Snippet} from 'svelte';
   import Headwords from './Headwords.svelte';
@@ -115,7 +116,7 @@
       {/if}
       <span>
         {#each sense.glossesAndDefs as glossAndDef (glossAndDef.wsId)}
-          <sub class="-mr-0.5">{glossAndDef.wsAbbr}</sub>
+          <WsCode plain abbreviation={glossAndDef.wsAbbr} class="-mr-0.5 align-sub" />
           {#if glossAndDef.gloss}
             <span class={glossAndDef.color}>{glossAndDef.gloss}</span>{#if glossAndDef.definition};{/if}
           {/if}

--- a/frontend/viewer/src/lib/components/field-editors/multi-ws-input.svelte
+++ b/frontend/viewer/src/lib/components/field-editors/multi-ws-input.svelte
@@ -2,7 +2,7 @@
   import {type IMultiString, type IWritingSystem} from '$lib/dotnet-types';
   import type {ReadonlyDeep} from 'type-fest';
   import {tryUseFieldBody} from '../editor/field/field-root.svelte';
-  import {Label} from '../ui/label';
+  import WsCode from '../writing-system/WsCode.svelte';
   import StompSafeInput from '../stomp/stomp-safe-input.svelte';
   import AudioInput from './audio-input.svelte';
   import {useProjectContext} from '$project/project-context.svelte';
@@ -37,7 +37,7 @@
       class="grid gap-y-2 @lg/editor:grid-cols-subgrid col-span-full items-baseline"
       title={`${ws.name} (${ws.wsId})`}
     >
-      <Label id={labelId} for={inputId}>{ws.abbreviation}</Label>
+      <WsCode id={labelId} for={inputId} abbreviation={ws.abbreviation} class="justify-self-start" />
       {#if !ws.isAudio}
         <StompSafeInput
           bind:value={value[ws.wsId]}

--- a/frontend/viewer/src/lib/components/field-editors/rich-multi-ws-input.svelte
+++ b/frontend/viewer/src/lib/components/field-editors/rich-multi-ws-input.svelte
@@ -3,7 +3,7 @@
   import type {ReadonlyDeep} from 'type-fest';
   import type {IRichString} from '$lib/dotnet-types/generated-types/MiniLcm/Models/IRichString';
   import {tryUseFieldBody} from '../editor/field/field-root.svelte';
-  import {Label} from '../ui/label';
+  import WsCode from '../writing-system/WsCode.svelte';
   import StompSafeLcmRichTextEditor from '../stomp/stomp-safe-lcm-rich-text-editor.svelte';
   import AudioInput from '$lib/components/field-editors/audio-input.svelte';
   import {useProjectContext} from '$project/project-context.svelte';
@@ -58,7 +58,7 @@
       class="grid gap-y-2 @lg/editor:grid-cols-subgrid col-span-full items-baseline"
       title={`${ws.name} (${ws.wsId})`}
     >
-      <Label id={labelId} for={inputId}>{ws.abbreviation}</Label>
+      <WsCode id={labelId} for={inputId} abbreviation={ws.abbreviation} class="justify-self-start" />
       {#if !ws.isAudio}
         <StompSafeLcmRichTextEditor
           bind:value={value[ws.wsId]}

--- a/frontend/viewer/src/lib/components/writing-system/WsCode.svelte
+++ b/frontend/viewer/src/lib/components/writing-system/WsCode.svelte
@@ -23,7 +23,10 @@
   for={forId}
   {id}
   class={cn(
-    'font-mono text-xs',
+    'font-mono',
+    // Monospace renders ~one step smaller than the app's sans, so the chip uses text-sm to match the
+    // text-xs-sans label floor it replaced; the plain form stays text-xs to recede inline beside the gloss.
+    plain ? 'text-xs' : 'text-sm',
     !plain && 'rounded border border-border bg-muted/50 px-1',
     // The plain form is a subordinate annotation in the read-only dictionary/activity views, so it reads
     // lighter than the value text — but at foreground/75 (~9:1 on white and muted), not the AA-floor grey,

--- a/frontend/viewer/src/lib/components/writing-system/WsCode.svelte
+++ b/frontend/viewer/src/lib/components/writing-system/WsCode.svelte
@@ -1,0 +1,35 @@
+<script lang="ts">
+  import {cn} from '$lib/utils';
+  import type {HTMLAttributes} from 'svelte/elements';
+
+  let {
+    abbreviation,
+    id,
+    for: forId,
+    plain = false,
+    class: className,
+    ...restProps
+  }: HTMLAttributes<HTMLElement> & {
+    abbreviation: string;
+    id?: string;
+    for?: string;
+    /** Drop the chip chrome (border/background) for print-like contexts, e.g. the dictionary preview. */
+    plain?: boolean;
+  } = $props();
+</script>
+
+<svelte:element
+  this={forId ? 'label' : 'span'}
+  for={forId}
+  {id}
+  class={cn(
+    'font-mono text-xs',
+    !plain && 'rounded border border-border bg-muted/50 px-1',
+    // Not text-muted-foreground: on the muted chip fill (and muted preview surfaces) that lands at ~4.4:1,
+    // under the 4.5:1 WCAG AA floor for this 12px text. foreground/60 keeps the same light-grey look while
+    // clearing AA on every surface in both themes (verified: worst case ~5.1:1 on the light muted fill).
+    'text-foreground/60',
+    className,
+  )}
+  {...restProps}>{abbreviation}</svelte:element
+>

--- a/frontend/viewer/src/lib/components/writing-system/WsCode.svelte
+++ b/frontend/viewer/src/lib/components/writing-system/WsCode.svelte
@@ -25,11 +25,12 @@
   class={cn(
     'font-mono text-xs',
     !plain && 'rounded border border-border bg-muted/50 px-1',
-    // The plain form is a passive annotation in the read-only dictionary/activity views, so it recedes at
-    // foreground/60 — chosen over text-muted-foreground, which lands ~4.4:1 on the muted surface, under the
-    // 4.5:1 AA floor for this 12px text. The chip is a field's writing-system label in the editor, where a
-    // misread means data entered under the wrong writing system, so it runs full contrast (both themes).
-    plain ? 'text-foreground/60' : 'text-foreground',
+    // The plain form is a subordinate annotation in the read-only dictionary/activity views, so it reads
+    // lighter than the value text — but at foreground/75 (~9:1 on white and muted), not the AA-floor grey,
+    // since the reader still parses it to tell which writing system each gloss is. The chip is a field's
+    // writing-system label in the editor, where a misread writes data under the wrong writing system, so it
+    // runs full contrast (both themes).
+    plain ? 'text-foreground/75' : 'text-foreground',
     className,
   )}
   {...restProps}>{abbreviation}</svelte:element

--- a/frontend/viewer/src/lib/components/writing-system/WsCode.svelte
+++ b/frontend/viewer/src/lib/components/writing-system/WsCode.svelte
@@ -25,10 +25,11 @@
   class={cn(
     'font-mono text-xs',
     !plain && 'rounded border border-border bg-muted/50 px-1',
-    // Not text-muted-foreground: on the muted chip fill (and muted preview surfaces) that lands at ~4.4:1,
-    // under the 4.5:1 WCAG AA floor for this 12px text. foreground/60 keeps the same light-grey look while
-    // clearing AA on every surface in both themes (verified: worst case ~5.1:1 on the light muted fill).
-    'text-foreground/60',
+    // The plain form is a passive annotation in the read-only dictionary/activity views, so it recedes at
+    // foreground/60 — chosen over text-muted-foreground, which lands ~4.4:1 on the muted surface, under the
+    // 4.5:1 AA floor for this 12px text. The chip is a field's writing-system label in the editor, where a
+    // misread means data entered under the wrong writing system, so it runs full contrast (both themes).
+    plain ? 'text-foreground/60' : 'text-foreground',
     className,
   )}
   {...restProps}>{abbreviation}</svelte:element


### PR DESCRIPTION
*[Claude, autonomous]*

Render writing-system codes as monospace chips via a new `WsCode` component: a bordered `chip` for the editor's multi-writing-system field labels (`multi-ws-input`, `rich-multi-ws-input`) and a chrome-less `plain` variant in the dictionary preview. Part 2/8 of the activity redesign; follows #2435.

Groundwork for rendering writing-system codes in the activity-item summaries later in the series. The monospace treatment came from a UX reviewer's suggestion that the codes should read more like *codes*.

Chip text uses `text-foreground/60` (not `text-muted-foreground`) to clear WCAG AA on the muted fill at 12px.

## Screenshots

All-writing-systems demo entry (`!nyumba`); click to enlarge.

| Context | Before | After · light | After · dark |
| --- | --- | --- | --- |
| Editor field labels | <a href="https://raw.githubusercontent.com/myieye/pr-screenshots/main/wscode/5a8f4b3efe291d19.png"><img width="240" src="https://raw.githubusercontent.com/myieye/pr-screenshots/main/wscode/5a8f4b3efe291d19.png"></a> | <a href="https://raw.githubusercontent.com/myieye/pr-screenshots/main/wscode/37337466d3a1cae5.png"><img width="240" src="https://raw.githubusercontent.com/myieye/pr-screenshots/main/wscode/37337466d3a1cae5.png"></a> | <a href="https://raw.githubusercontent.com/myieye/pr-screenshots/main/wscode/2e4ac127011934e9.png"><img width="240" src="https://raw.githubusercontent.com/myieye/pr-screenshots/main/wscode/2e4ac127011934e9.png"></a> |
| Dictionary preview | <a href="https://raw.githubusercontent.com/myieye/pr-screenshots/main/wscode/7ee58f830ed60ecf.png"><img width="240" src="https://raw.githubusercontent.com/myieye/pr-screenshots/main/wscode/7ee58f830ed60ecf.png"></a> | <a href="https://raw.githubusercontent.com/myieye/pr-screenshots/main/wscode/6c024ea61b8b4a41.png"><img width="240" src="https://raw.githubusercontent.com/myieye/pr-screenshots/main/wscode/6c024ea61b8b4a41.png"></a> | <a href="https://raw.githubusercontent.com/myieye/pr-screenshots/main/wscode/f9b1c508370ef6bc.png"><img width="240" src="https://raw.githubusercontent.com/myieye/pr-screenshots/main/wscode/f9b1c508370ef6bc.png"></a> |
