### PR TITLE
[claude] Fix FwHeadless silently dropping FieldWorks edits (chorusmerge handler discovery)

### DIFF
--- a/backend/FwHeadless/Dockerfile
+++ b/backend/FwHeadless/Dockerfile
@@ -43,6 +43,10 @@ RUN test -f FixFwData \
     && python3 -c "import zipfile; open('/tmp/smoke.fwdata','wb').write(zipfile.ZipFile('/tmp/test-template-repo.zip').read('kevin-test-01.fwdata'))" \
     && ./FixFwData /tmp/smoke.fwdata; ec=$?; rm -f /tmp/test-template-repo.zip /tmp/smoke.fwdata; \
     if [ $ec -gt 1 ]; then echo "FixFwData smoke test failed with exit $ec"; exit 1; fi
+# Smoke-test: chorusmerge must engage the FieldWorks merge handler, not silently keep one
+# whole file (#2508). Runs the real wrapper from a non-/app cwd, exactly as hg does.
+COPY FwHeadless/chorusmerge-smoke/ /opt/chorusmerge-smoke/
+RUN chmod +x /opt/chorusmerge-smoke/run.sh && /opt/chorusmerge-smoke/run.sh
 USER www-data:www-data
 ENV XDG_DATA_HOME=/var/www/.local/share
 ENTRYPOINT ["tini", "--"]

--- a/backend/FwHeadless/Dockerfile
+++ b/backend/FwHeadless/Dockerfile
@@ -45,8 +45,9 @@ RUN test -f FixFwData \
     if [ $ec -gt 1 ]; then echo "FixFwData smoke test failed with exit $ec"; exit 1; fi
 # Smoke-test: chorusmerge must engage the FieldWorks merge handler, not silently keep one
 # whole file (#2508). Runs the real wrapper from a non-/app cwd, exactly as hg does.
-COPY FwHeadless/chorusmerge-smoke/ /opt/chorusmerge-smoke/
-RUN chmod +x /opt/chorusmerge-smoke/run.sh && /opt/chorusmerge-smoke/run.sh
+# Bind-mount rather than COPY so the fixture/script don't ship in the runtime image.
+RUN --mount=type=bind,source=FwHeadless/chorusmerge-smoke,target=/opt/chorusmerge-smoke \
+    bash /opt/chorusmerge-smoke/run.sh
 USER www-data:www-data
 ENV XDG_DATA_HOME=/var/www/.local/share
 ENTRYPOINT ["tini", "--"]

--- a/backend/FwHeadless/chorusmerge
+++ b/backend/FwHeadless/chorusmerge
@@ -1,6 +1,10 @@
 #!/bin/bash
 
-# cwd while running script is inside hg repo, so ensure we look for ChorusMerge.dll in right place
+# cwd while running script is inside the hg repo. ChorusMerge finds its FieldWorks merge
+# handlers by scanning the cwd for *-ChorusPlugin.dll (MEF DirectoryCatalog(".")), so cd to
+# where they sit next to ChorusMerge.dll, else merges silently fall back to "keep ours".
+# hg passes absolute file paths to the merge tool, so changing cwd is safe.
 SCRIPT_DIR=$(dirname $(readlink -f "$0"))
+cd "$SCRIPT_DIR"
 
 exec dotnet "${SCRIPT_DIR}/ChorusMerge.dll" "$@"

--- a/backend/FwHeadless/chorusmerge
+++ b/backend/FwHeadless/chorusmerge
@@ -5,6 +5,8 @@
 # where they sit next to ChorusMerge.dll, else merges silently fall back to "keep ours".
 # hg passes absolute file paths to the merge tool, so changing cwd is safe.
 SCRIPT_DIR=$(dirname $(readlink -f "$0"))
-cd "$SCRIPT_DIR"
+# Fail loudly rather than merge from the wrong cwd: a merge without the handlers silently
+# keeps "ours" (the #2508 data loss); a non-zero exit makes Chorus roll back and throw.
+cd "$SCRIPT_DIR" || { echo "chorusmerge: cannot cd to $SCRIPT_DIR; refusing to merge without the FieldWorks handlers" >&2; exit 1; }
 
 exec dotnet "${SCRIPT_DIR}/ChorusMerge.dll" "$@"

