### PR TITLE
[claude] Add agent privacy and cluster-access rules

### DIFF
--- a/.github/AGENTS.md
+++ b/.github/AGENTS.md
@@ -16,6 +16,12 @@ The CI/CD setup is:
 3. Consider if changes will increase build times
 4. Check if the change needs to work across multiple OS/platforms
 
+## 🔒 Cluster Access and Privacy (non-negotiable)
+
+- **NEVER access a k8s cluster without explicit permission** for that specific cluster — no `kubectl`, `helm`, `k9s`, port-forwards, or log pulls. Production requires an instruction that explicitly names production. The only exception is a throwaway local cluster (e.g. kind) you started yourself.
+- **Never push to the fleet repo** — pushing there IS deploying.
+- **Everything from a real environment is private.** Logs, DB contents, project codes, project/language names, user names: none of it goes into GitHub issues/PRs/comments or anywhere else online. Full rules in the root `AGENTS.md` (🔒 Privacy and Production Access).
+
 ---
 
 ## Workflow Overview

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -48,6 +48,25 @@ Key documentation for this project:
 - `frontend/viewer/AGENTS.md` - **FwLite Viewer** (Specific frontend rules)
 - `deployment/README.md` - Deployment and infrastructure
 
+## 🔒 Privacy and Production Access (non-negotiable)
+
+These two rules override every task. No goal (a bug report, debugging, being thorough or helpful) justifies breaking them.
+
+### NEVER post project or user data online
+
+This repo and its issue tracker are public. Anything you post to GitHub (issues, PRs, comments, reviews, commit messages, branch names) or anywhere else online must contain ZERO identifying information about real projects or people:
+
+- ❌ Project codes (e.g. `abc-flex`) and project or language names tied to real data
+- ❌ User names, emails, org names
+- ❌ Content from real project data (entry text, filenames, media)
+- ❌ Stats or details that identify a specific project even without naming it
+
+Describe real cases generically instead ("a ~9k-entry production project") and give the identifying details to the user privately; they decide what gets shared and where. If you are unsure whether something is identifying, treat it as identifying and leave it out. This applies no matter where the data came from: logs, a database, a screenshot, or earlier in the conversation.
+
+### NEVER access a Kubernetes cluster without explicit permission
+
+Do not run `kubectl`, `helm`, `k9s`, port-forwards, or anything else that reads from or writes to a k8s cluster unless the user has clearly approved it for that specific cluster in the current task. Production is strictly off-limits without an instruction that explicitly names production. The only case that needs no ask is a throwaway local dev cluster (e.g. kind) that you started yourself for the task.
+
 ## Guidelines
 
 ### Testing
@@ -64,7 +83,7 @@ Key documentation for this project:
 - Check existing issues: `gh issue list --limit 30`
 - Look at recent commits: `git log --oneline -20`
 - Read the docs in `docs/` directory
-- Create a GitHub issue if unsure
+- Create a GitHub issue if unsure (public! — see 🔒 Privacy rules above)
 - Ask the user to clarify
 
 ### Pre-Flight Check
@@ -84,6 +103,7 @@ Before implementing any change that will touch many files or is in a 🔴 **Crit
 - ✅ Prefer IDE diagnostics (compiler/lint errors) over CLI tools for identifying issues. Fixing these diagnostics is part of completing any instruction.
 - ✅ When handling a user prompt ALWAYS ask for clarification if there are details to clarify, important decisions that must be made first or the plan sounds unwise
 - ❌ Do NOT git commit or git push without explicit user approval
+- ❌ Do NOT post project/user identifiers or any real-project data online, and do NOT touch a k8s cluster without explicit permission — see **🔒 Privacy and Production Access** above
 - ⚠️ **Pre-commit hook prettier-formats staged `*.{js,ts,svelte,css,md,json}` files** (yes, incl. `.md`/docs) via `frontend/viewer`. If your commit stages any of those and `frontend/viewer/node_modules` is missing (fresh worktree/clone), run `cd frontend && pnpm install` first (~45s, once per worktree) — don't `--no-verify` to dodge it, that just defers the format failure to CI. If it stages none of those (e.g. backend-only), the hook is a no-op: it passes with no install, and `--no-verify` is fine.
 
 ### 🛡️ VIGILANCE

--- a/backend/FwHeadless/AGENTS.md
+++ b/backend/FwHeadless/AGENTS.md
@@ -17,7 +17,7 @@ Headless service for FieldWorks data processing. Handles Mercurial sync, FwData 
 
 ## 🔒 Debugging real projects: privacy and cluster access
 
-Investigating a sync problem often means looking at a real user's project. That data is private: NEVER put project codes, project/language names, user names, or stats that identify a specific project into GitHub issues/PRs/comments or anywhere else online — describe the case generically and hand identifying details to the user privately. And NEVER access a k8s cluster (production or otherwise) without explicit permission. Full rules in the root `AGENTS.md` (🔒 Privacy and Production Access).
+Investigating a sync problem often means looking at a real user's project. That data is private: NEVER put project codes, project/language names, user names, or stats that identify a specific project into GitHub issues/PRs/comments or anywhere else online — describe the case generically and hand identifying details to the user privately. And NEVER access a k8s cluster without explicit permission (one local-dev exception). Full rules in the root `AGENTS.md` (🔒 Privacy and Production Access).
 
 ---
 

--- a/backend/FwHeadless/AGENTS.md
+++ b/backend/FwHeadless/AGENTS.md
@@ -15,6 +15,10 @@ Headless service for FieldWorks data processing. Handles Mercurial sync, FwData 
 - Lose data during format conversion
 - Create divergent data that can't be reconciled
 
+## 🔒 Debugging real projects: privacy and cluster access
+
+Investigating a sync problem often means looking at a real user's project. That data is private: NEVER put project codes, project/language names, user names, or stats that identify a specific project into GitHub issues/PRs/comments or anywhere else online — describe the case generically and hand identifying details to the user privately. And NEVER access a k8s cluster (production or otherwise) without explicit permission. Full rules in the root `AGENTS.md` (🔒 Privacy and Production Access).
+
 ---
 
 ## Quick Start


### PR DESCRIPTION
*[Claude, autonomous]*

Makes two rules explicit in the root, .github, and FwHeadless AGENTS.md files: agents must never post project/user identifiers or any real-project data publicly, and must never access a k8s cluster without explicit permission. Prompted by an agent recently posting a real project code in public issue comments.

🤖 Generated with [Claude Code](https://claude.com/claude-code)