### PR TITLE
Drop stale media-sync TODO comment

### DIFF
--- a/backend/FwHeadless/Media/MediaFileService.cs
+++ b/backend/FwHeadless/Media/MediaFileService.cs
@@ -17,7 +17,7 @@ namespace FwHeadless.Media;
 public class MediaFileService(LexBoxDbContext dbContext, IOptions<FwHeadlessConfig> config, ISendReceiveService sendReceiveService)
 {
     public record MediaFileSyncResult(List<MediaFile> Added, List<MediaFile> Removed);
-    // TODO: This assumes FieldWorks is the source of truth, which is not true when FWL starts adding/deleting files
+
     public virtual async Task<MediaFileSyncResult> SyncMediaFiles(LcmCache cache)
     {
         var result = new MediaFileSyncResult([], []);


### PR DESCRIPTION
Removes a stale `TODO` in `MediaFileService.SyncMediaFiles`.

Safe to drop: the comment claimed the reconcile assumes FieldWorks is the source of truth and would break once FWL adds/deletes files. That's not true. FWL media uploads go through the upload endpoint, which writes the file into the `LinkedFiles` folder, commits it to hg, and records it in the DB, exactly like a FieldWorks-added file. `SyncMediaFiles` reconciles the DB against the on-disk hg files, so an FWL-added file is on disk and handled identically.