### PR TITLE
Enable Prettier format:check in FwLite viewer CI

### DIFF
--- a/.github/workflows/fw-lite.yaml
+++ b/.github/workflows/fw-lite.yaml
@@ -215,10 +215,9 @@ jobs:
         working-directory: frontend/viewer
         run: pnpm run build
 
-      # Disabled so we can format in a seperate commit and ignore it in git blame
-      # - name: Check code formatting with Prettier
-      #   working-directory: frontend/viewer
-      #   run: pnpm run format:check
+      - name: Check code formatting with Prettier
+        working-directory: frontend/viewer
+        run: pnpm run format:check
 
       - name: Upload viewer artifacts
         uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5.0.0


### PR DESCRIPTION
Re-enables the viewer's `format:check` CI step, left commented out after the components-only Prettier rollout (#2151). The format commit is already in `.git-blame-ignore-revs` and the check passes today.

Prettier is still scoped to `src/lib/components/**` via `.prettierignore`; widening it to the whole viewer is tracked in #2474.