### PR TITLE
Don't give up on popstate event too quickly

### DIFF
--- a/frontend/viewer/src/lib/utils/history.ts
+++ b/frontend/viewer/src/lib/utils/history.ts
@@ -47,7 +47,7 @@ async function doHistoryChange(change: HistoryChange): Promise<void> {
   }
 }
 
-export async function awaitPopstate(timeout = 100): Promise<boolean> {
+export async function awaitPopstate(timeout = 500): Promise<boolean> {
   const controller = new AbortController();
   const result = await Promise.any([
     new Promise<'popstate'>(resolve => {


### PR DESCRIPTION
Occasionally, in dev, popstate can take more than 100ms to return, such as when a dialog change ends up loading new code that Vite hasn't compiled yet (which happens synchronously while the await is still waiting to be fulfilled). A 500ms timeout should be enough for most situations, while still being short enough not to be annoying to wait for if it is reporting an actual error.

Fixes #2480.