### PR TITLE
[claude] Keep LcmDebugger run output in timestamped log files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,7 @@ backend/FwLite/FwLiteShared/wwwroot/viewer
 *.props.user
 *.log
 failedSyncs/
+backend/FwLite/LcmDebugger/logs/
 
 # just ignore everything rider related
 .idea

--- a/backend/FwLite/LcmDebugger/LcmDebugger.csproj
+++ b/backend/FwLite/LcmDebugger/LcmDebugger.csproj
@@ -11,5 +11,6 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Hosting"/>
     <PackageReference Include="Moq"/>
+    <PackageReference Include="NReco.Logging.File"/>
   </ItemGroup>
 </Project>

--- a/backend/FwLite/LcmDebugger/Program.cs
+++ b/backend/FwLite/LcmDebugger/Program.cs
@@ -9,10 +9,12 @@ using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using MiniLcm.Project;
 using Moq;
+using NReco.Logging.File;
 
 var builder = Host.CreateApplicationBuilder();
 //slows down import to log all sql.
 builder.Logging.AddFilter("Microsoft.EntityFrameworkCore", LogLevel.Warning);
+builder.Logging.AddFile(RunOutput.FilePath("run.log"));
 builder.Services.AddFwDataBridge();
 builder.Services.AddLcmCrdtClient();
 builder.Services.AddFwLiteProjectSync();

--- a/backend/FwLite/LcmDebugger/RunOutput.cs
+++ b/backend/FwLite/LcmDebugger/RunOutput.cs
@@ -1,0 +1,26 @@
+using System.Runtime.CompilerServices;
+
+namespace LcmDebugger;
+
+/// <summary>
+/// Names the files a run leaves behind, in LcmDebugger/logs (gitignored, never pruned).
+/// One timestamp per process, so a run's log and its dry run records sort together.
+/// </summary>
+public static class RunOutput
+{
+    private static readonly string RunStarted = $"{DateTime.Now:yyyy-MM-dd_HH-mm-ss}";
+    private static readonly string LogDir = GetLogDir();
+
+    public static string FilePath(string name)
+    {
+        Directory.CreateDirectory(LogDir);
+        return Path.Combine(LogDir, $"{RunStarted}-{name}");
+    }
+
+    private static string GetLogDir([CallerFilePath] string thisFilePath = "")
+    {
+        var sourceDir = Path.GetDirectoryName(thisFilePath) ??
+            throw new InvalidOperationException("Could not determine source file directory");
+        return Path.Combine(sourceDir, "logs");
+    }
+}

