### PR TITLE
[claude] Fix crash on /sync-harmony when request scope already has project context

### DIFF
--- a/backend/FwHeadless/FwHeadless.csproj
+++ b/backend/FwHeadless/FwHeadless.csproj
@@ -3,6 +3,9 @@
     <Mercurial4ChorusDestDir>$(MSBuildProjectDirectory)</Mercurial4ChorusDestDir>
   </PropertyGroup>
   <ItemGroup>
+    <InternalsVisibleTo Include="Testing" />
+  </ItemGroup>
+  <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" />
     <PackageReference Include="MimeMapping" />
     <PackageReference Include="Npgsql.OpenTelemetry" />

--- a/backend/FwHeadless/Routes/MergeRoutes.cs
+++ b/backend/FwHeadless/Routes/MergeRoutes.cs
@@ -77,10 +77,9 @@ public static class MergeRoutes
         return TypedResults.Ok();
     }
 
-    static async Task<Results<Ok, NotFound<string>>> SyncHarmonyProject(
+    internal static async Task<Results<Ok, NotFound<string>>> SyncHarmonyProject(
         Guid projectId,
         IProjectLookupService projectLookupService,
-        CrdtSyncService crdtSyncService,
         IServiceProvider services,
         CancellationToken stoppingToken
     )
@@ -94,7 +93,10 @@ public static class MergeRoutes
             return TypedResults.NotFound("Project not found");
         }
 
-        var syncWorker = ActivatorUtilities.CreateInstance<SyncWorker>(services, projectId);
+        // Fresh scope so the worker's CurrentProjectService isn't the one the request-pipeline
+        // middleware already set the project context on (which would trip SetupProjectContext).
+        await using var scope = services.CreateAsyncScope();
+        var syncWorker = ActivatorUtilities.CreateInstance<SyncWorker>(scope.ServiceProvider, projectId);
         await syncWorker.ExecuteSync(stoppingToken, onlyHarmony: true);
 
         return TypedResults.Ok();

--- a/backend/Testing/FwHeadless/Services/SyncWorkerTestHarness.cs
+++ b/backend/Testing/FwHeadless/Services/SyncWorkerTestHarness.cs
@@ -3,11 +3,13 @@ using FwDataMiniLcmBridge.Api;
 using FwDataMiniLcmBridge.Tests.Fixtures;
 using FwHeadless;
 using FwHeadless.Media;
+using FwHeadless.Routes;
 using FwHeadless.Services;
 using FwLiteProjectSync;
 using LcmCrdt;
 using LcmCrdt.RemoteSync;
 using LexCore.Sync;
+using Microsoft.AspNetCore.Http.HttpResults;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
@@ -161,6 +163,41 @@ internal sealed class SyncWorkerTestHarness : IDisposable
         await using var scope = sp.CreateAsyncScope();
         var worker = ActivatorUtilities.CreateInstance<SyncWorker>(scope.ServiceProvider, ProjectId);
         return await worker.ExecuteSync(CancellationToken.None, onlyHarmony);
+    }
+
+    /// <summary>
+    /// Runs the real /sync-harmony route handler on a request scope that already has the current
+    /// project set, reproducing the ProjectContextFromIdService middleware that runs first in the
+    /// FwHeadless pipeline. The handler must isolate the worker in its own scope so this doesn't
+    /// collide in CurrentProjectService.SetupProjectContext.
+    /// </summary>
+    public async Task<Results<Ok, NotFound<string>>> RunHarmonyRouteWithPrePopulatedContextAsync()
+    {
+        Steps.Clear();
+        _didCrdtSyncOrImport = false;
+        _createFwDataFileAfterClone = true;
+
+        ProjectLookupMock.Setup(s => s.ProjectExists(ProjectId)).ReturnsAsync(true);
+
+        var sp = BuildServiceProvider(new SyncResult(0, 0));
+        try
+        {
+            SetupFwDataProject(sp, createFile: true);
+
+            await using var requestScope = sp.CreateAsyncScope();
+            requestScope.ServiceProvider.GetRequiredService<CurrentProjectService>()
+                .SetupProjectContextForNewDb(new CrdtProject("crdt", Config.GetCrdtFile(ProjectCode, ProjectId)));
+
+            return await MergeRoutes.SyncHarmonyProject(
+                ProjectId,
+                ProjectLookupMock.Object,
+                requestScope.ServiceProvider,
+                CancellationToken.None);
+        }
+        finally
+        {
+            await sp.DisposeAsync();
+        }
     }
 
     private void SetupDefaultMocks()