--- a/backend/FwHeadless/chorusmerge-smoke/PartsOfSpeech.base.list
+++ b/backend/FwHeadless/chorusmerge-smoke/PartsOfSpeech.base.list
@@ -1,0 +1,246 @@
+<?xml version="1.0" encoding="utf-8"?>
+<PartsOfSpeech>
+	<CmPossibilityList
+		guid="64dd1920-ba7a-43ca-9577-4dcc3b8ede9a">
+		<Abbreviation>
+			<AUni
+				ws="en">Pos</AUni>
+		</Abbreviation>
+		<DateCreated
+			val="2023-08-16 09:28:29.486" />
+		<DateModified
+			val="2023-08-16 09:28:29.486" />
+		<Depth
+			val="127" />
+		<DisplayOption
+			val="0" />
+		<IsClosed
+			val="False" />
+		<IsSorted
+			val="True" />
+		<IsVernacular
+			val="False" />
+		<ItemClsid
+			val="5049" />
+		<ListVersion
+			val="00000000-0000-0000-0000-000000000000" />
+		<Name>
+			<AUni
+				ws="en">Parts Of Speech</AUni>
+		</Name>
+		<Possibilities>
+			<ownseq
+				class="PartOfSpeech"
+				guid="46e4fe08-ffa0-4c8b-bf98-2c56f38904d9">
+				<Abbreviation>
+					<AUni
+						ws="en">adv</AUni>
+				</Abbreviation>
+				<BackColor
+					val="-1073741824" />
+				<CatalogSourceId>
+					<Uni>Adverb</Uni>
+				</CatalogSourceId>
+				<DateCreated
+					val="2023-08-16 09:28:29.490" />
+				<DateModified
+					val="2023-08-16 09:28:29.490" />
+				<Description>
+					<AStr
+						ws="en">
+						<Run
+							ws="en">An adverb, narrowly defined, is a part of speech whose members modify verbs for such categories as time, manner, place, or direction. An adverb, broadly defined, is a part of speech whose members modify any constituent class of words other than nouns, such as verbs, adjectives, adverbs, phrases, clauses, or sentences. Under this definition, the possible type of modification depends on the class of the constituent being modified.</Run>
+					</AStr>
+				</Description>
+				<ForeColor
+					val="6303632" />
+				<Hidden
+					val="False" />
+				<IsProtected
+					val="False" />
+				<Name>
+					<AUni
+						ws="en">Adverb</AUni>
+				</Name>
+				<SortSpec
+					val="0" />
+				<UnderColor
+					val="-1073741824" />
+				<UnderStyle
+					val="1" />
+			</ownseq>
+			<ownseq
+				class="PartOfSpeech"
+				guid="a8e41fd3-e343-4c7c-aa05-01ea3dd5cfb5">
+				<Abbreviation>
+					<AUni
+						ws="en">n</AUni>
+				</Abbreviation>
+				<BackColor
+					val="-1073741824" />
+				<CatalogSourceId>
+					<Uni>Noun</Uni>
+				</CatalogSourceId>
+				<DateCreated
+					val="2023-08-16 09:28:29.491" />
+				<DateModified
+					val="2023-08-16 09:28:29.491" />
+				<Description>
+					<AStr
+						ws="en">
+						<Run
+							ws="en">A noun is a broad classification of parts of speech which include substantives and nominals.</Run>
+					</AStr>
+				</Description>
+				<ForeColor
+					val="6303632" />
+				<Hidden
+					val="False" />
+				<IsProtected
+					val="False" />
+				<Name>
+					<AUni
+						ws="en">Noun</AUni>
+				</Name>
+				<SortSpec
+					val="0" />
+				<UnderColor
+					val="-1073741824" />
+				<UnderStyle
+					val="1" />
+			</ownseq>
+			<ownseq
+				class="PartOfSpeech"
+				guid="a4fc78d6-7591-4fb3-8edd-82f10ae3739d">
+				<Abbreviation>
+					<AUni
+						ws="en">pro-form</AUni>
+				</Abbreviation>
+				<BackColor
+					val="-1073741824" />
+				<CatalogSourceId>
+					<Uni>Pro-form</Uni>
+				</CatalogSourceId>
+				<DateCreated
+					val="2023-08-16 09:28:29.491" />
+				<DateModified
+					val="2023-08-16 09:28:29.491" />
+				<Description>
+					<AStr
+						ws="en">
+						<Run
+							ws="en">A pro-form is a part of speech whose members usually substitute for other constituents, including phrases, clauses, or sentences, and whose meaning is recoverable from the linguistic or extralinguistic context.</Run>
+					</AStr>
+				</Description>
+				<ForeColor
+					val="6303632" />
+				<Hidden
+					val="False" />
+				<IsProtected
+					val="False" />
+				<Name>
+					<AUni
+						ws="en">Pro-form</AUni>
+				</Name>
+				<SortSpec
+					val="0" />
+				<SubPossibilities>
+					<ownseq
+						class="PartOfSpeech"
+						guid="a3274cfd-225f-45fd-8851-a7b1a1e1037a">
+						<Abbreviation>
+							<AUni
+								ws="en">pro</AUni>
+						</Abbreviation>
+						<BackColor
+							val="-1073741824" />
+						<CatalogSourceId>
+							<Uni>Pronoun</Uni>
+						</CatalogSourceId>
+						<DateCreated
+							val="2023-08-16 09:28:29.491" />
+						<DateModified
+							val="2023-08-16 09:28:29.491" />
+						<Description>
+							<AStr
+								ws="en">
+								<Run
+									ws="en">A pronoun is a pro-form which functions like a noun and substitutes for a noun or noun phrase.</Run>
+							</AStr>
+						</Description>
+						<ForeColor
+							val="6303632" />
+						<Hidden
+							val="False" />
+						<IsProtected
+							val="False" />
+						<Name>
+							<AUni
+								ws="en">Pronoun</AUni>
+						</Name>
+						<SortSpec
+							val="0" />
+						<UnderColor
+							val="-1073741824" />
+						<UnderStyle
+							val="1" />
+					</ownseq>
+				</SubPossibilities>
+				<UnderColor
+					val="-1073741824" />
+				<UnderStyle
+					val="1" />
+			</ownseq>
+			<ownseq
+				class="PartOfSpeech"
+				guid="86ff66f6-0774-407a-a0dc-3eeaf873daf7">
+				<Abbreviation>
+					<AUni
+						ws="en">v</AUni>
+				</Abbreviation>
+				<BackColor
+					val="-1073741824" />
+				<CatalogSourceId>
+					<Uni>Verb</Uni>
+				</CatalogSourceId>
+				<DateCreated
+					val="2023-08-16 09:28:29.491" />
+				<DateModified
+					val="2023-08-16 09:28:29.491" />
+				<Description>
+					<AStr
+						ws="en">
+						<Run
+							ws="en">A verb is a part of speech whose members typically signal events and actions; constitute, singly or in a phrase, a minimal predicate in a clause; govern the number and types of other constituents which may occur in the clause; and, in inflectional languages, may be inflected for tense, aspect, voice, modality, or agreement with other constituents in person, number, or grammatical gender.</Run>
+					</AStr>
+				</Description>
+				<ForeColor
+					val="6303632" />
+				<Hidden
+					val="False" />
+				<IsProtected
+					val="False" />
+				<Name>
+					<AUni
+						ws="en">Verb</AUni>
+				</Name>
+				<SortSpec
+					val="0" />
+				<UnderColor
+					val="-1073741824" />
+				<UnderStyle
+					val="1" />
+			</ownseq>
+		</Possibilities>
+		<PreventChoiceAboveLevel
+			val="0" />
+		<PreventDuplicates
+			val="True" />
+		<PreventNodeChoices
+			val="False" />
+		<UseExtendedFields
+			val="True" />
+		<WsSelector
+			val="-3" />
+	</CmPossibilityList>
+</PartsOfSpeech>

