### PR TITLE
Fix the is harmony project data loader

### DIFF
--- a/backend/LexBoxApi/GraphQL/CustomTypes/IsHarmonyProjectDataLoader.cs
+++ b/backend/LexBoxApi/GraphQL/CustomTypes/IsHarmonyProjectDataLoader.cs
@@ -6,13 +6,14 @@ using SIL.Harmony.Core;
 namespace LexBoxApi.GraphQL.CustomTypes;
 
 public class IsHarmonyProjectDataLoader(
-    LexBoxDbContext dbContext,
+    IDbContextFactory<LexBoxDbContext> dbContextFactory,
     IBatchScheduler batchScheduler,
     DataLoaderOptions options)
     : BatchDataLoader<Guid, bool>(batchScheduler, options), IIsHarmonyProjectDataLoader
 {
     protected override async Task<IReadOnlyDictionary<Guid, bool>> LoadBatchAsync(IReadOnlyList<Guid> keys, CancellationToken cancellationToken)
     {
+        await using var dbContext = await dbContextFactory.CreateDbContextAsync(cancellationToken);
         var serverCommits = dbContext.Set<ServerCommit>().AsQueryable();
         if (keys.Count < 100) serverCommits = serverCommits.Where(c => keys.Contains(c.ProjectId));
         var isHarmonyProject = await serverCommits

--- a/backend/LexBoxApi/GraphQL/GraphQlSetupKernel.cs
+++ b/backend/LexBoxApi/GraphQL/GraphQlSetupKernel.cs
@@ -53,6 +53,7 @@ public static class GraphQlSetupKernel
                 descriptor.AddDeterministicInvariantContainsFilter();
             })
             .AddProjections()
+            .RegisterDbContextFactory<LexBoxDbContext>()
             .ModifyPagingOptions(options =>
             {
                 options.DefaultPageSize = 100;

--- a/backend/LexData/DataKernel.cs
+++ b/backend/LexData/DataKernel.cs
@@ -23,7 +23,7 @@ public static class DataKernel
             services.AddScoped<SeedingData>();
 
         LinqToDBForEFTools.Initialize();
-        services.AddDbContext<LexBoxDbContext>((serviceProvider, options) =>
+        services.AddPooledDbContextFactory<LexBoxDbContext>((serviceProvider, options) =>
         {
             options.EnableDetailedErrors();
             options.UseNpgsql(serviceProvider.GetRequiredService<IOptions<DbConfig>>().Value.LexBoxConnectionString);
@@ -47,7 +47,10 @@ public static class DataKernel
 #if DEBUG
             options.EnableSensitiveDataLogging();
 #endif
-        }, dbContextLifeTime);
+        });
+        //we're now using a pooled db context factory, but we don't want to rewrite everything else to use it, so we'll expose `LexBoxDbContext` as a service
+        //it'll get disposed properly when the service scope is disposed, just like before.
+        services.Add(new ServiceDescriptor(typeof(LexBoxDbContext), sp => sp.GetRequiredService<IDbContextFactory<LexBoxDbContext>>().CreateDbContext(), dbContextLifeTime));
         services.AddLogging();
         services.AddHealthChecks()
             .AddDbContextCheck<LexBoxDbContext>(customTestQuery: (context, token) => context.HeathCheck(token));


### PR DESCRIPTION
right now in production (not staging sadly) if you execute a gql query like
```gql
query {
    projects {
      code
      hasHarmonyCommits
    }
}
```
then it will fail with `A second operation was started on this context instance before a previous operation completed. This is usually caused by different threads concurrently using the same instance of DbContext. For more information on how to avoid threading issues with DbContext, see https://go.microsoft.com/fwlink/?linkid=2097913.`
this is due to a race condition where the DbContext instance is being used in 2 places at once, the way to fix this is to use a db context factory. Normally this would require rewriting all of our code to use this directly instead of just injecting `LexboxDbContext`, however with a simple service registration we can ensure that a new instance is gotten from the factory when requested on a scope, and then it will be disposed once the request is over. Now we have the best of both worlds. Also we have context pooling now, so rather than recreating the context from scratch on each request they will be returned to a pool and reused.