--- a/backend/Testing/FwHeadless/Services/SyncWorkerTests.cs
+++ b/backend/Testing/FwHeadless/Services/SyncWorkerTests.cs
@@ -1,5 +1,6 @@
 using FwHeadless.Services;
 using LexCore.Sync;
+using Microsoft.AspNetCore.Http.HttpResults;
 using Moq;
 using static Testing.FwHeadless.Services.SyncStep;
 
@@ -7,6 +8,20 @@ namespace Testing.FwHeadless.Services;
 
 public class SyncWorkerTests
 {
+    [Fact]
+    public async Task SyncHarmonyRoute_SucceedsWhenRequestScopeAlreadyHasProjectContext()
+    {
+        using var h = new SyncWorkerTestHarness();
+
+        // Regression: the route used to run the worker in the request scope that the
+        // ProjectContextFromIdService middleware had already set the project on, so the worker's
+        // second SetupProjectContext threw "Can't setup project context for crdt ...".
+        var result = await h.RunHarmonyRouteWithPrePopulatedContextAsync();
+
+        result.Result.Should().BeOfType<Ok>();
+        h.Steps.Should().Contain(HarmonySync);
+    }
+
     [Fact]
     public async Task ExecuteSync_SuccessWithCrdtAndFwChanges_RegeneratesSnapshotAfterSendReceive()
     {


### PR DESCRIPTION
*[Claude, autonomous]*

`POST /api/merge/sync-harmony` throws `InvalidOperationException: Can't setup project context for crdt when already in context of project crdt`.

```
fail: Microsoft.AspNetCore.Diagnostics.ExceptionHandlerMiddleware[1]
      An unhandled exception has occurred while executing the request.
      System.InvalidOperationException: Can't setup project context for crdt when already in context of project crdt
         at LcmCrdt.CurrentProjectService.SetupProjectContext(CrdtProject project) in /FwLite/LcmCrdt/CurrentProjectService.cs:line 78
         at LcmCrdt.LcmCrdtKernel.OpenCrdtProject(IServiceProvider services, CrdtProject project) in /FwLite/LcmCrdt/LcmCrdtKernel.cs:line 425
         at FwHeadless.Services.SyncWorker.ExecuteSync(CancellationToken stoppingToken, Boolean onlyHarmony) in /FwHeadless/Services/SyncHostedService.cs:line 196
         at FwHeadless.Services.SyncWorker.ExecuteSync(CancellationToken stoppingToken, Boolean onlyHarmony) in /FwHeadless/Services/SyncHostedService.cs:line 276
         at FwHeadless.Routes.MergeRoutes.SyncHarmonyProject(Guid projectId, IProjectLookupService projectLookupService, CrdtSyncService crdtSyncService, IServiceProvider services, CancellationToken stoppingToken) in /FwHeadless/Routes/MergeRoutes.cs:line 98
         at Microsoft.AspNetCore.Http.RequestDelegateFactory.ExecuteTaskResult[T](Task`1 task, HttpContext httpContext)
         at Microsoft.AspNetCore.Routing.EndpointMiddleware.<Invoke>g__AwaitRequestTask|7_0(Endpoint endpoint, Task requestTask, ILogger logger)
         at Microsoft.AspNetCore.Diagnostics.ExceptionHandlerMiddlewareImpl.<Invoke>g__Awaited|10_0(ExceptionHandlerMiddlewareImpl middleware, HttpContext context, Task task)
```

The `ProjectContextFromIdService` middleware runs first on every request carrying `projectId` and (when the crdt file exists) calls `SetupProjectContext` on the request-scoped `CurrentProjectService`. The handler then ran `SyncWorker` in that **same** request scope, so the worker's `OpenCrdtProject` tried to set up a second, different `CrdtProject` instance and tripped the reference-equality guard. Both instances carry the hardcoded name `"crdt"`, hence the self-referential-looking message.

The queued path (`/execute` → `SyncHostedService.ExecuteAsync`) never hits this because it runs the worker in a fresh scope. Fix: `/sync-harmony` now does the same.

Only reproduces on a previously-synced project (the middleware's `File.Exists` gate) — i.e. exactly the "restore a reset project" case this endpoint serves.

Test: `SyncWorkerTests.SyncHarmonyRoute_SucceedsWhenRequestScopeAlreadyHasProjectContext` invokes the real handler on a pre-populated request scope; it fails with the exact production exception on the old code and passes with the fix.