### PR TITLE
Fix FwHeadless sync-cycle doc: merge is user-triggered, not detected

### DIFF
--- a/backend/FwHeadless/AGENTS.md
+++ b/backend/FwHeadless/AGENTS.md
@@ -79,7 +79,7 @@ flowchart TD
 
 ```mermaid
 flowchart TD
-    A[1. FieldWorks user does Send/Receive] --> B[2. FwHeadless detects Mercurial changes<br/>SyncHostedService]
+    A["1. User clicks Sync (FW Lite dialog<br/>or LexBox project page)"] --> B["2. POST /api/merge/execute queues a job;<br/>SyncHostedService drains the queue,<br/>one project at a time server-wide"]
     B --> C[3. Load FwData project<br/>FwDataFactory]
     C --> D[4. Sync FwData → CRDT<br/>CrdtFwdataProjectSyncService]
     D --> E[5. Sync CRDT → LexBox server<br/>CrdtSyncService]


### PR DESCRIPTION
The FwHeadless AGENTS.md sync-cycle diagram claimed `SyncHostedService` detects Mercurial changes, but it only drains a job queue fed by user-initiated sync (the FW Lite Sync dialog / LexBox project page button), so the diagram now says the merge is user-triggered, queued, and processed one project at a time server-wide.

🤖 Generated with [Claude Code](https://claude.com/claude-code)