### PR TITLE
Document theme toggling for screenshots and the pre-commit prettier hook

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -83,6 +83,7 @@ Before implementing any change that will touch many files or is in a 🔴 **Crit
 - ✅ Prefer IDE diagnostics (compiler/lint errors) over CLI tools for identifying issues. Fixing these diagnostics is part of completing any instruction.
 - ✅ When handling a user prompt ALWAYS ask for clarification if there are details to clarify, important decisions that must be made first or the plan sounds unwise
 - ❌ Do NOT git commit or git push without explicit user approval
+- ⚠️ **Pre-commit hook prettier-formats staged `*.{js,ts,svelte,css,md,json}` files** (yes, incl. `.md`/docs) via `frontend/viewer`. If your commit stages any of those and `frontend/viewer/node_modules` is missing (fresh worktree/clone), run `cd frontend && pnpm install` first (~45s, once per worktree) — don't `--no-verify` to dodge it, that just defers the format failure to CI. If it stages none of those (e.g. backend-only), the hook is a no-op: it passes with no install, and `--no-verify` is fine.
 
 ### 🛡️ VIGILANCE
 

--- a/frontend/viewer/AGENTS.md
+++ b/frontend/viewer/AGENTS.md
@@ -54,6 +54,20 @@ task test:ui-standalone
 task test:ui-standalone -- entries-list --ui
 ```
 
+### Theme (light/dark + color) for screenshots
+
+Theming is `mode-watcher`. Don't click the `ThemePicker` popover — set it directly.
+
+**Light/dark mode** defaults to `system` (follows `prefers-color-scheme`), so emulate that media query:
+- Playwright: `await page.emulateMedia({colorScheme: 'dark'})` (or `'light'`). For both, use the `assertScreenshotInBothColorSchemes` helper.
+- Browser MCP: pass `colorScheme: 'dark'` to `resize_window`.
+
+(Only breaks if something first called `setMode`, which persists a preference that overrides system.)
+
+**Color theme** (`green`/`blue`/`rose`/`orange`/`violet`/`stone`; `blue` is the default) has no media query — set the `data-theme` attribute on `<html>` instead:
+- `document.documentElement.setAttribute('data-theme','violet')` (Browser MCP `javascript_tool`, or Playwright `page.evaluate`).
+- To survive a reload, set `localStorage['mode-watcher-theme']` before load.
+
 ## Tech Stack
 
 - **Framework**: SvelteKit + Vite


### PR DESCRIPTION
Two agent-facing doc notes: how to flip light/dark mode and color theme when taking screenshots (viewer AGENTS.md), and when the pre-commit prettier hook needs a `pnpm install` vs. when `--no-verify` is fine (root AGENTS.md).