--- a/backend/FwHeadless/chorusmerge-smoke/run.sh
+++ b/backend/FwHeadless/chorusmerge-smoke/run.sh
@@ -23,12 +23,13 @@ sed 's#>Verb</AUni>#>Verb_THEIRS</AUni>#'   "$BASE" > "$WORK/theirs.list"
 cp "$WORK/ours.list" "$WORK/merged.list"   # ChorusMerge writes the result back to arg 0
 
 cd "$WORK"   # a non-/app cwd, exactly as hg runs the merge tool inside the repo
-ChorusPathToRepository="$WORK" "$APP/chorusmerge" "$WORK/merged.list" "$BASE" "$WORK/theirs.list" || true
+rc=0
+ChorusPathToRepository="$WORK" "$APP/chorusmerge" "$WORK/merged.list" "$BASE" "$WORK/theirs.list" || rc=$?
 
 if grep -q Adverb_OURS "$WORK/merged.list" && grep -q Verb_THEIRS "$WORK/merged.list"; then
   echo "chorusmerge smoke OK: FieldWorks 3-way merge engaged; both edits preserved"
 else
-  echo "chorusmerge smoke FAILED: merge dropped a side (FieldWorks handler not engaged)"
+  echo "chorusmerge smoke FAILED: merge dropped a side (FieldWorks handler not engaged; chorusmerge exit=$rc)"
   echo "  Adverb_OURS=$(grep -c Adverb_OURS "$WORK/merged.list" || true)  Verb_THEIRS=$(grep -c Verb_THEIRS "$WORK/merged.list" || true)"
   exit 1
 fi

