### PR TITLE
Set CI timezone via TZ env var instead of timedatectl

### DIFF
--- a/.github/workflows/fw-lite.yaml
+++ b/.github/workflows/fw-lite.yaml
@@ -86,7 +86,9 @@ jobs:
         # Hosted runners default to UTC, which hides date bugs: the error equals the local UTC
         # offset, which is zero on UTC (see #2092). Eastern is non-UTC, observes DST, and has a
         # negative offset, so date round-trips run the way real users actually hit them.
-        run: sudo timedatectl set-timezone America/New_York
+        # .NET reads TZ for TimeZoneInfo.Local on Linux, so set that rather than `timedatectl`,
+        # which the hosted runner denies (no systemd access); $GITHUB_ENV carries it to the test step.
+        run: echo "TZ=America/New_York" >> "$GITHUB_ENV"
 
       - name: Dotnet test
         # Benchmarks run in a separate Release-mode job — see `benchmark` below.


### PR DESCRIPTION
`sudo timedatectl set-timezone` fails on hosted runners with "Access denied" (no systemd access). .NET's `TimeZoneInfo.Local` honors the `TZ` env var on Linux, so set it via `$GITHUB_ENV` (which carries to the Dotnet test step). Same observable non-UTC timezone, no privileges needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_012ZQhkqK7EkcYREkEhvgBoD)_