### PR TITLE
Update SQLite to latest version (3.53.3)

### DIFF
--- a/backend/Directory.Packages.props
+++ b/backend/Directory.Packages.props
@@ -119,10 +119,10 @@
     <!-- Only included so it can be excluded. See FwLiteMaui.csproj. -->
     <PackageVersion Include="Mono.Unix" Version="7.1.0-final.1.21458.1" />
     <PackageVersion Include="Soenneker.Utils.AutoBogus" Version="4.0.895" />
-    <PackageVersion Include="SQLitePCLRaw.bundle_e_sqlite3" Version="3.0.3" />
-    <PackageVersion Include="SQLitePCLRaw.core" Version="3.0.3" />
-    <PackageVersion Include="SQLitePCLRaw.lib.e_sqlite3" Version="3.0.3" />
-    <PackageVersion Include="SQLitePCLRaw.provider.e_sqlite3" Version="3.0.3" />
+    <PackageVersion Include="SQLitePCLRaw.bundle_e_sqlite3" Version="3.0.4" />
+    <PackageVersion Include="SQLitePCLRaw.core" Version="3.0.4" />
+    <PackageVersion Include="SQLitePCLRaw.lib.e_sqlite3" Version="3.53.3" />
+    <PackageVersion Include="SQLitePCLRaw.provider.e_sqlite3" Version="3.0.4" />
     <PackageVersion Include="Squidex.Assets.TusClient" Version="8.0.1" />
     <PackageVersion Include="structuremap.patched" Version="4.7.3" />
     <PackageVersion Include="Swashbuckle.AspNetCore" Version="10.1.7" />


### PR DESCRIPTION
Recent SQLite releases have fixed a bug that can result in data corruption in some rare cases, so it's worth upgrading.

NOTE: The SQLitePCLRaw.lib.e_sqlite3 version number is the version number of the included SQLite code, not the version number of the rest of the library. That's why it's at 3.53.3, not 3.0.4.

Fixes #2465.