### PR TITLE
Remove unused _partsOfSpeechCacheByGuid field

### DIFF
--- a/backend/LfClassicData/LfClassicMiniLcmApi.cs
+++ b/backend/LfClassicData/LfClassicMiniLcmApi.cs
@@ -19,7 +19,6 @@ public class LfClassicMiniLcmApi(string projectCode, ProjectDbContext dbContext,
     private IMongoCollection<Entities.Entry> Entries => dbContext.Entries(projectCode);
 
 
-    private Dictionary<Guid, PartOfSpeech>? _partsOfSpeechCacheByGuid = null;
     private Dictionary<string, PartOfSpeech>? _partsOfSpeechCacheByStringKey = null;
 
     public async Task<WritingSystems> GetWritingSystems()


### PR DESCRIPTION
*[Claude, autonomous]*

Fixes the CS0414 "assigned but never used" build warning in `LfClassicMiniLcmApi`. Only `_partsOfSpeechCacheByStringKey` is ever read; the by-Guid cache field was dead. No other unused-field warnings exist in the backend (checked a full solution build).