--- a/backend/FwHeadless/chorusmerge-smoke/run.sh
+++ b/backend/FwHeadless/chorusmerge-smoke/run.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+# Smoke-test: does chorusmerge actually engage the FieldWorks merge handler, or silently
+# fall back to keeping one whole file? See sillsdev/languageforge-lexbox#2508 / #2509.
+#
+# PartsOfSpeech.base.list is the FLExBridge split (nested) form of a possibility list — what
+# hg actually versions and merges. Regenerate from a .fwdata with the FLExBridge split CLI.
+#
+# The handler is discovered by scanning the *current working directory* for *-ChorusPlugin.dll,
+# and hg runs the merge tool with cwd = the repo (not /app). So this MUST run from a non-/app
+# cwd to be meaningful — running it from /app would hide the bug and pass falsely.
+set -euo pipefail
+
+APP=${APP:-/app}
+SMOKE="$(dirname "$(readlink -f "$0")")"
+BASE="$SMOKE/PartsOfSpeech.base.list"
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+# Two edits to DIFFERENT possibility items (different guids) => they must auto-merge cleanly.
+# A real 3-way merge keeps both; the whole-file "keep ours" fallback drops the theirs edit.
+sed 's#>Adverb</AUni>#>Adverb_OURS</AUni>#' "$BASE" > "$WORK/ours.list"
+sed 's#>Verb</AUni>#>Verb_THEIRS</AUni>#'   "$BASE" > "$WORK/theirs.list"
+cp "$WORK/ours.list" "$WORK/merged.list"   # ChorusMerge writes the result back to arg 0
+
+cd "$WORK"   # a non-/app cwd, exactly as hg runs the merge tool inside the repo
+ChorusPathToRepository="$WORK" "$APP/chorusmerge" "$WORK/merged.list" "$BASE" "$WORK/theirs.list" || true
+
+if grep -q Adverb_OURS "$WORK/merged.list" && grep -q Verb_THEIRS "$WORK/merged.list"; then
+  echo "chorusmerge smoke OK: FieldWorks 3-way merge engaged; both edits preserved"
+else
+  echo "chorusmerge smoke FAILED: merge dropped a side (FieldWorks handler not engaged)"
+  echo "  Adverb_OURS=$(grep -c Adverb_OURS "$WORK/merged.list" || true)  Verb_THEIRS=$(grep -c Verb_THEIRS "$WORK/merged.list" || true)"
+  exit 1
+fi


### PR DESCRIPTION
*[Claude, autonomous]*

FwHeadless silently drops FieldWorks-desktop edits when a file needs a real 3-way merge: the ChorusMerge process never finds its `*-ChorusPlugin.dll` handlers (the MEF scan is cwd-relative and hg runs the merge tool from the repo, not `/app`), so conflicts fall back to whole-file "keep ours". Background in #2508.

Two commits, landing intentionally red → green:
1. A build-time smoke-test that runs the real `chorusmerge` from a non-`/app` cwd on a split `PartsOfSpeech.list`, editing two different possibility items, and asserts both survive. **Red on the current setup** — it reproduces the data loss in CI.
2. The fix: `cd` into the script dir so ChorusMerge's cwd-relative handler scan lands on `/app`. hg passes absolute file paths to the merge tool, so changing cwd is safe. Turns the smoke-test green.

Interim shim (#2510); the durable upstream fix is tracked in #2511 / sillsdev/chorus#392.

Closes #2509, #2510.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