--- a/backend/FwLite/LcmDebugger/RunOutput.cs
+++ b/backend/FwLite/LcmDebugger/RunOutput.cs
@@ -8,14 +8,19 @@ namespace LcmDebugger;
 /// </summary>
 public static class RunOutput
 {
-    private static readonly string RunStarted = $"{DateTimeOffset.Now:yyyy-MM-dd_HH-mm-ss}";
+    // milliseconds so two runs started in the same second don't share a name
+    private static readonly string RunStarted = $"{DateTimeOffset.Now:yyyy-MM-dd_HH-mm-ss-fff}";
     private static readonly string LogDir = GetLogDir();
 
     public static string FilePath(string name)
     {
         Directory.CreateDirectory(LogDir);
-        return Path.Combine(LogDir, $"{RunStarted}-{name}");
+        return Path.Combine(LogDir, $"{RunStarted}-{AsFileName(name)}");
     }
+
+    // callers name files after a project, whose path can be nested
+    private static string AsFileName(string name) =>
+        string.Join('-', name.Split(Path.GetInvalidFileNameChars(), StringSplitOptions.RemoveEmptyEntries));
 
     private static string GetLogDir([CallerFilePath] string thisFilePath = "")
     {

--- a/backend/FwLite/LcmDebugger/RunOutput.cs
+++ b/backend/FwLite/LcmDebugger/RunOutput.cs
@@ -8,7 +8,7 @@ namespace LcmDebugger;
 /// </summary>
 public static class RunOutput
 {
-    private static readonly string RunStarted = $"{DateTime.Now:yyyy-MM-dd_HH-mm-ss}";
+    private static readonly string RunStarted = $"{DateTimeOffset.Now:yyyy-MM-dd_HH-mm-ss}";
     private static readonly string LogDir = GetLogDir();
 
     public static string FilePath(string name)

--- a/backend/FwLite/LcmDebugger/Utils.cs
+++ b/backend/FwLite/LcmDebugger/Utils.cs
@@ -5,6 +5,7 @@ using FwDataMiniLcmBridge.Api;
 using FwDataMiniLcmBridge.LcmUtils;
 using FwLiteProjectSync;
 using LcmCrdt;
+using LexCore.Sync;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using SIL.Harmony;
@@ -98,12 +99,22 @@ public static class Utils
         var crdtMiniLcmApi = project.CrdtApi;
         var fwDataMiniLcmApi = project.FwApi;
         var projectSnapshot = await snapshotService.GetProjectSnapshot(fwDataMiniLcmApi.Project);
-        var result = projectSnapshot is null
-                    ? await syncService.Import(crdtMiniLcmApi, fwDataMiniLcmApi, dryRun)
-                    : await syncService.Sync(crdtMiniLcmApi, fwDataMiniLcmApi, projectSnapshot, dryRun);
-        if (!dryRun)
+        SyncResult result;
+        try
         {
-            await snapshotService.RegenerateProjectSnapshot(crdtMiniLcmApi, fwDataMiniLcmApi.Project, keepBackup: false);
+            result = projectSnapshot is null
+                        ? await syncService.Import(crdtMiniLcmApi, fwDataMiniLcmApi, dryRun)
+                        : await syncService.Sync(crdtMiniLcmApi, fwDataMiniLcmApi, projectSnapshot, dryRun);
+            if (!dryRun)
+            {
+                await snapshotService.RegenerateProjectSnapshot(crdtMiniLcmApi, fwDataMiniLcmApi.Project, keepBackup: false);
+            }
+        }
+        catch (Exception e)
+        {
+            // the runtime prints an unhandled exception to stderr, which the file logger never sees
+            services.Logger().LogError(e, "Sync failed");
+            throw;
         }
         services.Logger().LogInformation("Sync completed successfully. Crdt changes: {CrdtChanges}, Fwdata changes: {FwdataChanges}.",
             result.CrdtChanges, result.FwdataChanges);

--- a/backend/FwLite/LcmDebugger/Utils.cs
+++ b/backend/FwLite/LcmDebugger/Utils.cs
@@ -1,16 +1,18 @@
 using System.Runtime.CompilerServices;
+using System.Text.Json;
 using FwDataMiniLcmBridge;
 using FwDataMiniLcmBridge.Api;
 using FwDataMiniLcmBridge.LcmUtils;
 using FwLiteProjectSync;
 using LcmCrdt;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 using SIL.Harmony;
 using SIL.LCModel;
 
 namespace LcmDebugger;
 
-public record FwHeadlessProject(CrdtMiniLcmApi CrdtApi, FwDataMiniLcmApi FwApi) : IDisposable
+public record FwHeadlessProject(CrdtMiniLcmApi CrdtApi, FwDataMiniLcmApi FwApi, string Name) : IDisposable
 {
     public void Dispose()
     {
@@ -21,6 +23,9 @@ public record FwHeadlessProject(CrdtMiniLcmApi CrdtApi, FwDataMiniLcmApi FwApi) 
 
 public static class Utils
 {
+    private static ILogger Logger(this IServiceProvider services) =>
+        services.GetRequiredService<ILoggerFactory>().CreateLogger("LcmDebugger");
+
     public static LcmCache? LoadProject(this IServiceProvider services, FwDataProject project)
     {
         var projectLoader = services.GetRequiredService<IProjectLoader>();
@@ -69,21 +74,21 @@ public static class Utils
             // Make a copy of the project to avoid modifying the original download
             var tempDir = Path.Combine(Path.GetTempPath(), $"{relativePath}_{Guid.NewGuid().ToString().Split('-')[0]}");
             Directory.CreateDirectory(tempDir);
-            Console.WriteLine($"Copying project to temporary directory: {tempDir}");
+            services.Logger().LogInformation("Copying project to temporary directory: {TempDir}", tempDir);
             LexCore.Utils.FileUtils.CopyFilesRecursively(new DirectoryInfo(currProjRoot), new DirectoryInfo(tempDir));
             currProjRoot = tempDir;
         }
 
         var fwDataProject = new FwDataProject("fw", currProjRoot);
         var fwDataMiniLcmApi = services.GetRequiredService<FwDataFactory>().GetFwDataMiniLcmApi(fwDataProject, false);
-        Console.WriteLine($"Project ID: {fwDataMiniLcmApi.ProjectId}");
+        services.Logger().LogInformation("Project ID: {ProjectId}", fwDataMiniLcmApi.ProjectId);
 
         var crdtDbPath = Path.Combine(currProjRoot, "crdt.sqlite");
         var crdtProject = new CrdtProject("unused-project-code", crdtDbPath);
         var crdtMiniLcmApi = (CrdtMiniLcmApi)await services.GetRequiredService<CrdtProjectsService>().OpenProject(crdtProject, services);
-        Console.WriteLine($"Crdt Project: {crdtMiniLcmApi.ProjectData.Code}");
+        services.Logger().LogInformation("Crdt Project: {Code}", crdtMiniLcmApi.ProjectData.Code);
 
-        return new FwHeadlessProject(crdtMiniLcmApi, fwDataMiniLcmApi);
+        return new FwHeadlessProject(crdtMiniLcmApi, fwDataMiniLcmApi, relativePath);
     }
 
     public static async Task SyncFwHeadlessProject(this IServiceProvider services, FwHeadlessProject project, bool dryRun = true)
@@ -100,7 +105,23 @@ public static class Utils
         {
             await snapshotService.RegenerateProjectSnapshot(crdtMiniLcmApi, fwDataMiniLcmApi.Project, keepBackup: false);
         }
-        Console.WriteLine($"Sync completed successfully. Crdt changes: {result.CrdtChanges}, Fwdata changes: {result.FwdataChanges}.");
+        services.Logger().LogInformation("Sync completed successfully. Crdt changes: {CrdtChanges}, Fwdata changes: {FwdataChanges}.",
+            result.CrdtChanges, result.FwdataChanges);
+
+        // A dry run's whole output is its records; too much to read in a log, so they get their own file.
+        if (result is CrdtFwdataProjectSyncService.DryRunSyncResult dryRunResult)
+        {
+            await services.WriteDryRunRecords(project.Name, "crdt", dryRunResult.CrdtDryRunRecords);
+            await services.WriteDryRunRecords(project.Name, "fwdata", dryRunResult.FwDataDryRunRecords);
+        }
+    }
+
+    private static async Task WriteDryRunRecords(this IServiceProvider services, string projectName, string side, List<RecordingMiniLcmApi.RunRecord> records)
+    {
+        var path = RunOutput.FilePath($"{projectName}-dry-run-{side}-records.json");
+        await using var file = File.Create(path);
+        await JsonSerializer.SerializeAsync(file, records, new JsonSerializerOptions { WriteIndented = true });
+        services.Logger().LogInformation("Wrote {RecordCount} {Side} dry run records to {Path}", records.Count, side, path);
     }
 
     private static string GetDefaultDownloadsPath([CallerFilePath] string callerFilePath = "")

--- a/backend/FwLite/LcmDebugger/Utils.cs
+++ b/backend/FwLite/LcmDebugger/Utils.cs
@@ -5,7 +5,6 @@ using FwDataMiniLcmBridge.Api;
 using FwDataMiniLcmBridge.LcmUtils;
 using FwLiteProjectSync;
 using LcmCrdt;
-using LexCore.Sync;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using SIL.Harmony;
@@ -94,36 +93,35 @@ public static class Utils
 
     public static async Task SyncFwHeadlessProject(this IServiceProvider services, FwHeadlessProject project, bool dryRun = true)
     {
-        var syncService = services.GetRequiredService<CrdtFwdataProjectSyncService>();
-        var snapshotService = services.GetRequiredService<ProjectSnapshotService>();
-        var crdtMiniLcmApi = project.CrdtApi;
-        var fwDataMiniLcmApi = project.FwApi;
-        var projectSnapshot = await snapshotService.GetProjectSnapshot(fwDataMiniLcmApi.Project);
-        SyncResult result;
         try
         {
-            result = projectSnapshot is null
+            var syncService = services.GetRequiredService<CrdtFwdataProjectSyncService>();
+            var snapshotService = services.GetRequiredService<ProjectSnapshotService>();
+            var crdtMiniLcmApi = project.CrdtApi;
+            var fwDataMiniLcmApi = project.FwApi;
+            var projectSnapshot = await snapshotService.GetProjectSnapshot(fwDataMiniLcmApi.Project);
+            var result = projectSnapshot is null
                         ? await syncService.Import(crdtMiniLcmApi, fwDataMiniLcmApi, dryRun)
                         : await syncService.Sync(crdtMiniLcmApi, fwDataMiniLcmApi, projectSnapshot, dryRun);
             if (!dryRun)
             {
                 await snapshotService.RegenerateProjectSnapshot(crdtMiniLcmApi, fwDataMiniLcmApi.Project, keepBackup: false);
             }
+            services.Logger().LogInformation("Sync completed successfully. Crdt changes: {CrdtChanges}, Fwdata changes: {FwdataChanges}.",
+                result.CrdtChanges, result.FwdataChanges);
+
+            // A dry run's whole output is its records; too much to read in a log, so they get their own file.
+            if (result is CrdtFwdataProjectSyncService.DryRunSyncResult dryRunResult)
+            {
+                await services.WriteDryRunRecords(project.Name, "crdt", dryRunResult.CrdtDryRunRecords);
+                await services.WriteDryRunRecords(project.Name, "fwdata", dryRunResult.FwDataDryRunRecords);
+            }
         }
         catch (Exception e)
         {
             // the runtime prints an unhandled exception to stderr, which the file logger never sees
-            services.Logger().LogError(e, "Sync failed");
+            services.Logger().LogError(e, "Run failed");
             throw;
-        }
-        services.Logger().LogInformation("Sync completed successfully. Crdt changes: {CrdtChanges}, Fwdata changes: {FwdataChanges}.",
-            result.CrdtChanges, result.FwdataChanges);
-
-        // A dry run's whole output is its records; too much to read in a log, so they get their own file.
-        if (result is CrdtFwdataProjectSyncService.DryRunSyncResult dryRunResult)
-        {
-            await services.WriteDryRunRecords(project.Name, "crdt", dryRunResult.CrdtDryRunRecords);
-            await services.WriteDryRunRecords(project.Name, "fwdata", dryRunResult.FwDataDryRunRecords);
         }
     }
 


### PR DESCRIPTION
*[Claude, autonomous]*

Each LcmDebugger run now writes `logs/<timestamp>-run.log`, and a dry run's records go to `logs/<timestamp>-<project>-dry-run-{crdt,fwdata}-records.json` instead of the throwaway project copy, where they were deleted along with it. Nothing is pruned, and a failed run logs its exception (unhandled ones only reach stderr, which the file logger never sees).

`NReco.Logging.File` is already used by FwLiteWeb and FwLiteMaui with its version pinned centrally, so this only adds a reference to it.